### PR TITLE
Support generic YAML references in eval harness

### DIFF
--- a/eval/datasets/plan_check_smoke.yaml
+++ b/eval/datasets/plan_check_smoke.yaml
@@ -1,10 +1,5 @@
 - id: check_no_replan
-  input:
-    step_resolutions:
-      - "Boil water: done"
-    remaining_steps:
-      - "Steep tea"
-    goal: "Prepare tea"
+  input_path: plan_check_state.yaml
   expect:
     validators:
       - type: jsonschema

--- a/eval/datasets/plan_check_state.yaml
+++ b/eval/datasets/plan_check_state.yaml
@@ -1,0 +1,17 @@
+messages: []
+plan:
+  goal: "Prepare tea"
+  steps:
+    - action: "Boil water"
+      objective: "Boil water"
+    - action: "Steep tea"
+      objective: "Steep tea"
+  assumptions: []
+  risks: []
+step_index: 1
+history:
+  - action: "Boil water"
+    objective: "Boil water"
+    resolution: "done"
+needs_replan: false
+learnings: []

--- a/eval/plan_check_graph.py
+++ b/eval/plan_check_graph.py
@@ -1,0 +1,8 @@
+from langchain_core.runnables import RunnableLambda
+from assist.reflexion_agent import build_plan_check_node, _default_llm
+
+
+def plan_checker_runnable_v1():
+    """Runnable wrapper around the plan check node."""
+    node = build_plan_check_node(_default_llm(), [])
+    return RunnableLambda(node)

--- a/playground/plan_check_node_example.py
+++ b/playground/plan_check_node_example.py
@@ -1,10 +1,15 @@
-"""Example showing how to pass a ReflexionState to a single plan_check_node."""
+"""Example showing how to pass a ReflexionState to a plan_check_node from YAML."""
+
+import pathlib
+import sys
+import yaml
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 from assist.reflexion_agent import (
     build_plan_check_node,
     Plan,
     PlanRetrospective,
-    Step,
     StepResolution,
     ReflexionState,
 )
@@ -25,38 +30,31 @@ class DummyLLM(Runnable):
         if self._schema is PlanRetrospective:
             # Always indicate no replan is needed
             return PlanRetrospective(needs_replan=False, learnings=None)
-        raise ValueError("Unexpected schema: {self._schema}")
+        raise ValueError(f"Unexpected schema: {self._schema}")
 
 
 # Build the node using the dummy llm
 llm = DummyLLM()
 plan_check_node = build_plan_check_node(llm, callbacks=None)
 
-# Create a sample plan and history for the state
-plan = Plan(
-    goal="Test goal",
-    steps=[Step(action="do something", objective="achieve something")],
-    assumptions=[],
-    risks=[],
+# Load the ReflexionState from a YAML file
+data = yaml.safe_load(
+    pathlib.Path(__file__).with_name("plan_check_state.yaml").read_text()
 )
 
-history = [
-    StepResolution(
-        action="do something",
-        objective="achieve something",
-        resolution="completed",
-    )
-]
+plan = Plan.model_validate(data["plan"])
+history = [StepResolution.model_validate(h) for h in data["history"]]
 
 state: ReflexionState = {
-    "messages": [],
+    "messages": data.get("messages", []),
     "plan": plan,
-    "step_index": 1,
+    "step_index": data["step_index"],
     "history": history,
-    "needs_replan": False,
-    "learnings": [],
+    "needs_replan": data.get("needs_replan", False),
+    "learnings": data.get("learnings", []),
 }
 
-# Invoke the node with the prepared ReflexionState
-result = plan_check_node(state)
-print(result)
+if __name__ == "__main__":
+    # Invoke the node with the prepared ReflexionState
+    result = plan_check_node(state)
+    print(result)

--- a/playground/plan_check_state.yaml
+++ b/playground/plan_check_state.yaml
@@ -1,0 +1,15 @@
+messages: []
+plan:
+  goal: "Test goal"
+  steps:
+    - action: "do something"
+      objective: "achieve something"
+  assumptions: []
+  risks: []
+step_index: 1
+history:
+  - action: "do something"
+    objective: "achieve something"
+    resolution: "completed"
+needs_replan: false
+learnings: []


### PR DESCRIPTION
## Summary
- allow `_path` keys in eval configs to load external YAML/JSON/text files recursively
- update plan-check smoke test to use generic `input_path`

## Testing
- `python playground/plan_check_node_example.py`
- `PYTHONPATH=src pytest`
- `PYTHONPATH=src python -m eval.harness eval/datasets/plan_check_smoke.yaml --variants /tmp/plan_checker_variant.yaml --out /tmp/plan_check_results.jsonl`


------
https://chatgpt.com/codex/tasks/task_e_68af0c60ad08832b84601c8bde25f0ce