### PR TITLE
Pass conversation context to planner and summarizer

### DIFF
--- a/src/assist/promptable.py
+++ b/src/assist/promptable.py
@@ -1,5 +1,7 @@
 import inspect
 
+from typing import Any
+
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 env = Environment(
@@ -22,12 +24,12 @@ def _infer_module() -> str:
     raise RuntimeError("Could not infer caller module")
 
 
-def base_prompt_for(prompt_path: str, **kwargs) -> str:
+def base_prompt_for(prompt_path: str, **kwargs: Any) -> str:
     template = env.get_template(prompt_path)
     return template.render(**kwargs)
 
 
-def prompt_for(prompt_name: str, *, module: str | None = None, **kwargs) -> str:
+def prompt_for(prompt_name: str, *, module: str | None = None, **kwargs: Any) -> str:
     """Render ``prompt_name`` for ``module`` using optional ``kwargs``.
 
     If ``module`` is not provided, it is inferred from the caller's module.
@@ -44,5 +46,5 @@ class Promptable:
     def prompts_folder(self) -> str:
         return _folder_from_module(self.__module__)
 
-    def prompt_for(self, prompt_name: str, **kwargs) -> str:
+    def prompt_for(self, prompt_name: str, **kwargs: Any) -> str:
         return prompt_for(prompt_name, **kwargs)


### PR DESCRIPTION
## Summary
- surface server system messages under a "Here is guidance from the user:" section for planner and summarizer
- remove misplaced context note from README
- type annotate prompt rendering helpers

## Testing
- `pytest`
- `mypy src` *(fails: many typing errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68be043f1338832ba19356296465363e