### PR TITLE
threads-db Layer 2: per-thread checkpoint retention

### DIFF
--- a/assist/checkpointer.py
+++ b/assist/checkpointer.py
@@ -1,0 +1,221 @@
+"""Checkpoint retention wrapper.
+
+Layer 2 of the threads.db growth plan
+(docs/2026-05-04-threads-db-layer-2-checkpoint-pruning.org).
+Wraps langgraph's SqliteSaver to bound per-thread checkpoint count.
+
+On every ``put()`` the wrapper retains only the most-recent
+``ASSIST_RETAIN_LAST`` checkpoints per ``(thread_id, checkpoint_ns)``
+and deletes the older rows from ``checkpoints`` and ``writes`` in the
+same transaction as the ``INSERT``.
+
+Pinned against ``langgraph-checkpoint-sqlite==3.0.3``.  See
+``EXPECTED_TABLES`` for the schema assertion that flags upstream drift.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import (
+    ChannelVersions,
+    Checkpoint,
+    CheckpointMetadata,
+    get_checkpoint_metadata,
+)
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RETAIN_LAST = 10
+
+# Tables the wrapper expects to find.  A schema drift (extra or
+# missing tables) is logged at first put() and disables pruning for
+# the saver's lifetime — the prune is a best-effort optimization,
+# never let it block a put.
+EXPECTED_TABLES = frozenset({"checkpoints", "writes"})
+
+
+def _resolve_retain_last() -> int:
+    """Read ASSIST_RETAIN_LAST.
+
+    - unset → DEFAULT_RETAIN_LAST
+    - "0" / "" / "disabled" / "off" / "false" → 0 (no-op pass-through)
+    - positive int → retain that many
+    - anything else → DEFAULT_RETAIN_LAST with a warning (typo → loud
+      log, never silently disabled)
+    """
+    raw = os.environ.get("ASSIST_RETAIN_LAST")
+    if raw is None:
+        return DEFAULT_RETAIN_LAST
+    norm = raw.strip().lower()
+    if norm in ("", "disabled", "off", "false"):
+        return 0
+    try:
+        n = int(norm)
+    except ValueError:
+        logger.warning(
+            "ASSIST_RETAIN_LAST=%r is not an integer; defaulting to %d",
+            raw, DEFAULT_RETAIN_LAST,
+        )
+        return DEFAULT_RETAIN_LAST
+    if n < 0:
+        logger.warning(
+            "ASSIST_RETAIN_LAST=%d is negative; defaulting to %d",
+            n, DEFAULT_RETAIN_LAST,
+        )
+        return DEFAULT_RETAIN_LAST
+    return n
+
+
+class CheckpointRetentionSaver(SqliteSaver):
+    """SqliteSaver that prunes old checkpoints inline with each put().
+
+    Retention count is read from ``ASSIST_RETAIN_LAST`` at construction
+    time (unless overridden via ``retain_last=`` kwarg for tests).
+    ``retain_last == 0`` makes the wrapper a no-op pass-through —
+    operational kill switch.
+
+    The async API (``aput`` etc.) is not overridden because upstream's
+    sync ``SqliteSaver`` raises ``NotImplementedError`` from all async
+    methods (see ``_AIO_ERROR_MSG`` in the upstream module).
+    """
+
+    def __init__(self, *args, retain_last: int | None = None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.retain_last = (
+            retain_last if retain_last is not None else _resolve_retain_last()
+        )
+        # None = not yet checked; True/False = result cached.
+        self._schema_ok: bool | None = None
+        if self.retain_last == 0:
+            logger.info("CheckpointRetentionSaver: pruning disabled")
+        else:
+            logger.info(
+                "CheckpointRetentionSaver: retaining last %d checkpoints "
+                "per (thread_id, checkpoint_ns)",
+                self.retain_last,
+            )
+
+    def _verify_schema(self, cur) -> bool:
+        """Return True if the live schema matches EXPECTED_TABLES.
+
+        Cached after the first call.  A mismatch logs once and disables
+        pruning for the saver's lifetime — operator must bump the pin
+        and update EXPECTED_TABLES.
+        """
+        if self._schema_ok is not None:
+            return self._schema_ok
+        cur.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+        )
+        actual = frozenset(row[0] for row in cur.fetchall())
+        if actual != EXPECTED_TABLES:
+            logger.warning(
+                "CheckpointRetentionSaver: schema drift detected — "
+                "expected %s, got %s (extras=%s, missing=%s); "
+                "pruning disabled.  Bump langgraph-checkpoint-sqlite "
+                "and update EXPECTED_TABLES in assist/checkpointer.py.",
+                sorted(EXPECTED_TABLES), sorted(actual),
+                sorted(actual - EXPECTED_TABLES),
+                sorted(EXPECTED_TABLES - actual),
+            )
+            self._schema_ok = False
+        else:
+            self._schema_ok = True
+        return self._schema_ok
+
+    def put(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        """Save a checkpoint and prune older ones in one transaction.
+
+        Mirrors upstream SqliteSaver.put (langgraph-checkpoint-sqlite==3.0.3,
+        lines 380-436) so the INSERT and the prune share a single
+        cursor + lock acquisition + commit.  Re-validate this body on
+        langgraph upgrades.
+
+        Prune failures are caught and logged — the INSERT is the
+        load-bearing operation; the prune self-heals on the next put.
+        """
+        thread_id = config["configurable"]["thread_id"]
+        checkpoint_ns = config["configurable"]["checkpoint_ns"]
+        type_, serialized_checkpoint = self.serde.dumps_typed(checkpoint)
+        serialized_metadata = json.dumps(
+            get_checkpoint_metadata(config, metadata), ensure_ascii=False
+        ).encode("utf-8", "ignore")
+
+        with self.cursor() as cur:
+            cur.execute(
+                "INSERT OR REPLACE INTO checkpoints "
+                "(thread_id, checkpoint_ns, checkpoint_id, "
+                "parent_checkpoint_id, type, checkpoint, metadata) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    str(thread_id),
+                    checkpoint_ns,
+                    checkpoint["id"],
+                    config["configurable"].get("checkpoint_id"),
+                    type_,
+                    serialized_checkpoint,
+                    serialized_metadata,
+                ),
+            )
+
+            if self.retain_last > 0 and self._verify_schema(cur):
+                try:
+                    self._prune(cur, str(thread_id), checkpoint_ns)
+                except Exception:
+                    logger.exception(
+                        "Prune failed for thread_id=%r checkpoint_ns=%r; "
+                        "checkpoint inserted, prune self-heals on next put.",
+                        thread_id, checkpoint_ns,
+                    )
+
+        return {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+
+    def _prune(self, cur, thread_id: str, checkpoint_ns: str) -> None:
+        """Delete checkpoints beyond the retention window for one (tid, ns).
+
+        Scoped by the full ``(thread_id, checkpoint_ns)`` pair so two
+        namespaces under the same ``thread_id`` retain N each.
+        Deletes from ``writes`` before ``checkpoints`` because writes
+        references checkpoints semantically, even though no FK
+        enforces it — keeps the invariant clean if a future schema
+        adds one.
+        """
+        cur.execute(
+            "SELECT checkpoint_id FROM checkpoints "
+            "WHERE thread_id = ? AND checkpoint_ns = ? "
+            "ORDER BY checkpoint_id DESC LIMIT -1 OFFSET ?",
+            (thread_id, checkpoint_ns, self.retain_last),
+        )
+        old_ids = [row[0] for row in cur.fetchall()]
+        if not old_ids:
+            return
+        placeholders = ",".join("?" * len(old_ids))
+        cur.execute(
+            f"DELETE FROM writes "
+            f"WHERE thread_id = ? AND checkpoint_ns = ? "
+            f"AND checkpoint_id IN ({placeholders})",
+            (thread_id, checkpoint_ns, *old_ids),
+        )
+        cur.execute(
+            f"DELETE FROM checkpoints "
+            f"WHERE thread_id = ? AND checkpoint_ns = ? "
+            f"AND checkpoint_id IN ({placeholders})",
+            (thread_id, checkpoint_ns, *old_ids),
+        )

--- a/assist/thread.py
+++ b/assist/thread.py
@@ -10,13 +10,13 @@ from typing import Literal, Dict, Any, Callable, List, Iterator
 
 import sqlite3
 from langchain.messages import HumanMessage, AIMessage, AnyMessage
-from langgraph.checkpoint.sqlite import SqliteSaver
 from langchain_core.language_models.chat_models import BaseChatModel
 
 from assist.promptable import base_prompt_for
 from assist.model_manager import select_chat_model
 from assist.agent import create_research_agent, create_agent
 from assist.checkpoint_rollback import invoke_with_rollback
+from assist.checkpointer import CheckpointRetentionSaver
 from assist.sandbox_manager import SandboxManager
 
 logger = logging.getLogger(__name__)
@@ -170,9 +170,13 @@ n    checkpointing via SqliteSaver.
         # Ensure DB file exists upfront
         if not os.path.exists(self.db_path):
             open(self.db_path, "a").close()
-        # SqliteSaver expects a sqlite3.Connection
+        # CheckpointRetentionSaver subclasses upstream SqliteSaver and
+        # prunes per-thread checkpoint history inline with each put().
+        # Behavior toggle: ASSIST_RETAIN_LAST env (default 10, 0=off).
+        # Layer 2 of the threads.db growth plan
+        # (docs/2026-05-04-threads-db-layer-2-checkpoint-pruning.org).
         self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        self.checkpointer = SqliteSaver(self.conn)
+        self.checkpointer = CheckpointRetentionSaver(self.conn)
         # Lazily resolve the chat model so the web server can boot before
         # the LLM endpoint is reachable.  First request triggers the probe;
         # the lock prevents two concurrent first-requests from probing twice.

--- a/docs/2026-05-04-threads-db-layer-2-checkpoint-pruning.org
+++ b/docs/2026-05-04-threads-db-layer-2-checkpoint-pruning.org
@@ -1,11 +1,79 @@
 #+TITLE: Layer 2 — Per-thread checkpoint retention
 #+DATE: 2026-05-04
-State: PR open 2026-05-05, awaiting review
+State: PR #88 open since 2026-05-05, awaiting review (no review activity yet)
 
-* Session handoff (2026-05-05)
+* Session handoff (latest at top, last updated 2026-05-06)
 This section is for whoever picks the work back up.  The design
 sections below are unchanged history; this block tracks current
 state.
+
+** Update 2026-05-06 — Layer 3 has shipped without Layer 2
+Significant context shift: *Layer 3 (per-checkpoint tool-result
+eviction) was deployed to prod 2026-05-05 13:20 PDT* on its own
+feature branch (PR #89, branch =layer-3-tool-result-eviction=).
+Layer 2 is still unmerged.
+
+What this means for Layer 2:
+- *Composition order has flipped.*  Layer 3's =EvictionSaver=
+  currently subclasses upstream =SqliteSaver= directly, not
+  =CheckpointRetentionSaver=.  When Layer 2 merges, the integration
+  is one-line: change =class EvictionSaver(SqliteSaver):= →
+  =class EvictionSaver(CheckpointRetentionSaver):= and
+  thread =retain_last= through the constructor.  See the Layer 3
+  doc's "Pending" section item 2 for the merge-order options.
+- *No file conflict on merge.*  Layer 3 lives in
+  =assist/eviction_saver.py= (separate file from Layer 2's
+  =assist/checkpointer.py=) precisely so the two PRs don't
+  collide.  Both modify =assist/thread.py= at
+  =ThreadManager.__init__=, but each substitutes a different
+  saver class — the merge will require choosing the composition
+  (likely =EvictionSaver(...)= wrapping the retention base).
+- *Layer 2 still useful.*  Layer 3 caps =per-checkpoint= bytes;
+  Layer 2 caps =per-thread checkpoint count=.  Without Layer 2, a
+  long-running thread can still accumulate hundreds of (now-small)
+  checkpoint rows in the DB.  The two are multiplicative — the
+  bound becomes =100 threads × 10 checkpoints × 250 KB stub
+  size= rather than =100 × 10 × 100 MB=.  See the relative-gains
+  chat in the session log; both layers have a meaningful slot.
+
+** Prod state at 2026-05-06
+- =threads.db= = 175 GB (unchanged from yesterday's deploy).  No
+  Sunday VACUUM has run since Layer 3 deployed; expect significant
+  reclamation when the next one fires.  Layer 2 will accelerate
+  this once it merges by deleting old checkpoint rows so VACUUM
+  has more freelist to reclaim.
+- 85 thread directories under =/home/pierre/deploy/assist/threads/=
+  (under MIN_THREADS=100, so the next sweep won't prune any).
+- Two threads have produced Layer 3 disk artifacts, totalling
+  192 KB.  No Layer 2 activity (it's not deployed yet).
+
+** Cross-cutting observations from the Layer 3 session
+Worth scanning before re-engaging with Layer 2:
+- *Editable-install side-finding.*  The dev =.venv= had
+  =.venv/src/assist/= as a stale snapshot from a prior
+  =pip install --src= flow.  Scripts run as
+  =.venv/bin/python <script.py>= imported the stale code
+  because =sys.path[0]= is the script's directory and the
+  editable finder's MAPPING pointed at the snapshot.  Fix:
+  =.venv/bin/pip install -e . --no-deps=.  If Layer 2 work
+  involves running scripts (not pytest, which adds project
+  root to sys.path itself), check this first.
+- *Eval-reliability finding.*  =eval_large_tool_results.py=
+  was patching =ddgs.DDGS.text= but =ddgs.DDGS= is a thin
+  proxy class; instances use =ddgs.ddgs.DDGS=.  Fix
+  committed on Layer 3 branch (=68a6e38=) to patch
+  =ddgs.ddgs.DDGS.text= and accept =self= in the mock.  If
+  Layer 2 reviewers want to run that eval against this branch
+  too, cherry-pick that one-file change first or just be
+  aware of the issue.
+- *Memory notes.*  Two new feedback memories from the session:
+  =feedback_deploy_from_feature_branch.md= (user OK'd
+  feature-branch deploys; CLAUDE.md's blanket prohibition is
+  not absolute) and =feedback_thread_failure_should_terminate.md=
+  (don't build heal-and-retry for sandbox/long-request
+  failures; let the thread die and the user start a new one).
+  Neither directly affects Layer 2 design but both are worth
+  scanning.
 
 ** What's landed
 - Branch: =layer-2-checkpoint-retention= (forked from =main= at
@@ -49,35 +117,54 @@ file.  Run from =~/src/assist=:
 
 ** Pending — what the next session should do
 1. *Address PR review comments* on
-   https://github.com/pierrel/assist/pull/88 .  Expect feedback
-   on the option-A code-duplication of upstream's =put= body
-   (we mirror lines 380-436 of =langgraph-checkpoint-sqlite==3.0.3=
-   verbatim; the trade-off was justified by the single-TX
-   guarantee).
-2. *Merge to main* once approved.  Standard squash-or-merge per
+   https://github.com/pierrel/assist/pull/88 .  No review activity
+   yet.  Expect feedback if any on the option-A code-duplication of
+   upstream's =put= body (we mirror lines 380-436 of
+   =langgraph-checkpoint-sqlite==3.0.3= verbatim; the trade-off was
+   justified by the single-TX guarantee).
+2. *Resolve merge-order with Layer 3.*  Layer 3 is already in prod
+   on a feature branch.  When Layer 2 merges to main, Layer 3's
+   branch needs a follow-up edit to swap =class EvictionSaver(SqliteSaver):=
+   to =class EvictionSaver(CheckpointRetentionSaver):= and pass
+   =retain_last= through the constructor.  Either order works; the
+   final state is identical.  Coordinate with the Layer 3 doc's
+   merge-order section.
+3. *Merge to main* once approved.  Standard squash-or-merge per
    project convention (Layer 0 used a regular merge — match it).
-3. *Deploy to prod*.  =make deploy= from =~/src/assist= ships the
+4. *Deploy to prod*.  =make deploy= from =~/src/assist= ships the
    change.  =ASSIST_RETAIN_LAST= is *not* in =.deploy.env=, which
-   means it falls back to the default (10).  No env edit needed
-   for the default rollout.
-4. *Smoke + observe*.  After =make deploy= and =make restart=:
+   means it falls back to the default (10).  No env edit needed for
+   the default rollout.  *Note:* the user has authorized
+   feature-branch deploys (see
+   =feedback_deploy_from_feature_branch.md= memory) — don't block
+   on merge if a quick prod test is wanted first.
+5. *Smoke + observe*.  After deploy + restart:
    - =make smoke= or =./scripts/smoke_test.sh= for the basic
      end-to-end (tiny inference + assist-web reachability).
    - Watch =journalctl -u assist-web -f= for
      "CheckpointRetentionSaver: retaining last 10 checkpoints
      per (thread_id, checkpoint_ns)" at startup.
-   - Run an eval suite (=make eval= or wait for the 23:00 cron;
-     see the eval-deadline memory note).  Confirm no regression
-     in pass rates.
+   - Run an eval suite (=make eval=).  Confirm no regression in
+     pass rates.  Be aware of the eval mock-path bug noted above
+     if running =eval_large_tool_results.py= on this branch.
    - Optional: pick one chatty research-agent thread, then
      =sqlite3 threads.db "SELECT thread_id, checkpoint_ns,
      COUNT(*) FROM checkpoints GROUP BY thread_id, checkpoint_ns
-     ORDER BY 3 DESC LIMIT 10;"= — every (tid, ns) row should
-     show ≤10.
-5. *Decide whether to lower N*.  If observation shows rollback
-   never reaches near 10, drop the default to 5 in
-   =assist/checkpointer.py= (=DEFAULT_RETAIN_LAST=).  Code
-   already supports it; this is a one-line follow-up PR.
+     ORDER BY 3 DESC LIMIT 10;"= — every (tid, ns) row should show
+     ≤10.
+6. *Decide whether to lower N*.  After Layer 2 has been live for a
+   week, if observation shows rollback never reaches near 10, drop
+   the default to 5 in =assist/checkpointer.py=
+   (=DEFAULT_RETAIN_LAST=).  Code already supports it; one-line
+   follow-up PR.
+7. *Watch the threads.db reduction curve.*  Layer 2 will free
+   freelist pages on every put (deleting old checkpoint rows).  The
+   next Sunday VACUUM after Layer 2 deploys should produce a
+   meaningful drop in the .db file size — meaningful in the same
+   ballpark as Layer 0's one-time cleanup, since it removes the
+   per-thread historical accumulation.  Track =du -sh
+   /home/pierre/deploy/assist/threads/threads.db= weekly and note
+   the ratio before/after.
 
 ** Kill switch (if Layer 2 misbehaves in prod)
 Add to =/home/pierre/deploy/assist/code/.deploy.env= on the prod

--- a/docs/2026-05-04-threads-db-layer-2-checkpoint-pruning.org
+++ b/docs/2026-05-04-threads-db-layer-2-checkpoint-pruning.org
@@ -1,6 +1,106 @@
 #+TITLE: Layer 2 — Per-thread checkpoint retention
 #+DATE: 2026-05-04
-State: Implemented 2026-05-05 on branch =layer-2-checkpoint-retention=
+State: PR open 2026-05-05, awaiting review
+
+* Session handoff (2026-05-05)
+This section is for whoever picks the work back up.  The design
+sections below are unchanged history; this block tracks current
+state.
+
+** What's landed
+- Branch: =layer-2-checkpoint-retention= (forked from =main= at
+  =e8f7705=).
+- Commit: =816dc28= "threads-db Layer 2: per-thread checkpoint
+  retention" — wrapper + tests + doc.
+- Pushed to =origin/layer-2-checkpoint-retention=.
+- PR: https://github.com/pierrel/assist/pull/88 (base =main=).
+
+** What's in the diff
+- =assist/checkpointer.py= (new) — =CheckpointRetentionSaver=
+  subclass.  Override =put()= only; option (A) inline prune in one
+  =self.cursor()= block (single TX, single lock acq, single
+  commit).  Env switch =ASSIST_RETAIN_LAST= (default 10, =0= /
+  ="disabled"= / ="off"= / ="false"= = no-op pass-through).
+  Schema-drift assertion against =EXPECTED_TABLES = {checkpoints,
+  writes}= cached after first =put=.  Prune wrapped in
+  try/except — fail-open (INSERT survives a prune failure;
+  self-heals on next put).
+- =assist/thread.py= — swapped =SqliteSaver= import +
+  instantiation site at =ThreadManager.__init__= for the new
+  wrapper.  Did *not* override =delete_thread=; Layer 0's
+  =hard_delete= path uses upstream's per-table wipe unchanged.
+- =tests/test_checkpointer_retention.py= (new) — 17 tests
+  covering: basic prune, namespace isolation, thread isolation,
+  =writes=-table lockstep, =delete_thread= compat, rollback depth
+  (N=10 vs =max_rollback_depth=3=), retention disabled (N=0),
+  prune-fails-open, concurrent puts (two Python threads),
+  =aput= still raises, EXPLAIN QUERY PLAN uses PK index, schema
+  drift disables pruning, env-var parsing × 5.
+- This doc — corrections from the design review (2 tables not 3,
+  compound PK, sync-only saver, rollback depth resolved at 3).
+
+** Test status
+Local: =297/297= passing in the full suite, =17/17= in the new
+file.  Run from =~/src/assist=:
+#+begin_src
+.venv/bin/python -m pytest tests/test_checkpointer_retention.py
+.venv/bin/python -m pytest tests/  # full suite
+#+end_src
+
+** Pending — what the next session should do
+1. *Address PR review comments* on
+   https://github.com/pierrel/assist/pull/88 .  Expect feedback
+   on the option-A code-duplication of upstream's =put= body
+   (we mirror lines 380-436 of =langgraph-checkpoint-sqlite==3.0.3=
+   verbatim; the trade-off was justified by the single-TX
+   guarantee).
+2. *Merge to main* once approved.  Standard squash-or-merge per
+   project convention (Layer 0 used a regular merge — match it).
+3. *Deploy to prod*.  =make deploy= from =~/src/assist= ships the
+   change.  =ASSIST_RETAIN_LAST= is *not* in =.deploy.env=, which
+   means it falls back to the default (10).  No env edit needed
+   for the default rollout.
+4. *Smoke + observe*.  After =make deploy= and =make restart=:
+   - =make smoke= or =./scripts/smoke_test.sh= for the basic
+     end-to-end (tiny inference + assist-web reachability).
+   - Watch =journalctl -u assist-web -f= for
+     "CheckpointRetentionSaver: retaining last 10 checkpoints
+     per (thread_id, checkpoint_ns)" at startup.
+   - Run an eval suite (=make eval= or wait for the 23:00 cron;
+     see the eval-deadline memory note).  Confirm no regression
+     in pass rates.
+   - Optional: pick one chatty research-agent thread, then
+     =sqlite3 threads.db "SELECT thread_id, checkpoint_ns,
+     COUNT(*) FROM checkpoints GROUP BY thread_id, checkpoint_ns
+     ORDER BY 3 DESC LIMIT 10;"= — every (tid, ns) row should
+     show ≤10.
+5. *Decide whether to lower N*.  If observation shows rollback
+   never reaches near 10, drop the default to 5 in
+   =assist/checkpointer.py= (=DEFAULT_RETAIN_LAST=).  Code
+   already supports it; this is a one-line follow-up PR.
+
+** Kill switch (if Layer 2 misbehaves in prod)
+Add to =/home/pierre/deploy/assist/code/.deploy.env= on the prod
+host:
+#+begin_src
+ASSIST_RETAIN_LAST=0
+#+end_src
+Then =sudo systemctl restart assist-web=.  The wrapper becomes a
+no-op pass-through; behavior reverts to upstream =SqliteSaver=
+without a code rollback.
+
+** Known dev-environment gotcha
+The dev venv at =~/src/assist/.venv= was rebuilt at Python 3.14
+during this session (the system upgrade earlier on 2026-05-05
+removed =python3.13=; the existing venv's site-packages were at
+=lib/python3.13/site-packages/= and ImportError'd until rebuilt
+with =python3.14 -m venv .venv && .venv/bin/pip install -e . -r
+requirements.txt=).  See the
+=project_pacman_python_bump_breaks_venv.md= memory for the same
+failure mode on the deploy copy.  If a fresh clone or a future
+=pacman -Syu= breaks imports, rebuild the venv the same way.
+
+* Original design (history below)
 
 Layer 2 of the prod =threads.db= growth plan (overview:
 [[file:2026-05-03-prod-threads-db-growth.org][2026-05-03-prod-threads-db-growth.org]]; Layer 0 sibling:

--- a/docs/2026-05-04-threads-db-layer-2-checkpoint-pruning.org
+++ b/docs/2026-05-04-threads-db-layer-2-checkpoint-pruning.org
@@ -1,6 +1,6 @@
 #+TITLE: Layer 2 — Per-thread checkpoint retention
 #+DATE: 2026-05-04
-State: Not started
+State: Implemented 2026-05-05 on branch =layer-2-checkpoint-retention=
 
 Layer 2 of the prod =threads.db= growth plan (overview:
 [[file:2026-05-03-prod-threads-db-growth.org][2026-05-03-prod-threads-db-growth.org]]; Layer 0 sibling:
@@ -26,40 +26,82 @@ N=10 is generously larger than rollback's 1–2 turn reach in
 practice, so this loses no real recovery surface.
 
 * Approach
-Subclass =SqliteSaver= (or wrap it via the public =BaseCheckpointSaver=
-protocol) so that on every =put()= the wrapper:
+Subclass =SqliteSaver= and override =put()= so it:
 
-1. Calls the underlying =put()= as usual.
-2. =SELECT checkpoint_id FROM checkpoints WHERE thread_id=?
-   ORDER BY checkpoint_id DESC LIMIT -1 OFFSET 10= — the IDs to
-   delete.
-3. =DELETE FROM checkpoints WHERE thread_id=? AND checkpoint_id IN (...)=
-   plus the same against =writes= and =checkpoint_blobs= (the
-   SqliteSaver schema's three tables, joined on (=thread_id=,
-   =checkpoint_id=)).
+1. Runs the upstream INSERT (mirrored verbatim from
+   =langgraph-checkpoint-sqlite==3.0.3=, =__init__.py:380-436=).
+2. =SELECT checkpoint_id FROM checkpoints WHERE thread_id=? AND
+   checkpoint_ns=? ORDER BY checkpoint_id DESC LIMIT -1 OFFSET N=
+   — the IDs to delete.
+3. =DELETE FROM writes= then =DELETE FROM checkpoints=, both
+   scoped by =(thread_id, checkpoint_ns, checkpoint_id IN (...))=.
 
-All deletes batched in a single transaction with the put.  No
-external timer, no startup pass.
+All four statements share one =with self.cursor() as cur:= block,
+so they run under one =self.lock= acquisition and one =commit()=
+on context exit.  No external timer, no startup pass.
+
+Schema details (verified against =3.0.3=):
+- *Two tables, not three*: =checkpoints= and =writes=.  No
+  =checkpoint_blobs= and no separate =checkpoint_writes=.
+- *Compound PK includes =checkpoint_ns==: scope every WHERE by
+  the full =(thread_id, checkpoint_ns, checkpoint_id)= triple.
+  Two namespaces under the same =thread_id= retain N each.
+- *Async path is N/A*: upstream sync =SqliteSaver.aput= raises
+  =NotImplementedError= (=AIO_ERROR_MSG=, =__init__.py:535=); we
+  use only the sync class.  Don't override =aput=.
+
+Prune failures are caught and logged — the INSERT is the
+load-bearing operation; a failed prune self-heals on the next
+=put()=.
 
 * Key decisions
-- *RETAIN_LAST=10* default, env-overridable.  Conservative; could
-  go to 5 once we measure rollback depth in practice.
+- *RETAIN_LAST=10* default, env-overridable via
+  =ASSIST_RETAIN_LAST=.  =0= / ="disabled"= / ="off"= / ="false"=
+  makes the wrapper a no-op pass-through (operational kill
+  switch).  Negative or non-integer values fall back to 10 with
+  a loud warning so a typo never silently disables retention.
+- *=RollbackRunnable.max_rollback_depth=3=* (=assist/checkpoint_rollback.py:51=).
+  N=10 has a 3× margin.
 - *Sync prune on put*, not async sweep.  Avoids a "drift then
-  catch up" pattern; per-put cost is small (a few row deletes
-  with an index on =(thread_id, checkpoint_id)=).
-- *Implementation as a wrapper, not a fork.*  Subclassing keeps us
-  on the upstream code path; we only override =put= / =aput=.
+  catch up" pattern; per-put cost is one indexed lookup against
+  the PK =(thread_id, checkpoint_ns, checkpoint_id)= plus a
+  ≤(N+M) row delete.
+- *Subclass, don't fork.*  Override =put= only; everything else
+  (=get_tuple=, =list=, =put_writes=, =delete_thread=) flows
+  through upstream unchanged.  In particular *do not* override
+  =delete_thread= — Layer 0's =hard_delete= path needs the
+  upstream per-table wipe.
+- *Schema-drift assertion.* On first =put= the wrapper compares
+  =sqlite_master= against =EXPECTED_TABLES= (a frozenset pinned
+  to the langgraph version).  A mismatch logs once and disables
+  pruning for the saver's lifetime.  Bumping
+  =langgraph-checkpoint-sqlite= requires updating
+  =EXPECTED_TABLES=.
 
-* Open questions
-- Does =RollbackRunnable= ever reach back further than 10 in the
-  agent flows we run?  Need to instrument or grep the rollback
-  code path before locking N=10 in.  Default could ship as
-  =RETAIN_LAST=20= and lower it after observation.
-- Async path: =aput= delegates to =put= via a thread executor in
-  upstream =SqliteSaver=; verify the wrapper covers both.
-- Multiple writers: prod has one writer process (assist-web), but
-  evals can run a second.  =DELETE= during a concurrent =put= is
-  fine within SQLite's WAL mode, but worth a stress test.
+* Open questions (resolved)
+- *Rollback depth* — =max_rollback_depth=3= in
+  =assist/checkpoint_rollback.py:51=.  N=10 is sufficient with
+  3× margin.  Closed.
+- *Async path* — irrelevant: sync =SqliteSaver.aput= raises
+  =NotImplementedError= and we never use =AsyncSqliteSaver=.
+  The wrapper overrides only =put=; a regression test asserts
+  =aput= still raises so we don't accidentally enable the async
+  path.  Closed.
+- *Multiple writers* — Layer 0 retention runs offline (the
+  weekly cron in =scripts/threads-db-retention.cron= stops
+  assist-web first; =retention.py= refuses to run if any other
+  process holds =threads.db=).  Layer 0 and Layer 2 are
+  temporally disjoint by construction.  The sync wrapper's
+  per-thread concurrency is covered by the upstream
+  =self.lock=; a regression test exercises two Python threads
+  writing concurrently.  Closed.
+
+* Orthogonal: VACUUM
+Layer 2 frees pages; SQLite WAL marks them free for reuse but
+does not shrink the file.  Disk reclamation is Layer 1's job
+(=scripts/threads-db-vacuum.sh=).  Without Layer 1, Layer 2
+prevents *unbounded* growth but doesn't shrink an already-bloated
+file.
 
 * Files this touches
 - =assist/checkpointer.py= (new) — the wrapper class.
@@ -81,8 +123,18 @@ external timer, no startup pass.
   introspection finds extra tables we don't know about.
 
 * Order of operations
-1. Wrapper + tests (no behavior change yet — wire it in but with
-   N=10000 effectively-disabled).
-2. Lower N=10 in dev; observe behavior across an eval suite run.
-3. Ship to prod.
-4. Lower N if observation supports it.
+The original plan staged a "ship inert with N=10000" step before
+turning retention on.  Skipped: Layer 2 ships behind
+=ASSIST_RETAIN_LAST= (default 10, =0= = no-op).  The env
+variable provides the same operational guarantee — flip to =0=
+in =.deploy.env= if anything misbehaves and restart assist-web —
+without a double deploy.  Layer 0's review caught real bugs
+that justified the inert-first approach there; Layer 2's blast
+radius is "checkpoints stop being deleted" or "checkpoints get
+over-deleted", both reversible.
+
+1. Wrapper + tests on =layer-2-checkpoint-retention= (done
+   2026-05-05).
+2. Push, deploy, smoke; observe behavior across an eval suite
+   run.
+3. Lower N if observation supports it.

--- a/tests/test_checkpointer_retention.py
+++ b/tests/test_checkpointer_retention.py
@@ -1,0 +1,321 @@
+"""Tests for ``assist.checkpointer.CheckpointRetentionSaver``.
+
+Layer 2 of the threads.db growth plan
+(docs/2026-05-04-threads-db-layer-2-checkpoint-pruning.org).
+
+Real sqlite + real upstream SqliteSaver behind the wrapper.  Mocks
+would hide the schema-drift case the wrapper is meant to detect, and
+the row-count assertions need a real DB anyway.
+"""
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import threading
+from unittest import TestCase
+
+from langgraph.checkpoint.base import empty_checkpoint
+
+from assist.checkpointer import (
+    DEFAULT_RETAIN_LAST,
+    CheckpointRetentionSaver,
+    _resolve_retain_last,
+)
+
+
+def _config(thread_id: str, ns: str = "") -> dict:
+    return {"configurable": {"thread_id": thread_id, "checkpoint_ns": ns}}
+
+
+def _ckpt(seq: int) -> dict:
+    """Return a Checkpoint with a deterministic, lex-sortable id.
+
+    Real langgraph uses uuid6 (monotonic by time); zero-padded
+    integers reproduce the DESC-ordering invariant the wrapper
+    relies on without test flakiness from clock resolution.
+    """
+    c = empty_checkpoint()
+    c["id"] = f"{seq:08d}"
+    return c
+
+
+def _put_n(saver: CheckpointRetentionSaver, n: int, *, tid: str, ns: str = "") -> list[str]:
+    """Write ``n`` checkpoints; return the ids in insertion order."""
+    ids = []
+    for i in range(n):
+        c = _ckpt(i)
+        saver.put(_config(tid, ns), c, {}, {})
+        ids.append(c["id"])
+    return ids
+
+
+def _ids_in_db(saver: CheckpointRetentionSaver, tid: str, ns: str = "") -> list[str]:
+    cur = saver.conn.cursor()
+    cur.execute(
+        "SELECT checkpoint_id FROM checkpoints "
+        "WHERE thread_id = ? AND checkpoint_ns = ? "
+        "ORDER BY checkpoint_id DESC",
+        (tid, ns),
+    )
+    return [row[0] for row in cur.fetchall()]
+
+
+def _writes_count(saver: CheckpointRetentionSaver, tid: str, ns: str = "") -> int:
+    cur = saver.conn.cursor()
+    cur.execute(
+        "SELECT COUNT(*) FROM writes WHERE thread_id = ? AND checkpoint_ns = ?",
+        (tid, ns),
+    )
+    return cur.fetchone()[0]
+
+
+def _new_saver(retain_last: int = 10) -> CheckpointRetentionSaver:
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    return CheckpointRetentionSaver(conn, retain_last=retain_last)
+
+
+class TestBasicPrune(TestCase):
+    def test_15_puts_retains_only_last_10(self):
+        saver = _new_saver(retain_last=10)
+        ids = _put_n(saver, 15, tid="t1")
+        survivors = _ids_in_db(saver, "t1")
+        # DESC order; 5 oldest dropped.
+        self.assertEqual(survivors, list(reversed(ids[5:])))
+        self.assertEqual(len(survivors), 10)
+
+
+class TestNamespaceIsolation(TestCase):
+    """Two namespaces under the same thread retain N each independently."""
+
+    def test_each_ns_retains_independently(self):
+        saver = _new_saver(retain_last=10)
+        _put_n(saver, 15, tid="t1", ns="")
+        _put_n(saver, 15, tid="t1", ns="sub")
+        self.assertEqual(len(_ids_in_db(saver, "t1", "")), 10)
+        self.assertEqual(len(_ids_in_db(saver, "t1", "sub")), 10)
+
+
+class TestThreadIsolation(TestCase):
+    """Two threads retain N each — DELETE must include thread_id predicate."""
+
+    def test_each_thread_retains_independently(self):
+        saver = _new_saver(retain_last=10)
+        _put_n(saver, 15, tid="ta")
+        _put_n(saver, 15, tid="tb")
+        self.assertEqual(len(_ids_in_db(saver, "ta")), 10)
+        self.assertEqual(len(_ids_in_db(saver, "tb")), 10)
+
+
+class TestWritesPrunedInLockstep(TestCase):
+    """``writes`` rows for pruned checkpoints are also deleted."""
+
+    def test_writes_for_pruned_checkpoints_are_deleted(self):
+        saver = _new_saver(retain_last=10)
+        # Seed 15 checkpoints; for each, drop one write row.  Use
+        # put_writes so the ids match.
+        for i in range(15):
+            c = _ckpt(i)
+            saver.put(_config("t1"), c, {}, {})
+            saver.put_writes(
+                {"configurable": {
+                    "thread_id": "t1",
+                    "checkpoint_ns": "",
+                    "checkpoint_id": c["id"],
+                }},
+                [("channel", "value")],
+                task_id=f"task-{i}",
+            )
+        # Only 10 checkpoints survive → only 10 writes rows survive.
+        self.assertEqual(_writes_count(saver, "t1"), 10)
+        survivors = set(_ids_in_db(saver, "t1"))
+        cur = saver.conn.cursor()
+        cur.execute(
+            "SELECT DISTINCT checkpoint_id FROM writes WHERE thread_id = ?",
+            ("t1",),
+        )
+        write_ids = set(row[0] for row in cur.fetchall())
+        self.assertEqual(write_ids, survivors)
+
+
+class TestDeleteThreadStillWipes(TestCase):
+    """Layer 0 hard_delete path: ``delete_thread`` must still drop everything."""
+
+    def test_delete_thread_after_prune_wipes_all(self):
+        saver = _new_saver(retain_last=10)
+        _put_n(saver, 15, tid="t1")
+        self.assertEqual(len(_ids_in_db(saver, "t1")), 10)
+        saver.delete_thread("t1")
+        self.assertEqual(_ids_in_db(saver, "t1"), [])
+        self.assertEqual(_writes_count(saver, "t1"), 0)
+
+
+class TestRollbackHasEnoughDepth(TestCase):
+    """N=10 covers RollbackRunnable.max_rollback_depth=3 with margin."""
+
+    def test_can_walk_back_3_checkpoints_after_prune(self):
+        saver = _new_saver(retain_last=10)
+        _put_n(saver, 15, tid="t1")
+        survivors_desc = _ids_in_db(saver, "t1")
+        # 3rd-most-recent must still exist.
+        self.assertGreaterEqual(len(survivors_desc), 4)
+        third_back = survivors_desc[3]
+        cur = saver.conn.cursor()
+        cur.execute(
+            "SELECT 1 FROM checkpoints WHERE thread_id = ? AND checkpoint_id = ?",
+            ("t1", third_back),
+        )
+        self.assertIsNotNone(cur.fetchone())
+
+
+class TestRetentionDisabled(TestCase):
+    """retain_last=0 → wrapper is a no-op pass-through."""
+
+    def test_zero_skips_prune(self):
+        saver = _new_saver(retain_last=0)
+        _put_n(saver, 25, tid="t1")
+        self.assertEqual(len(_ids_in_db(saver, "t1")), 25)
+
+
+class TestPruneFailsOpen(TestCase):
+    """A failure inside ``_prune`` must not lose the put."""
+
+    def test_delete_failure_is_swallowed_insert_survives(self):
+        saver = _new_saver(retain_last=10)
+        _put_n(saver, 10, tid="t1")  # seed the prune to actually have work
+
+        original_prune = saver._prune
+        calls = {"n": 0}
+
+        def boom(cur, thread_id, checkpoint_ns):
+            calls["n"] += 1
+            raise sqlite3.OperationalError("synthetic failure")
+
+        saver._prune = boom  # type: ignore[method-assign]
+        try:
+            # The 11th put should succeed even though _prune raises.
+            saver.put(_config("t1"), _ckpt(100), {}, {})
+        finally:
+            saver._prune = original_prune  # type: ignore[method-assign]
+
+        self.assertEqual(calls["n"], 1)
+        # 10 originals + the new one = 11 (no prune happened).
+        self.assertEqual(len(_ids_in_db(saver, "t1")), 11)
+
+
+class TestConcurrentPuts(TestCase):
+    """Two Python threads writing to different ``thread_id``s serialize via the upstream lock."""
+
+    def test_no_deadlock_and_correct_counts(self):
+        saver = _new_saver(retain_last=10)
+
+        errors: list[BaseException] = []
+
+        def writer(tid: str):
+            try:
+                _put_n(saver, 15, tid=tid)
+            except BaseException as e:  # noqa: BLE001
+                errors.append(e)
+
+        t_a = threading.Thread(target=writer, args=("ta",))
+        t_b = threading.Thread(target=writer, args=("tb",))
+        t_a.start()
+        t_b.start()
+        t_a.join(timeout=10)
+        t_b.join(timeout=10)
+        self.assertFalse(t_a.is_alive())
+        self.assertFalse(t_b.is_alive())
+        self.assertEqual(errors, [])
+        self.assertEqual(len(_ids_in_db(saver, "ta")), 10)
+        self.assertEqual(len(_ids_in_db(saver, "tb")), 10)
+
+
+class TestAputStillRaises(TestCase):
+    """Sanity: we don't accidentally enable the async path."""
+
+    def test_aput_raises_not_implemented(self):
+        saver = _new_saver(retain_last=10)
+        with self.assertRaises(NotImplementedError):
+            asyncio.run(saver.aput(_config("t1"), _ckpt(0), {}, {}))
+
+
+class TestExplainQueryPlanUsesPkIndex(TestCase):
+    """The prune SELECT must hit the PK index, not a table scan."""
+
+    def test_prune_select_uses_index(self):
+        saver = _new_saver(retain_last=10)
+        # Realize the schema; setup() runs lazily via cursor(), so
+        # do one put first.
+        saver.put(_config("t1"), _ckpt(0), {}, {})
+        cur = saver.conn.cursor()
+        cur.execute(
+            "EXPLAIN QUERY PLAN "
+            "SELECT checkpoint_id FROM checkpoints "
+            "WHERE thread_id = ? AND checkpoint_ns = ? "
+            "ORDER BY checkpoint_id DESC LIMIT -1 OFFSET ?",
+            ("t1", "", 10),
+        )
+        plan = " ".join(str(row) for row in cur.fetchall()).upper()
+        # SQLite's planner reports either "USING INDEX" or "USING
+        # COVERING INDEX" or "USING PRIMARY KEY".  Any of those is
+        # fine; a "SCAN TABLE" without an index is not.
+        self.assertIn("INDEX", plan + "PRIMARY KEY")
+        self.assertNotIn("SCAN CHECKPOINTS", plan)
+
+
+class TestSchemaDriftDisablesPrune(TestCase):
+    """An unexpected upstream schema (extra/missing table) disables pruning."""
+
+    def test_extra_table_disables_prune(self):
+        saver = _new_saver(retain_last=10)
+        # Realize the schema (lazy via cursor()), then add a sentinel
+        # table that doesn't belong to the pin.  Use a non-colliding
+        # seed id so the subsequent _put_n's INSERT OR REPLACE doesn't
+        # overwrite it.
+        saver.put(_config("t1"), _ckpt(999), {}, {})
+        saver.conn.execute("CREATE TABLE sentinel (x INTEGER)")
+        # Reset the cached check so the next put re-evaluates.
+        saver._schema_ok = None
+        with self.assertLogs("assist.checkpointer", level="WARNING") as cm:
+            _put_n(saver, 15, tid="t1")
+        self.assertTrue(
+            any("schema drift" in m for m in cm.output),
+            f"expected schema-drift warning, got: {cm.output!r}",
+        )
+        # Drift disables pruning → all 16 checkpoints survive (the
+        # seed at id=999 + 15 more at ids 0-14).
+        self.assertEqual(len(_ids_in_db(saver, "t1")), 16)
+
+
+class TestEnvVarResolution(TestCase):
+    def test_unset_returns_default(self, ):
+        from unittest.mock import patch
+        with patch.dict("os.environ", {}, clear=False):
+            import os as _os
+            _os.environ.pop("ASSIST_RETAIN_LAST", None)
+            self.assertEqual(_resolve_retain_last(), DEFAULT_RETAIN_LAST)
+
+    def test_explicit_integer(self):
+        from unittest.mock import patch
+        with patch.dict("os.environ", {"ASSIST_RETAIN_LAST": "42"}):
+            self.assertEqual(_resolve_retain_last(), 42)
+
+    def test_disabled_keywords_zero_out(self):
+        from unittest.mock import patch
+        for raw in ("0", "disabled", "off", "false", "DISABLED", ""):
+            with patch.dict("os.environ", {"ASSIST_RETAIN_LAST": raw}):
+                self.assertEqual(
+                    _resolve_retain_last(), 0,
+                    f"expected 0 for ASSIST_RETAIN_LAST={raw!r}",
+                )
+
+    def test_invalid_falls_back_with_warning(self):
+        from unittest.mock import patch
+        with patch.dict("os.environ", {"ASSIST_RETAIN_LAST": "not-a-number"}):
+            with self.assertLogs("assist.checkpointer", level="WARNING"):
+                self.assertEqual(_resolve_retain_last(), DEFAULT_RETAIN_LAST)
+
+    def test_negative_falls_back_with_warning(self):
+        from unittest.mock import patch
+        with patch.dict("os.environ", {"ASSIST_RETAIN_LAST": "-5"}):
+            with self.assertLogs("assist.checkpointer", level="WARNING"):
+                self.assertEqual(_resolve_retain_last(), DEFAULT_RETAIN_LAST)


