### PR TITLE
Render reflexion agent graph during CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -e .
+      - name: Render reflexion graph
+        run: |
+          python scripts/render_reflexion_graph.py --output-dir generated/reflexion_graph
+          git diff --exit-code generated/reflexion_graph
       - name: Static type analysis
         run: mypy src | tee mypy-report.txt
         continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 **/#*#
 .ob-jupyter
 keys
+src/assist.egg-info/
+.coverage
+coverage.xml

--- a/generated/reflexion_graph/reflexion_graph.mmd
+++ b/generated/reflexion_graph/reflexion_graph.mmd
@@ -1,0 +1,27 @@
+---
+config:
+  flowchart:
+    curve: linear
+---
+graph TD;
+	__start__([<p>__start__</p>]):::first
+	plan(plan)
+	execute(execute)
+	plan_check(plan_check)
+	summarize(summarize)
+	recursion(recursion)
+	__end__([<p>__end__</p>]):::last
+	__start__ --> plan;
+	execute -.-> plan_check;
+	execute -.-> summarize;
+	plan --> execute;
+	plan_check -.-> execute;
+	plan_check -.-> plan;
+	plan_check -.-> recursion;
+	plan_check -.-> summarize;
+	recursion --> __end__;
+	summarize --> __end__;
+	execute -.-> execute;
+	classDef default fill:#f2f0ff,line-height:1.2
+	classDef first fill-opacity:0
+	classDef last fill:#bfb6fc

--- a/scripts/render_reflexion_graph.py
+++ b/scripts/render_reflexion_graph.py
@@ -1,0 +1,85 @@
+"""Render the reflexion agent state graph to a Mermaid diagram."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any, Iterable
+
+from langchain_core.messages import AIMessage
+from pydantic import BaseModel
+
+from assist import reflexion_agent
+from assist.reflexion_agent import Plan, PlanRetrospective
+
+
+class _StructuredDummyLLM:
+    """Return minimal objects expected by ``with_structured_output`` calls."""
+
+    def __init__(self, schema: type[BaseModel]):
+        self._schema = schema
+
+    def invoke(self, _messages: Iterable[Any], _options: Any | None = None) -> BaseModel:
+        schema = self._schema
+        if schema is Plan:
+            return Plan(goal="graph", steps=[], assumptions=[], risks=[])
+        if schema is PlanRetrospective:
+            return PlanRetrospective(needs_replan=False, learnings=None)
+        return schema()  # type: ignore[call-arg]
+
+
+class DummyLLM:
+    """Lightweight chat model stub sufficient for graph compilation."""
+
+    model = "reflexion-graph-renderer"
+
+    def with_structured_output(self, schema: type[BaseModel]) -> _StructuredDummyLLM:
+        return _StructuredDummyLLM(schema)
+
+    def invoke(self, _messages: Iterable[Any], _options: Any | None = None) -> AIMessage:
+        return AIMessage(content="stub")
+
+
+class DummyAgent:
+    """Minimal agent used to satisfy ``build_reflexion_graph`` dependencies."""
+
+    def invoke(self, _inputs: Any, _options: Any | None = None) -> dict[str, list[AIMessage]]:
+        return {"messages": [AIMessage(content="stub")]} 
+
+
+def render_reflexion_graph(output_dir: Path) -> Path:
+    """Generate the reflexion agent graph diagram into ``output_dir``."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "reflexion_graph.mmd"
+
+    dummy_llm = DummyLLM()
+    dummy_agent = DummyAgent()
+
+    original_general_agent = reflexion_agent.general_agent
+    try:
+        reflexion_agent.general_agent = lambda _llm, _tools: dummy_agent  # type: ignore[assignment]
+        graph = reflexion_agent.build_reflexion_graph(dummy_llm, tools=[], callbacks=[])
+    finally:
+        reflexion_agent.general_agent = original_general_agent
+
+    mermaid = graph.get_graph().draw_mermaid()
+    output_path.write_text(mermaid, encoding="utf-8")
+    return output_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render the reflexion agent graph.")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("generated/reflexion_graph"),
+        help="Directory where the Mermaid diagram should be written.",
+    )
+    args = parser.parse_args()
+
+    output_path = render_reflexion_graph(args.output_dir)
+    print(f"Reflexion graph written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small script that compiles `assist.reflexion_agent` and exports its graph as a Mermaid diagram
- commit the generated `generated/reflexion_graph/reflexion_graph.mmd` artifact
- wire the graph renderer into the CI workflow and ignore build artefacts from editable installs and coverage runs

## Testing
- python scripts/render_reflexion_graph.py
- pytest -vv *(fails: AttributeError: '_DeterministicEmbedding' object has no attribute 'embed_query' in query.)*

------
https://chatgpt.com/codex/tasks/task_e_68d3331a82f4832b8ab0f0424476d5ea