### PR TITLE
Refactor agents to use Promptable templates

### DIFF
--- a/src/assist/fake_runnable.py
+++ b/src/assist/fake_runnable.py
@@ -1,5 +1,21 @@
-from typing import List
+from typing import List, Tuple, Iterator, Dict, Any
 from langchain_core.messages import BaseMessage
+
+class FakeInvocation:
+    """Container that behaves like both an iterable of messages and a dict."""
+
+    def __init__(self, messages: List[BaseMessage]):
+        self._messages = messages
+
+    def __iter__(self) -> Iterator[Tuple[BaseMessage, Dict[str, Any]]]:
+        for m in self._messages:
+            yield m, {}
+
+    def __getitem__(self, key: str):
+        if key == "messages":
+            return self._messages
+        raise KeyError(key)
+
 
 class FakeRunnable:
     """A simple runnable that returns predetermined message sequences."""
@@ -7,10 +23,21 @@ class FakeRunnable:
     def __init__(self, responses: List[List[BaseMessage]]):
         self._responses = responses
         self._idx = 0
+        self._schema = None
+
+    def with_structured_output(self, schema):
+        self._schema = schema
+        return self
 
     def invoke(self, *_args, **_kwargs):
         if self._idx >= len(self._responses):
             raise IndexError("No more fake responses")
         resp = self._responses[self._idx]
         self._idx += 1
-        return {"messages": resp}
+        if self._schema:
+            content = resp[0].content
+            steps = [line.split('. ', 1)[1] if '. ' in line else line for line in content.splitlines() if line]
+            schema = self._schema
+            self._schema = None
+            return schema(goal="", steps=steps)
+        return FakeInvocation(resp)

--- a/src/assist/templates/planner_agent/make_plan_system.txt
+++ b/src/assist/templates/planner_agent/make_plan_system.txt
@@ -1,0 +1,1 @@
+You are a planning assistant. Given a task and available tools, produce a numbered list describing how to accomplish the task using those tools.

--- a/src/assist/templates/planner_agent/make_plan_user.txt
+++ b/src/assist/templates/planner_agent/make_plan_user.txt
@@ -1,0 +1,3 @@
+Tools: {{ tools }}
+Task: {{ task }}
+Plan:

--- a/src/assist/templates/reflexion_agent/follow_plan.txt
+++ b/src/assist/templates/reflexion_agent/follow_plan.txt
@@ -1,0 +1,2 @@
+Follow this plan:
+{{ plan }}

--- a/tests/test_promptable.py
+++ b/tests/test_promptable.py
@@ -1,0 +1,14 @@
+from assist.promptable import Promptable
+
+class MyClass(Promptable):
+    pass
+
+
+def test_prompts_folder():
+    assert MyClass().prompts_folder() == "my_class"
+
+
+def test_prompt_for_renders_template():
+    mc = MyClass()
+    result = mc.prompt_for("test_template.txt", here="somewhere")
+    assert "somewhere" in result


### PR DESCRIPTION
## Summary
- refactor PlannerAgent and ReflexionAgent to subclass Promptable and load prompts from templates
- add planning and execution prompt templates
- expand FakeRunnable to mimic structured and streaming outputs for tests
- add unit tests for Promptable rendering

## Testing
- `PYTHONPATH=src python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899f9156df4832b929d0da15ea030c7