### PR TITLE
Add coverage and mypy reporting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,5 +18,22 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -e .
-      - name: Run tests
+      - name: Static type analysis
+        run: mypy src | tee mypy-report.txt
+        continue-on-error: true
+      - name: Upload mypy report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: mypy-report
+          path: mypy-report.txt
+          if-no-files-found: ignore
+      - name: Run tests with coverage
         run: pytest -vv
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: coverage.xml
+          if-no-files-found: ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         continue-on-error: true
       - name: Upload mypy report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mypy-report
           path: mypy-report.txt
@@ -32,7 +32,7 @@ jobs:
         run: pytest -vv
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage.xml

--- a/README.org
+++ b/README.org
@@ -49,11 +49,20 @@ Install the package in editable mode so Emacs/Elpy can discover the modules:
 pip install -e .
 #+end_src
 
-Run the tests with:
+Run the tests with coverage:
 
 #+begin_src shell
 pytest
 #+end_src
+
+Generate a static type report:
+
+#+begin_src shell
+mypy src
+#+end_src
+
+Both coverage and type checking run in CI for pull requests and pushes to main.
+Reports are uploaded as artifacts and do not block the build.
 
 Run the integration tests with:
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --ignore=tests/integration
+addopts = --ignore=tests/integration --cov=src --cov-report=xml --cov-report=term

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ langgraph
 tavily-python
 chromadb
 pytest
+pytest-cov
 sentence-transformers
 vgrep==0.1.4
 Jinja2==3.1.6


### PR DESCRIPTION
## Summary
- run mypy and upload reports during CI without failing the build
- gather code coverage for test runs and publish the report
- document coverage and mypy usage and configure pytest to produce coverage data

## Testing
- `pytest -vv`
- `mypy src` *(fails: Function is missing a type annotation for one or more arguments; run interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bda1d4bab4832bbf6e3f9ce3dc4aea