### PR TITLE
Add safe Python execution tool

### DIFF
--- a/README.org
+++ b/README.org
@@ -4,7 +4,7 @@ Assist is an extensible, local-focused, llm-based assistant. The principles guid
 - Extensibility - All agentic behavior is easy to modify or add to.
 - Generic - Assist can help with anything.
 
-It currently provides an OpenAI-compatible API with a ReAct agent and some simple tools. It's currently very tailored to Emacs, but hopefully can be extended in the future to handle other editors.
+It currently provides an OpenAI-compatible API with a ReAct agent and some simple tools, including a safe Python execution tool for read-only computations with limited builtins (e.g., =abs=, =sum=) and modules (=math=, =statistics=, =random=, =numpy= if available). A small demonstration lives in =playground/play_safe_python.py= using =ChatOpenAI= with the safe Python tool to compute compound savings. It's currently very tailored to Emacs, but hopefully can be extended in the future to handle other editors.
 
 Streaming responses now send only the assistant's latest message rather than replaying prior conversation history.
 

--- a/README.org
+++ b/README.org
@@ -4,7 +4,7 @@ Assist is an extensible, local-focused, llm-based assistant. The principles guid
 - Extensibility - All agentic behavior is easy to modify or add to.
 - Generic - Assist can help with anything.
 
-It currently provides an OpenAI-compatible API with a ReAct agent and some simple tools, including a safe Python execution tool for read-only computations with limited builtins (e.g., =abs=, =sum=) and modules (=math=, =statistics=, =random=, =numpy= if available). A small demonstration lives in =playground/play_safe_python.py= using =ChatOpenAI= with the safe Python tool to compute compound savings. It's currently very tailored to Emacs, but hopefully can be extended in the future to handle other editors.
+It currently provides an OpenAI-compatible API with a ReAct agent and some simple tools, including a safe Python execution tool for read-only computations with limited builtins (e.g., =abs=, =sum=, =pow=) and modules (=math=, =statistics=, =random=, =numpy= if available). A small demonstration lives in =playground/play_safe_python.py= using =ChatOpenAI= with the safe Python tool to compute compound savings. It's currently very tailored to Emacs, but hopefully can be extended in the future to handle other editors.
 
 Streaming responses now send only the assistant's latest message rather than replaying prior conversation history.
 

--- a/playground/play_safe_python.py
+++ b/playground/play_safe_python.py
@@ -1,0 +1,24 @@
+"""Demonstrate using SafePythonTool with a real LLM."""
+
+from assist.general_agent import general_agent
+from assist.tools.safe_python import SafePythonTool
+from langchain_core.messages import HumanMessage
+from langchain_openai import ChatOpenAI
+
+
+def main() -> None:
+    """Run a simple agent that computes compound savings."""
+    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0.4)
+    agent = general_agent(llm, [SafePythonTool()])
+
+    prompt = (
+        "If I save $100 every month in an account that started with $10,000 and "
+        "provides an interest rate of 3%, how much will the account have in 10 years?"
+    )
+    resp = agent.invoke({"messages": [HumanMessage(content=prompt)]})
+    print(resp)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/assist/tools/base.py
+++ b/src/assist/tools/base.py
@@ -7,6 +7,7 @@ from assist.tools.unit_conversion import UnitConversionTool
 from assist.tools.timer import TimerTool
 from assist.tools.web_search import site_search, page_search
 from assist.tools.date_utils import current_date, date_offset, date_diff
+from assist.tools.safe_python import SafePythonTool
 from pathlib import Path
 
 
@@ -23,6 +24,7 @@ def base_tools(index_path: Path) -> List[BaseTool]:
         filesystem.project_context,
         UnitConversionTool(),
         TimerTool(),
+        SafePythonTool(),
         site_search,
         page_search,
         current_date,

