### PR TITLE
Handle planning recursion with clarifying question node

### DIFF
--- a/src/assist/templates/reflexion_agent/plan_check_user.txt
+++ b/src/assist/templates/reflexion_agent/plan_check_user.txt
@@ -2,7 +2,7 @@ Here is the overall user task {{ goal }}
 
 Here are the steps and their resolution:
 {% for plan_step in step_resolutions %}
-  Step {{ loop.index+1 }}:
+  Step {{ loop.index }}:
   - Objective: {{ plan_step.objective }}
   - Action {{ plan_step.action }}
   - Resolution: {{ plan_step.resolution }}
@@ -10,7 +10,7 @@ Here are the steps and their resolution:
 
 Here are the remaining steps to be taken:
 {% for next_plan_step in remaining_steps %}
-  Remaining Step {{ loop.index+1 }}:
+  Step {{ loop.index + (step_resolutions|length) }}:
   - Objective: {{ next_plan_step.objective }}
   - Action: {{ next_plan_step.action }}
 {% endfor %}

--- a/src/assist/templates/reflexion_agent/recursion_system.txt
+++ b/src/assist/templates/reflexion_agent/recursion_system.txt
@@ -1,0 +1,2 @@
+You are a planning assistant that is stuck in a loop.
+Using the provided plan and executed steps, craft a single clarifying question for the user that will help you continue the task.

--- a/src/assist/templates/reflexion_agent/recursion_user.txt
+++ b/src/assist/templates/reflexion_agent/recursion_user.txt
@@ -1,0 +1,9 @@
+Goal: {{ goal }}
+
+Planned steps:
+{{ plan_steps }}
+
+Completed steps:
+{{ history }}
+
+The plan keeps repeating without progress. Ask the user a specific question that would help resolve the issue.


### PR DESCRIPTION
## Summary
- track replan count and limit replanning loops
- add recursion node using planner LLM to ask clarifying question
- include prompt templates for recursion handling and test coverage

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c35d903f48832baf108f7455ceccd3