### PR TITLE
Add roadmap task list with actionable steps and estimates

### DIFF
--- a/ROADMAP_TODO.org
+++ b/ROADMAP_TODO.org
@@ -1,0 +1,299 @@
+* Guidance
+** TODO Improve summarization step
+:PROPERTIES:
+:ESTIMATE: 4h
+:END:
+   - [ ] Review existing summarization logic
+   - [ ] Identify missing context or detail
+   - [ ] Implement improved summary generator
+   - [ ] Validate quality with sample conversations
+** TODO Improve tool understanding and usage
+:PROPERTIES:
+:ESTIMATE: 4h
+:END:
+   - [ ] Audit current tool metadata
+   - [ ] Document tool limitations and capabilities
+   - [ ] Update tool selection heuristics
+   - [ ] Track performance metrics
+** TODO Simplify node/prompt/graph interaction and composition
+:PROPERTIES:
+:ESTIMATE: 5h
+:END:
+   - [ ] Map current interaction workflow
+   - [ ] Remove redundant components
+   - [ ] Create templates for common patterns
+   - [ ] Document simplified design
+** TODO Optimize prompts and flows
+:PROPERTIES:
+:ESTIMATE: 4h
+:END:
+   - [ ] Review existing prompts for verbosity
+   - [ ] Apply best practices for prompt engineering
+   - [ ] A/B test alternative flows
+   - [ ] Record results for future tuning
+** TODO Integrate system message to LLM
+:PROPERTIES:
+:ESTIMATE: 3h
+:END:
+   - [ ] Define standard system message format
+   - [ ] Update LLM calls to include system message
+   - [ ] Verify compatibility across models
+   - [ ] Gather feedback on behavior change
+** TODO Support automatic LLM selection
+:PROPERTIES:
+:ESTIMATE: 4h
+:END:
+   - [ ] Catalog available LLMs and capabilities
+   - [ ] Define selection criteria based on task
+   - [ ] Implement selection logic
+   - [ ] Monitor usage and adjust criteria
+** TODO Implement multi-turn interactions
+:PROPERTIES:
+:ESTIMATE: 5h
+:END:
+   - [ ] Design conversation state management
+   - [ ] Update interface to handle context
+   - [ ] Test with sample multi-turn sessions
+   - [ ] Fix issues found during testing
+** TODO Store cross-project user preferences
+:PROPERTIES:
+:ESTIMATE: 6h
+:END:
+   - [ ] Identify data to persist across projects
+   - [ ] Choose storage solution
+   - [ ] Implement preference serialization
+   - [ ] Provide retrieval mechanism in new sessions
+** TODO Add shared external tool docs
+:PROPERTIES:
+:ESTIMATE: 3h
+:END:
+   - [ ] Gather existing external tool documentation
+   - [ ] Standardize doc format
+   - [ ] Host docs in accessible location
+   - [ ] Link docs within project
+** TODO Handle re-write use-case
+:PROPERTIES:
+:ESTIMATE: 4h
+:END:
+   - [ ] Determine triggers for rewrite requests
+   - [ ] Implement rewrite detection logic
+   - [ ] Provide editable rewrite suggestions
+   - [ ] Validate rewrites with user approval
+** TODO Track user preferences and facts
+:PROPERTIES:
+:ESTIMATE: 5h
+:END:
+   - [ ] Define schema for preferences and facts
+   - [ ] Implement storage and retrieval APIs
+   - [ ] Update workflows to reference stored data
+   - [ ] Ensure privacy and security compliance
+* Action
+** TODO Implement diff-based project file edits
+:PROPERTIES:
+:ESTIMATE: 6h
+:END:
+   - [ ] Parse diffs to identify target lines
+   - [ ] Apply edits while preserving formatting
+   - [ ] Preview changes before applying
+   - [ ] Log applied diffs
+** TODO Validate file edits with tests
+:PROPERTIES:
+:ESTIMATE: 4h
+:END:
+   - [ ] Detect relevant test suites
+   - [ ] Run tests after edits
+   - [ ] Capture and report failures
+   - [ ] Retry after addressing issues
+** TODO Commit applied edits with message template
+:PROPERTIES:
+:ESTIMATE: 2h
+:END:
+   - [ ] Define commit message template
+   - [ ] Populate template with change details
+   - [ ] Execute commit command
+   - [ ] Verify commit appears in history
+** TODO Provide rollback mechanism for edits
+:PROPERTIES:
+:ESTIMATE: 4h
+:END:
+   - [ ] Record pre-edit file snapshots
+   - [ ] Implement rollback command
+   - [ ] Test rollback on sample commits
+   - [ ] Document rollback process
+** TODO Build framework for side-effecting API requests
+:PROPERTIES:
+:ESTIMATE: 6h
+:END:
+   - [ ] Create API request abstraction
+   - [ ] Support configurable endpoints
+   - [ ] Handle responses and errors uniformly
+   - [ ] Provide hooks for logging
+** TODO Manage API credentials securely
+:PROPERTIES:
+:ESTIMATE: 5h
+:END:
+   - [ ] Choose secure credential storage
+   - [ ] Implement access controls
+   - [ ] Rotate credentials periodically
+   - [ ] Audit credential usage
+** TODO Log side-effecting API interactions
+:PROPERTIES:
+:ESTIMATE: 4h
+:END:
+   - [ ] Define log schema for requests and responses
+   - [ ] Store logs in persistent system
+   - [ ] Provide search and filter tools
+   - [ ] Set retention policies
+** TODO Integrate headless browser automation
+:PROPERTIES:
+:ESTIMATE: 6h
+:END:
+   - [ ] Select headless browser library
+   - [ ] Wrap library with unified interface
+   - [ ] Support navigation commands
+   - [ ] Handle asynchronous events
+** TODO Support navigation and form submission
+:PROPERTIES:
+:ESTIMATE: 5h
+:END:
+   - [ ] Implement URL navigation helpers
+   - [ ] Fill and submit forms programmatically
+   - [ ] Capture responses and errors
+   - [ ] Validate form submission results
+** TODO Capture screenshots of browser results
+:PROPERTIES:
+:ESTIMATE: 3h
+:END:
+   - [ ] Provide screenshot API
+   - [ ] Store images with context metadata
+   - [ ] Include screenshots in logs
+   - [ ] Offer retrieval through interface
+* Proactivity
+** TODO Analyze project to suggest next steps
+:PROPERTIES:
+:ESTIMATE: 4h
+:END:
+   - [ ] Scan repository structure
+   - [ ] Identify incomplete or outdated components
+   - [ ] Generate improvement suggestions
+   - [ ] Present suggestions to user
+** TODO Rank suggestions by impact
+:PROPERTIES:
+:ESTIMATE: 3h
+:END:
+   - [ ] Define impact scoring criteria
+   - [ ] Score generated suggestions
+   - [ ] Sort suggestions by score
+   - [ ] Highlight top recommendations
+** TODO Generate PR-style proposed changes
+:PROPERTIES:
+:ESTIMATE: 5h
+:END:
+   - [ ] Create patches with explanatory comments
+   - [ ] Compose commit message summaries
+   - [ ] Assemble PR descriptions
+   - [ ] Provide patches for review
+** TODO Run tests on proposed changes
+:PROPERTIES:
+:ESTIMATE: 3h
+:END:
+   - [ ] Identify relevant test suites
+   - [ ] Execute tests in isolated environment
+   - [ ] Collect and summarize results
+   - [ ] Provide rerun option for failures
+** TODO Configure starter Docker server for autonomous runs
+:PROPERTIES:
+:ESTIMATE: 8h
+:END:
+   - [ ] Define base Docker image
+   - [ ] Install required dependencies
+   - [ ] Set up runtime entrypoints
+   - [ ] Publish image for reuse
+** TODO Automate repository pulling
+:PROPERTIES:
+:ESTIMATE: 4h
+:END:
+   - [ ] Script git clone and update
+   - [ ] Handle authentication tokens
+   - [ ] Schedule periodic syncs
+   - [ ] Report pull status
+** TODO Automate project build process
+:PROPERTIES:
+:ESTIMATE: 5h
+:END:
+   - [ ] Define build steps in script
+   - [ ] Resolve build dependencies
+   - [ ] Run build in clean environment
+   - [ ] Surface build artifacts
+** TODO Attempt to execute user requests autonomously
+:PROPERTIES:
+:ESTIMATE: 8h
+:END:
+   - [ ] Parse request into actionable steps
+   - [ ] Map steps to available tools
+   - [ ] Execute tasks sequentially
+   - [ ] Record outcomes for review
+** TODO Validate results of autonomous actions
+:PROPERTIES:
+:ESTIMATE: 4h
+:END:
+   - [ ] Establish validation criteria
+   - [ ] Compare results against expectations
+   - [ ] Flag discrepancies
+   - [ ] Summarize validation report
+** TODO Re-run tasks when validation fails
+:PROPERTIES:
+:ESTIMATE: 3h
+:END:
+   - [ ] Identify failing steps
+   - [ ] Adjust parameters or environment
+   - [ ] Re-execute affected tasks
+   - [ ] Log final outcome
+** TODO Optimize prompts for standalone operation
+:PROPERTIES:
+:ESTIMATE: 4h
+:END:
+   - [ ] Gather prompts used in autonomous mode
+   - [ ] Analyze prompt failures
+   - [ ] Refine prompts for clarity
+   - [ ] Document optimized versions
+** TODO Summarize recommendations for user
+:PROPERTIES:
+:ESTIMATE: 3h
+:END:
+   - [ ] Aggregate findings from proactive scans
+   - [ ] Prioritize recommendations
+   - [ ] Create concise summaries
+   - [ ] Deliver summary through preferred channel
+** TODO Detect potential purchases
+:PROPERTIES:
+:ESTIMATE: 2h
+:END:
+   - [ ] Monitor requests for purchase signals
+   - [ ] Maintain list of approved vendors
+   - [ ] Estimate cost implications
+   - [ ] Notify user of potential spend
+** TODO Request approval before purchases
+:PROPERTIES:
+:ESTIMATE: 2h
+:END:
+   - [ ] Generate purchase request summary
+   - [ ] Send approval prompt to user
+   - [ ] Await confirmation
+   - [ ] Proceed only after approval
+** TODO Schedule periodic proactive scans
+:PROPERTIES:
+:ESTIMATE: 3h
+:END:
+   - [ ] Determine default scan frequency
+   - [ ] Set up scheduling mechanism
+   - [ ] Run scans at scheduled intervals
+   - [ ] Record scan history
+** TODO Allow user configuration of scan frequency
+:PROPERTIES:
+:ESTIMATE: 3h
+:END:
+   - [ ] Provide interface for frequency settings
+   - [ ] Store user preferences
+   - [ ] Apply custom schedules
+   - [ ] Confirm configuration to user


### PR DESCRIPTION
## Summary
- add org-mode TODO list tracking roadmap tasks with concrete step checklists
- assign effort estimates to each TODO using headline properties

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'assist')*

------
https://chatgpt.com/codex/tasks/task_e_68afad5d55ac832b877987b006333319