### PR TITLE
Add streaming response tests

### DIFF
--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -1,0 +1,36 @@
+import json
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from langchain_core.messages import HumanMessage, AIMessage
+from tests.utils import make_test_agent
+from assist import server
+
+
+def test_streaming_chat_completions():
+    msgs = [
+        HumanMessage(content="Hello"),
+        AIMessage(content="Hi"),
+    ]
+    agent = make_test_agent([msgs])
+    with patch("assist.server.get_agent", return_value=agent):
+        client = TestClient(server.app)
+        payload = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": True,
+        }
+        with client.stream("POST", "/chat/completions", json=payload) as resp:
+            events = []
+            for line in resp.iter_lines():
+                if line:
+                    assert line.startswith("data:")
+                    data = line[len("data: "):]
+                    if data == "[DONE]":
+                        break
+                    events.append(json.loads(data))
+    assert events[0]["choices"][0]["delta"]["role"] == "assistant"
+    content = "".join(
+        e["choices"][0]["delta"].get("content", "") for e in events[1:-1]
+    )
+    assert content == "Hi"
+    assert events[-1]["choices"][0]["finish_reason"] == "stop"

--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -1,36 +1,84 @@
 import json
+import time
+from threading import Thread
 from unittest.mock import patch
-from fastapi.testclient import TestClient
-from langchain_core.messages import HumanMessage, AIMessage
-from tests.utils import make_test_agent
+
+import pytest
+import requests
+import uvicorn
+from langchain_core.messages import AIMessage, HumanMessage
+
 from assist import server
+from tests.utils import make_test_agent
 
 
-def test_streaming_chat_completions():
+@pytest.fixture(scope="module")
+def run_server():
+    """Start the FastAPI server in a background thread and stop it after tests."""
+    long_content = (
+        "I can assist with answering questions, writing code, debugging, and more."
+    )
     msgs = [
-        HumanMessage(content="Hello"),
-        AIMessage(content="Hi"),
+        HumanMessage(content="What kinds of things can you help me with?"),
+        AIMessage(content=long_content),
     ]
     agent = make_test_agent([msgs])
+    port = 5001
+
     with patch("assist.server.get_agent", return_value=agent):
-        client = TestClient(server.app)
-        payload = {
-            "model": "test-model",
-            "messages": [{"role": "user", "content": "Hello"}],
-            "stream": True,
-        }
-        with client.stream("POST", "/chat/completions", json=payload) as resp:
-            events = []
-            for line in resp.iter_lines():
-                if line:
-                    assert line.startswith("data:")
-                    data = line[len("data: "):]
-                    if data == "[DONE]":
-                        break
-                    events.append(json.loads(data))
+        config = uvicorn.Config(server.app, host="127.0.0.1", port=port, log_level="info")
+        srv = uvicorn.Server(config)
+        thread = Thread(target=srv.run, daemon=True)
+        thread.start()
+
+        base_url = f"http://127.0.0.1:{port}"
+        timeout = time.time() + 5
+        while True:
+            try:
+                requests.get(base_url)
+                break
+            except Exception:
+                if time.time() > timeout:
+                    raise RuntimeError("Server failed to start")
+                time.sleep(0.1)
+
+        yield base_url
+
+        srv.should_exit = True
+        thread.join()
+
+
+def test_streaming_chat_completions(run_server):
+    url = f"{run_server}/chat/completions"
+    payload = {
+        "model": "test-model",
+        "messages": [
+            {
+                "role": "user",
+                "content": "What kinds of things can you help me with?",
+            }
+        ],
+        "stream": True,
+    }
+    with requests.post(url, json=payload, stream=True) as resp:
+        events = []
+        for line in resp.iter_lines():
+            if line:
+                line = line.decode("utf-8")
+                assert line.startswith("data:")
+                data = line[len("data: ") :]
+                if data == "[DONE]":
+                    break
+                events.append(json.loads(data))
+
     assert events[0]["choices"][0]["delta"]["role"] == "assistant"
     content = "".join(
         e["choices"][0]["delta"].get("content", "") for e in events[1:-1]
     )
-    assert content == "Hi"
+    assert len(events) > 20
+    assert (
+        content
+        == "I can assist with answering questions, writing code, debugging, and more."
+    )
     assert events[-1]["choices"][0]["finish_reason"] == "stop"
+

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,14 @@
 from unittest import TestCase
-from langchain_core.messages import SystemMessage, HumanMessage, AIMessage, ToolMessage
+from unittest.mock import patch
+import asyncio
+import json
+from langchain_core.messages import (
+    SystemMessage,
+    HumanMessage,
+    AIMessage,
+    ToolMessage,
+)
+from fastapi.responses import StreamingResponse
 from .utils import make_test_agent
 from assist import server  # under test
 
@@ -33,3 +42,37 @@ class TestServer(TestCase):
         work_message_types = [type(m) for m in work_messages]
         self.assertListEqual(work_message_types, [AIMessage, ToolMessage, AIMessage])
         self.assertEqual(len(work_messages), 3)
+
+    def test_streaming_response(self):
+        msgs = [
+            HumanMessage(content="Hello"),
+            AIMessage(content="Hi"),
+        ]
+        agent = make_test_agent([msgs])
+        req = server.ChatCompletionRequest(
+            model="test-model",
+            messages=[server.ChatMessage(role="user", content="Hello")],
+            stream=True,
+        )
+        with patch("assist.server.get_agent", return_value=agent):
+            resp = server.chat_completions(req)
+        self.assertIsInstance(resp, StreamingResponse)
+
+        async def _collect(gen):
+            return [chunk async for chunk in gen]
+
+        chunks = list(asyncio.run(_collect(resp.body_iterator)))
+        events = []
+        for chunk in chunks:
+            self.assertTrue(chunk.startswith("data:"))
+            payload = chunk[len("data: "):].strip()
+            if payload == "[DONE]":
+                break
+            events.append(json.loads(payload))
+
+        self.assertEqual(events[0]["choices"][0]["delta"]["role"], "assistant")
+        content = "".join(
+            e["choices"][0]["delta"].get("content", "") for e in events[1:-1]
+        )
+        self.assertEqual(content, "Hi")
+        self.assertEqual(events[-1]["choices"][0]["finish_reason"], "stop")


### PR DESCRIPTION
## Summary
- add unit test for server streaming responses
- add integration test that exercises streaming SSE endpoint

## Testing
- `PYTHONPATH=src pytest tests/test_server.py tests/integration/test_streaming.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897cc618d00832b8bf2c233aa3b29f0