### PR TITLE
feat: log execution steps in console callback

### DIFF
--- a/README.org
+++ b/README.org
@@ -82,7 +82,9 @@ pytest tests/integration/validation/test_planner_node.py
 ** Debugging
 To see every prompt and response during an agent run, use
 `ReadableConsoleCallbackHandler`. Each LLM call prints the node, model, prompt,
-and response in a readable format.
+and response in a readable format. The handler also shows the generated plan,
+tool invocations with their arguments and results, and the final response from
+the execution node.
 
 ** Validations
 There's a set of tests in =tests/integration/validations= that stress a live llm within the agent and different nodes in different conditions.

--- a/src/assist/reflexion_agent.py
+++ b/src/assist/reflexion_agent.py
@@ -172,9 +172,10 @@ def build_execute_node(
             ),
         ]
         try:
-            result_raw = agent.invoke({"messages": messages,
-                                       "callbacks": callbacks,
-                                       "tags": ["execute"]})
+            result_raw = agent.invoke(
+                {"messages": messages},
+                {"callbacks": callbacks, "tags": ["execute"]},
+            )
             result = AgentInvokeResult.model_validate(result_raw)
             output_msg = result.messages[-1]
             resolution = output_msg.content


### PR DESCRIPTION
## Summary
- extend `ReadableConsoleCallbackHandler` to log plan JSON, tool arguments and outputs, and final execution responses
- document enhanced callback capabilities
- test plan, tool, and execution logging

## Testing
- `pytest tests/test_debug_callback.py`


------
https://chatgpt.com/codex/tasks/task_e_68c58f75b708832b827d09500c3afe9c