### PR TITLE
feat: split planning and execution llms

### DIFF
--- a/src/assist/model_manager.py
+++ b/src/assist/model_manager.py
@@ -1,0 +1,47 @@
+"""Utilities for managing chat models for the server.
+
+This module encapsulates the logic for selecting chat models and mapping
+planning models to their corresponding execution models.
+"""
+from __future__ import annotations
+
+from typing import Tuple
+
+from langchain_core.runnables import Runnable
+from langchain_ollama import ChatOllama
+try:  # pragma: no cover - optional dependency
+    from langchain_openai import ChatOpenAI
+except Exception:  # pragma: no cover
+    ChatOpenAI = None  # type: ignore
+
+# Mapping of planning models to their corresponding execution models
+MODEL_EXECUTION_MAP: dict[str, str] = {
+    "gpt-4o": "gpt-4o-mini",
+    "gpt-4o-mini": "gpt-4o-mini",
+}
+
+
+def select_chat_model(model: str, temperature: float) -> Runnable:
+    """Return the appropriate chat model for ``model``.
+
+    If the model string indicates a ChatGPT model (``gpt-*``) a ``ChatOpenAI``
+    instance is returned, otherwise a ``ChatOllama`` instance is used.
+    """
+    if model.startswith("gpt-"):
+        if ChatOpenAI is None:  # pragma: no cover - environment dependent
+            raise RuntimeError("ChatOpenAI is not available")
+        return ChatOpenAI(model=model, temperature=temperature)
+    return ChatOllama(model=model, temperature=temperature)
+
+
+def get_model_pair(model: str, temperature: float) -> Tuple[Runnable, Runnable]:
+    """Return a pair of (planning_llm, execution_llm) for ``model``.
+
+    The planning model is always ``model`` and the execution model is looked up
+    in ``MODEL_EXECUTION_MAP``. If there is no mapping, the planning model is
+    also used for execution.
+    """
+    plan_llm = select_chat_model(model, temperature)
+    exec_model = MODEL_EXECUTION_MAP.get(model, model)
+    exec_llm = select_chat_model(exec_model, temperature)
+    return plan_llm, exec_llm

--- a/src/assist/reflexion_agent.py
+++ b/src/assist/reflexion_agent.py
@@ -253,12 +253,20 @@ def big_condition(state: ReflexionState) -> Literal["execute", "plan", "summariz
 def build_reflexion_graph(
     llm: Runnable,
     tools: List[BaseTool],
-    callbacks: Optional[List] = None
+    callbacks: Optional[List] = None,
+    execution_llm: Optional[Runnable] = None,
 ) -> Runnable:
-    """Compose planning, step execution and summarization using LangGraph."""
+    """Compose planning, step execution and summarization using LangGraph.
+
+    ``llm`` is used for planning related tasks (planning, plan checking and
+    summarization) while ``execution_llm`` – if provided – is used for step
+    execution. When ``execution_llm`` is ``None`` the planner ``llm`` is also
+    used for execution.
+    """
 
     callbacks = callbacks or [ConsoleCallbackHandler()]
-    agent = general_agent(llm, tools)
+    exec_llm = execution_llm or llm
+    agent = general_agent(exec_llm, tools)
     graph = StateGraph(ReflexionState)
 
     graph.add_node("plan", build_plan_node(llm,


### PR DESCRIPTION
## Summary
- support separate LLMs for planning and execution in reflexion graph
- server chooses ChatOpenAI for GPT models, ChatOllama otherwise, with mapping for cheaper execution model
- move model selection and mapping into dedicated `model_manager` module

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b22fd091ac832bbfc97626b8ddf68e