### PR TITLE
Add validation tests for reflexion completion

### DIFF
--- a/tests/integration/validation/test_reflexion_completion.py
+++ b/tests/integration/validation/test_reflexion_completion.py
@@ -1,0 +1,248 @@
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from langchain_core.messages import HumanMessage
+
+from assist.reflexion_agent import build_reflexion_graph
+
+from .utils import actual_llm, base_tools_for_test
+
+
+def _setup_project_dir() -> str:
+    """Create a temporary git repository populated with example files."""
+
+    tmpdir = tempfile.mkdtemp()
+    root = Path(tmpdir)
+
+    (root / ".gitignore").write_text("hobbies.org\n")
+    (root / "health.org").write_text(
+        "General health information about diet and exercise. I am vegan.\n"
+    )
+    (root / "inbox.org").write_text(
+        """* TODO Buy groceries
+* TODO Call mom
+* TODO Write report
+* TODO Clean house
+* TODO Study Spanish
+"""
+    )
+    (root / "finance.org").write_text("Tracking finances. I own a home.\n")
+    secrets = "\n".join([f"Fact {i}" for i in range(1, 11)]) + "\n"
+    (root / ".secrets").write_text(secrets)
+    (root / "hobbies.org").write_text("Running, painting and chess.\n")
+    (root / "goals.org").write_text("1. Promote peace.\n2. End hunger.\n")
+
+    subprocess.run(["git", "init"], cwd=tmpdir, check=True, stdout=subprocess.PIPE)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmpdir,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmpdir,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    subprocess.run(
+        [
+            "git",
+            "add",
+            "health.org",
+            "inbox.org",
+            "finance.org",
+            ".secrets",
+            "goals.org",
+            ".gitignore",
+        ],
+        cwd=tmpdir,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=tmpdir,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+
+    return tmpdir
+
+
+class TestReflexionCompletion(TestCase):
+    def setUp(self) -> None:
+        os.environ["ASSIST_SERVER_PROJECT_ROOT"] = ""
+        self.llm = actual_llm()
+        self.graph = build_reflexion_graph(self.llm, base_tools_for_test())
+        self.validation_llm = actual_llm()
+
+    def _assert_completion(self, query: str) -> None:
+        project_dir = _setup_project_dir()
+        full_query = (
+            f"{query}\nThis is the project directory within the context of this request: {project_dir}"
+        )
+        state = self.graph.invoke({"messages": [HumanMessage(content=full_query)]})
+        response = state["messages"][-1].content
+
+        validation_query = (
+            f"Is the following a question: {response}\n\nONLY response with \"True\" or \"False\""
+        )
+        verdict = (
+            self.validation_llm.invoke([HumanMessage(content=validation_query)])
+            .content.strip()
+            .lower()
+        )
+        self.assertEqual(verdict, "false")
+
+    def test_dont_write_file(self) -> None:
+        self._assert_completion("What is the capital of France?")
+
+    def test_should_write_file(self) -> None:
+        self._assert_completion(
+            "Write me a python script to use in my project at /home/pierre/myproject"
+        )
+
+    def test_search_website(self) -> None:
+        self._assert_completion(
+            "I remember seeing something about college campuses with the best food on this website: https://www.mentalfloss.com. What's the URL for that article?"
+        )
+
+    def test_search_webpage(self) -> None:
+        self._assert_completion(
+            "Which campus has the best food according to this website: https://www.mentalfloss.com/food/best-and-worst-college-campus-food?utm_source=firefox-newtab-en-us ?"
+        )
+
+    def test_project_context_without_project(self) -> None:
+        self._assert_completion(
+            "Hello, can you explain to me what's in the README file?"
+        )
+
+    def test_project_context_with_project(self) -> None:
+        self._assert_completion(
+            "Hello, can you explain to me what's in the README file?\n\nThe context for this request is /home/myhome/project"
+        )
+
+    def test_tea_brew(self) -> None:
+        self._assert_completion("How do I brew a cup of tea?")
+
+    def test_rewrite_more_professional(self) -> None:
+        query = "Rewrite this to be more professional."
+        examples = [
+            "hey—need that report asap. thx.",
+            "We kinda dropped the ball on the Q3 metrics.",
+        ]
+        for example in examples:
+            self._assert_completion(f"{query} {example}")
+
+    def test_rephrase_for_ninth_grade(self) -> None:
+        query = "Rephrase for a 9th-grade reading level."
+        examples = [
+            "The municipality’s fiscal posture necessitates austerity measures.",
+            "Our platform leverages distributed systems to optimize throughput.",
+        ]
+        for example in examples:
+            self._assert_completion(f"{query} {example}")
+
+    def test_extract_entities_to_json(self) -> None:
+        query = (
+            "Extract all dates, people, and organizations from this text into JSON and consult external references for JSON schema or entity recognition guidelines."
+        )
+        examples = [
+            "On March 2, 2024, Mayor London Breed met with leaders from SFUSD.",
+            "Apple hired Sam Patel on 2023-11-14 after interviews at UCSF.",
+        ]
+        for example in examples:
+            self._assert_completion(f"{query} {example}")
+
+    def test_classify_customer_messages(self) -> None:
+        query = "Classify these customer messages into issue categories; return CSV."
+        examples = [
+            "App crashes when I upload a photo.",
+            "How do I reset my password?",
+            "Please cancel my subscription.",
+            "Charged twice for August.",
+            "Search results are super slow.",
+            "Two-factor code never arrives.",
+            "Dark mode text is unreadable.",
+        ]
+        for example in examples:
+            self._assert_completion(f"{query} {example}")
+
+    def test_refactor_function_readability(self) -> None:
+        query = (
+            "Refactor this function for readability and add docstrings and type hints."
+        )
+        examples = [
+            """def f(a,b):
+    r=[]
+    for i in a:
+        if i not in r: r.append(i)
+    for j in b:
+        if j not in r: r.append(j)
+    return r""",
+            """def calc(x):
+    t=0
+    for i in range(len(x)):
+        t=t+x[i]
+    return t/len(x)""",
+        ]
+        for example in examples:
+            self._assert_completion(f"{query}\n{example}")
+
+    def test_build_python_cli(self) -> None:
+        query = (
+            "Implement a small Python CLI with argparse that performs tasks X and Y."
+        )
+        examples = [
+            "X = convert a .txt file to uppercase, Y = count words and print top-5 by frequency.",
+            "X = merge two CSVs by 'id', Y = filter rows where 'amount' > 100 and save.",
+        ]
+        for example in examples:
+            self._assert_completion(f"{query} {example}")
+
+    def test_research_watches(self) -> None:
+        query = "Research the best minimalist mechanical watches under $3k; compare and cite."
+        examples = [
+            "Field watches under $1.5k, 38–40 mm, sapphire, no date.",
+            "Dress watches under $2.5k, <10 mm thick, Bauhaus aesthetics.",
+        ]
+        for example in examples:
+            self._assert_completion(f"{query} {example}")
+
+    def test_day_trip_plan(self) -> None:
+        query = (
+            "Create a day-trip plan using rideshare only; estimate times/costs; output a tweakable sheet."
+        )
+        examples = [
+            "Sonoma plaza stroll + one tasting + lunch, 4 adults, Saturday 9/20.",
+            "Half Moon Bay coastal walk + café lunch, 2 adults, Sunday 10/5.",
+        ]
+        for example in examples:
+            self._assert_completion(f"{query} {example}")
+
+    def test_file_expense_report(self) -> None:
+        query = (
+            "File an expense report from provided PDFs: extract line items, code them, total, attach, submit, and reference IRS guidelines for expense categories."
+        )
+        examples = [
+            "Receipts = 'Lyft $28.34 (08/12), Coffee $6.50 (08/12), Lunch w/ client $54.20 (08/12).',",
+            "Receipts = 'SFO⇄LAX airfare $216.90 (08/25), Hotel 1 night $189.00 (08/25), Per-diem dinner $35.00.',",
+        ]
+        for example in examples:
+            self._assert_completion(f"{query} {example}")
+
+    def test_run_llm_benchmark(self) -> None:
+        query = (
+            "Run a benchmark comparing three LLMs on a supplied prompt suite; chart quality/latency; memo."
+        )
+        examples = [
+            "Coding suite with tasks like writing a JSON Schema and fixing a failing pytest.",
+            "Reasoning suite with summarization, extraction, and classification prompts.",
+        ]
+        for example in examples:
+            self._assert_completion(f"{query} {example}")
+


### PR DESCRIPTION
## Summary
- add integration tests ensuring reflexion agent completions are not questions via LLM-based validation
- set up temporary git repositories with sample files for each test scenario

## Testing
- `pytest tests/integration/validation/test_reflexion_completion.py::TestReflexionCompletion::test_dont_write_file -q`
- `pytest tests/integration/validation/test_reflexion_completion.py -q` *(fails: test_build_python_cli error)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cb20e4b4832bb6cfd2f6757ef5e3