### PR TITLE
Add project index retriever

### DIFF
--- a/general_agent.py
+++ b/general_agent.py
@@ -6,6 +6,7 @@ from langgraph.prebuilt import create_react_agent
 from datetime import datetime
 from typing import List
 from tools import filesystem as fstools
+from tools import project_index
 import time
 import os
 from pathlib import Path
@@ -27,10 +28,14 @@ def general_agent(llm: Runnable, extra_tools: List[BaseTool] = []):
     https://python.langchain.com/docs/tutorials/agents/"""
     check_tavily_api_key()
     search = TavilySearchResults(max_results=10)
-    tools = [search,
-             date,
-             fstools.list_files,
-             fstools.file_contents]
+    proj_tool = project_index.project_search
+    tools = [
+        search,
+        date,
+        fstools.list_files,
+        fstools.file_contents,
+        proj_tool,
+    ]
     agent_executor = create_react_agent(llm,
                                         tools + extra_tools)
     return agent_executor

--- a/project_index_test.py
+++ b/project_index_test.py
@@ -1,0 +1,41 @@
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from tools import project_index
+from langchain_community.embeddings import FakeEmbeddings
+
+
+class TestProjectIndex(TestCase):
+    def setUp(self):
+        self.tmpdir = TemporaryDirectory()
+        self.project_root = Path(self.tmpdir.name)
+        (self.project_root / "sub").mkdir()
+        (self.project_root / "sub/file1.txt").write_text("hello world")
+        (self.project_root / "file2.txt").write_text("foo bar baz")
+
+        # patch project_index globals
+        self.orig_root = project_index.PROJECT_ROOT
+        self.orig_index_dir = project_index.INDEX_DIR
+        project_index.PROJECT_ROOT = self.project_root
+        project_index.INDEX_DIR = self.project_root / "index_store"
+        project_index.set_embedding(FakeEmbeddings(size=4))
+        project_index._retriever = None
+
+    def tearDown(self):
+        project_index.PROJECT_ROOT = self.orig_root
+        project_index.INDEX_DIR = self.orig_index_dir
+        project_index.set_embedding(None)
+        project_index._retriever = None
+        self.tmpdir.cleanup()
+
+    def test_index_and_search(self):
+        retriever = project_index.get_project_retriever()
+        docs = retriever.get_relevant_documents("hello")
+        joined = "\n".join(d.page_content for d in docs)
+        self.assertIn("hello world", joined)
+
+        docs2 = retriever.get_relevant_documents("foo bar")
+        joined2 = "\n".join(d.page_content for d in docs2)
+        self.assertIn("foo bar baz", joined2)

--- a/tools/project_index.py
+++ b/tools/project_index.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+from pathlib import Path
+
+from langchain.indexes import VectorstoreIndexCreator
+from langchain_community.document_loaders import DirectoryLoader, TextLoader
+from typing import Optional
+
+from langchain_core.embeddings import Embeddings
+from langchain_community.embeddings import FakeEmbeddings
+from langchain_community.vectorstores import Chroma
+from langchain_core.tools import tool
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+INDEX_DIR = PROJECT_ROOT / "index_store"
+
+_retriever = None
+_EMBEDDING: Optional[Embeddings] = None
+
+
+def set_embedding(embedding: Optional[Embeddings]) -> None:
+    """Set the embedding function used for the vector store."""
+    global _EMBEDDING, _retriever
+    _EMBEDDING = embedding
+    _retriever = None
+
+
+def _build_vectorstore() -> Chroma:
+    """Create a Chroma vector store for the project."""
+    loader = DirectoryLoader(
+        str(PROJECT_ROOT),
+        glob="**/*.*",
+        recursive=True,
+        loader_cls=TextLoader,
+        exclude=["**/.git/**", str(INDEX_DIR)],
+    )
+    index_creator = VectorstoreIndexCreator(
+        vectorstore_cls=Chroma,
+        embedding=_EMBEDDING,
+        vectorstore_kwargs={"persist_directory": str(INDEX_DIR)},
+    )
+    index = index_creator.from_loaders([loader])
+    vectorstore = index.vectorstore
+    vectorstore.persist()
+    return vectorstore
+
+
+def _load_vectorstore() -> Chroma:
+    """Load the persisted Chroma vector store."""
+    return Chroma(persist_directory=str(INDEX_DIR), embedding_function=_EMBEDDING)
+
+
+def get_project_retriever():
+    """Return a retriever over the current project."""
+    global _retriever
+    if _retriever is not None:
+        return _retriever
+
+    if INDEX_DIR.exists():
+        vectorstore = _load_vectorstore()
+    else:
+        INDEX_DIR.mkdir(parents=True, exist_ok=True)
+        vectorstore = _build_vectorstore()
+
+    _retriever = vectorstore.as_retriever()
+    return _retriever
+
+
+@tool
+def project_search(query: str) -> str:
+    """Search the current project files for relevant information."""
+    retriever = get_project_retriever()
+    docs = retriever.get_relevant_documents(query)
+    return "\n".join(doc.page_content for doc in docs)


### PR DESCRIPTION
## Summary
- index repository into a vector store
- expose project search via new tool
- wire new tool into `general_agent`
- allow configuring embedding function for vector store
- add tests indexing temporary files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864322870bc832bbc8523c708ac665b