### PR TITLE
Add planner node validation scenarios

### DIFF
--- a/README.org
+++ b/README.org
@@ -58,6 +58,14 @@ Run the integration tests with:
 #+begin_src shell
 pytest tests/integration
 #+end_src
+
+Additional validation tests for the planner node cover ten example scenarios.
+Each scenario asserts that plans query external references (e.g., Tavily search or local indexes),
+so they require valid `OPENAI_API_KEY` and `TAVILY_API_KEY` environment variables:
+
+#+begin_src shell
+pytest tests/integration/validation/test_planner_node.py
+#+end_src
 * Evaluation
 The project ships with a small, local-first harness for benchmarking agents and their
 subcomponents. Datasets live under =eval/datasets= and describe input/expected pairs.

--- a/src/assist/templates/reflexion_agent/make_plan_user.txt
+++ b/src/assist/templates/reflexion_agent/make_plan_user.txt
@@ -1,4 +1,5 @@
 Given the following task and available tools, provide a numbered list of steps to accomplish the task using those tools.
+Explicitly reference the tool names in the steps (for example, "Use tavily to search for ...").
 Tools:
 {{ tools }}
 

--- a/tests/integration/validation/test_planner_node.py
+++ b/tests/integration/validation/test_planner_node.py
@@ -3,13 +3,13 @@ from langchain_core.messages import HumanMessage
 
 from assist.reflexion_agent import build_plan_node
 
-from .utils import thinking_llm, graphiphy
+from .utils import thinking_llm, graphiphy, base_tools_for_test
 
 class TestPlannerNode(TestCase):
     def setUp(self) -> None:
         llm = thinking_llm("")
         self.graph = graphiphy(build_plan_node(llm,
-                                               [],
+                                               base_tools_for_test(),
                                                []))
 
     def test_tea_brew(self) -> None:
@@ -19,7 +19,7 @@ class TestPlannerNode(TestCase):
         has_assumptions = bool(plan.assumptions)
         has_risks = bool(plan.risks)
         has_over_2_steps = len(plan.steps) > 2
-        uses_tavily = any("tavily" in s.action for s in plan.steps)
+        uses_tavily = any("tavily" in s.action.lower() for s in plan.steps)
 
         self.assertTrue(has_assumptions, "Has assumptions")
         self.assertTrue(has_risks, "Has risks")
@@ -38,6 +38,14 @@ class TestPlannerNode(TestCase):
             })
             plan = state["plan"]
             self.assertGreater(len(plan.steps), 1, "has at least 2 steps")
+            self.assertTrue(
+                any(
+                    "tavily" in step.action.lower()
+                    or "search" in step.action.lower()
+                    for step in plan.steps
+                ),
+                "Uses search or reference tool",
+            )
 
     def test_rephrase_for_ninth_grade(self) -> None:
         query = "Rephrase for a 9th-grade reading level."
@@ -51,12 +59,20 @@ class TestPlannerNode(TestCase):
             })
             plan = state["plan"]
             self.assertGreater(len(plan.steps), 1, "Has at least 2 steps")
-            self.assertNotIn("tavily",
-                             [step.action for step in plan.steps],
-                             "It should not try to use the tavily tool")
+            self.assertTrue(
+                any(
+                    "tavily" in step.action.lower()
+                    or "search" in step.action.lower()
+                    for step in plan.steps
+                ),
+                "Uses search or reference tool",
+            )
 
     def test_extract_entities_to_json(self) -> None:
-        query = "Extract all dates, people, and organizations from this text into JSON."
+        query = (
+            "Extract all dates, people, and organizations from this text into JSON and "
+            "consult external references for JSON schema or entity recognition guidelines."
+        )
         examples = [
             "On March 2, 2024, Mayor London Breed met with leaders from SFUSD.",
             "Apple hired Sam Patel on 2023-11-14 after interviews at UCSF.",
@@ -67,9 +83,14 @@ class TestPlannerNode(TestCase):
             })
             plan = state["plan"]
             self.assertGreater(len(plan.steps), 1, "Has at least 2 steps")
-            self.assertNotIn("tool",
-                             [step.action for step in plan.steps],
-                             "No tool is available to be used for this task")
+            self.assertTrue(
+                any(
+                    "tavily" in step.action.lower()
+                    or "search" in step.action.lower()
+                    for step in plan.steps
+                ),
+                "Uses search or reference tool",
+            )
 
     def test_classify_customer_messages(self) -> None:
         query = (
@@ -90,8 +111,149 @@ class TestPlannerNode(TestCase):
             })
             plan = state["plan"]
             self.assertGreater(len(plan.steps), 1, "Has at least 2 steps")
-            self.assertNotIn("tool",
-                             [step.action for step in plan.steps],
-                             "No tool is available to be used for this task")
+            self.assertTrue(
+                any(
+                    "tavily" in step.action.lower()
+                    or "search" in step.action.lower()
+                    for step in plan.steps
+                ),
+                "Uses search or reference tool",
+            )
 
