### PR TITLE
Add safe Python execution tool

### DIFF
--- a/README.org
+++ b/README.org
@@ -4,7 +4,7 @@ Assist is an extensible, local-focused, llm-based assistant. The principles guid
 - Extensibility - All agentic behavior is easy to modify or add to.
 - Generic - Assist can help with anything.
 
-It currently provides an OpenAI-compatible API with a ReAct agent and some simple tools, including a safe Python execution tool for read-only computations. It's currently very tailored to Emacs, but hopefully can be extended in the future to handle other editors.
+It currently provides an OpenAI-compatible API with a ReAct agent and some simple tools, including a safe Python execution tool for read-only computations with limited builtins (e.g., =abs=, =sum=) and modules (=math=, =statistics=, =random=, =numpy= if available). It's currently very tailored to Emacs, but hopefully can be extended in the future to handle other editors.
 
 Streaming responses now send only the assistant's latest message rather than replaying prior conversation history.
 

--- a/README.org
+++ b/README.org
@@ -4,7 +4,7 @@ Assist is an extensible, local-focused, llm-based assistant. The principles guid
 - Extensibility - All agentic behavior is easy to modify or add to.
 - Generic - Assist can help with anything.
 
-It currently provides an OpenAI-compatible API with a ReAct agent and some simple tools. It's currently very tailored to Emacs, but hopefully can be extended in the future to handle other editors.
+It currently provides an OpenAI-compatible API with a ReAct agent and some simple tools, including a safe Python execution tool for read-only computations. It's currently very tailored to Emacs, but hopefully can be extended in the future to handle other editors.
 
 Streaming responses now send only the assistant's latest message rather than replaying prior conversation history.
 

--- a/playground/play_safe_python.py
+++ b/playground/play_safe_python.py
@@ -1,0 +1,12 @@
+from assist.general_agent import general_agent
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
+from assist.tools.safe_python import SafePythonTool
+
+
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0.4)
+agent = general_agent(llm, [SafePythonTool()])
+
+resp = agent.invoke({"messages": [HumanMessage(content="If I save $100 every month in an account that started with $10,000 and provides an interest rate of 3%, how much will the account have in 10 years?")]})
+print(resp)
+                                  

--- a/src/assist/tools/base.py
+++ b/src/assist/tools/base.py
@@ -7,6 +7,7 @@ from assist.tools.unit_conversion import UnitConversionTool
 from assist.tools.timer import TimerTool
 from assist.tools.web_search import site_search, page_search
 from assist.tools.date_utils import current_date, date_offset, date_diff
+from assist.tools.safe_python import SafePythonTool
 from pathlib import Path
 
 
@@ -23,6 +24,7 @@ def base_tools(index_path: Path) -> List[BaseTool]:
         filesystem.project_context,
         UnitConversionTool(),
         TimerTool(),
+        SafePythonTool(),
         site_search,
         page_search,
         current_date,

