### PR TITLE
refactor: rename tools and expand metadata

### DIFF
--- a/src/assist/tools/base.py
+++ b/src/assist/tools/base.py
@@ -5,8 +5,8 @@ from assist.tools import filesystem, project_index
 from assist.tools.system_info import SystemInfoIndex
 from assist.tools.unit_conversion import UnitConversionTool
 from assist.tools.timer import TimerTool
-from assist.tools.web_search import site_search, page_search
-from assist.tools.date_utils import current_date, date_offset, date_diff
+from assist.tools.web_search import search_site, search_page
+from assist.tools.date_utils import get_current_date, offset_date, diff_dates
 from assist.tools.safe_python import SafePythonTool
 from pathlib import Path
 
@@ -26,9 +26,9 @@ def base_tools(index_path: Path) -> List[BaseTool]:
         UnitConversionTool(),
         TimerTool(),
         SafePythonTool(),
-        site_search,
-        page_search,
-        current_date,
-        date_offset,
-        date_diff,
+        search_site,
+        search_page,
+        get_current_date,
+        offset_date,
+        diff_dates,
     ]

--- a/src/assist/tools/base.py
+++ b/src/assist/tools/base.py
@@ -1,11 +1,10 @@
 from typing import List
 from langchain_core.tools import BaseTool
-from langchain_tavily import TavilySearch
 from assist.tools import filesystem, project_index
 from assist.tools.system_info import SystemInfoIndex
 from assist.tools.unit_conversion import UnitConversionTool
 from assist.tools.timer import TimerTool
-from assist.tools.web_search import search_site, search_page
+from assist.tools.web_search import SearchWeb, search_site, search_page
 from assist.tools.date_utils import get_current_date, offset_date, diff_dates
 from assist.tools.safe_python import SafePythonTool
 from pathlib import Path