+    def test_refactor_function_readability(self) -> None:
+        query = (
+            "Refactor this function for readability and add docstrings and type hints."
+        )
+        examples = [
+            """def f(a,b):
+    r=[]
+    for i in a:
+        if i not in r: r.append(i)
+    for j in b:
+        if j not in r: r.append(j)
+    return r""",
+            """def calc(x):
+    t=0
+    for i in range(len(x)):
+        t=t+x[i]
+    return t/len(x)""",
+        ]
+        for example in examples:
+            state = self.graph.invoke({
+                "messages": [HumanMessage(content=f"{query}\n{example}")]
+            })
+            plan = state["plan"]
+            self.assertGreater(len(plan.steps), 1, "Has at least 2 steps")
+            self.assertTrue(
+                any(
+                    "tavily" in step.action.lower()
+                    or "search" in step.action.lower()
+                    for step in plan.steps
+                ),
+                "Uses search or reference tool",
+            )
+
+    def test_build_python_cli(self) -> None:
+        query = "Implement a small Python CLI with argparse that performs tasks X and Y."
+        examples = [
+            "X = convert a .txt file to uppercase, Y = count words and print top-5 by frequency.",
+            "X = merge two CSVs by 'id', Y = filter rows where 'amount' > 100 and save.",
+        ]
+        for example in examples:
+            state = self.graph.invoke({
+                "messages": [HumanMessage(content=f"{query} {example}")]
+            })
+            plan = state["plan"]
+            self.assertGreater(len(plan.steps), 1, "Has at least 2 steps")
+            self.assertTrue(
+                any(
+                    "tavily" in step.action.lower()
+                    or "search" in step.action.lower()
+                    for step in plan.steps
+                ),
+                "Uses search or reference tool",
+            )
+
+    def test_research_watches(self) -> None:
+        query = "Research the best minimalist mechanical watches under $3k; compare and cite."
+        examples = [
+            "Field watches under $1.5k, 38–40 mm, sapphire, no date.",
+            "Dress watches under $2.5k, <10 mm thick, Bauhaus aesthetics.",
+        ]
+        for example in examples:
+            state = self.graph.invoke({
+                "messages": [HumanMessage(content=f"{query} {example}")]
+            })
+            plan = state["plan"]
+            self.assertGreater(len(plan.steps), 1, "Has at least 2 steps")
+            self.assertTrue(
+                any("tavily" in step.action.lower() for step in plan.steps),
+                "Mentions tavily in any step",
+            )
+
+    def test_day_trip_plan(self) -> None:
+        query = (
+            "Create a day-trip plan using rideshare only; estimate times/costs; output a tweakable sheet."
+        )
+        examples = [
+            "Sonoma plaza stroll + one tasting + lunch, 4 adults, Saturday 9/20.",
+            "Half Moon Bay coastal walk + café lunch, 2 adults, Sunday 10/5.",
+        ]
+        for example in examples:
+            state = self.graph.invoke({
+                "messages": [HumanMessage(content=f"{query} {example}")]
+            })
+            plan = state["plan"]
+            self.assertGreater(len(plan.steps), 1, "Has at least 2 steps")
+            self.assertTrue(
+                any("tavily" in step.action.lower() for step in plan.steps),
+                "Mentions tavily in any step",
+            )
+
+    def test_file_expense_report(self) -> None:
+        query = (
+            "File an expense report from provided PDFs: extract line items, code them, total, attach, submit, "
+            "and reference IRS guidelines for expense categories."
+        )
+        examples = [
+            "Receipts = 'Lyft $28.34 (08/12), Coffee $6.50 (08/12), Lunch w/ client $54.20 (08/12).',",
+            "Receipts = 'SFO⇄LAX airfare $216.90 (08/25), Hotel 1 night $189.00 (08/25), Per-diem dinner $35.00.',",
+        ]
+        for example in examples:
+            state = self.graph.invoke({
+                "messages": [HumanMessage(content=f"{query} {example}")]
+            })
+            plan = state["plan"]
+            self.assertGreater(len(plan.steps), 1, "Has at least 2 steps")
+            self.assertTrue(
+                any(
+                    "tavily" in step.action.lower()
+                    or "search" in step.action.lower()
+                    for step in plan.steps
+                ),
+                "Uses search or reference tool",
+            )
+
+    def test_run_llm_benchmark(self) -> None:
+        query = (
+            "Run a benchmark comparing three LLMs on a supplied prompt suite; chart quality/latency; memo."
+        )
+        examples = [
+            "Coding suite with tasks like writing a JSON Schema and fixing a failing pytest.",
+            "Reasoning suite with summarization, extraction, and classification prompts.",
+        ]
+        for example in examples:
+            state = self.graph.invoke({
+                "messages": [HumanMessage(content=f"{query} {example}")]
+            })
+            plan = state["plan"]
+            self.assertGreater(len(plan.steps), 1, "Has at least 2 steps")
+            self.assertTrue(
+                any(
+                    "tavily" in step.action.lower()
+                    or "search" in step.action.lower()
+                    for step in plan.steps
+                ),
+                "Uses search or reference tool",
+            )
 


### PR DESCRIPTION
## Summary
- enforce external reference steps in planner validation scenarios
- ensure entity-extraction and expense-report queries request outside guidance
- document that planner tests verify use of search or indexes

## Testing
- `PYTHONPATH=src pytest tests/integration/validation/test_planner_node.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68baed5dc0d0832bb4871a578859f8dd