### PR TITLE
Add validation tests for planner node

### DIFF
--- a/tests/integration/validation/test_planner_node.py
+++ b/tests/integration/validation/test_planner_node.py
@@ -6,13 +6,13 @@ from assist.reflexion_agent import build_plan_node
 from .utils import thinking_llm, graphiphy
 
 class TestPlannerNode(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         llm = thinking_llm("")
         self.graph = graphiphy(build_plan_node(llm,
                                                [],
                                                []))
 
-    def test_tea_brew(self):
+    def test_tea_brew(self) -> None:
         state = self.graph.invoke({"messages": [HumanMessage(content="How do I brew a cup of tea?")]})
         
         plan = state["plan"]
@@ -26,7 +26,7 @@ class TestPlannerNode(TestCase):
         self.assertGreater(len(plan.steps), 2, "Should have more than 2 steps")
         self.assertTrue(uses_tavily, "Mentions tavily in any step")
 
-    def test_rewrite_more_professional(self):
+    def test_rewrite_more_professional(self) -> None:
         query = "Rewrite this to be more professional."
         examples = [
             "hey—need that report asap. thx.",
@@ -37,9 +37,9 @@ class TestPlannerNode(TestCase):
                 "messages": [HumanMessage(content=f"{query} {example}")]
             })
             plan = state["plan"]
-            assert len(plan.steps) > 1
+            self.assertGreater(len(plan.steps), 1, "Has at least 2 steps")
 
-    def test_rephrase_for_ninth_grade(self):
+    def test_rephrase_for_ninth_grade(self) -> None:
         query = "Rephrase for a 9th-grade reading level."
         examples = [
             "The municipality’s fiscal posture necessitates austerity measures.",
@@ -50,9 +50,9 @@ class TestPlannerNode(TestCase):
                 "messages": [HumanMessage(content=f"{query} {example}")]
             })
             plan = state["plan"]
-            assert len(plan.steps) > 1
+            self.assertGreater(len(plan.steps), 1, "Has at least 2 steps")
 
-    def test_extract_entities_to_json(self):
+    def test_extract_entities_to_json(self) -> None:
         query = "Extract all dates, people, and organizations from this text into JSON."
         examples = [
             "On March 2, 2024, Mayor London Breed met with leaders from SFUSD.",
@@ -63,9 +63,9 @@ class TestPlannerNode(TestCase):
                 "messages": [HumanMessage(content=f"{query} {example}")]
             })
             plan = state["plan"]
-            assert len(plan.steps) > 1
+            self.assertGreater(len(plan.steps), 1, "Has at least 2 steps")
 
-    def test_classify_customer_messages(self):
+    def test_classify_customer_messages(self) -> None:
         query = (
             "Classify these customer messages into issue categories; return CSV."
         )
@@ -83,5 +83,5 @@ class TestPlannerNode(TestCase):
                 "messages": [HumanMessage(content=f"{query} {example}")]
             })
             plan = state["plan"]
-            assert len(plan.steps) > 1
+            self.assertGreater(len(plan.steps), 1, "Has at least 2 steps")
 

--- a/tests/integration/validation/test_planner_node.py
+++ b/tests/integration/validation/test_planner_node.py
@@ -21,7 +21,10 @@ class TestPlannerNode(TestCase):
         has_over_2_steps = len(plan.steps) > 2
         uses_tavily = any("tavily" in s.action for s in plan.steps)
 
-        assert has_assumptions and has_risks and has_over_2_steps and uses_tavily
+        self.assertTrue(has_assumptions, "Has assumptions")
+        self.assertTrue(has_risks, "Has risks")
+        self.assertGreater(len(plan.steps), 2, "Should have more than 2 steps")
+        self.assertTrue(uses_tavily, "Mentions tavily in any step")
 
     def test_rewrite_more_professional(self):
         query = "Rewrite this to be more professional."

--- a/tests/integration/validation/test_planner_node.py
+++ b/tests/integration/validation/test_planner_node.py
@@ -1,18 +1,15 @@
-import pytest
 from unittest import TestCase
 from langchain_core.messages import HumanMessage
 
-from assist.reflexion_agent import build_plan_node, ReflexionState
-from assist.tools.base import base_tools
-from eval.types import Validation
+from assist.reflexion_agent import build_plan_node
 
-from .utils import run_validation, thinking_llm, base_tools_for_test, graphiphy
+from .utils import thinking_llm, graphiphy
 
 class TestPlannerNode(TestCase):
     def setUp(self):
         llm = thinking_llm("")
         self.graph = graphiphy(build_plan_node(llm,
-                                               base_tools_for_test(),
+                                               [],
                                                []))
 
     def test_tea_brew(self):
@@ -23,6 +20,65 @@ class TestPlannerNode(TestCase):
         has_risks = bool(plan.risks)
         has_over_2_steps = len(plan.steps) > 2
         uses_tavily = any("tavily" in s.action for s in plan.steps)
-        
+
         assert has_assumptions and has_risks and has_over_2_steps and uses_tavily
+
+    def test_rewrite_more_professional(self):
+        query = "Rewrite this to be more professional."
+        examples = [
+            "hey—need that report asap. thx.",
+            "We kinda dropped the ball on the Q3 metrics.",
+        ]
+        for example in examples:
+            state = self.graph.invoke({
+                "messages": [HumanMessage(content=f"{query} {example}")]
+            })
+            plan = state["plan"]
+            assert len(plan.steps) > 1
+
+    def test_rephrase_for_ninth_grade(self):
+        query = "Rephrase for a 9th-grade reading level."
+        examples = [
+            "The municipality’s fiscal posture necessitates austerity measures.",
+            "Our platform leverages distributed systems to optimize throughput.",
+        ]
+        for example in examples:
+            state = self.graph.invoke({
+                "messages": [HumanMessage(content=f"{query} {example}")]
+            })
+            plan = state["plan"]
+            assert len(plan.steps) > 1
+
+    def test_extract_entities_to_json(self):
+        query = "Extract all dates, people, and organizations from this text into JSON."
+        examples = [
+            "On March 2, 2024, Mayor London Breed met with leaders from SFUSD.",
+            "Apple hired Sam Patel on 2023-11-14 after interviews at UCSF.",
+        ]
+        for example in examples:
+            state = self.graph.invoke({
+                "messages": [HumanMessage(content=f"{query} {example}")]
+            })
+            plan = state["plan"]
+            assert len(plan.steps) > 1
+
+    def test_classify_customer_messages(self):
+        query = (
+            "Classify these customer messages into issue categories; return CSV."
+        )
+        examples = [
+            "App crashes when I upload a photo.",
+            "How do I reset my password?",
+            "Please cancel my subscription.",
+            "Charged twice for August.",
+            "Search results are super slow.",
+            "Two-factor code never arrives.",
+            "Dark mode text is unreadable.",
+        ]
+        for example in examples:
+            state = self.graph.invoke({
+                "messages": [HumanMessage(content=f"{query} {example}")]
+            })
+            plan = state["plan"]
+            assert len(plan.steps) > 1
 


### PR DESCRIPTION
## Summary
- add planner node tests for rewriting, rephrasing, entity extraction, and message classification prompts
- ensure each plan contains multiple steps

## Testing
- `PYTHONPATH=src pytest tests/integration/validation/test_planner_node.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b904ea3044832bb7a448964afc8e48