### PR TITLE
Add project context and system info tools with enhanced file listing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,5 @@ sentence-transformers
 vgrep==0.1.1
 Jinja2==3.1.6
 mypy
+pathspec
 

--- a/src/assist/tools/filesystem.py
+++ b/src/assist/tools/filesystem.py
@@ -1,17 +1,65 @@
 from langchain_core.tools import tool
 import os
+from datetime import datetime
+from pathlib import Path
+from pathspec import PathSpec
+
 # Tools for working with the filesystem
 
 
 @tool
 def list_files(root: str) -> list[str]:
-    """List all files recursively in the given ``root`` directory.
+    """Recursively list files under ``root`` with creation and modification times.
 
-    Use this to learn more about the structure of the project files.
+    Files matching patterns from a ``.gitignore`` file in ``root`` are skipped.
+    The results are sorted by last modified date in descending order and each
+    entry includes the absolute path, creation date, and last modified date.
+
+    Args:
+        root: Directory to search.
 
     Returns:
-    list[str]: A list of the absolute paths of all files under ``root``."""
-    return [f for f in os.listdir(root) if os.path.isfile(os.path.join(root, f))]
+        list[str]: ``"<path> (created: <cdate>, modified: <mdate>)"`` entries
+        for every file under ``root`` that isn't ignored.
+    """
+    root_path = Path(root)
+    ignore_spec: PathSpec | None = None
+    gitignore = root_path / ".gitignore"
+    if gitignore.exists():
+        try:
+            ignore_spec = PathSpec.from_lines("gitwildmatch", gitignore.read_text().splitlines())
+        except OSError:
+            ignore_spec = None
+
+    files: list[tuple[str, float, float]] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        rel_dir = Path(os.path.relpath(dirpath, root_path))
+        if str(rel_dir) == ".":
+            rel_dir = Path()
+
+        if ignore_spec:
+            dirnames[:] = [
+                d for d in dirnames
+                if not ignore_spec.match_file((rel_dir / d).as_posix())
+            ]
+
+        for name in filenames:
+            rel_file = (rel_dir / name).as_posix()
+            if ignore_spec and ignore_spec.match_file(rel_file):
+                continue
+            path = Path(dirpath) / name
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            files.append((str(path.resolve()), stat.st_ctime, stat.st_mtime))
+
+    files.sort(key=lambda x: x[2], reverse=True)
+
+    def fmt(ts: float) -> str:
+        return datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
+
+    return [f"{p} (created: {fmt(c)}, modified: {fmt(m)})" for p, c, m in files]
 
 
 @tool
