### PR TITLE
Guard execute agent from oversized tool output

### DIFF
--- a/README.org
+++ b/README.org
@@ -6,8 +6,6 @@ Assist is an extensible, local-focused, llm-based assistant. The principles guid
 
 It currently provides an OpenAI-compatible API with a ReAct agent and some simple tools, including a safe Python execution tool for read-only computations with limited builtins (e.g., =abs=, =sum=, =pow=) and modules (=math=, =statistics=, =random=, =numpy= if available). To capture a value, assign it to a variable named =result= or print it. A small demonstration lives in =playground/play_safe_python.py= using =ChatOpenAI= with the safe Python tool to compute compound savings. It's currently very tailored to Emacs, but hopefully can be extended in the future to handle other editors.
 
-Streaming responses now send only the assistant's latest message rather than replaying prior conversation history.
-
 It is not /just/ a coding assistant, but should be able to help with any project or goal.
 When running the server, built-in tools refuse to read from or write to the Assist codebase itself for safety. The planner and executor prompts explicitly forbid using any tool to access that directory.
 This warning is only shown when the server knows its project root.
@@ -103,6 +101,11 @@ python playground/tool_exception.py
 The script defines a tool that always fails, wires a live model to it, and prints the
 resulting messages, including the tool error. Provide a valid `OPENAI_API_KEY` in the
 environment.
+* Implementation notes
+Streaming responses send only the assistant's latest message rather than replaying prior conversation history.
+
+During execution, tool outputs are capped to 90% of the model's context window to leave room for other messages and, when truncated, end with a notice that the message was shortened.
+
 * User flows
 These are the main user flows for working with Assist
 ** Re-write

--- a/src/assist/general_agent.py
+++ b/src/assist/general_agent.py
@@ -1,18 +1,55 @@
 from langchain_core.runnables import Runnable
 from langchain_core.messages import HumanMessage, SystemMessage
-from langchain_core.tools import tool, BaseTool
+from langchain_core.tools import BaseTool
 from langgraph.prebuilt import create_react_agent
 from datetime import datetime
 from typing import Any, List
 import time
-import os
+
+from assist.model_manager import get_context_limit
+
+TRUNCATE_MSG = "\n[Message truncated to fit context window]"
+# Limit tool output to 90% of the context window to leave headroom for other messages
+CONTEXT_BUFFER_RATIO = 0.9
+
+
+def _truncate(content: str, limit: int) -> str:
+    if len(content) <= limit:
+        return content
+    return content[:limit] + TRUNCATE_MSG
+
+
+def _guard_tool(tool: BaseTool, limit: int) -> BaseTool:
+    class GuardedTool(BaseTool):
+        name: str = tool.name
+        description: str = tool.description
+        args_schema: Any = tool.args_schema
+        return_direct: bool = tool.return_direct
+
+        def _run(self, *args: Any, config: Any | None = None, run_manager: Any = None, **kwargs: Any) -> Any:  # pragma: no cover - thin wrapper
+            res = tool._run(*args, config=config, run_manager=run_manager, **kwargs)
+            if isinstance(res, str):
+                return _truncate(res, limit)
+            return res
+
+        async def _arun(self, *args: Any, config: Any | None = None, run_manager: Any = None, **kwargs: Any) -> Any:  # pragma: no cover - thin wrapper
+            res = await tool._arun(*args, config=config, run_manager=run_manager, **kwargs)
+            if isinstance(res, str):
+                return _truncate(res, limit)
+            return res
+
+    return GuardedTool()
 
 def general_agent(
     llm: Runnable[Any, Any],
     tools: List[BaseTool] | None = None,
 ) -> Runnable[Any, Any]:
     """Return a ReAct agent configured with useful tools."""
-    agent_executor = create_react_agent(llm, tools or [])
+    limit = get_context_limit(llm)
+    limit = int(limit * CONTEXT_BUFFER_RATIO) - len(TRUNCATE_MSG)
+    limit = max(limit, 0)
+    guarded = [_guard_tool(t, limit) for t in tools or []]
+    agent_executor = create_react_agent(llm, guarded)
     return agent_executor
 
 def test_agents() -> None:

--- a/src/assist/model_manager.py
+++ b/src/assist/model_manager.py
@@ -20,6 +20,17 @@ MODEL_EXECUTION_MAP: dict[str, str] = {
     "gpt-4o-mini": "gpt-4o-mini",
 }
 
+# Mapping of model names to their character context limits
+MODEL_CONTEXT_LIMITS: dict[str, int] = {
+    # OpenAI models expose a 128k token context window, which comfortably
+    # exceeds most tool outputs. The limits here are expressed in characters
+    # rather than tokens for simplicity.
+    "gpt-4o": 128_000,
+    "gpt-4o-mini": 128_000,
+}
+
+DEFAULT_CONTEXT_LIMIT = 32_768
+
 
 def select_chat_model(model: str, temperature: float) -> BaseChatModel:
     """Return the appropriate chat model for ``model``.
@@ -45,3 +56,12 @@ def get_model_pair(model: str, temperature: float) -> Tuple[BaseChatModel, BaseC
     exec_model = MODEL_EXECUTION_MAP.get(model, model)
     exec_llm = select_chat_model(exec_model, temperature)
     return plan_llm, exec_llm
+
+
+def get_context_limit(llm: BaseChatModel) -> int:
+    """Return the character context limit for ``llm``.
+
+    If ``llm.model`` is unknown, ``DEFAULT_CONTEXT_LIMIT`` is used.
+    """
+    model_name = getattr(llm, "model", "")
+    return MODEL_CONTEXT_LIMITS.get(model_name, DEFAULT_CONTEXT_LIMIT)


### PR DESCRIPTION
## Summary
- Limit tool responses in the execute agent to 90% of the model's context window, leaving headroom for other messages and appending a truncation notice when clipping
- Document buffered truncation behaviour
- Adjust tests to assert the buffered limit

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bede0729b8832bb1c7eaa0237a5286