### PR TITLE
feat: add shared ignore spec for indexing tools

### DIFF
--- a/src/assist/tools/filesystem.py
+++ b/src/assist/tools/filesystem.py
@@ -3,10 +3,10 @@ import os
 import tempfile
 from datetime import datetime
 from pathlib import Path
-from pathspec import PathSpec
-
 from assist import git
 from assist.tools.safeguard import in_server_project, ensure_outside_server
+from .ignore import load_ignore_spec
+
 
 # Tools for working with the filesystem
 
@@ -15,12 +15,11 @@ from assist.tools.safeguard import in_server_project, ensure_outside_server
 def list_files(root: str) -> list[str]:
     """Recursively list files under ``root`` with creation and modification times.
 
-    Files matching patterns from a ``.gitignore`` file in ``root`` are skipped.
-    The results are sorted by last modified date in descending order and each
-    entry includes the absolute path, creation date, and last modified date.
-    Only the 200 most recently modified files are returned. If more than 200
-    files are found, the final entry will be the string ``"Limit of 200 files"
-    ``"reached"`` to indicate truncation.
+    Results are sorted by last modified date in descending order and each entry
+    includes the absolute path, creation date, and last modified date. Only the
+    200 most recently modified files are returned. If more than 200 files are
+    found, the final entry will be the string ``"Limit of 200 files"`` ``"reached"``
+    to indicate truncation.
 
     Args:
         root: Directory to search.
@@ -31,13 +30,7 @@ def list_files(root: str) -> list[str]:
     root_path = Path(root)
     if in_server_project(root_path):
         return ["Access to server project files is not allowed"]
-    ignore_spec: PathSpec | None = None
-    gitignore = root_path / ".gitignore"
-    if gitignore.exists():
-        try:
-            ignore_spec = PathSpec.from_lines("gitwildmatch", gitignore.read_text().splitlines())
-        except OSError:
-            ignore_spec = None
+    ignore_spec = load_ignore_spec(root_path)
 
     files: list[tuple[str, float, float]] = []
     for dirpath, dirnames, filenames in os.walk(root_path):
@@ -45,15 +38,14 @@ def list_files(root: str) -> list[str]:
         if str(rel_dir) == ".":
             rel_dir = Path()
 
-        if ignore_spec:
-            dirnames[:] = [
-                d for d in dirnames
-                if not ignore_spec.match_file((rel_dir / d).as_posix())
-            ]
+        dirnames[:] = [
+            d for d in dirnames
+            if not ignore_spec.match_file((rel_dir / d).as_posix())
+        ]
 
         for name in filenames:
             rel_file = (rel_dir / name).as_posix()
-            if ignore_spec and ignore_spec.match_file(rel_file):
+            if ignore_spec.match_file(rel_file):
                 continue
             path = Path(dirpath) / name
             try:
@@ -108,9 +100,20 @@ def project_context(root: str) -> str:
     root_path = Path(root)
     if in_server_project(root_path):
         return "Access to server project files is not allowed"
+    ignore_spec = load_ignore_spec(root_path)
     paths: list[Path] = []
-    for dirpath, _dirnames, filenames in os.walk(root_path):
+    for dirpath, dirnames, filenames in os.walk(root_path):
+        rel_dir = Path(os.path.relpath(dirpath, root_path))
+        if str(rel_dir) == ".":
+            rel_dir = Path()
+        dirnames[:] = [
+            d for d in dirnames
+            if not ignore_spec.match_file((rel_dir / d).as_posix())
+        ]
         for name in filenames:
+            rel_file = (rel_dir / name).as_posix()
+            if ignore_spec.match_file(rel_file):
+                continue
             upper = name.upper()
             if upper.startswith("README") or upper.startswith("AGENTS"):
                 paths.append(Path(dirpath) / name)

--- a/src/assist/tools/ignore.py
+++ b/src/assist/tools/ignore.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+from pathspec import PathSpec
+
+# Default ignore patterns for files and directories.
+DEFAULT_IGNORE_PATTERNS = [
+    "**/.*",  # all dotfiles and directories
+    "**/__pycache__/",
+    "**/*.py[cod]",
+    "**/.mypy_cache/",
+    "**/.pytest_cache/",
+    "**/*.egg-info/",
+    "**/build/",
+    "**/dist/",
+    "**/node_modules/",
+    "**/.venv/",
+    "**/venv/",
+    "**/.DS_Store",
+    "**/Thumbs.db",
+]
+
+
+def load_ignore_spec(root: Path) -> PathSpec:
+    """Return a PathSpec ignoring ``.gitignore`` entries and default patterns."""
+    patterns: list[str] = []
+    gitignore = root / ".gitignore"
+    if gitignore.exists():
+        try:
+            patterns.extend(gitignore.read_text().splitlines())
+        except OSError:
+            pass
+    patterns.extend(DEFAULT_IGNORE_PATTERNS)
+    return PathSpec.from_lines("gitwildmatch", patterns)
+
+
+def apply_vgrep_ignore() -> None:
+    """Apply default ignore patterns to ``vgrep``'s filesystem walker."""
+    import vgrep.fs
+
+    vgrep.fs.DEFAULT_IGNORE_PATTERNS = list(DEFAULT_IGNORE_PATTERNS)

