### PR TITLE
Handle non-dict plan outputs in console callback

### DIFF
--- a/src/assist/debug_callback.py
+++ b/src/assist/debug_callback.py
@@ -137,11 +137,13 @@ class ReadableConsoleCallbackHandler(BaseCallbackHandler):
         tags = kwargs.get("tags") or []
         node = tags[0] if tags else ""
         if node == "plan":
-            plan = outputs.get("plan", outputs)
-            if hasattr(plan, "model_dump"):
-                plan = plan.model_dump()
+            plan_obj: Any = outputs
+            if isinstance(outputs, dict):
+                plan_obj = outputs.get("plan", outputs)
+            if hasattr(plan_obj, "model_dump"):
+                plan_obj = plan_obj.model_dump()
             print("Plan:")
-            print(self._pretty(plan))
+            print(self._pretty(plan_obj))
         elif node == "execute":
             history = outputs.get("history", [])
             resolution: Any = ""

--- a/tests/test_debug_callback.py
+++ b/tests/test_debug_callback.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from uuid import uuid4
 
 from langchain_core.outputs import LLMResult, Generation
+from assist.reflexion_agent import Plan, Step
 
 SPEC = importlib.util.spec_from_file_location(
     "debug_callback", Path(__file__).resolve().parents[1] / "src" / "assist" / "debug_callback.py"
@@ -41,3 +42,11 @@ def test_plan_and_execute_and_tool(capsys):
     assert json.dumps(plan, indent=2) in out
     assert "tool-a" in out and '"x": 1' in out and '"result": 2' in out
     assert "Final Response:" in out and "done" in out
+
+
+def test_plan_object_handled(capsys):
+    handler = ReadableConsoleCallbackHandler()
+    plan = Plan(goal="g", steps=[Step(action="a", objective="b")], assumptions=[], risks=[])
+    handler.on_chain_end(plan, run_id=uuid4(), tags=["plan"])
+    out = capsys.readouterr().out
+    assert "Plan:" in out and "g" in out


### PR DESCRIPTION
## Summary
- fix ReadableConsoleCallbackHandler to support Plan objects returned from plan node
- test callback with Plan pydantic model

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5f714c750832b88de94f7593270b9