### PR TITLE
Fix project search tool binding

### DIFF
--- a/src/assist/general_agent.py
+++ b/src/assist/general_agent.py
@@ -10,7 +10,6 @@ from assist.tools import project_index
 from langchain_community.embeddings import HuggingFaceEmbeddings
 import time
 import os
-from pathlib import Path
 
 @tool
 def date() -> str:
@@ -24,9 +23,11 @@ def check_tavily_api_key():
         raise RuntimeError('Please define the environment variable TAVILY_API_KEY')
     
 
-def general_agent(llm: Runnable, extra_tools: List[BaseTool] = []):
-    """Returns an Agent as described in
-    https://python.langchain.com/docs/tutorials/agents/"""
+def general_agent(
+    llm: Runnable,
+    extra_tools: List[BaseTool] = [],
+):
+    """Return a ReAct agent configured with useful tools."""
     check_tavily_api_key()
     search = TavilySearchResults(max_results=10)
     hf = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")

--- a/src/assist/tools/project_index.py
+++ b/src/assist/tools/project_index.py
@@ -1,45 +1,52 @@
 from __future__ import annotations
+
+import hashlib
+import tempfile
 from pathlib import Path
+from typing import Optional, Dict
 
 from langchain.indexes import VectorstoreIndexCreator
 from langchain_community.document_loaders import DirectoryLoader, TextLoader
-from typing import Optional
-
-from langchain_core.embeddings import Embeddings
 from langchain_community.vectorstores import Chroma
+from langchain_core.embeddings import Embeddings
 from langchain_core.tools import tool
 
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
-INDEX_DIR = PROJECT_ROOT / "index_store"
-
-_retriever = None
+_retrievers: Dict[str, Chroma] = {}
 _EMBEDDING: Optional[Embeddings] = None
 
 
 def set_embedding(embedding: Optional[Embeddings]) -> None:
     """Set the embedding function used for the vector store."""
-    global _EMBEDDING, _retriever
+    global _EMBEDDING, _retrievers
     _EMBEDDING = embedding
-    _retriever = None
+    _retrievers = {}
 
 
-def _build_vectorstore() -> Chroma:
+def _index_dir(project_root: Path) -> Path:
+    """Return a unique directory for storing the vector index."""
+    digest = hashlib.md5(str(project_root.resolve()).encode()).hexdigest()[:8]
+    return Path(tempfile.gettempdir()) / f"assist_index_{digest}"
+
+
+def _build_vectorstore(project_root: Path, index_dir: Path) -> Chroma:
     """Create a Chroma vector store for the project."""
     loader = DirectoryLoader(
-        str(PROJECT_ROOT),
+        str(project_root),
         glob="**/*.*",
         recursive=True,
         loader_cls=TextLoader,
-        exclude=["**/.git/**",
-                 "**/.venv/**",
-                 "**/__pycache__/**",
-                 str(INDEX_DIR)],
+        exclude=[
+            "**/.git/**",
+            "**/.venv/**",
+            "**/__pycache__/**",
+            str(index_dir),
+        ],
     )
     index_creator = VectorstoreIndexCreator(
         vectorstore_cls=Chroma,
         embedding=_EMBEDDING,
-        vectorstore_kwargs={"persist_directory": str(INDEX_DIR)},
+        vectorstore_kwargs={"persist_directory": str(index_dir)},
     )
     index = index_creator.from_loaders([loader])
     vectorstore = index.vectorstore
@@ -47,30 +54,37 @@ def _build_vectorstore() -> Chroma:
     return vectorstore
 
 
-def _load_vectorstore() -> Chroma:
+def _load_vectorstore(index_dir: Path) -> Chroma:
     """Load the persisted Chroma vector store."""
-    return Chroma(persist_directory=str(INDEX_DIR), embedding_function=_EMBEDDING)
+    return Chroma(persist_directory=str(index_dir), embedding_function=_EMBEDDING)
 
 
-def get_project_retriever():
-    """Return a retriever over the current project."""
-    global _retriever
-    if _retriever is not None:
-        return _retriever
+def get_project_retriever(project_root: Path | str):
+    """Return a retriever over ``project_root``."""
+    global _retrievers
+    root = Path(project_root)
+    key = str(root.resolve())
+    if key in _retrievers:
+        return _retrievers[key]
 
-    if INDEX_DIR.exists():
-        vectorstore = _load_vectorstore()
+    index_dir = _index_dir(root)
+    if index_dir.exists():
+        vectorstore = _load_vectorstore(index_dir)
     else:
-        INDEX_DIR.mkdir(parents=True, exist_ok=True)
-        vectorstore = _build_vectorstore()
+        index_dir.mkdir(parents=True, exist_ok=True)
+        vectorstore = _build_vectorstore(root, index_dir)
 
-    _retriever = vectorstore.as_retriever()
-    return _retriever
+    retriever = vectorstore.as_retriever()
+    _retrievers[key] = retriever
+    return retriever
 
 
 @tool
-def project_search(query: str) -> str:
-    """Search the current project files for relevant information."""
-    retriever = get_project_retriever()
+def project_search(project_root: Path | str, query: str) -> str:
+    """Search ``project_root`` for relevant information."""
+    retriever = get_project_retriever(project_root)
     docs = retriever.get_relevant_documents(query)
     return "\n".join(doc.page_content for doc in docs)
+
+
+__all__ = ["set_embedding", "get_project_retriever", "project_search"]

--- a/tests/test_project_index.py
+++ b/tests/test_project_index.py
@@ -15,23 +15,16 @@ class TestProjectIndex(TestCase):
         (self.project_root / "sub/file1.txt").write_text("hello world")
         (self.project_root / "file2.txt").write_text("foo bar baz")
 
-        # patch project_index globals
-        self.orig_root = project_index.PROJECT_ROOT
-        self.orig_index_dir = project_index.INDEX_DIR
-        project_index.PROJECT_ROOT = self.project_root
-        project_index.INDEX_DIR = self.project_root / "index_store"
         project_index.set_embedding(FakeEmbeddings(size=4))
-        project_index._retriever = None
+        project_index._retrievers = {}
 
     def tearDown(self):
-        project_index.PROJECT_ROOT = self.orig_root
-        project_index.INDEX_DIR = self.orig_index_dir
         project_index.set_embedding(None)
-        project_index._retriever = None
+        project_index._retrievers = {}
         self.tmpdir.cleanup()
 
     def test_index_and_search(self):
-        retriever = project_index.get_project_retriever()
+        retriever = project_index.get_project_retriever(self.project_root)
         docs = retriever.get_relevant_documents("hello")
         joined = "\n".join(d.page_content for d in docs)
         self.assertIn("hello world", joined)
@@ -39,3 +32,4 @@ class TestProjectIndex(TestCase):
         docs2 = retriever.get_relevant_documents("foo bar")
         joined2 = "\n".join(d.page_content for d in docs2)
         self.assertIn("foo bar baz", joined2)
+


### PR DESCRIPTION
## Summary
- keep general_agent simple; provide a project_search tool that takes a `project_root` argument when called
- expose project_search directly instead of creating tools bound to a project root

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'Undefined' from 'pydantic.fields')*

------
https://chatgpt.com/codex/tasks/task_e_686b00c6c158832bb98331da133ec9f0