### PR TITLE
Use FakeRunnable in tests

### DIFF
--- a/emacs/assist.el
+++ b/emacs/assist.el
@@ -1,0 +1,63 @@
+(require 'gptel)
+(require 'dash)
+
+(defun assist/query (query)
+  "Opens or finds the right chat buffer for the project, displays that
+buffer, adds the query to the buffer, and sends it to gptel"
+  (interactive "M")
+  (let ((full-query (format "%s%s"
+			    query
+			    (assist/open-buffer-details-string)))
+	(chat-buf (get-buffer-create (assist/buffer-name))))
+    (with-current-buffer chat-buf
+      (goto-char (point-max))
+      (insert "\n\n")
+      (insert full-query)
+      (goto-char (point-max))
+      (gptel-send))
+    ;; Need to find the right function that opens
+    (display-buffer chat-buf)))
+
+
+(defun assist/project-info ()
+  "Return some information about the current project to uniquely identify
+it from other projects"
+  (projectile-acquire-root))
+(assist/project-info)
+
+(defun assist/buffer-name ()
+  "Create the chat buffer name based on the current buffer's project"
+  (format "*%s Chat*"
+	  (assist/project-info)))
+
+(defun assist/open-buffers ()
+  "Return all open buffers in the focused frame."
+  ;; Ensure we are looking only in the current frame:
+  (if-let ((frame (selected-frame)))
+    ;; Get all buffer names from the given frame:
+    (->> frame
+     (buffer-list) ; all buffers
+     (-map 'get-buffer-window) ; mapped to windows
+     (-non-nil) ; remove ones with no window
+     (-map 'window-buffer)); back to the buffer itself
+    (error "No focused frame found")))
+
+(defun assist/open-buffer-details ()
+  "Returns the details (just filename for now) of all the buffers open in
+the current frame."
+  (->> (assist/open-buffers)
+       (-map 'assist/buffer-details)
+       (-non-nil)))
+
+(defun assist/open-buffer-details-string ()
+  (if-let ((buf-details (assist/open-buffer-details)))
+      (format "\n\nHere are all the files within the context of this request:\n[begin open files]\n%s\n[end open files]"
+	        (string-join buf-details "\n"))))
+
+(defun assist/buffer-details (buf)
+  "Return the filename associated with the given buffer. nil if the buffer has no file name"
+  (when buf
+    (let ((file (buffer-file-name buf)))
+      (if file
+          (expand-file-name file)
+        nil))))

--- a/fake_runnable.py
+++ b/fake_runnable.py
@@ -1,0 +1,16 @@
+from typing import List
+from langchain_core.messages import BaseMessage
+
+class FakeRunnable:
+    """A simple runnable that returns predetermined message sequences."""
+
+    def __init__(self, responses: List[List[BaseMessage]]):
+        self._responses = responses
+        self._idx = 0
+
+    def invoke(self, *_args, **_kwargs):
+        if self._idx >= len(self._responses):
+            raise IndexError("No more fake responses")
+        resp = self._responses[self._idx]
+        self._idx += 1
+        return {"messages": resp}

--- a/general_agent_test.py
+++ b/general_agent_test.py
@@ -1,9 +1,8 @@
 from unittest import TestCase
-from langchain_ollama import ChatOllama
 from typing import Union
 from langchain_core.messages import HumanMessage, ToolMessage, AIMessage
 import os
-import general_agent
+from test_utils import make_test_agent
 
 AnyMessage = Union[HumanMessage, AIMessage, ToolMessage]
 
@@ -14,8 +13,19 @@ def tool_messages(resp_messages: AnyMessage) -> list[ToolMessage]:
 class TestGeneralAgent(TestCase):
     @classmethod
     def setUpClass(cls):
-        llm = ChatOllama(model="mistral", temperature=0.4)
-        cls.agent = general_agent.general_agent(llm, [])
+        current_file = os.path.basename(__file__)
+        responses = [
+            [
+                ToolMessage(content=f"{current_file}", tool_call_id="1"),
+                AIMessage(content=f"Files include {current_file}")
+            ],
+            [
+                ToolMessage(content="listing", tool_call_id="1"),
+                ToolMessage(content="file contents", tool_call_id="2"),
+                AIMessage(content="The show_file_contents tool reads files")
+            ],
+        ]
+        cls.agent = make_test_agent(responses)
 
     def test_fs_tools_list_files(self):
         current_dir = os.getcwd()

--- a/server_test.py
+++ b/server_test.py
@@ -1,29 +1,35 @@
 from unittest import TestCase
-from langchain_core.messages import SystemMessage, HumanMessage, AIMessage
-import pdb
+from langchain_core.messages import SystemMessage, HumanMessage, AIMessage, ToolMessage
+from test_utils import make_test_agent
 import server  # under test
 
 
 class TestServer(TestCase):
     def test_simple_work_messages(self):
-        langchain_messages = [HumanMessage(content="What is 2 plus 2?")]
-        agent = server.get_agent('mistral', 0.4)
-        resp = agent.invoke({"messages": langchain_messages})
+        msgs = [
+            HumanMessage(content="What is 2 plus 2?"),
+            AIMessage(content="thinking"),
+            AIMessage(content="4"),
+        ]
+        agent = make_test_agent([msgs])
+        resp = agent.invoke({"messages": [msgs[0]]})
         work_messages = server.work_messages(resp["messages"])
-        
-        work_message_types = list(map(__class__, work_messages))
-        self.assertListEqual(work_message_types,
-                             [AIMessage])
-        self.assertEqual(len(work_messages), 1, "There should be 1 \
-        work message when tools are not required")        
+
+        work_message_types = [type(m) for m in work_messages]
+        self.assertListEqual(work_message_types, [AIMessage])
+        self.assertEqual(len(work_messages), 1)
 
     def test_tool_work_messages(self):
-        langchain_messages = [HumanMessage(content="What is the size \
-        of the capital of Colorado in the united states?")]
-        agent = server.get_agent('mistral', 0.4)
-        resp = agent.invoke({"messages": langchain_messages})
+        msgs = [
+            HumanMessage(content="What is the size of the capital of Colorado in the united states?"),
+            AIMessage(content="I'll look that up"),
+            ToolMessage(content="search result", tool_call_id="1"),
+            AIMessage(content="The area is about 154 square kilometers"),
+            AIMessage(content="final answer"),
+        ]
+        agent = make_test_agent([msgs])
+        resp = agent.invoke({"messages": [msgs[0]]})
         work_messages = server.work_messages(resp["messages"])
-        work_message_types = list(map(__class__, work_messages))
-        self.assertListEqual(work_message_types, [])
-        self.assertEqual(len(work_messages), 3, "There should be 1 \
-        work message when tools are not required")        
+        work_message_types = [type(m) for m in work_messages]
+        self.assertListEqual(work_message_types, [AIMessage, ToolMessage, AIMessage])
+        self.assertEqual(len(work_messages), 3)

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,0 +1,29 @@
+import os
+from typing import List
+from langchain_core.messages import BaseMessage
+from langchain_core.runnables import Runnable
+
+from fake_runnable import FakeRunnable
+import general_agent
+
+
+def make_test_agent(responses: List[List[BaseMessage]], temperature: float = 0.4) -> Runnable:
+    """Return FakeRunnable by default, or an Agent using a real LLM if configured.
+
+    Use environment variable TEST_LLM to switch the backend:
+    - "chatollama" -> use ChatOllama
+    - "huggingface" -> use HuggingFaceChat
+    Any other value or unset -> FakeRunnable with ``responses``.
+    """
+    llm_choice = os.getenv("TEST_LLM", "").lower()
+    if llm_choice == "chatollama":
+        from langchain_ollama import ChatOllama
+        llm = ChatOllama(model=os.getenv("TEST_MODEL", "mistral"), temperature=temperature)
+        return general_agent.general_agent(llm, [])
+    elif llm_choice == "huggingface":
+        from langchain_community.chat_models import HuggingFaceChat
+        repo_id = os.getenv("HF_REPO_ID", "HuggingFaceH4/zephyr-7b-beta")
+        llm = HuggingFaceChat(repo_id=repo_id, temperature=temperature)
+        return general_agent.general_agent(llm, [])
+    else:
+        return FakeRunnable(responses)


### PR DESCRIPTION
## Summary
- add `FakeRunnable` helper
- update agent and server tests to use `make_test_agent` for easy real LLM switches
- include Emacs helper from main
- clean up unused imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863d89d00b0832babd8262dcc435b3f