@@ -14,7 +13,7 @@ from pathlib import Path
 def base_tools(index_path: Path) -> List[BaseTool]:
     sys_index = SystemInfoIndex(base_dir=index_path)
     return [
-        TavilySearch(max_results=10),
+        SearchWeb(max_results=10),
         project_index.ProjectIndex(base_dir=index_path).search_tool(),
         #sys_index.search_tool(),
         #sys_index.list_tool(),

--- a/src/assist/tools/date_utils.py
+++ b/src/assist/tools/date_utils.py
@@ -7,7 +7,7 @@ from langchain_core.tools import tool
 
 @tool
 def get_current_date() -> dict:
-    """one_line: Returns today's date in ISO format (YYYY-MM-DD).
+    """Returns today's date in ISO format (YYYY-MM-DD).
 
     when_to_use:
     - Need the current date for logging or scheduling.
@@ -31,8 +31,6 @@ def get_current_date() -> dict:
     examples:
     - input: {}
       output: {"date": "2025-09-01", "brief_summary": "2025-09-01"}
-    version: "1.0"
-    owner: "assist"
     """
     today = date.today().isoformat()
     return {"date": today, "brief_summary": today}
@@ -40,7 +38,7 @@ def get_current_date() -> dict:
 
 @tool
 def offset_date(base_date: str, days: int = 0, weeks: int = 0, months: int = 0) -> dict:
-    """one_line: Returns the ISO date offset from ``base_date`` by the given days, weeks, or months.
+    """Returns the ISO date offset from ``base_date`` by the given days, weeks, or months.
 
     when_to_use:
     - Calculate a deadline or reminder date.
@@ -70,8 +68,6 @@ def offset_date(base_date: str, days: int = 0, weeks: int = 0, months: int = 0) 
     examples:
     - input: {"base_date": "2025-09-01", "days": 7}
       output: {"date": "2025-09-08", "brief_summary": "2025-09-08"}
-    version: "1.0"
-    owner: "assist"
     """
     dt = datetime.fromisoformat(base_date).date()
     dt = dt + relativedelta(days=days, weeks=weeks, months=months)
@@ -86,7 +82,7 @@ def diff_dates(
     unit: str = "days",
     mode: str = "all",
 ) -> dict:
-    """one_line: Returns the difference between two dates in the specified unit.
+    """Returns the difference between two dates in the specified unit.
 
     when_to_use:
     - Measure duration between two dates.
@@ -117,8 +113,6 @@ def diff_dates(
     examples:
     - input: {"start_date": "2025-09-01", "end_date": "2025-09-10"}
       output: {"difference": 9, "brief_summary": "9 days"}
-    version: "1.0"
-    owner: "assist"
     """
     start = datetime.fromisoformat(start_date).date()
     end = datetime.fromisoformat(end_date).date()

--- a/src/assist/tools/web_search.py
+++ b/src/assist/tools/web_search.py
@@ -10,7 +10,7 @@ from langchain_tavily import TavilySearch
 
 
 class SearchWeb(TavilySearch):
-    """one_line: Searches the public web; returns up to `max_results` entries with title, url and content.
+    """Searches the public web; returns up to `max_results` entries with title, url and content.
 
     when_to_use:
     - Need information from across the web.
@@ -63,7 +63,7 @@ class SearchWeb(TavilySearch):
 
 @tool
 def search_site(domain: str, query: str) -> dict:
-    """one_line: Searches a domain for pages matching a query; returns up to five "title - URL" results.
+    """Searches a domain for pages matching a query; returns up to five "title - URL" results.
 
     when_to_use:
     - Need web pages from a specific site.
@@ -96,8 +96,6 @@ def search_site(domain: str, query: str) -> dict:
     - input: {"domain": "wikipedia.org", "query": "AI"}
       output: {"results": ["Artificial intelligence - https://wikipedia.org/..."],
                "brief_summary": "5 results"}
-    version: "1.0"
-    owner: "assist"
     """
     params = {"q": f"site:{domain} {query}"}
     resp = requests.get("https://duckduckgo.com/html/", params=params, timeout=10)
@@ -115,7 +113,7 @@ def search_site(domain: str, query: str) -> dict:
 
 @tool
 def search_page(url: str, query: str) -> dict:
-    """one_line: Finds up to five snippets from a page containing a query string.
+    """Finds up to five snippets from a page containing a query string.
 
     when_to_use:
     - Extract context from a single known URL.
@@ -146,8 +144,6 @@ def search_page(url: str, query: str) -> dict:
       output: {"snippets": ["Call us ..."], "brief_summary": "1 match"}
     - input: {"url": "https://example.com", "query": "foo"}
       output: {"snippets": ["No matches"], "brief_summary": "0 matches"}
-    version: "1.0"
-    owner: "assist"
     """
     resp = requests.get(url, timeout=10)
     text = re.sub(r"<[^>]+>", " ", resp.text)

--- a/src/assist/tools/web_search.py
+++ b/src/assist/tools/web_search.py
@@ -9,10 +9,42 @@ from langchain_core.tools import tool
 
 
 @tool
-def site_search(domain: str, query: str) -> List[str]:
-    """Search within ``domain`` for pages matching ``query``.
+def search_site(domain: str, query: str) -> dict:
+    """one_line: Searches a domain for pages matching a query; returns up to five "title - URL" results.
 
-    Uses DuckDuckGo to retrieve up to 5 result URLs and titles.
+    when_to_use:
+    - Need web pages from a specific site.
+    - Verify information hosted on a known domain.
+    - Restrict search scope for precision.
+    when_not_to_use:
+    - Require results across many domains.
+    - Domain is unknown or inaccessible.
+    - Operating without internet access.
+    args_schema:
+    - domain (str): Target domain, e.g. "example.com".
+    - query (str): Search terms, e.g. "privacy policy".
+    preconditions_permissions:
+    - Domain must be publicly reachable.
+    side_effects:
+    - Sends HTTP requests; idempotent: true; retry_safe: true.
+    cost_latency: "~200-1000ms; free"
+    pagination_cursors:
+    - input_cursor: none
+    - next_cursor: none
+    errors:
+    - network_error: Request failed; check connectivity and retry.
+    returns:
+    - results (list[str]): "Title - URL" entries.
+    - brief_summary (str): Short result count summary.
+    examples:
+    - input: {"domain": "example.com", "query": "about"}
+      output: {"results": ["About Us - https://example.com/about"],
+               "brief_summary": "1 result"}
+    - input: {"domain": "wikipedia.org", "query": "AI"}
+      output: {"results": ["Artificial intelligence - https://wikipedia.org/..."],
+               "brief_summary": "5 results"}
+    version: "1.0"
+    owner: "assist"
     """
     params = {"q": f"site:{domain} {query}"}
     resp = requests.get("https://duckduckgo.com/html/", params=params, timeout=10)
@@ -24,14 +56,45 @@ def site_search(domain: str, query: str) -> List[str]:
         results.append(f"{title} - {url}")
         if len(results) >= 5:
             break
-    return results
+    summary = f"{len(results)} result" if len(results) == 1 else f"{len(results)} results"
+    return {"results": results, "brief_summary": summary}
 
 
 @tool
-def page_search(url: str, query: str) -> List[str]:
-    """Return snippets from ``url`` containing ``query``.
+def search_page(url: str, query: str) -> dict:
+    """one_line: Finds up to five snippets from a page containing a query string.
 
-    Fetches the page and returns up to 5 text snippets around each match.
+    when_to_use:
+    - Extract context from a single known URL.
+    - Verify that a page mentions specific terms.
+    - Retrieve short quotes from a document.
+    when_not_to_use:
+    - Need to search across multiple pages or domains.
+    - URL content is inaccessible.
+    - No internet access is available.
+    args_schema:
+    - url (str): Web page URL, e.g. "https://example.com".
+    - query (str): Text to locate, e.g. "license".
+    preconditions_permissions:
+    - URL must be publicly reachable.
+    side_effects:
+    - Sends HTTP requests; idempotent: true; retry_safe: true.
+    cost_latency: "~200-1000ms; free"
+    pagination_cursors:
+    - input_cursor: none
+    - next_cursor: none
+    errors:
+    - network_error: Request failed; check connectivity and retry.
+    returns:
+    - snippets (list[str]): Text around each match or ["No matches"].
+    - brief_summary (str): Short result count summary.
+    examples:
+    - input: {"url": "https://example.com", "query": "contact"}
+      output: {"snippets": ["Call us ..."], "brief_summary": "1 match"}
+    - input: {"url": "https://example.com", "query": "foo"}
+      output: {"snippets": ["No matches"], "brief_summary": "0 matches"}
+    version: "1.0"
+    owner: "assist"
     """
     resp = requests.get(url, timeout=10)
     text = re.sub(r"<[^>]+>", " ", resp.text)
@@ -44,7 +107,10 @@ def page_search(url: str, query: str) -> List[str]:
         snippets.append(snippet.strip())
         if len(snippets) >= 5:
             break
-    return snippets if snippets else ["No matches"]
+    summary = f"{len(snippets)} match" if len(snippets) == 1 else f"{len(snippets)} matches"
+    if not snippets:
+        snippets = ["No matches"]
+    return {"snippets": snippets, "brief_summary": summary}
 
 
-__all__ = ["site_search", "page_search"]
+__all__ = ["search_site", "search_page"]

--- a/tests/integration/validation/test_planner_node.py
+++ b/tests/integration/validation/test_planner_node.py
@@ -43,13 +43,13 @@ class TestPlannerNode(TestCase):
     def test_search_website(self) -> None:
         state = self.ask_node("I remember seeing something about college campuses with the best food on this website: https://www.mentalfloss.com. What's the URL for that article?")
 
-        self.assertInPlan("site_search", state)
+        self.assertInPlan("search_site", state)
 
 
     def test_search_webpage(self) -> None:
         state = self.ask_node("Which campus has the best food according to this website: https://www.mentalfloss.com/food/best-and-worst-college-campus-food?utm_source=firefox-newtab-en-us ?")
 
-        self.assertInPlan("page_search", state)
+        self.assertInPlan("search_page", state)
 
 
     def test_project_context_without_project(self):

--- a/tests/integration/validation/test_search_web.py
+++ b/tests/integration/validation/test_search_web.py
@@ -1,0 +1,13 @@
+from assist.tools.web_search import SearchWeb
+from langchain_tavily import TavilySearch
+
+
+def test_search_web_accepts_config(monkeypatch):
+    def fake_run(self, query, **kwargs):
+        return {"results": [{"title": "t", "url": "u", "content": "c"}]}
+
+    monkeypatch.setattr(TavilySearch, "_run", fake_run)
+
+    tool = SearchWeb(max_results=1)
+    result = tool.invoke("test", config={})
+    assert result["brief_summary"] == "1 result"


### PR DESCRIPTION
## Summary
- rename web search functions to verb-first names and return structured summaries
- add detailed usage metadata for date utility tools
- adjust base tool registry and tests for new tool names

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5e2aa7c2c832b89aa62d922a9ed89