### PR DESCRIPTION
## Summary
- New `assist/checkpointer.py` wraps `SqliteSaver` so each `put()` keeps only the most-recent `ASSIST_RETAIN_LAST` checkpoints per `(thread_id, checkpoint_ns)`. Default 10; `0` / `disabled` / `off` / `false` is the operational kill switch.
- One `with self.cursor()` block holds the upstream INSERT plus the SELECT+DELETE pair, so all four statements share one lock acquisition and one commit (option A from the design review).
- Schema pinned against `langgraph-checkpoint-sqlite==3.0.3` (two tables: `checkpoints`, `writes`). `EXPECTED_TABLES` is checked against `sqlite_master` on the first `put`; drift logs once and disables pruning so an upstream rename can never silently orphan rows.
- Prune failures are caught and logged — the INSERT is the load-bearing op; a failed prune self-heals on the next `put`. `delete_thread` is intentionally not overridden so Layer 0's `hard_delete` continues to use the upstream per-table wipe.
- Design doc updated with the corrections from the pre-implementation review (2 tables not 3, compound PK includes `checkpoint_ns`, sync-only saver so `aput` is N/A, rollback depth resolved at 3 with 3× margin, "ship inert" replaced by the env switch).

## Test plan
- [x] `pytest tests/test_checkpointer_retention.py` — 17 new tests pass
- [x] `pytest tests/test_thread_manager_hard_delete.py tests/test_thread_manager_lazy.py tests/test_checkpoint_rollback.py tests/test_retention_sweep.py` — Layer 0 + rollback + sweep regression suites pass (49/49)
- [x] Full local suite: 297/297
- [ ] Deploy to prod with `ASSIST_RETAIN_LAST=10` (default), watch one eval suite run, then a research-agent loop
- [ ] If retention behaves, leave default; if it misbehaves, set `ASSIST_RETAIN_LAST=0` in `.deploy.env` and restart assist-web (no rollback deploy needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)