--- a/src/assist/tools/safe_python.py
+++ b/src/assist/tools/safe_python.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""Execute Python code in a restricted, read-only environment."""
+
+import builtins
+import contextlib
+import io
+from typing import Dict, Any
+from langchain_core.tools import BaseTool
+
+
+class SafePythonTool(BaseTool):
+    """Execute Python code without filesystem side effects."""
+
+    name: str = "python"
+    description: str = (
+        "Execute Python code in a sandboxed environment. "
+        "The code cannot access the filesystem or network."
+    )
+
+    def __init__(self) -> None:
+        super().__init__()
+        allowed_builtins = {
+            name: getattr(builtins, name)
+            for name in [
+                "abs",
+                "min",
+                "max",
+                "sum",
+                "len",
+                "range",
+                "enumerate",
+                "zip",
+                "map",
+                "filter",
+                "sorted",
+                "round",
+                "all",
+                "any",
+                "print",
+                "float",
+                "int",
+                "str",
+                "bool",
+                "dict",
+                "list",
+                "tuple",
+                "set",
+            ]
+        }
+        allowed_modules = {"math", "statistics", "random", "numpy"}
+
+        def _safe_import(name: str, globals: Any | None = None, locals: Any | None = None,
+                         fromlist: tuple[str, ...] = (), level: int = 0) -> Any:
+            if name in allowed_modules:
+                return __import__(name, globals, locals, fromlist, level)
+            raise ImportError(f"Module '{name}' not allowed")
+
+        allowed_builtins["__import__"] = _safe_import
+        self._globals: Dict[str, Any] = {"__builtins__": allowed_builtins}
+        for mod in allowed_modules:
+            try:
+                self._globals[mod] = __import__(mod)
+            except Exception:
+                pass
+
+    def _run(self, code: str) -> str:
+        locals_dict: Dict[str, Any] = {}
+        stdout = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(stdout):
+                exec(code, self._globals, locals_dict)
+        except Exception as exc:  # pragma: no cover - errors handled
+            return f"Error: {exc}"
+        output = stdout.getvalue().strip()
+        result = locals_dict.get("result")
+        if result is not None:
+            result_str = repr(result)
+            return f"{output}\n{result_str}" if output else result_str
+        return output or "None"
+
+    async def _arun(self, *args: Any, **kwargs: Any) -> str:  # pragma: no cover - sync only
+        raise NotImplementedError
+
+
+__all__ = ["SafePythonTool"]

--- a/src/assist/tools/safe_python.py
+++ b/src/assist/tools/safe_python.py
@@ -68,10 +68,11 @@ class SafePythonTool(BaseTool):
         builtins_str = ", ".join(sorted(b for b in allowed_builtins if b != "__import__"))
         modules_str = ", ".join(sorted(allowed_modules))
         description = (
-            "Execute Python code in a sandboxed environment. "
+            "Execute Python code in a sandboxed environment. Use this tool for calculations and statistics tasks."
             "No filesystem or network access. "
-            f"Builtins: {builtins_str}. "
-            f"Modules: {modules_str}."
+            f"The only builtins available are: {builtins_str}. "
+            f"The only modules available are: {modules_str}. "
+            "Do not attempt to use any builtins or modules outside of those lists."
         )
         super().__init__(description=description)
 

--- a/tests/integration/validation/test_planner_node.py
+++ b/tests/integration/validation/test_planner_node.py
@@ -24,11 +24,16 @@ class TestPlannerNode(TestCase):
                         f"{thing} should be in a plan step")
 
     def assertInPlan(self,
-                        thing: str,
-                        state: ReflexionState):
+                     thing: str,
+                     state: ReflexionState):
         plan = state["plan"]
         self.assertTrue(any([thing in s.action for s in plan.steps]),
                         f"{thing} should not be in a plan step")
+
+    def test_python_usage(self) -> None:
+        state = self.ask_node("If I save $100 every month in an account that started with $10,000 and provides an interest rate of 3%, how much will the account have in 10 years?")
+
+        self.assertInPlan("python", state)
     
     def test_dont_write_file(self) -> None:
         state = self.ask_node("What is the capital of France?")

--- a/tests/test_base_tools.py
+++ b/tests/test_base_tools.py
@@ -2,6 +2,13 @@ from assist.tools.base import base_tools
 from assist.tools import filesystem
 
 
+def test_base_tools_includes_python(tmp_path, monkeypatch):
+    monkeypatch.setenv("TAVILY_API_KEY", "test")
+    tools = base_tools(tmp_path)
+    names = [t.name for t in tools]
+    assert "python" in names
+
+
 def test_base_tools_includes_write_file(tmp_path, monkeypatch):
     monkeypatch.setenv("TAVILY_API_KEY", "test")
     tools = base_tools(tmp_path)

--- a/tests/test_safe_python.py
+++ b/tests/test_safe_python.py
@@ -1,0 +1,20 @@
+from assist.tools.safe_python import SafePythonTool
+
+
+def test_executes_math():
+    tool = SafePythonTool()
+    output = tool.run("result = sum(i*i for i in range(5))")
+    assert "30" in output
+
+
+def test_blocks_file_write(tmp_path):
+    tool = SafePythonTool()
+    code = "open('x.txt', 'w').write('hi')"
+    out = tool.run(code)
+    assert "Error" in out
+
+
+def test_blocks_os_import():
+    tool = SafePythonTool()
+    out = tool.run("import os")
+    assert "not allowed" in out

--- a/tests/test_safe_python.py
+++ b/tests/test_safe_python.py
@@ -25,7 +25,7 @@ def test_blocks_os_import():
 def test_description_mentions_limits():
     tool = SafePythonTool()
     desc = tool.description
-    assert "Builtins" in desc and "Modules" in desc
+    assert "builtins" in desc and "modules" in desc
     assert "abs" in desc and "math" in desc
 
 

--- a/tests/test_safe_python.py
+++ b/tests/test_safe_python.py
@@ -1,3 +1,5 @@
+import importlib
+
 from assist.tools.safe_python import SafePythonTool
 
 
@@ -18,3 +20,20 @@ def test_blocks_os_import():
     tool = SafePythonTool()
     out = tool.run("import os")
     assert "not allowed" in out
+
+
+def test_description_mentions_limits():
+    tool = SafePythonTool()
+    desc = tool.description
+    assert "Builtins" in desc and "Modules" in desc
+    assert "abs" in desc and "math" in desc
+
+
+def test_numpy_mention_matches_installation():
+    tool = SafePythonTool()
+    try:
+        importlib.import_module("numpy")
+    except Exception:
+        assert "numpy" not in tool.description
+    else:
+        assert "numpy" in tool.description


### PR DESCRIPTION
## Summary
- add `SafePythonTool` for sandboxed Python code execution without filesystem access
- expose tool through `base_tools`
- document new tool and test coverage

## Testing
- `PYTHONPATH=src pytest`
- `PYTHONPATH=src mypy src` *(fails: Build finished... 6 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bdda77e210832ba8fe29886a3b18aa