--- a/src/assist/tools/safe_python.py
+++ b/src/assist/tools/safe_python.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+"""Execute Python code in a restricted, read-only environment."""
+
+import builtins
+import contextlib
+import io
+from typing import Dict, Any
+from langchain_core.tools import BaseTool
+
+
+class SafePythonTool(BaseTool):
+    """Execute Python code without filesystem side effects."""
+
+    name: str = "python"
+    description: str = ""
+
+    def __init__(self) -> None:
+        allowed_builtins = {
+            name: getattr(builtins, name)
+            for name in [
+                "abs",
+                "min",
+                "max",
+                "sum",
+                "len",
+                "range",
+                "enumerate",
+                "zip",
+                "map",
+                "filter",
+                "sorted",
+                "round",
+                "all",
+                "any",
+                "print",
+                "float",
+                "int",
+                "str",
+                "bool",
+                "dict",
+                "list",
+                "tuple",
+                "set",
+            ]
+        }
+        allowed_modules = {"math", "statistics", "random"}
+        for mod in ("numpy",):
+            try:
+                __import__(mod)
+            except Exception:  # pragma: no cover - optional dependency
+                continue
+            allowed_modules.add(mod)
+
+        def _safe_import(
+            name: str,
+            globals: Any | None = None,
+            locals: Any | None = None,
+            fromlist: tuple[str, ...] = (),
+            level: int = 0,
+        ) -> Any:
+            if name in allowed_modules:
+                return __import__(name, globals, locals, fromlist, level)
+            raise ImportError(f"Module '{name}' not allowed")
+
+        allowed_builtins["__import__"] = _safe_import
+
+        builtins_str = ", ".join(sorted(b for b in allowed_builtins if b != "__import__"))
+        modules_str = ", ".join(sorted(allowed_modules))
+        description = (
+            "Execute Python code in a sandboxed environment. "
+            "No filesystem or network access. "
+            f"Builtins: {builtins_str}. "
+            f"Modules: {modules_str}."
+        )
+        super().__init__(description=description)
+
+        self._globals: Dict[str, Any] = {"__builtins__": allowed_builtins}
+        for mod in allowed_modules:
+            try:
+                self._globals[mod] = __import__(mod)
+            except Exception:  # pragma: no cover - import guard
+                pass
+
+    def _run(self, code: str) -> str:
+        locals_dict: Dict[str, Any] = {}
+        stdout = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(stdout):
+                exec(code, self._globals, locals_dict)
+        except Exception as exc:  # pragma: no cover - errors handled
+            return f"Error: {exc}"
+        output = stdout.getvalue().strip()
+        result = locals_dict.get("result")
+        if result is not None:
+            result_str = repr(result)
+            return f"{output}\n{result_str}" if output else result_str
+        return output or "None"
+
+    async def _arun(self, *args: Any, **kwargs: Any) -> str:  # pragma: no cover - sync only
+        raise NotImplementedError
+
+
+__all__ = ["SafePythonTool"]

--- a/src/assist/tools/safe_python.py
+++ b/src/assist/tools/safe_python.py
@@ -42,6 +42,7 @@ class SafePythonTool(BaseTool):
                 "list",
                 "tuple",
                 "set",
+                "pow",
             ]
         }
         allowed_modules = {"math", "statistics", "random"}

--- a/tests/test_base_tools.py
+++ b/tests/test_base_tools.py
@@ -2,6 +2,13 @@ from assist.tools.base import base_tools
 from assist.tools import filesystem
 
 
+def test_base_tools_includes_python(tmp_path, monkeypatch):
+    monkeypatch.setenv("TAVILY_API_KEY", "test")
+    tools = base_tools(tmp_path)
+    names = [t.name for t in tools]
+    assert "python" in names
+
+
 def test_base_tools_includes_write_file(tmp_path, monkeypatch):
     monkeypatch.setenv("TAVILY_API_KEY", "test")
     tools = base_tools(tmp_path)

--- a/tests/test_safe_python.py
+++ b/tests/test_safe_python.py
@@ -1,0 +1,39 @@
+import importlib
+
+from assist.tools.safe_python import SafePythonTool
+
+
+def test_executes_math():
+    tool = SafePythonTool()
+    output = tool.run("result = sum(i*i for i in range(5))")
+    assert "30" in output
+
+
+def test_blocks_file_write(tmp_path):
+    tool = SafePythonTool()
+    code = "open('x.txt', 'w').write('hi')"
+    out = tool.run(code)
+    assert "Error" in out
+
+
+def test_blocks_os_import():
+    tool = SafePythonTool()
+    out = tool.run("import os")
+    assert "not allowed" in out
+
+
+def test_description_mentions_limits():
+    tool = SafePythonTool()
+    desc = tool.description
+    assert "Builtins" in desc and "Modules" in desc
+    assert "abs" in desc and "math" in desc
+
+
+def test_numpy_mention_matches_installation():
+    tool = SafePythonTool()
+    try:
+        importlib.import_module("numpy")
+    except Exception:
+        assert "numpy" not in tool.description
+    else:
+        assert "numpy" in tool.description

--- a/tests/test_safe_python.py
+++ b/tests/test_safe_python.py
@@ -26,7 +26,13 @@ def test_description_mentions_limits():
     tool = SafePythonTool()
     desc = tool.description
     assert "Builtins" in desc and "Modules" in desc
-    assert "abs" in desc and "math" in desc
+    assert "abs" in desc and "pow" in desc and "math" in desc
+
+
+def test_pow_builtin():
+    tool = SafePythonTool()
+    out = tool.run("result = pow(2, 3)")
+    assert out.strip().endswith("8")
 
 
 def test_numpy_mention_matches_installation():


### PR DESCRIPTION
## Summary
- add `SafePythonTool` for sandboxed Python code execution without filesystem or network access
- document allowed builtins and modules, including optional `numpy` if installed
- expose tool through `base_tools` and update documentation and tests
- provide `play_safe_python.py` playground example using `SafePythonTool` with ChatOpenAI

## Testing
- `PYTHONPATH=src pytest`
- `PYTHONPATH=src mypy src` *(process hung; terminated without output)*
- `PYTHONPATH=src python playground/play_safe_python.py` *(fails: Recursion limit of 25 reached)*

------
https://chatgpt.com/codex/tasks/task_e_68bdda77e210832ba8fe29886a3b18aa