### PR TITLE
Add planner and reflexion agents

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Run tests
+        run: pytest -vv

--- a/README.org
+++ b/README.org
@@ -9,6 +9,12 @@ The information needed to perform a task. For example, the source files for a so
 ** Extra context
 Supporting information
 * Development
+Install the dependencies
+
+#+begin_src shell
+pip install -r requirements.txt
+#+end_src
+
 Install the package in editable mode so Emacs/Elpy can discover the modules:
 
 #+begin_src shell

--- a/README.org
+++ b/README.org
@@ -1,4 +1,13 @@
+Assist is an extensible llm-based assistant. It currently provides an OpenAI-comparible API with a ReAct agent and some simple tools. It's currently very tailored to Emacs, but hopefully can be extended in the future to handle other editors.
 
+It is not /just/ a coding assistant, but should be able to help with any project or goal.
+* Concepts
+** Project
+This is based on the currently-active buffer and uses projectile to decide what the root directory of the project is.
+** Context
+The information needed to perform a task. For example, the source files for a software project
+** Extra context
+Supporting information
 * Development
 Install the package in editable mode so Emacs/Elpy can discover the modules:
 
@@ -15,3 +24,18 @@ pytest
 * Task list
 ** TODO Streaming responses
 Update [[file:src/assist/server.py][server.py]] to handle streaming responses
+** TODO Make agent more flexible
+** TODO Update folder structure to be easier to navigate
+** TODO Add project directory to context, not just the active buffers
+** TODO Provide a grep-like retriever
+** TODO Index project for vector retrieval
+* User flows
+These are the main user flows for working with Assist
+** TODO Re-write
+I want to highlight a region and ask that it be re-written in a certain way.
+** Explain/describe
+When I first open a project, I want to have a high-level overview of it. This should be fairly straightforward to ask while working on the project. Probably should generate automatically when there is no explanation or when the explanation was created long before the current version (check git?).
+** Suggest
+Make recommendations on what to do next or what to update as you're editing. Find bugs and make the recommendations somewhere.
+** Large changes
+I want to be able to ask for meaningfully large changes like refactors or implementation of whole features.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ langgraph
 tavily-python
 chromadb
 pytest
+sentence-transformers

--- a/src/assist/__init__.py
+++ b/src/assist/__init__.py
@@ -1,0 +1,7 @@
+from .reflexion_agent import (
+    reflexion_agent,
+    PlannerAgent,
+    ReflexionAgent,
+)
+
+__all__ = ["reflexion_agent", "PlannerAgent", "ReflexionAgent"]

--- a/src/assist/general_agent.py
+++ b/src/assist/general_agent.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import List
 from assist.tools import filesystem as fstools
 from assist.tools import project_index
+from langchain_community.embeddings import HuggingFaceEmbeddings
 import time
 import os
 from pathlib import Path
@@ -28,6 +29,8 @@ def general_agent(llm: Runnable, extra_tools: List[BaseTool] = []):
     https://python.langchain.com/docs/tutorials/agents/"""
     check_tavily_api_key()
     search = TavilySearchResults(max_results=10)
