### PR TITLE
Add threaded server startup script

### DIFF
--- a/playground/server.py
+++ b/playground/server.py
@@ -1,7 +1,9 @@
 import sys
+import time
 from pathlib import Path
 import threading
 
+import requests
 import uvicorn
 
 # Ensure the package can be imported when running this script directly.
@@ -26,3 +28,23 @@ def run_server() -> tuple[uvicorn.Server, threading.Thread]:
 
 
 server, server_thread = run_server()
+
+# Wait for the server to start before sending the request
+while not server.started:
+    time.sleep(0.1)
+
+response = requests.post(
+    "http://0.0.0.0:5000/chat/completions",
+    json={
+        "model": "gpt-4o-mini",
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello from the client."},
+        ],
+    },
+)
+print(response.text)
+
+# Shut down the server gracefully
+server.should_exit = True
+server_thread.join()

--- a/playground/server.py
+++ b/playground/server.py
@@ -12,6 +12,10 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 from assist.server import app
 
 
+HOST = "0.0.0.0"
+PORT = 5000
+
+
 def run_server() -> tuple[uvicorn.Server, threading.Thread]:
     """Run the FastAPI server in a separate thread.
 
@@ -20,7 +24,7 @@ def run_server() -> tuple[uvicorn.Server, threading.Thread]:
     tuple[uvicorn.Server, threading.Thread]
         The running server instance and the thread executing it.
     """
-    config = uvicorn.Config(app, host="0.0.0.0", port=5000, log_level="debug")
+    config = uvicorn.Config(app, host=HOST, port=PORT, log_level="debug")
     server = uvicorn.Server(config)
     thread = threading.Thread(target=server.run, daemon=True)
     thread.start()
@@ -34,7 +38,7 @@ while not server.started:
     time.sleep(0.1)
 
 response = requests.post(
-    "http://0.0.0.0:5000/chat/completions",
+    f"http://{HOST}:{PORT}/chat/completions",
     json={
         "model": "gpt-4o-mini",
         "messages": [

--- a/playground/server.py
+++ b/playground/server.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+import threading
+
+import uvicorn
+
+# Ensure the package can be imported when running this script directly.
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from assist.server import app
+
+
+def run_server() -> tuple[uvicorn.Server, threading.Thread]:
+    """Run the FastAPI server in a separate thread.
+
+    Returns
+    -------
+    tuple[uvicorn.Server, threading.Thread]
+        The running server instance and the thread executing it.
+    """
+    config = uvicorn.Config(app, host="0.0.0.0", port=5000, log_level="debug")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    return server, thread
+
+
+server, server_thread = run_server()


### PR DESCRIPTION
## Summary
- add playground/server.py to start uvicorn server on a background thread and expose server/thread

## Testing
- `python -m py_compile playground/server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2266a9c88832b9e243e907c79babe