--- a/src/assist/tools/project_index.py
+++ b/src/assist/tools/project_index.py
@@ -11,8 +11,9 @@ import numpy as np
 from langchain_core.documents import Document
 from langchain_core.tools import BaseTool, tool
 from vgrep.manager import Manager
+from .ignore import apply_vgrep_ignore
 
-from pathlib import Path
+apply_vgrep_ignore()
 
 def is_filesystem_root(path_str: str | Path) -> bool:
     """

--- a/tests/test_list_files.py
+++ b/tests/test_list_files.py
@@ -20,6 +20,22 @@ def test_list_files_respects_gitignore(tmp_path):
     assert str(secret) not in result
 
 
+def test_list_files_uses_default_ignore(tmp_path):
+    visible = tmp_path / "visible.txt"
+    visible.write_text("visible")
+    hidden = tmp_path / ".hidden.txt"
+    hidden.write_text("hidden")
+    pycache = tmp_path / "__pycache__"
+    pycache.mkdir()
+    cache_file = pycache / "cache.pyc"
+    cache_file.write_text("cache")
+
+    result = "\n".join(list_files(str(tmp_path)))
+    assert str(visible) in result
+    assert str(hidden) not in result
+    assert str(cache_file) not in result
+
+
 def test_list_files_limit(tmp_path):
     for i in range(205):
         f = tmp_path / f"file_{i}.txt"

--- a/tests/test_project_context.py
+++ b/tests/test_project_context.py
@@ -13,3 +13,24 @@ def test_project_context(tmp_path):
 
     assert "hello readme" in result
     assert "agent info" in result
+
+
+def test_project_context_respects_ignore(tmp_path):
+    readme = tmp_path / "README.md"
+    readme.write_text("root readme")
+    hidden = tmp_path / ".secret"
+    hidden.mkdir()
+    hidden_readme = hidden / "README"
+    hidden_readme.write_text("hidden")
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    ignored_agents = docs / "AGENTS.md"
+    ignored_agents.write_text("ignored")
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text("docs/\n")
+
+    result = project_context(str(tmp_path))
+
+    assert "root readme" in result
+    assert "hidden" not in result
+    assert "ignored" not in result

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -12,6 +12,7 @@ def _create_info_root(tmp_path):
     (info_root / "beta.info").write_text(
         "Beta file documenting apples."
     )
+    (info_root / ".hidden.info").write_text("secret")
 
     # Directory listing used by ``list_tool``
     dir_content = (
@@ -38,3 +39,11 @@ def test_system_info_search(tmp_path):
     search_tool = idx.search_tool()
     result = search_tool.invoke("bananas")
     assert "bananas" in result
+
+
+def test_system_info_ignores_hidden(tmp_path):
+    info_root = _create_info_root(tmp_path)
+    idx = SystemInfoIndex(info_root)
+    search_tool = idx.search_tool()
+    result = search_tool.invoke("secret")
+    assert "secret" not in result


### PR DESCRIPTION
## Summary
- centralize default ignore patterns and PathSpec utilities
- apply shared ignore rules to filesystem, project index, and system info tools
- test indexing to ensure hidden and gitignored files are skipped

## Testing
- `PYTHONPATH=src pytest tests/test_list_files.py tests/test_project_context.py tests/test_project_index.py tests/test_system_info.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5a00d7e64832bb87901fbd1b4dee4