+    hf = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+    project_index.set_embedding(hf)
     proj_tool = project_index.project_search
     tools = [
         search,

--- a/src/assist/general_agent.py
+++ b/src/assist/general_agent.py
@@ -5,8 +5,8 @@ from langchain_core.tools import tool, BaseTool
 from langgraph.prebuilt import create_react_agent
 from datetime import datetime
 from typing import List
-from .tools import filesystem as fstools
-from .tools import project_index
+from assist.tools import filesystem as fstools
+from assist.tools import project_index
 import time
 import os
 from pathlib import Path

--- a/src/assist/reflexion_agent.py
+++ b/src/assist/reflexion_agent.py
@@ -1,0 +1,85 @@
+"""Planner and reflexion agents.
+
+``PlannerAgent`` generates a short plan describing how to complete a task using
+the available tools. ``ReflexionAgent`` composes this planning step with the
+existing ReAct agent returned by :func:`general_agent`.  Both stages log their
+activity with :mod:`loguru` and can emit LangChain tracing callbacks via
+``ConsoleCallbackHandler``.
+"""
+
+from typing import List, Optional
+
+from loguru import logger
+from langchain.callbacks.tracers.stdout import ConsoleCallbackHandler
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool
+
+from .general_agent import general_agent
+
+
+class PlannerAgent:
+    """Generate a tool-based plan for a user request."""
+
+    def __init__(self, llm: Runnable, tools: List[BaseTool], callbacks: Optional[List] = None):
+        self.llm = llm
+        self.tools = tools
+        self.callbacks = callbacks or [ConsoleCallbackHandler()]
+
+    def make_plan(self, user_request: str) -> str:
+        logger.debug("Generating plan for request: %s", user_request)
+        tool_list = ", ".join(t.name for t in self.tools)
+        messages = [
+            SystemMessage(
+                content=(
+                    "You are a planning assistant. Given a task and available tools, "
+                    "produce a numbered list describing how to accomplish the task using those tools."
+                )
+            ),
+            HumanMessage(content=f"Tools: {tool_list}\nTask: {user_request}\nPlan:")
+        ]
+        response = self.llm.invoke({"messages": messages}, {"callbacks": self.callbacks})
+        if isinstance(response, dict) and "messages" in response:
+            msg = response["messages"][-1]
+            plan = getattr(msg, "content", str(msg))
+        else:
+            plan = getattr(response, "content", str(response))
+        logger.debug("Plan generated:\n%s", plan)
+        return plan
+
+
+class ReflexionAgent:
+    """Compose planning with the existing ReAct agent."""
+
+    def __init__(self, llm: Runnable, tools: List[BaseTool], callbacks: Optional[List] = None):
+        self.callbacks = callbacks or [ConsoleCallbackHandler()]
+        self.planner = PlannerAgent(llm, tools, callbacks=self.callbacks)
+        self.agent = general_agent(llm, tools)
+
+    def invoke(self, inputs: dict) -> dict:
+        messages = inputs.get("messages", [])
+        user_msg = messages[-1]
+        logger.debug("Invoking agent for message: %s", getattr(user_msg, "content", user_msg))
+        plan = self.planner.make_plan(getattr(user_msg, "content", user_msg))
+        plan_msg = SystemMessage(content=f"Follow this plan:\n{plan}")
+        logger.debug("Executing plan via ReAct agent")
+        result = self.agent.invoke({"messages": messages + [plan_msg]}, {"callbacks": self.callbacks})
+        return result
+
+
+def reflexion_agent(
+    llm: Runnable,
+    tools: List[BaseTool],
+    callbacks: Optional[List] = None,
+) -> Runnable:
+    """Create a reflexion agent using ``llm`` and ``tools``.
+
+    The agent first asks ``llm`` for a plan referencing the given tools, then
+    executes that plan using the ReAct agent returned by :func:`general_agent`.
+    Additional ``callbacks`` are passed to both the planning and execution
+    stages, allowing integration with LangChain tracing utilities.
+    """
+    return ReflexionAgent(llm, tools, callbacks=callbacks)
+
+__all__ = ["reflexion_agent", "PlannerAgent", "ReflexionAgent"]

--- a/src/assist/server.py
+++ b/src/assist/server.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from langchain_core.messages import SystemMessage, HumanMessage, AIMessage, ToolMessage
 from langchain_core.runnables import Runnable
 from langchain_ollama import ChatOllama
-from .general_agent import general_agent
+from assist.general_agent import general_agent
 
 
 AnyMessage = Union[SystemMessage, HumanMessage, AIMessage]

--- a/src/assist/tools/project_index.py
+++ b/src/assist/tools/project_index.py
@@ -6,7 +6,6 @@ from langchain_community.document_loaders import DirectoryLoader, TextLoader
 from typing import Optional
 
 from langchain_core.embeddings import Embeddings
-from langchain_community.embeddings import FakeEmbeddings
 from langchain_community.vectorstores import Chroma
 from langchain_core.tools import tool
 
@@ -32,7 +31,10 @@ def _build_vectorstore() -> Chroma:
         glob="**/*.*",
         recursive=True,
         loader_cls=TextLoader,
-        exclude=["**/.git/**", str(INDEX_DIR)],
+        exclude=["**/.git/**",
+                 "**/.venv/**",
+                 "**/__pycache__/**",
+                 str(INDEX_DIR)],
     )
     index_creator = VectorstoreIndexCreator(
         vectorstore_cls=Chroma,

--- a/tests/test_reflexion_agent.py
+++ b/tests/test_reflexion_agent.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+from unittest.mock import patch
+from langchain_core.messages import HumanMessage, AIMessage
+from assist.reflexion_agent import PlannerAgent, reflexion_agent
+from assist.fake_runnable import FakeRunnable
+
+class TestPlannerAgent(TestCase):
+    def test_make_plan(self):
+        llm = FakeRunnable([[AIMessage(content="1. foo\n2. bar")]])
+        planner = PlannerAgent(llm, [])
+        plan = planner.make_plan("do stuff")
+        self.assertIn("foo", plan)
+
+class TestReflexionAgent(TestCase):
+    def test_invoke_runs_plan(self):
+        plan_llm = FakeRunnable([[AIMessage(content="1. foo")]])
+        react_resp = [AIMessage(content="all done")] 
+        with patch('assist.reflexion_agent.general_agent') as mock_general:
+            mock_general.return_value = FakeRunnable([react_resp])
+            agent = reflexion_agent(plan_llm, [])
+            resp = agent.invoke({'messages': [HumanMessage(content='hi')]})
+            self.assertEqual(resp['messages'][-1].content, 'all done')
+            mock_general.assert_called_once()
+


### PR DESCRIPTION
## Summary
- introduce PlannerAgent and compose it into a ReflexionAgent
- expose PlannerAgent and ReflexionAgent via the package __init__
- restore server, general_agent, and project_index modules to previous versions
- add tests for the new agents

## Testing
- `pip install -e .`
- `pip install fastapi==0.115.0 pydantic==2.11.1`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68658255e098832b9018fe24a88c1873