### PR TITLE
feat: filter system info files

### DIFF
--- a/README.org
+++ b/README.org
@@ -4,7 +4,7 @@ Assist is an extensible, local-focused, llm-based assistant. The principles guid
 - Extensibility - All agentic behavior is easy to modify or add to.
 - Generic - Assist can help with anything.
 
-It currently provides an OpenAI-compatible API with a ReAct agent and some simple tools, including a safe Python execution tool for read-only computations with limited builtins (e.g., =abs=, =sum=, =pow=) and modules (=math=, =statistics=, =random=, =numpy= if available). To capture a value, assign it to a variable named =result= or print it. A small demonstration lives in =playground/play_safe_python.py= using =ChatOpenAI= with the safe Python tool to compute compound savings. It's currently very tailored to Emacs, but hopefully can be extended in the future to handle other editors.
+It currently provides an OpenAI-compatible API with a ReAct agent and some simple tools, including a safe Python execution tool for read-only computations with limited builtins (e.g., =abs=, =sum=, =pow=) and modules (=math=, =statistics=, =random=, =numpy= if available). A system information searcher indexes local =info= documentation and can restrict the index to files containing specified keywords. To capture a value, assign it to a variable named =result= or print it. A small demonstration lives in =playground/play_safe_python.py= using =ChatOpenAI= with the safe Python tool to compute compound savings. It's currently very tailored to Emacs, but hopefully can be extended in the future to handle other editors.
 
 Streaming responses now send only the assistant's latest message rather than replaying prior conversation history.
 

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -38,3 +38,15 @@ def test_system_info_search(tmp_path):
     search_tool = idx.search_tool()
     result = search_tool.invoke("bananas")
     assert "bananas" in result
+
+
+def test_system_info_keyword_filter(tmp_path):
+    info_root = _create_info_root(tmp_path)
+    idx = SystemInfoIndex(info_root, keywords=["bananas"])
+    search_tool = idx.search_tool()
+    assert "bananas" in search_tool.invoke("bananas")
+    assert "apples" not in search_tool.invoke("apples")
+    list_tool = idx.list_tool()
+    files = list_tool.invoke({})
+    assert "alpha - Alpha info file." in files
+    assert all("beta" not in f for f in files)


### PR DESCRIPTION
## Summary
- allow SystemInfoIndex to accept keywords and index only matching files
- expose filtered list of info files
- document system info keyword filtering and cover with tests

## Testing
- `pytest`
- `mypy src`


------
https://chatgpt.com/codex/tasks/task_e_68bee35ff1fc832b82c91a823bc1a197