### PR TITLE
feat: study agent for summarizing long file reads

### DIFF
--- a/src/assist/study_agent.py
+++ b/src/assist/study_agent.py
@@ -1,0 +1,85 @@
+"""Utilities for studying large files by summarizing them chunk by chunk."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from assist.model_manager import select_chat_model, get_context_limit
+
+# Leave room for prompts, user context and running summary
+CONTEXT_FRACTION = 0.8
+
+
+def _summarize_chunk(
+    llm: BaseChatModel,
+    chunk: str,
+    task: str,
+    request: str,
+    prior: str,
+) -> str:
+    """Return a summary for ``chunk`` building on ``prior``."""
+
+    messages = [
+        SystemMessage(
+            content=(
+                "You are a study agent. Summarize file chunks so the user can "
+                "complete their task."
+            )
+        ),
+        HumanMessage(
+            content=(
+                f"Original request:\n{request}\n\n"
+                f"Current task:\n{task}\n\n"
+                f"Previous summary:\n{prior}\n\n"
+                f"File chunk:\n{chunk}\n\n"
+                "Provide an updated concise summary relevant to the task."
+            )
+        ),
+    ]
+    resp = llm.invoke(messages)
+    return getattr(resp, "content", str(resp))
+
+
+def study_file(
+    path: Path | str,
+    task: str = "",
+    request: str = "",
+    llm: Optional[BaseChatModel] = None,
+) -> str:
+    """Return the contents of ``path`` or a summary if it's too large.
+
+    The file is read in chunks sized to the language model's context window. A
+    running summary is updated after each chunk so that the final result fits
+    within the model's limits and remains focused on the ``task`` and
+    ``request``.
+    """
+
+    p = Path(path)
+    if llm is None:
+        model = os.getenv("STUDY_AGENT_MODEL", "gpt-4o-mini")
+        llm = select_chat_model(model, temperature=0)
+
+    limit = get_context_limit(llm)
+    chunk_size = int(limit * CONTEXT_FRACTION)
+
+    text = p.read_text(encoding="utf-8", errors="ignore")
+    if len(text) <= chunk_size:
+        return text
+
+    summary = ""
+    start = 0
+    end = len(text)
+    while start < end:
+        chunk = text[start : start + chunk_size]
+        summary = _summarize_chunk(llm, chunk, task, request, summary)
+        start += chunk_size
+    return summary
+
+
+__all__ = ["study_file"]
+

--- a/src/assist/templates/reflexion_agent/make_plan_system.txt
+++ b/src/assist/templates/reflexion_agent/make_plan_system.txt
@@ -10,6 +10,8 @@ Definitions of done must be mechanically checkable. Include verification within 
 
 Do not include use of any tools that write content unless it's clear that a write is desired.
 
+NO plan step should prompt the user with a question. Use the context of the messages to make reasonable assumptions about what should be done. Use tools to explore.
+
 If task is unsafe/illegal, insert a safety gate and propose safer alternatives.
 
 Consider things like the overall goal and objective of each step as well as any assumptions and risks.

--- a/src/assist/tools/filesystem.py
+++ b/src/assist/tools/filesystem.py
@@ -6,6 +6,7 @@ from pathspec import PathSpec
 
 from assist import git
 from assist.tools.safeguard import in_server_project, ensure_outside_server
+from assist.study_agent import study_file
 
 # Tools for working with the filesystem
 
@@ -73,20 +74,26 @@ def list_files(root: str) -> list[str]:
 
 
 @tool
-def file_contents(path: str) -> str:
-    """Returns the contents of the file at `path`.
+def file_contents(path: str, task: str = "", request: str = "") -> str:
+    """Return the contents or a summary of ``path``.
+
+    When the file is small enough to fit within the model's context window the
+    full contents are returned.  For larger files a dedicated study agent reads
+    the file in chunks and summarizes it using ``task`` and ``request`` as
+    guidance so the result can be used to complete the user's objective.
 
     Args:
-        path (str): The path to the desired file.
+        path: The path to the desired file.
+        task: Description of the current execution step.
+        request: Original user request or broader context.
 
     Returns:
-        str: The content of the specified file as a string.
+        str: The file's content or a summary suitable for the task.
     """
     p = Path(path)
     if in_server_project(p):
         return "Access to server project files is not allowed"
-    with open(p, 'r') as f:
-        return f.read()
+    return study_file(p, task=task, request=request)
 
 
 @tool

--- a/tests/test_study_file_tool.py
+++ b/tests/test_study_file_tool.py
@@ -1,0 +1,42 @@
+from unittest.mock import patch
+
+from assist.tools import filesystem
+from langchain_core.messages import AIMessage
+
+
+class DummyLLM:
+    def __init__(self, responses):
+        self._responses = responses
+        self.calls = 0
+
+    def invoke(self, messages, *args, **kwargs):  # pragma: no cover - trivial
+        resp = self._responses[self.calls]
+        self.calls += 1
+        return AIMessage(content=resp)
+
+
+def test_short_file_returns_content(tmp_path):
+    file = tmp_path / "short.txt"
+    file.write_text("hello")
+
+    dummy = DummyLLM([])
+    with patch("assist.study_agent.select_chat_model", return_value=dummy), \
+         patch("assist.study_agent.get_context_limit", return_value=1000):
+        out = filesystem.file_contents.invoke({"path": str(file)})
+
+    assert out == "hello"
+    assert dummy.calls == 0
+
+
+def test_long_file_uses_study_agent(tmp_path):
+    file = tmp_path / "long.txt"
+    file.write_text("a" * 50)
+
+    dummy = DummyLLM(["s1", "s2", "s3", "s4"])
+    with patch("assist.study_agent.select_chat_model", return_value=dummy), \
+         patch("assist.study_agent.get_context_limit", return_value=20):
+        out = filesystem.file_contents.invoke({"path": str(file), "task": "t", "request": "r"})
+
+    assert out == "s4"
+    assert dummy.calls == 4
+


### PR DESCRIPTION
## Summary
- use a study agent when reading very large files
- summarize file chunks based on context window limits
- add tests for short and long file reads

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c57d917570832b9186f3a4bfab7b61