@@ -26,3 +74,36 @@ def file_contents(path: str) -> str:
     """
     with open(path, 'r') as f:
         return f.read()
+
+
+@tool
+def project_context(root: str) -> str:
+    """Return the contents of README and AGENTS files under ``root``.
+
+    Searches ``root`` recursively for files whose names begin with ``README`` or
+    ``AGENTS`` (case-insensitive) and returns their contents, each preceded by
+    the file's path.
+
+    Args:
+        root: Directory to search.
+
+    Returns:
+        str: Concatenated contents of matching files, each section prefixed with
+        the file path.
+    """
+    paths: list[Path] = []
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for name in filenames:
+            upper = name.upper()
+            if upper.startswith("README") or upper.startswith("AGENTS"):
+                paths.append(Path(dirpath) / name)
+
+    contents: list[str] = []
+    for p in paths:
+        try:
+            text = p.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        contents.append(f"# {p}\n{text}")
+
+    return "\n\n".join(contents)

--- a/src/assist/tools/system_info.py
+++ b/src/assist/tools/system_info.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import gzip
+import shutil
+from pathlib import Path
+from typing import List
+
+from langchain_core.tools import BaseTool, tool
+
+from .project_index import ProjectIndex
+
+
+class SystemInfoIndex:
+    """Index and search system info (``info``) documentation."""
+
+    def __init__(self, info_root: Path | str = Path("/usr/share/info")) -> None:
+        self._info_root = Path(info_root)
+        self._index = ProjectIndex()
+        self._prepared_dir: Path | None = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _prepare_dir(self) -> Path:
+        if self._prepared_dir is not None:
+            return self._prepared_dir
+
+        dest = self._index.index_dir(self._info_root) / "files"
+        dest.mkdir(parents=True, exist_ok=True)
+
+        for f in self._info_root.iterdir():
+            if not f.is_file():
+                continue
+            name = f.name
+            if "info" not in name:
+                continue
+            target = dest / name.replace(".gz", "")
+            if f.suffix == ".gz":
+                with gzip.open(f, "rb") as src, open(target, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+            else:
+                shutil.copy(f, target)
+
+        self._prepared_dir = dest
+        return dest
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def search(self, query: str) -> str:
+        root = self._prepare_dir()
+        return self._index.search(root, query)
+
+    def search_tool(self) -> BaseTool:
+        @tool
+        def system_info_search(query: str) -> str:
+            """Search system ``info`` files for technical information about ``query``."""
+            return self.search(query)
+
+        return system_info_search
+
+    def list_tool(self) -> BaseTool:
+        @tool
+        def list_system_info_files() -> List[str]:
+            """List available ``info`` files with short descriptions."""
+            dir_file = self._info_root / "dir"
+            if not dir_file.exists():
+                return []
+
+            entries: List[str] = []
+            with open(dir_file, "r", encoding="utf-8", errors="ignore") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line.startswith("* "):
+                        continue
+                    line = line[2:]
+                    if ":" not in line:
+                        continue
+                    name, rest = line.split(":", 1)
+                    # Description usually follows after '.\t'
+                    desc = rest.split(".\t", 1)[-1].strip()
+                    entries.append(f"{name.strip()} - {desc}")
+            return entries
+
+        return list_system_info_files
+
+
+__all__ = ["SystemInfoIndex"]

--- a/tests/test_list_files.py
+++ b/tests/test_list_files.py
@@ -1,0 +1,20 @@
+from assist.tools.filesystem import list_files
+
+
+def test_list_files_respects_gitignore(tmp_path):
+    visible = tmp_path / "visible.txt"
+    visible.write_text("visible")
+    ignored = tmp_path / "ignored.txt"
+    ignored.write_text("ignored")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    secret = sub / "secret.txt"
+    secret.write_text("secret")
+
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text("ignored.txt\nsub/\n")
+
+    result = "\n".join(list_files(str(tmp_path)))
+    assert str(visible) in result
+    assert str(ignored) not in result
+    assert str(secret) not in result

--- a/tests/test_project_context.py
+++ b/tests/test_project_context.py
@@ -1,0 +1,15 @@
+from assist.tools.filesystem import project_context
+
+
+def test_project_context(tmp_path):
+    readme = tmp_path / "README.md"
+    readme.write_text("hello readme")
+    sub = tmp_path / "docs"
+    sub.mkdir()
+    agents = sub / "AGENTS.md"
+    agents.write_text("agent info")
+
+    result = project_context(str(tmp_path))
+
+    assert "hello readme" in result
+    assert "agent info" in result

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -1,0 +1,40 @@
+from assist.tools.system_info import SystemInfoIndex
+
+
+def _create_info_root(tmp_path):
+    info_root = tmp_path / "info"
+    info_root.mkdir()
+
+    # Sample info documents
+    (info_root / "alpha.info").write_text(
+        "Alpha file about bananas and other fruit."
+    )
+    (info_root / "beta.info").write_text(
+        "Beta file documenting apples."
+    )
+
+    # Directory listing used by ``list_tool``
+    dir_content = (
+        "* alpha: (alpha).\tAlpha info file.\n"
+        "* beta: (beta).\tBeta info file.\n"
+    )
+    (info_root / "dir").write_text(dir_content)
+
+    return info_root
+
+
+def test_list_system_info_files(tmp_path):
+    info_root = _create_info_root(tmp_path)
+    idx = SystemInfoIndex(info_root)
+    list_tool = idx.list_tool()
+    files = list_tool.invoke({})
+    assert "alpha - Alpha info file." in files
+    assert "beta - Beta info file." in files
+
+
+def test_system_info_search(tmp_path):
+    info_root = _create_info_root(tmp_path)
+    idx = SystemInfoIndex(info_root)
+    search_tool = idx.search_tool()
+    result = search_tool.invoke("bananas")
+    assert "bananas" in result


### PR DESCRIPTION
## Summary
- extend filesystem list_files tool to recurse, include creation/modification times, and ignore .gitignore patterns
- add project_context tool to gather README and AGENTS files
- introduce SystemInfoIndex with tools to list and search system info documentation
- add tests for new tools and gitignore handling
- wire project_context and system info tools into server agent
- update SystemInfoIndex tests to use example info files

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a51a8001b8832b903d2b1d5f314bdc