### PR TITLE
test: add planner file-writing validations

### DIFF
--- a/README.org
+++ b/README.org
@@ -58,6 +58,9 @@ Run the integration tests with:
 #+begin_src shell
 pytest tests/integration
 #+end_src
+The integration suite includes validation tests ensuring the planner can
+independently employ the file-writing tool for tasks that create or update
+files.
 * Evaluation
 The project ships with a small, local-first harness for benchmarking agents and their
 subcomponents. Datasets live under =eval/datasets= and describe input/expected pairs.


### PR DESCRIPTION
## Summary
- extend planner validation tests with scenarios requiring `write_file`
- document new file-writing validation in README

## Testing
- `PYTHONPATH=src pytest tests/integration/validation/test_planner_node.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc69dbd078832bb5fdc5baf0f71ed0