### PR TITLE
feat: restrict file reading to absolute paths

### DIFF
--- a/playground/reflexion.py
+++ b/playground/reflexion.py
@@ -13,7 +13,7 @@ pi = project_index.ProjectIndex()
 proj_tool = pi.search_tool()
 search = TavilySearchResults(max_results=10)
 agent = build_reflexion_graph(llm,
-                              [filesystem.file_contents,
+                              [filesystem.read_file,
                                filesystem.list_files,
                                proj_tool,
                                search])

--- a/proposals/2025-09-06-new-tools.org
+++ b/proposals/2025-09-06-new-tools.org
@@ -4,7 +4,7 @@
 3. system_info_search - Search system ``info`` files for technical information about a query.
 4. list_system_info_files - List available ``info`` files with short descriptions.
 5. list_files - Recursively list files under a directory with creation and modification times.
-6. file_contents - Return the contents of a specified file path.
+6. read_file - Return the contents of a specified file path.
 7. project_context - Collect the contents of README and AGENTS files for quick project onboarding.
 
 * Problem

--- a/src/assist/tools/base.py
+++ b/src/assist/tools/base.py
@@ -20,7 +20,7 @@ def base_tools(index_path: Path) -> List[BaseTool]:
         filesystem.write_file_user,
         filesystem.write_file_tmp,
         filesystem.list_files,
-        filesystem.file_contents,
+        filesystem.read_file,
         filesystem.project_context,
         UnitConversionTool(),
         TimerTool(),

--- a/tests/test_general_agent.py
+++ b/tests/test_general_agent.py
@@ -25,7 +25,7 @@ class TestGeneralAgent(TestCase):
             [
                 ToolMessage(content="listing", tool_call_id="1"),
                 ToolMessage(content="file contents", tool_call_id="2"),
-                AIMessage(content="The show_file_contents tool reads files")
+                AIMessage(content="The read_file tool reads files")
             ],
         ]
         cls.agent = make_test_agent(responses)
@@ -41,7 +41,7 @@ class TestGeneralAgent(TestCase):
         self.assertEqual(len(tool_messages(resp_messages)), 1)
         self.assertTrue(current_file in resp_messages[-1].content)
 
-    def test_fs_tools_show_file_contents(self):
+    def test_fs_tools_read_file(self):
         current_dir = os.getcwd()
         current_file = os.path.basename(__file__)
 
@@ -51,7 +51,7 @@ class TestGeneralAgent(TestCase):
         resp_messages = resp['messages']
 
         self.assertEqual(len(tool_messages(resp_messages)), 2)
-        self.assertTrue("show_file_contents" in resp_messages[-1].content)
+        self.assertTrue("read_file" in resp_messages[-1].content)
 
 
 def test_guard_tool_truncates_output():

--- a/tests/test_study_file_tool.py
+++ b/tests/test_study_file_tool.py
@@ -22,7 +22,7 @@ def test_short_file_returns_content(tmp_path):
     dummy = DummyLLM([])
     with patch("assist.study_agent.select_chat_model", return_value=dummy), \
          patch("assist.study_agent.get_context_limit", return_value=1000):
-        out = filesystem.file_contents.invoke({"path": str(file)})
+        out = filesystem.read_file.invoke({"absolute_path": str(file)})
 
     assert out == "hello"
     assert dummy.calls == 0
@@ -35,8 +35,20 @@ def test_long_file_uses_study_agent(tmp_path):
     dummy = DummyLLM(["s1", "s2", "s3", "s4"])
     with patch("assist.study_agent.select_chat_model", return_value=dummy), \
          patch("assist.study_agent.get_context_limit", return_value=20):
-        out = filesystem.file_contents.invoke({"path": str(file), "task": "t", "request": "r"})
+        out = filesystem.read_file.invoke({"absolute_path": str(file), "task": "t", "request": "r"})
 
     assert out == "s4"
     assert dummy.calls == 4
+
+
+def test_relative_path_raises(tmp_path):
+    file = tmp_path / "rel.txt"
+    file.write_text("hi")
+    rel = file.relative_to(tmp_path)
+    try:
+        filesystem.read_file.invoke({"absolute_path": str(rel)})
+    except ValueError as e:
+        assert "absolute" in str(e)
+    else:  # pragma: no cover - ensure exception
+        assert False, "Expected ValueError for relative path"
 


### PR DESCRIPTION
## Summary
- rename `file_contents` to `read_file` and require absolute paths
- surface `read_file` in base tools
- add tests ensuring relative paths raise errors and update existing references

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5f55a7db0832b81ade4f50ca5b541