### PR TITLE
Refactor validation tests to new planner-node template

### DIFF
--- a/tests/validation/test_greet_node.py
+++ b/tests/validation/test_greet_node.py
@@ -1,23 +1,19 @@
 import re
-import pytest
-
-from eval.types import Validation
-from .utils import run_validation
+from unittest import TestCase
 
 
 def greet_node(state: dict) -> str:
     return f"Hello, {state['name']}!"
 
 
-GRAPH = greet_node
+class TestGreetNode(TestCase):
+    def setUp(self):
+        self.node = greet_node
 
-VALIDATIONS = [
-    Validation(input={"name": "Alice"}, check=re.compile(r"Hello, Alice!")),
-    Validation(input={"name": "Bob"}, check=lambda out: out.endswith("Bob!")),
-]
+    def test_alice(self):
+        result = self.node({"name": "Alice"})
+        self.assertRegex(result, r"Hello, Alice!")
 
-
-@pytest.mark.validation
-@pytest.mark.parametrize("validation", VALIDATIONS)
-def test_greet_node(validation: Validation) -> None:
-    assert run_validation(GRAPH, validation)
+    def test_bob(self):
+        result = self.node({"name": "Bob"})
+        self.assertTrue(result.endswith("Bob!"))

--- a/tests/validation/test_reflexion_node.py
+++ b/tests/validation/test_reflexion_node.py
@@ -1,48 +1,38 @@
-import pytest
+from unittest import TestCase
 from langchain_core.messages import HumanMessage, AIMessage
 
 import assist.reflexion_agent as reflexion_agent
-from assist.reflexion_agent import build_reflexion_graph, ReflexionState
-from eval.types import Validation
+from assist.reflexion_agent import build_reflexion_graph
 
-from .utils import run_validation, DummyLLM, DummyAgent
-
-
-def check_result(result: ReflexionState) -> bool:
-    message = result["messages"][-1]
-    is_aimessage = isinstance(message, AIMessage)
-    does_not_say_summary = "ummary" not in message.content
-    says_france = "France" in message.content
-    return is_aimessage and does_not_say_summary and says_france
+from .utils import DummyLLM, DummyAgent
 
 
-LLM = DummyLLM(message="The capital of France is Paris.")
+class TestReflexionNode(TestCase):
+    def setUp(self):
+        self.llm = DummyLLM(message="The capital of France is Paris.")
 
+        def fake_general_agent(_llm, _tools):
+            return DummyAgent(message="Paris is the capital of France.")
 
-def fake_general_agent(_llm, _tools):
-    return DummyAgent(message="Paris is the capital of France.")
+        self.orig_agent = reflexion_agent.general_agent
+        reflexion_agent.general_agent = fake_general_agent
+        self.graph = build_reflexion_graph(self.llm, [], [], self.llm)
 
+    def tearDown(self):
+        reflexion_agent.general_agent = self.orig_agent
 
-reflexion_agent.general_agent = fake_general_agent
-GRAPH = build_reflexion_graph(LLM, [], [], LLM)
-
-
-VALIDATIONS = [
-    Validation(
-        input={
-            "messages": [
-                HumanMessage(
-                    content="Identify the capital of France and provide one fact about it."
-                )
-            ]
-        },
-        check=check_result,
-    )
-]
-
-
-@pytest.mark.validation
-@pytest.mark.parametrize("validation", VALIDATIONS)
-def test_reflexion_node(validation: Validation) -> None:
-    assert run_validation(GRAPH, validation)
+    def test_reflexion_node(self):
+        state = self.graph.invoke(
+            {
+                "messages": [
+                    HumanMessage(
+                        content="Identify the capital of France and provide one fact about it."
+                    )
+                ]
+            }
+        )
+        message = state["messages"][-1]
+        self.assertIsInstance(message, AIMessage)
+        self.assertNotIn("ummary", message.content)
+        self.assertIn("France", message.content)
 

--- a/tests/validation/test_step_executor_node.py
+++ b/tests/validation/test_step_executor_node.py
@@ -1,46 +1,46 @@
-import pytest
+from unittest import TestCase
 from langchain_core.messages import SystemMessage, HumanMessage
 
 from assist.reflexion_agent import build_execute_node, Plan, Step, ReflexionState
-from eval.types import Validation
 
-from .utils import run_validation, DummyLLM, DummyAgent
-
-
-def has_resolution(state: ReflexionState) -> bool:
-    return state["history"][0].resolution not in (None, "")
+from .utils import DummyLLM, DummyAgent, graphiphy
 
 
-LLM = DummyLLM()
+class TestStepExecutorNode(TestCase):
+    def setUp(self):
+        llm = DummyLLM()
 
-def fake_general_agent(_llm, _tools):
-    return DummyAgent(message="step done")
+        def fake_general_agent(_llm, _tools):
+            return DummyAgent(message="step done")
 
-AGENT = fake_general_agent(LLM, [])
-GRAPH = build_execute_node(AGENT, [])
+        agent = fake_general_agent(llm, [])
+        self.graph = graphiphy(build_execute_node(agent, []))
 
-PLAN = Plan(
-    goal="Greet user",
-    steps=[Step(action="Greet the user politely", objective="Provide a friendly greeting")],
-    assumptions=[],
-    risks=[],
-)
+        plan = Plan(
+            goal="Greet user",
+            steps=[
+                Step(
+                    action="Greet the user politely",
+                    objective="Provide a friendly greeting",
+                )
+            ],
+            assumptions=[],
+            risks=[],
+        )
 
-STATE: ReflexionState = {
-    "messages": [SystemMessage("You are a helpful assistant"), HumanMessage("Hello, how are you?")],
-    "plan": PLAN,
-    "step_index": 0,
-    "history": [],
-    "needs_replan": False,
-    "learnings": [],
-}
+        self.state: ReflexionState = {
+            "messages": [
+                SystemMessage("You are a helpful assistant"),
+                HumanMessage("Hello, how are you?"),
+            ],
+            "plan": plan,
+            "step_index": 0,
+            "history": [],
+            "needs_replan": False,
+            "learnings": [],
+        }
 
-
-VALIDATIONS = [Validation(input=STATE, check=has_resolution)]
-
-
-@pytest.mark.validation
-@pytest.mark.parametrize("validation", VALIDATIONS)
-def test_step_executor_node(validation: Validation) -> None:
-    assert run_validation(GRAPH, validation)
+    def test_step_execution_adds_resolution(self):
+        result = self.graph.invoke(self.state)
+        self.assertTrue(result["history"][0].resolution)
 


### PR DESCRIPTION
## Summary
- Align validation tests with the updated planner-node style
- Replace Validation/run_validation patterns with unittest TestCase assertions
- Ensure test graphs run via graphiphy and dummy components

## Testing
- `TAVILY_API_KEY=dummy PYTHONPATH=src pytest tests/validation -q`


------
https://chatgpt.com/codex/tasks/task_e_68b852421eec832b8ef1d312bbd0d8f3