### PR TITLE
threads-db Layer 3: per-checkpoint tool-result eviction

### DIFF
--- a/.deploy.env.example
+++ b/.deploy.env.example
@@ -28,6 +28,14 @@ ASSIST_PORT=8000
 # See docs/2026-05-04-threads-db-layer-0-thread-retention.org.
 MIN_THREADS=100
 
+# Layer 3: tool-result eviction threshold (KB).  Any ToolMessage or
+# /large_tool_results/ files-channel entry larger than this is moved
+# out of the checkpoint and onto the filesystem at write time;
+# rehydrated automatically on read.  0 / disabled / off / false makes
+# the saver a no-op pass-through (kill switch).
+# See docs/2026-05-04-threads-db-layer-3-tool-result-eviction.org.
+ASSIST_EVICT_THRESHOLD_KB=20
+
 # Production Model Configuration
 # These will be set in the systemd service
 ASSIST_MODEL_URL=http://your-production-server:8000/v1

--- a/assist/eviction_saver.py
+++ b/assist/eviction_saver.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
-from typing import Any, Iterator
+from typing import Any, Iterator, Sequence
 
 from langchain_core.messages import ToolMessage
 from langchain_core.runnables import RunnableConfig
@@ -242,6 +242,53 @@ class EvictionSaver(SqliteSaver):
         new_checkpoint["channel_values"] = new_cv
         return new_checkpoint, side_effects
 
+    def _evict_one_message(
+        self,
+        msg: Any,
+        thread_id: str,
+        threshold_bytes: int,
+    ) -> tuple[Any, tuple[str, bytes] | None]:
+        """Evict a single ToolMessage if oversized.
+
+        Returns ``(new_msg, side_effect)`` where ``side_effect`` is the
+        ``(path, bytes)`` to flush, or ``None`` if the message is not
+        eligible (wrong type, too small, already evicted, copy failed).
+        """
+        if not isinstance(msg, ToolMessage):
+            return msg, None
+        ak = getattr(msg, "additional_kwargs", None) or {}
+        if EVICT_PATH_KEY in ak:
+            # Already evicted (idempotent re-put).  Catch the case
+            # where a stub somehow re-enters the write path without
+            # going through rehydration first.
+            return msg, None
+        content_bytes = _content_to_bytes(getattr(msg, "content", ""))
+        if len(content_bytes) <= threshold_bytes:
+            return msg, None
+        digest = hashlib.sha256(content_bytes).hexdigest()[:16]
+        path = self._eviction_path(thread_id, digest)
+        new_ak = {
+            **ak,
+            EVICT_PATH_KEY: path,
+            EVICT_SIZE_KEY: len(content_bytes),
+            EVICT_HASH_KEY: digest,
+        }
+        stub = (
+            f"[evicted: {len(content_bytes)} bytes tool result, "
+            f"see {LARGE_TOOL_RESULTS_PREFIX}{digest}]"
+        )
+        try:
+            new_msg = msg.model_copy(
+                update={"content": stub, "additional_kwargs": new_ak}
+            )
+        except Exception:
+            logger.exception(
+                "EvictionSaver: failed to copy ToolMessage; "
+                "skipping eviction for this message."
+            )
+            return msg, None
+        return new_msg, (path, content_bytes)
+
     def _evict_messages(
         self,
         messages: list | None,
@@ -253,42 +300,51 @@ class EvictionSaver(SqliteSaver):
             return None
         new_messages: list | None = None
         for i, msg in enumerate(messages):
-            if not isinstance(msg, ToolMessage):
-                continue
-            ak = getattr(msg, "additional_kwargs", None) or {}
-            if EVICT_PATH_KEY in ak:
-                # Already evicted in a prior put (idempotent).
-                continue
-            content_bytes = _content_to_bytes(getattr(msg, "content", ""))
-            if len(content_bytes) <= threshold_bytes:
-                continue
-            digest = hashlib.sha256(content_bytes).hexdigest()[:16]
-            path = self._eviction_path(thread_id, digest)
-            new_ak = {
-                **ak,
-                EVICT_PATH_KEY: path,
-                EVICT_SIZE_KEY: len(content_bytes),
-                EVICT_HASH_KEY: digest,
-            }
-            stub = (
-                f"[evicted: {len(content_bytes)} bytes tool result, "
-                f"see {LARGE_TOOL_RESULTS_PREFIX}{digest}]"
-            )
-            try:
-                new_msg = msg.model_copy(
-                    update={"content": stub, "additional_kwargs": new_ak}
-                )
-            except Exception:
-                logger.exception(
-                    "EvictionSaver: failed to copy ToolMessage; "
-                    "skipping eviction for this message."
-                )
+            new_msg, se = self._evict_one_message(msg, thread_id, threshold_bytes)
+            if se is None:
                 continue
             if new_messages is None:
                 new_messages = list(messages)
             new_messages[i] = new_msg
-            side_effects.append((path, content_bytes))
+            side_effects.append(se)
         return new_messages
+
+    def _evict_one_file(
+        self,
+        path: str,
+        fd: Any,
+        thread_id: str,
+        threshold_bytes: int,
+    ) -> tuple[Any, tuple[str, bytes] | None]:
+        """Evict a single files-channel entry if eligible.
+
+        Returns ``(new_fd, side_effect)`` or ``(fd, None)`` if not
+        eligible (path not under ``/large_tool_results/``, value not a
+        dict, too small, already evicted).
+        """
+        if not isinstance(path, str):
+            return fd, None
+        if not path.startswith(LARGE_TOOL_RESULTS_PREFIX):
+            return fd, None
+        if not isinstance(fd, dict):
+            return fd, None
+        if EVICT_PATH_KEY in fd:
+            return fd, None
+        content_bytes = _file_content_to_bytes(fd)
+        if len(content_bytes) <= threshold_bytes:
+            return fd, None
+        digest = hashlib.sha256(content_bytes).hexdigest()[:16]
+        evict_path = self._eviction_path(thread_id, digest)
+        stub: dict[str, Any] = {
+            EVICT_PATH_KEY: evict_path,
+            EVICT_SIZE_KEY: len(content_bytes),
+            EVICT_HASH_KEY: digest,
+            EVICT_ENCODING_KEY: fd.get("encoding", "utf-8"),
+        }
+        for k in ("created_at", "modified_at"):
+            if k in fd:
+                stub[k] = fd[k]
+        return stub, (evict_path, content_bytes)
 
     def _evict_files(
         self,
@@ -301,34 +357,53 @@ class EvictionSaver(SqliteSaver):
             return None
         new_files: dict | None = None
         for path, fd in files.items():
-            if not isinstance(path, str):
+            new_fd, se = self._evict_one_file(
+                path, fd, thread_id, threshold_bytes
+            )
+            if se is None:
                 continue
-            if not path.startswith(LARGE_TOOL_RESULTS_PREFIX):
-                continue
-            if not isinstance(fd, dict):
-                continue
-            if EVICT_PATH_KEY in fd:
-                # Already evicted (idempotent).
-                continue
-            content_bytes = _file_content_to_bytes(fd)
-            if len(content_bytes) <= threshold_bytes:
-                continue
-            digest = hashlib.sha256(content_bytes).hexdigest()[:16]
-            evict_path = self._eviction_path(thread_id, digest)
-            stub: dict[str, Any] = {
-                EVICT_PATH_KEY: evict_path,
-                EVICT_SIZE_KEY: len(content_bytes),
-                EVICT_HASH_KEY: digest,
-                EVICT_ENCODING_KEY: fd.get("encoding", "utf-8"),
-            }
-            for k in ("created_at", "modified_at"):
-                if k in fd:
-                    stub[k] = fd[k]
             if new_files is None:
                 new_files = dict(files)
-            new_files[path] = stub
-            side_effects.append((evict_path, content_bytes))
+            new_files[path] = new_fd
+            side_effects.append(se)
         return new_files
+
+    def _evict_write_value(
+        self,
+        channel: str,
+        value: Any,
+        thread_id: str,
+        threshold_bytes: int,
+        side_effects: list[tuple[str, bytes]],
+    ) -> Any | None:
+        """Evict large content from a single ``put_writes`` value.
+
+        Returns the new value if mutation happened, ``None`` if the
+        write is unchanged.  Handles three shapes per channel:
+
+        - ``messages``: a list of messages, or a single message
+          (langgraph's pregel emits both depending on the reducer).
+        - ``files``: a dict of ``path → FileData``.
+        - everything else: passes through.
+        """
+        if channel == "messages":
+            if isinstance(value, list):
+                return self._evict_messages(
+                    value, thread_id, threshold_bytes, side_effects
+                )
+            new_msg, se = self._evict_one_message(
+                value, thread_id, threshold_bytes
+            )
+            if se is None:
+                return None
+            side_effects.append(se)
+            return new_msg
+        if channel == "files":
+            if isinstance(value, dict):
+                return self._evict_files(
+                    value, thread_id, threshold_bytes, side_effects
+                )
+        return None
 
     def _flush_evictions(self, side_effects: list[tuple[str, bytes]]) -> None:
         """Write eviction blobs to disk.  Best-effort, content-hash dedup.
@@ -399,55 +474,109 @@ class EvictionSaver(SqliteSaver):
         new_checkpoint["channel_values"] = new_cv
         return new_checkpoint
 
+    def _rehydrate_one_message(self, msg: Any) -> Any | None:
+        """Return a rehydrated message, or ``None`` if ``msg`` is not a
+        stub (so the caller leaves it untouched)."""
+        ak = getattr(msg, "additional_kwargs", None)
+        if not isinstance(ak, dict) or EVICT_PATH_KEY not in ak:
+            return None
+        content_bytes = self._read_eviction(ak[EVICT_PATH_KEY])
+        cleaned_ak = {k: v for k, v in ak.items() if k not in EVICT_ALL_KEYS}
+        try:
+            return msg.model_copy(
+                update={
+                    "content": content_bytes.decode("utf-8", "replace"),
+                    "additional_kwargs": cleaned_ak,
+                }
+            )
+        except Exception:
+            logger.exception(
+                "EvictionSaver: failed to rehydrate ToolMessage; "
+                "leaving stub in place."
+            )
+            return None
+
     def _rehydrate_messages(self, messages: list | None) -> list | None:
         if not messages:
             return None
         new_messages: list | None = None
         for i, msg in enumerate(messages):
-            ak = getattr(msg, "additional_kwargs", None)
-            if not isinstance(ak, dict) or EVICT_PATH_KEY not in ak:
-                continue
-            content_bytes = self._read_eviction(ak[EVICT_PATH_KEY])
-            cleaned_ak = {k: v for k, v in ak.items() if k not in EVICT_ALL_KEYS}
-            try:
-                new_msg = msg.model_copy(
-                    update={
-                        "content": content_bytes.decode("utf-8", "replace"),
-                        "additional_kwargs": cleaned_ak,
-                    }
-                )
-            except Exception:
-                logger.exception(
-                    "EvictionSaver: failed to rehydrate ToolMessage; "
-                    "leaving stub in place."
-                )
+            new_msg = self._rehydrate_one_message(msg)
+            if new_msg is None:
                 continue
             if new_messages is None:
                 new_messages = list(messages)
             new_messages[i] = new_msg
         return new_messages
 
+    def _rehydrate_one_file(self, fd: Any) -> dict | None:
+        """Return a rehydrated FileData, or ``None`` if ``fd`` is not a stub.
+
+        The on-disk blob carries no format metadata, so rehydration
+        always restores to the v2 (modern) FileData shape: ``{"content":
+        str, "encoding": str, ...}``.  This is a one-way upgrade for
+        any v1 (``content: list[str]``) entries that were evicted —
+        ``StateBackend._normalize_content`` smooths the difference at
+        read time, so callers don't notice.
+        """
+        if not isinstance(fd, dict) or EVICT_PATH_KEY not in fd:
+            return None
+        content_bytes = self._read_eviction(fd[EVICT_PATH_KEY])
+        encoding = fd.get(EVICT_ENCODING_KEY, "utf-8")
+        content_str = content_bytes.decode(encoding, "replace")
+        restored: dict[str, Any] = {
+            "content": content_str,
+            "encoding": encoding,
+        }
+        for k in ("created_at", "modified_at"):
+            if k in fd:
+                restored[k] = fd[k]
+        return restored
+
     def _rehydrate_files(self, files: dict | None) -> dict | None:
         if not files or not isinstance(files, dict):
             return None
         new_files: dict | None = None
         for path, fd in files.items():
-            if not isinstance(fd, dict) or EVICT_PATH_KEY not in fd:
+            new_fd = self._rehydrate_one_file(fd)
+            if new_fd is None:
                 continue
-            content_bytes = self._read_eviction(fd[EVICT_PATH_KEY])
-            encoding = fd.get(EVICT_ENCODING_KEY, "utf-8")
-            content_str = content_bytes.decode(encoding, "replace")
-            restored: dict[str, Any] = {
-                "content": content_str,
-                "encoding": encoding,
-            }
-            for k in ("created_at", "modified_at"):
-                if k in fd:
-                    restored[k] = fd[k]
             if new_files is None:
                 new_files = dict(files)
-            new_files[path] = restored
+            new_files[path] = new_fd
         return new_files
+
+    def _rehydrate_write_value(self, channel: str, value: Any) -> Any | None:
+        """Rehydrate a single ``put_writes`` value.  Returns ``None`` if
+        the value is unchanged."""
+        if channel == "messages":
+            if isinstance(value, list):
+                return self._rehydrate_messages(value)
+            return self._rehydrate_one_message(value)
+        if channel == "files":
+            if isinstance(value, dict):
+                return self._rehydrate_files(value)
+        return None
+
+    def _rehydrate_pending_writes(
+        self, pending_writes: Sequence | None
+    ) -> list | None:
+        """Walk pending-writes (``[(task_id, channel, value), ...]``) and
+        rehydrate any stub values.  Returns ``None`` if nothing changed."""
+        if not pending_writes:
+            return None
+        new_writes: list | None = None
+        for i, entry in enumerate(pending_writes):
+            if not isinstance(entry, tuple) or len(entry) != 3:
+                continue
+            task_id, channel, value = entry
+            new_value = self._rehydrate_write_value(channel, value)
+            if new_value is None:
+                continue
+            if new_writes is None:
+                new_writes = list(pending_writes)
+            new_writes[i] = (task_id, channel, new_value)
+        return new_writes
 
     def _read_eviction(self, path: str) -> bytes:
         try:
@@ -489,16 +618,69 @@ class EvictionSaver(SqliteSaver):
             checkpoint_to_save = checkpoint
         return super().put(config, checkpoint_to_save, metadata, new_versions)
 
+    def put_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        """Pre-process per-task writes before they land in the ``writes``
+        table.
+
+        Each tool node's output flows through ``put_writes`` first;
+        without eviction here, the ``writes`` table accumulates the
+        full ToolMessage content per super-step until Layer 2's
+        retention sweep removes the parent checkpoint.  Within that
+        window, the per-thread DB cost would be roughly checkpoint-size
+        × number-of-writes-per-checkpoint without this hook.
+        """
+        if self.evict_threshold_kb <= 0 or self.eviction_root is None:
+            return super().put_writes(config, writes, task_id, task_path)
+        thread_id = str(config["configurable"]["thread_id"])
+        threshold_bytes = self.evict_threshold_kb * 1024
+        side_effects: list[tuple[str, bytes]] = []
+        new_writes: list | None = None
+        try:
+            for i, entry in enumerate(writes):
+                if not isinstance(entry, tuple) or len(entry) != 2:
+                    continue
+                channel, value = entry
+                new_value = self._evict_write_value(
+                    channel, value, thread_id, threshold_bytes, side_effects
+                )
+                if new_value is None:
+                    continue
+                if new_writes is None:
+                    new_writes = list(writes)
+                new_writes[i] = (channel, new_value)
+            if side_effects:
+                self._flush_evictions(side_effects)
+        except Exception:
+            logger.exception(
+                "EvictionSaver: put_writes eviction failed for "
+                "thread_id=%r task_id=%r; falling back to un-evicted writes.",
+                thread_id, task_id,
+            )
+            return super().put_writes(config, writes, task_id, task_path)
+        return super().put_writes(
+            config,
+            new_writes if new_writes is not None else writes,
+            task_id,
+            task_path,
+        )
+
     def get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
         tup = super().get_tuple(config)
         if tup is None:
             return None
         rehydrated = self._rehydrate_checkpoint(tup.checkpoint)
-        if rehydrated is tup.checkpoint:
+        new_pending = self._rehydrate_pending_writes(tup.pending_writes)
+        if rehydrated is tup.checkpoint and new_pending is None:
             return tup
         return CheckpointTuple(
             tup.config, rehydrated, tup.metadata, tup.parent_config,
-            tup.pending_writes,
+            new_pending if new_pending is not None else tup.pending_writes,
         )
 
     def list(
@@ -513,10 +695,12 @@ class EvictionSaver(SqliteSaver):
             config, filter=filter, before=before, limit=limit
         ):
             rehydrated = self._rehydrate_checkpoint(tup.checkpoint)
-            if rehydrated is tup.checkpoint:
+            new_pending = self._rehydrate_pending_writes(tup.pending_writes)
+            if rehydrated is tup.checkpoint and new_pending is None:
                 yield tup
             else:
                 yield CheckpointTuple(
-                    tup.config, rehydrated, tup.metadata,
-                    tup.parent_config, tup.pending_writes,
+                    tup.config, rehydrated, tup.metadata, tup.parent_config,
+                    new_pending if new_pending is not None
+                    else tup.pending_writes,
                 )

--- a/assist/eviction_saver.py
+++ b/assist/eviction_saver.py
@@ -1,0 +1,522 @@
+"""Tool-result eviction wrapper.
+
+Layer 3 of the threads.db growth plan
+(docs/2026-05-04-threads-db-layer-3-tool-result-eviction.org).
+Wraps langgraph's SqliteSaver to cap the size of any single
+checkpoint by moving large tool-result content out of the DB and
+onto the filesystem at write time, and rehydrating it on read.
+
+Two channels are evicted:
+
+1. ``channel_values["messages"]`` — any ``ToolMessage`` whose content
+   exceeds ``ASSIST_EVICT_THRESHOLD_KB`` is replaced with a stub
+   message; the original content is sha256-hashed and written to
+   ``<eviction_root>/<thread_id>/large_tool_results/<sha256_16>``.
+
+2. ``channel_values["files"]`` — any entry under ``/large_tool_results/``
+   that exceeds the threshold is replaced with a marker dict; the
+   content goes to the same disk path.  This is the channel the
+   existing ``ContextAwareToolEvictionMiddleware`` writes into via
+   ``StateBackend``; without draining it, the middleware merely moves
+   bytes from one channel to another inside the same checkpoint.
+
+The eviction directory lives *under* the per-thread directory, so
+Layer 0's ``hard_delete`` (``shutil.rmtree`` on the thread dir)
+cleans up eviction files for free.
+
+On read (``get_tuple``, ``list``), stubbed entries are rehydrated
+back to their original content by reading the on-disk file.  A
+missing eviction file raises ``EvictionFileMissingError`` rather
+than silently returning a half-restored checkpoint.
+
+Pinned against ``langgraph-checkpoint-sqlite==3.0.3``.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from typing import Any, Iterator
+
+from langchain_core.messages import ToolMessage
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import (
+    ChannelVersions,
+    Checkpoint,
+    CheckpointMetadata,
+    CheckpointTuple,
+)
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_EVICT_THRESHOLD_KB = 20
+
+# Sentinel keys used inside stub message ``additional_kwargs`` and
+# stub ``files`` channel entries.  Underscore-prefixed so they don't
+# collide with anything langchain or deepagents stores there.
+EVICT_PATH_KEY = "_evicted_to"
+EVICT_SIZE_KEY = "_evicted_size"
+EVICT_HASH_KEY = "_evicted_sha256"
+EVICT_ENCODING_KEY = "_evicted_encoding"
+EVICT_ALL_KEYS = (
+    EVICT_PATH_KEY,
+    EVICT_SIZE_KEY,
+    EVICT_HASH_KEY,
+    EVICT_ENCODING_KEY,
+)
+
+# Files-channel paths under this prefix are eligible for eviction.
+# Matches ``STATEFUL_PATHS`` in ``assist/backends.py`` and the path
+# the existing middleware writes to.
+LARGE_TOOL_RESULTS_PREFIX = "/large_tool_results/"
+
+
+class EvictionFileMissingError(RuntimeError):
+    """Raised when a rehydration target file is missing on disk.
+
+    The caller (rollback path, web UI, eval) decides how to surface
+    this — partial rehydration is never silently substituted.
+    """
+
+
+def _resolve_evict_threshold_kb() -> int:
+    """Read ``ASSIST_EVICT_THRESHOLD_KB``.
+
+    - unset → ``DEFAULT_EVICT_THRESHOLD_KB``
+    - "0" / "" / "disabled" / "off" / "false" → 0 (kill switch)
+    - positive int → use it
+    - anything else → default with a loud warning (typo never
+      silently disables)
+    """
+    raw = os.environ.get("ASSIST_EVICT_THRESHOLD_KB")
+    if raw is None:
+        return DEFAULT_EVICT_THRESHOLD_KB
+    norm = raw.strip().lower()
+    if norm in ("", "disabled", "off", "false"):
+        return 0
+    try:
+        n = int(norm)
+    except ValueError:
+        logger.warning(
+            "ASSIST_EVICT_THRESHOLD_KB=%r is not an integer; defaulting to %d",
+            raw, DEFAULT_EVICT_THRESHOLD_KB,
+        )
+        return DEFAULT_EVICT_THRESHOLD_KB
+    if n < 0:
+        logger.warning(
+            "ASSIST_EVICT_THRESHOLD_KB=%d is negative; defaulting to %d",
+            n, DEFAULT_EVICT_THRESHOLD_KB,
+        )
+        return DEFAULT_EVICT_THRESHOLD_KB
+    return n
+
+
+def _content_to_bytes(content: Any) -> bytes:
+    """Best-effort UTF-8 encoding of arbitrary message content.
+
+    ``ToolMessage.content`` may be a string or a list of content-part
+    dicts (``{"type": "text", "text": ...}``).  The list form is rare
+    for tool results in this repo but is still well-defined; collapse
+    it to a JSON-ish string so the size check is predictable.
+    """
+    if isinstance(content, str):
+        return content.encode("utf-8", "surrogatepass")
+    return str(content).encode("utf-8", "surrogatepass")
+
+
+def _file_content_to_bytes(fd: dict) -> bytes:
+    """Encode a state-backend ``FileData`` to UTF-8 bytes for sizing.
+
+    Handles both the modern ``content: str`` and the legacy
+    ``content: list[str]`` (joined on newlines) forms.
+    """
+    content = fd.get("content", "")
+    if isinstance(content, list):
+        content_str = "\n".join(str(x) for x in content)
+    else:
+        content_str = str(content)
+    return content_str.encode("utf-8", "surrogatepass")
+
+
+class EvictionSaver(SqliteSaver):
+    """SqliteSaver that evicts large tool-result content to disk on put().
+
+    Threshold is read from ``ASSIST_EVICT_THRESHOLD_KB`` at construction
+    time (unless overridden via ``evict_threshold_kb=`` for tests).
+    A threshold of 0 makes the wrapper a no-op pass-through —
+    operational kill switch.
+
+    ``eviction_root`` is the *parent* directory; the saver computes
+    ``<eviction_root>/<thread_id>/large_tool_results/<sha256_16>`` per
+    eviction file.  When ``eviction_root == ThreadManager.root_dir``,
+    the eviction directory lives inside the per-thread dir and Layer 0's
+    ``hard_delete`` wipes it for free.
+
+    Async methods (``aput`` etc.) are not overridden; upstream
+    ``SqliteSaver`` raises ``NotImplementedError`` from them and we
+    inherit that posture.
+    """
+
+    def __init__(
+        self,
+        *args,
+        evict_threshold_kb: int | None = None,
+        eviction_root: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.evict_threshold_kb = (
+            evict_threshold_kb if evict_threshold_kb is not None
+            else _resolve_evict_threshold_kb()
+        )
+        self.eviction_root = eviction_root
+        if self.evict_threshold_kb <= 0:
+            logger.info("EvictionSaver: eviction disabled")
+        elif self.eviction_root is None:
+            logger.warning(
+                "EvictionSaver: evict_threshold_kb=%d but no eviction_root; "
+                "disabling eviction (no place to write).",
+                self.evict_threshold_kb,
+            )
+            self.evict_threshold_kb = 0
+        else:
+            logger.info(
+                "EvictionSaver: evicting tool results > %d KB to %s/<tid>/%s",
+                self.evict_threshold_kb,
+                self.eviction_root,
+                "large_tool_results/<sha256_16>",
+            )
+
+    # ------------------------------------------------------------------
+    # Path helpers
+    # ------------------------------------------------------------------
+
+    def _eviction_dir(self, thread_id: str) -> str:
+        assert self.eviction_root is not None
+        return os.path.join(
+            self.eviction_root, str(thread_id), "large_tool_results"
+        )
+
+    def _eviction_path(self, thread_id: str, digest: str) -> str:
+        return os.path.join(self._eviction_dir(thread_id), digest)
+
+    # ------------------------------------------------------------------
+    # Eviction (write side)
+    # ------------------------------------------------------------------
+
+    def _evict_checkpoint(
+        self, checkpoint: Checkpoint, thread_id: str
+    ) -> tuple[Checkpoint, list[tuple[str, bytes]]]:
+        """Return a (possibly new) checkpoint with stubs in place of large
+        content, plus a list of ``(path, bytes)`` to write to disk.
+
+        Pure: never mutates the input checkpoint.  Lazily copies only
+        the parts that change — most checkpoints have no eligible
+        eviction targets, so we usually return ``checkpoint`` unchanged
+        with an empty side-effect list.
+        """
+        if self.evict_threshold_kb <= 0 or self.eviction_root is None:
+            return checkpoint, []
+
+        threshold_bytes = self.evict_threshold_kb * 1024
+        cv = checkpoint.get("channel_values") or {}
+        side_effects: list[tuple[str, bytes]] = []
+
+        new_messages = self._evict_messages(
+            cv.get("messages"), thread_id, threshold_bytes, side_effects
+        )
+        new_files = self._evict_files(
+            cv.get("files"), thread_id, threshold_bytes, side_effects
+        )
+
+        if new_messages is None and new_files is None:
+            return checkpoint, []
+
+        new_cv = dict(cv)
+        if new_messages is not None:
+            new_cv["messages"] = new_messages
+        if new_files is not None:
+            new_cv["files"] = new_files
+        new_checkpoint = dict(checkpoint)
+        new_checkpoint["channel_values"] = new_cv
+        return new_checkpoint, side_effects
+
+    def _evict_messages(
+        self,
+        messages: list | None,
+        thread_id: str,
+        threshold_bytes: int,
+        side_effects: list[tuple[str, bytes]],
+    ) -> list | None:
+        if not messages:
+            return None
+        new_messages: list | None = None
+        for i, msg in enumerate(messages):
+            if not isinstance(msg, ToolMessage):
+                continue
+            ak = getattr(msg, "additional_kwargs", None) or {}
+            if EVICT_PATH_KEY in ak:
+                # Already evicted in a prior put (idempotent).
+                continue
+            content_bytes = _content_to_bytes(getattr(msg, "content", ""))
+            if len(content_bytes) <= threshold_bytes:
+                continue
+            digest = hashlib.sha256(content_bytes).hexdigest()[:16]
+            path = self._eviction_path(thread_id, digest)
+            new_ak = {
+                **ak,
+                EVICT_PATH_KEY: path,
+                EVICT_SIZE_KEY: len(content_bytes),
+                EVICT_HASH_KEY: digest,
+            }
+            stub = (
+                f"[evicted: {len(content_bytes)} bytes tool result, "
+                f"see {LARGE_TOOL_RESULTS_PREFIX}{digest}]"
+            )
+            try:
+                new_msg = msg.model_copy(
+                    update={"content": stub, "additional_kwargs": new_ak}
+                )
+            except Exception:
+                logger.exception(
+                    "EvictionSaver: failed to copy ToolMessage; "
+                    "skipping eviction for this message."
+                )
+                continue
+            if new_messages is None:
+                new_messages = list(messages)
+            new_messages[i] = new_msg
+            side_effects.append((path, content_bytes))
+        return new_messages
+
+    def _evict_files(
+        self,
+        files: dict | None,
+        thread_id: str,
+        threshold_bytes: int,
+        side_effects: list[tuple[str, bytes]],
+    ) -> dict | None:
+        if not files or not isinstance(files, dict):
+            return None
+        new_files: dict | None = None
+        for path, fd in files.items():
+            if not isinstance(path, str):
+                continue
+            if not path.startswith(LARGE_TOOL_RESULTS_PREFIX):
+                continue
+            if not isinstance(fd, dict):
+                continue
+            if EVICT_PATH_KEY in fd:
+                # Already evicted (idempotent).
+                continue
+            content_bytes = _file_content_to_bytes(fd)
+            if len(content_bytes) <= threshold_bytes:
+                continue
+            digest = hashlib.sha256(content_bytes).hexdigest()[:16]
+            evict_path = self._eviction_path(thread_id, digest)
+            stub: dict[str, Any] = {
+                EVICT_PATH_KEY: evict_path,
+                EVICT_SIZE_KEY: len(content_bytes),
+                EVICT_HASH_KEY: digest,
+                EVICT_ENCODING_KEY: fd.get("encoding", "utf-8"),
+            }
+            for k in ("created_at", "modified_at"):
+                if k in fd:
+                    stub[k] = fd[k]
+            if new_files is None:
+                new_files = dict(files)
+            new_files[path] = stub
+            side_effects.append((evict_path, content_bytes))
+        return new_files
+
+    def _flush_evictions(self, side_effects: list[tuple[str, bytes]]) -> None:
+        """Write eviction blobs to disk.  Best-effort, content-hash dedup.
+
+        Uses ``O_CREAT | O_EXCL`` so a duplicate hash is a fast no-op
+        (treated as success).  Other errors are logged and propagated
+        so the caller can fall back to writing the un-evicted
+        checkpoint.
+        """
+        for path, content in side_effects:
+            d = os.path.dirname(path)
+            try:
+                os.makedirs(d, exist_ok=True)
+            except OSError:
+                logger.exception(
+                    "EvictionSaver: failed to create %s; aborting eviction.",
+                    d,
+                )
+                raise
+            try:
+                fd = os.open(
+                    path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600
+                )
+            except FileExistsError:
+                # Content-hash dedup: another (tid, checkpoint) already
+                # wrote this exact bytes.  Treat as success.
+                continue
+            try:
+                with os.fdopen(fd, "wb") as f:
+                    f.write(content)
+            except OSError:
+                # Tear down the partial file so the next put retries
+                # cleanly rather than seeing a truncated dedup hit.
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+                raise
+
+    # ------------------------------------------------------------------
+    # Rehydration (read side)
+    # ------------------------------------------------------------------
+
+    def _rehydrate_checkpoint(
+        self, checkpoint: Checkpoint | None
+    ) -> Checkpoint | None:
+        """Replace stub messages and files-channel entries with their
+        original content read from disk.
+
+        Pure: returns the input untouched if nothing needs rehydration.
+        Raises ``EvictionFileMissingError`` if a stub points at a
+        missing file — partial rehydration is never silently
+        substituted.
+        """
+        if checkpoint is None:
+            return checkpoint
+        cv = checkpoint.get("channel_values") or {}
+        new_messages = self._rehydrate_messages(cv.get("messages"))
+        new_files = self._rehydrate_files(cv.get("files"))
+        if new_messages is None and new_files is None:
+            return checkpoint
+        new_cv = dict(cv)
+        if new_messages is not None:
+            new_cv["messages"] = new_messages
+        if new_files is not None:
+            new_cv["files"] = new_files
+        new_checkpoint = dict(checkpoint)
+        new_checkpoint["channel_values"] = new_cv
+        return new_checkpoint
+
+    def _rehydrate_messages(self, messages: list | None) -> list | None:
+        if not messages:
+            return None
+        new_messages: list | None = None
+        for i, msg in enumerate(messages):
+            ak = getattr(msg, "additional_kwargs", None)
+            if not isinstance(ak, dict) or EVICT_PATH_KEY not in ak:
+                continue
+            content_bytes = self._read_eviction(ak[EVICT_PATH_KEY])
+            cleaned_ak = {k: v for k, v in ak.items() if k not in EVICT_ALL_KEYS}
+            try:
+                new_msg = msg.model_copy(
+                    update={
+                        "content": content_bytes.decode("utf-8", "replace"),
+                        "additional_kwargs": cleaned_ak,
+                    }
+                )
+            except Exception:
+                logger.exception(
+                    "EvictionSaver: failed to rehydrate ToolMessage; "
+                    "leaving stub in place."
+                )
+                continue
+            if new_messages is None:
+                new_messages = list(messages)
+            new_messages[i] = new_msg
+        return new_messages
+
+    def _rehydrate_files(self, files: dict | None) -> dict | None:
+        if not files or not isinstance(files, dict):
+            return None
+        new_files: dict | None = None
+        for path, fd in files.items():
+            if not isinstance(fd, dict) or EVICT_PATH_KEY not in fd:
+                continue
+            content_bytes = self._read_eviction(fd[EVICT_PATH_KEY])
+            encoding = fd.get(EVICT_ENCODING_KEY, "utf-8")
+            content_str = content_bytes.decode(encoding, "replace")
+            restored: dict[str, Any] = {
+                "content": content_str,
+                "encoding": encoding,
+            }
+            for k in ("created_at", "modified_at"):
+                if k in fd:
+                    restored[k] = fd[k]
+            if new_files is None:
+                new_files = dict(files)
+            new_files[path] = restored
+        return new_files
+
+    def _read_eviction(self, path: str) -> bytes:
+        try:
+            with open(path, "rb") as f:
+                return f.read()
+        except FileNotFoundError as e:
+            raise EvictionFileMissingError(
+                f"evicted content missing on disk: {path}"
+            ) from e
+
+    # ------------------------------------------------------------------
+    # SqliteSaver overrides
+    # ------------------------------------------------------------------
+
+    def put(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        """Pre-process the checkpoint to evict large content, then delegate."""
+        thread_id = str(config["configurable"]["thread_id"])
+        try:
+            evicted, side_effects = self._evict_checkpoint(checkpoint, thread_id)
+            if side_effects:
+                self._flush_evictions(side_effects)
+            checkpoint_to_save = evicted
+        except Exception:
+            # Eviction is best-effort; on any failure, write the
+            # un-evicted checkpoint so the put never blocks.  Disk is
+            # already strictly larger than DB, so this degrades to
+            # pre-Layer-3 behavior, never worse.
+            logger.exception(
+                "EvictionSaver: eviction failed for thread_id=%r; "
+                "falling back to un-evicted put.",
+                thread_id,
+            )
+            checkpoint_to_save = checkpoint
+        return super().put(config, checkpoint_to_save, metadata, new_versions)
+
+    def get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        tup = super().get_tuple(config)
+        if tup is None:
+            return None
+        rehydrated = self._rehydrate_checkpoint(tup.checkpoint)
+        if rehydrated is tup.checkpoint:
+            return tup
+        return CheckpointTuple(
+            tup.config, rehydrated, tup.metadata, tup.parent_config,
+            tup.pending_writes,
+        )
+
+    def list(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> Iterator[CheckpointTuple]:
+        for tup in super().list(
+            config, filter=filter, before=before, limit=limit
+        ):
+            rehydrated = self._rehydrate_checkpoint(tup.checkpoint)
+            if rehydrated is tup.checkpoint:
+                yield tup
+            else:
+                yield CheckpointTuple(
+                    tup.config, rehydrated, tup.metadata,
+                    tup.parent_config, tup.pending_writes,
+                )

--- a/assist/thread.py
+++ b/assist/thread.py
@@ -10,13 +10,13 @@ from typing import Literal, Dict, Any, Callable, List, Iterator
 
 import sqlite3
 from langchain.messages import HumanMessage, AIMessage, AnyMessage
-from langgraph.checkpoint.sqlite import SqliteSaver
 from langchain_core.language_models.chat_models import BaseChatModel
 
 from assist.promptable import base_prompt_for
 from assist.model_manager import select_chat_model
 from assist.agent import create_research_agent, create_agent
 from assist.checkpoint_rollback import invoke_with_rollback
+from assist.eviction_saver import EvictionSaver
 from assist.sandbox_manager import SandboxManager
 
 logger = logging.getLogger(__name__)
@@ -172,7 +172,12 @@ n    checkpointing via SqliteSaver.
             open(self.db_path, "a").close()
         # SqliteSaver expects a sqlite3.Connection
         self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        self.checkpointer = SqliteSaver(self.conn)
+        # EvictionSaver writes blobs under
+        # <root_dir>/<thread_id>/large_tool_results/, so Layer 0's
+        # hard_delete (rmtree on the thread dir) cleans them up for free.
+        self.checkpointer = EvictionSaver(
+            self.conn, eviction_root=self.root_dir
+        )
         # Lazily resolve the chat model so the web server can boot before
         # the LLM endpoint is reachable.  First request triggers the probe;
         # the lock prevents two concurrent first-requests from probing twice.

--- a/docs/2026-05-04-threads-db-layer-3-tool-result-eviction.org
+++ b/docs/2026-05-04-threads-db-layer-3-tool-result-eviction.org
@@ -1,6 +1,98 @@
 #+TITLE: Layer 3 — Tool-result eviction at write time
 #+DATE: 2026-05-04
-State: Not started
+State: PR open 2026-05-05, awaiting review
+
+* Session handoff (2026-05-05)
+This block is for whoever picks the work back up.  Design history is
+unchanged below.
+
+** What's landed
+- Branch: =layer-3-tool-result-eviction= (forked from =main= at
+  =e8f7705=).
+- Commit: "threads-db Layer 3: per-checkpoint tool-result eviction".
+- File =assist/eviction_saver.py= (new) — =EvictionSaver(SqliteSaver)=
+  subclass.  Overrides =put= (pre-evict + flush + super), =get_tuple=
+  (rehydrate), =list= (rehydrate per-tuple).
+- Wired into =assist/thread.py= at =ThreadManager.__init__= with
+  =eviction_root=self.root_dir=.  Eviction blobs live under
+  =<root_dir>/<tid>/large_tool_results/<sha256_16>= so Layer 0's
+  =hard_delete= rmtree wipes them for free.
+- Env switch =ASSIST_EVICT_THRESHOLD_KB= (default 20; =0= /
+  =disabled= / =off= / =false= = no-op kill switch).  Listed in
+  =.deploy.env.example=.
+
+** Trade-offs locked in by the implementation
+- *Subclass over wrapper-by-composition.*  Mirrors Layer 2's pattern.
+  Composition story when Layer 2 merges: change the base class from
+  =SqliteSaver= to =CheckpointRetentionSaver= and pass both env kwargs
+  through.  Single one-line edit.
+- *Single file, NOT folded into Layer 2's =assist/checkpointer.py=.*
+  Layer 2 (PR #88) is unmerged so reusing the filename would create a
+  hard merge conflict.  Eviction lives in =assist/eviction_saver.py=.
+- *=ToolMessage= eviction only.*  Other message types (Human, AI) are
+  passed through.  Tool results are the bloat surface; user input
+  isn't.
+- *=files= channel drained too.*  Entries under =/large_tool_results/=
+  larger than threshold are stubbed with =_evicted_to= markers.
+  That's the channel the existing =ContextAwareToolEvictionMiddleware=
+  writes to via =StateBackend=; without draining, the middleware
+  merely moves bytes from =messages= to =files= inside the same
+  checkpoint, leaving DB size untouched.
+- *Rehydration in =get_tuple= / =list=, NOT in =RollbackRunnable=.*
+  Every read path (rollback, =agent.get_state=, web UI rendering)
+  goes through the saver, so the saver is the single place to
+  rehydrate.
+- *Best-effort eviction.*  Disk-write failure logs and falls back to
+  the un-evicted checkpoint.  Pre-Layer-3 behavior is the worst case;
+  never a regression.
+- *=O_EXCL= dedup by content hash.*  Two checkpoints with the same
+  bytes share a single file, scoped per-thread (no cross-thread
+  ref-counting in v1).
+- *=EvictionFileMissingError= on missing rehydration target.*  Better
+  to surface clean than half-rehydrate.
+
+** Test status
+=24/24= passing in =tests/test_eviction_saver.py=, =311/311= in the
+full suite.  Run from =~/src/assist=:
+#+begin_src
+.venv/bin/python -m pytest tests/test_eviction_saver.py
+.venv/bin/python -m pytest tests/  # full suite
+#+end_src
+
+** Pending — what the next session should do
+1. *Address PR review comments.*  Particular surfaces to check:
+   the =files= channel drain logic (paths with no leading slash, v1
+   list-content format), and the round-trip on a real langgraph
+   checkpoint (the tests use synthetic ones).
+2. *Eval cadence.*  Per CLAUDE.md: post-impl N=3 → reviewer findings
+   addressed → N=5 → stability N=10.  Likely affected suites:
+   =edd/eval/test_research_multi_turn_token_regression.py=,
+   =edd/eval/eval_large_tool_results.py=,
+   =edd/eval/eval_multi_turn_research.py=,
+   =edd/eval/test_research_agent.py=.
+3. *Merge to main once approved.*  After Layer 2 lands too, fold
+   =EvictionSaver= to subclass =CheckpointRetentionSaver= so prune
+   and eviction share the same =put=.  Tests stay split.
+4. *Deploy + smoke.*  =make deploy= from =~/src/assist=.  Watch
+   =journalctl -u assist-web -f= for the
+   "EvictionSaver: evicting tool results > 20 KB" startup line.
+   Spot-check =du -sh /home/pierre/deploy/assist/threads/<tid>/
+   large_tool_results/= on a chatty research thread to confirm
+   blobs are landing on disk.
+
+** Kill switch (if Layer 3 misbehaves in prod)
+Add to =/home/pierre/deploy/assist/code/.deploy.env= on the prod
+host:
+#+begin_src
+ASSIST_EVICT_THRESHOLD_KB=0
+#+end_src
+Then =sudo systemctl restart assist-web=.  The wrapper becomes a
+no-op pass-through; behavior reverts to upstream =SqliteSaver=
+without a code rollback.  Already-evicted checkpoints continue to
+rehydrate correctly because =get_tuple= / =list= rehydrate
+unconditionally — the kill switch only stops *new* evictions.
+
+* Original design (history below)
 
 Layer 3 of the prod =threads.db= growth plan (overview:
 [[file:2026-05-03-prod-threads-db-growth.org][2026-05-03-prod-threads-db-growth.org]]).  This layer caps the size

--- a/docs/2026-05-04-threads-db-layer-3-tool-result-eviction.org
+++ b/docs/2026-05-04-threads-db-layer-3-tool-result-eviction.org
@@ -70,7 +70,11 @@ unchanged below.
 initial commit + 7 from the reviewer-driven follow-up: =put_writes=
 eviction, =pending_writes= rehydration, files-channel writes,
 kill-switch in =put_writes=, idempotency-skip on messages and on
-files).  Full suite passes.  Run from =~/src/assist=:
+files).  Plus =3/3= in =tests/test_eviction_saver_integration.py=:
+=ThreadManager= correctly wires =EvictionSaver=, real file-backed
+=threads.db= round-trip (100 KB content evicted + rehydrated), and
+Layer 0's =hard_delete= cascades to wipe eviction blobs.  Full
+suite =321/321=.  Run from =~/src/assist=:
 #+begin_src
 .venv/bin/python -m pytest tests/test_eviction_saver.py
 .venv/bin/python -m pytest tests/  # full suite
@@ -81,12 +85,22 @@ files).  Full suite passes.  Run from =~/src/assist=:
    the =files= channel drain logic (paths with no leading slash, v1
    list-content format), and the round-trip on a real langgraph
    checkpoint (the tests use synthetic ones).
-2. *Eval cadence.*  Per CLAUDE.md: post-impl N=3 → reviewer findings
-   addressed → N=5 → stability N=10.  Likely affected suites:
-   =edd/eval/test_research_multi_turn_token_regression.py=,
-   =edd/eval/eval_large_tool_results.py=,
-   =edd/eval/eval_multi_turn_research.py=,
-   =edd/eval/test_research_agent.py=.
+2. *Eval cadence — caveat from this session.*  =eval_large_tool_results.py=
+   was run N=3 on the latest commit; all three trials returned
+   =Large Results Evicted: NO= but the agent completed the task
+   successfully.  Root cause: Qwen3.6-27B knows the answer to "who
+   is the president of France" from training and never invokes
+   =search_internet=, so the mocked DDG payload is never produced —
+   no large tool result, nothing to evict.  This is a pre-existing
+   eval-reliability issue, NOT a Layer 3 regression.  The integration
+   test added in this PR (=tests/test_eviction_saver_integration.py=)
+   covers what the eval was meant to prove: real =ThreadManager= + real
+   file-backed =threads.db= + 100 KB content survives the round-trip
+   without inflating the DB blob.  =test_research_multi_turn_token_regression=
+   timed out at 600s on its first trial waiting on real DDG searches —
+   network-bound, not Layer 3.  Running these properly requires either
+   mock-the-LLM or a query the model demonstrably cannot answer from
+   training; defer to a future eval-reliability PR.
 3. *Merge to main once approved.*  After Layer 2 lands too, fold
    =EvictionSaver= to subclass =CheckpointRetentionSaver= so prune
    and eviction share the same =put=.  Tests stay split.

--- a/docs/2026-05-04-threads-db-layer-3-tool-result-eviction.org
+++ b/docs/2026-05-04-threads-db-layer-3-tool-result-eviction.org
@@ -1,10 +1,63 @@
 #+TITLE: Layer 3 — Tool-result eviction at write time
 #+DATE: 2026-05-04
-State: PR open 2026-05-05, awaiting review
+State: deployed to prod 2026-05-05; PR #89 still open / awaiting review
 
-* Session handoff (2026-05-05)
+* Session handoff (latest at top, last updated 2026-05-06)
 This block is for whoever picks the work back up.  Design history is
 unchanged below.
+
+** Production observation block (2026-05-06)
+Layer 3 has been live in prod for ~24h (deployed 2026-05-05 13:20
+PDT direct from the feature branch — user authorized
+feature-branch deploy, see
+=/home/pierre/.claude/projects/-home-pierre-src-assist/memory/feedback_deploy_from_feature_branch.md=).
+
+What we've observed so far:
+- =threads.db= still 175 GB.  Did NOT shrink at deploy as expected
+  — the next Sunday VACUUM is still pending, and Layer 3 only caps
+  *new* checkpoint growth, not the historical bloat (that's Layer 0
+  + Layer 1's job).
+- 24h of organic traffic produced only =192 KB= total Layer 3
+  on-disk artifacts (=140K + 52K=) across two threads, plus the
+  =EvictionSaver= startup log line for every thread restart.  That
+  is consistent with: most queries do not hit the 20 KB threshold;
+  the eviction win shows up in research-heavy sessions.
+- Zero =EvictionFileMissingError= or saver-side errors in the
+  journal.  No measured behavior regressions from the agent loop
+  through the eviction round-trip.
+- Two unrelated error patterns appeared during the observation
+  period — both pre-existing, NOT Layer 3:
+  1. =SandboxContainerLostError= recurring for a couple of
+     long-lived threads where the cached =DockerSandboxBackend= keeps
+     hitting a dead container ID across retries.  Pattern
+     understood; user's design preference is "thread should die
+     rather than heal-and-retry," see memory note.  Out of scope
+     for Layer 3.
+  2. =httpx.TimeoutException= bursts when llama.cpp is running
+     =--parallel 1=: parallel sub-agent requests serialize through
+     a single inference slot and the 10-min request timeout
+     (=_REQUEST_TIMEOUT_S = 600.0= in =assist/model_manager.py:62=)
+     fires under heavy load.  =ModelRetryMiddleware= recovers but
+     the user wants to reduce the timeout — folded into the
+     "thread should die" design memo above.
+
+** Deploy environment side-finding (2026-05-05)
+The dev =.venv= had a stale editable install under
+=.venv/src/assist/= that was being imported by scripts run as
+=.venv/bin/python <script.py>= because =sys.path[0]= is the
+script's directory (not the project root) — so any =import assist=
+fell through to the editable finder's MAPPING, which still pointed
+at the snapshot.  Symptoms: stale =model_manager.py= without the
+=_resolve_api_key= fallback, missing =assist/eviction_saver.py=
+import, and =evals running against the old code without us
+realising=.
+
+Fix: =.venv/bin/pip install -e . --no-deps= rewrites the editable
+finder MAPPING to point at =/home/pierre/src/assist/assist/=.
+Cosmetic for prod (the deployed venv at =/home/pierre/deploy/...=
+is a fresh editable install during =deploy-install=) but worth
+knowing if a future session sees similar "this code looks deployed
+but doesn't behave like it" symptoms.
 
 ** What's landed
 - Branch: =layer-3-tool-result-eviction= (forked from =main= at
@@ -80,36 +133,67 @@ suite =321/321=.  Run from =~/src/assist=:
 .venv/bin/python -m pytest tests/  # full suite
 #+end_src
 
+** Eval results (final, post-iteration)
+Three rounds of iteration:
+
+1. *First N=3* (commit =67fa9a1=, mocked DDG via
+   =patch('ddgs.DDGS.text', ...)=): 0/3 evictions observed.  Root
+   cause: =ddgs.DDGS= is a thin =_DDGSProxy=; instances bind
+   =text= from the real =ddgs.ddgs.DDGS= class.  Patching the proxy
+   was a no-op and real DDG was being hit.
+
+2. *Mock-path fix* (commit =68a6e38=, =patch('ddgs.ddgs.DDGS.text',
+   ...)= with =self= accepted in the mock signature): N=6 (3 of the
+   2-eval suite, then 3 of just the large-tool-results eval): 3 PASS,
+   3 INCONCLUSIVE, 0 FAIL.  When the model invokes =search_internet=,
+   the full path triggers cleanly: middleware evicts, Layer 3 catches
+   the files-channel write at =put_writes=, blobs land on disk under
+   the per-thread eviction dir, and the agent completes the task using
+   the rehydrated content.  When the model decides not to delegate to
+   the research sub-agent (model variance under temperature=0.1), the
+   mock never fires and we get =rc=2= (INCONCLUSIVE) — distinct from
+   FAIL, doesn't penalize Layer 3 for model unreliability.
+
+3. *Hardened prompt* (same commit =68a6e38=): added
+   =SEARCH-VERIFICATION-CODE: MOCK-RESULT-7K3F9P= sentinel buried
+   in the mocked search body.  The eval prompt now requires the
+   agent to find and quote that exact code, which is impossible to
+   fabricate from training data.  When the model does invoke search,
+   this confirms the rehydration round-trip end-to-end (model sees
+   the sentinel back through the eviction → stub → rehydrate path).
+
+The =test_research_multi_turn_token_regression= eval is
+network-bound on real DDG and consistently times out at 600-700s on
+trial 1.  Deferred to a separate eval-reliability PR; not a useful
+signal source for Layer 3 today.
+
 ** Pending — what the next session should do
-1. *Address PR review comments.*  Particular surfaces to check:
-   the =files= channel drain logic (paths with no leading slash, v1
-   list-content format), and the round-trip on a real langgraph
-   checkpoint (the tests use synthetic ones).
-2. *Eval cadence — caveat from this session.*  =eval_large_tool_results.py=
-   was run N=3 on the latest commit; all three trials returned
-   =Large Results Evicted: NO= but the agent completed the task
-   successfully.  Root cause: Qwen3.6-27B knows the answer to "who
-   is the president of France" from training and never invokes
-   =search_internet=, so the mocked DDG payload is never produced —
-   no large tool result, nothing to evict.  This is a pre-existing
-   eval-reliability issue, NOT a Layer 3 regression.  The integration
-   test added in this PR (=tests/test_eviction_saver_integration.py=)
-   covers what the eval was meant to prove: real =ThreadManager= + real
-   file-backed =threads.db= + 100 KB content survives the round-trip
-   without inflating the DB blob.  =test_research_multi_turn_token_regression=
-   timed out at 600s on its first trial waiting on real DDG searches —
-   network-bound, not Layer 3.  Running these properly requires either
-   mock-the-LLM or a query the model demonstrably cannot answer from
-   training; defer to a future eval-reliability PR.
-3. *Merge to main once approved.*  After Layer 2 lands too, fold
-   =EvictionSaver= to subclass =CheckpointRetentionSaver= so prune
-   and eviction share the same =put=.  Tests stay split.
-4. *Deploy + smoke.*  =make deploy= from =~/src/assist=.  Watch
-   =journalctl -u assist-web -f= for the
-   "EvictionSaver: evicting tool results > 20 KB" startup line.
-   Spot-check =du -sh /home/pierre/deploy/assist/threads/<tid>/
-   large_tool_results/= on a chatty research thread to confirm
-   blobs are landing on disk.
+1. *Address PR review comments.*  No reviews on PR #89 yet.  Likely
+   surfaces if questions come: the =files= channel drain logic
+   (paths with no leading slash, v1 list-content format), idempotent
+   re-put behavior on stub messages, and the round-trip on a real
+   langgraph checkpoint.  Tests cover all three.
+2. *Merge order.*  Layer 2 (PR #88) is still unmerged.  Cleanest
+   sequence: merge Layer 2 first, then on this branch swap the base
+   class from =SqliteSaver= to =CheckpointRetentionSaver= and pass
+   =retain_last= through alongside =evict_threshold_kb=.  Single
+   one-line edit.  Or merge in the opposite order — Layer 2 PR
+   re-bases on top of Layer 3 and the same edit lands there
+   instead.  Either way the final code is identical.
+3. *Prod observability after a week.*  Layer 3 has been live since
+   2026-05-05 13:20 PDT.  Re-run =du -sh
+   /home/pierre/deploy/assist/threads/threads.db= and =du -sh
+   /home/pierre/deploy/assist/threads/*/large_tool_results/= weekly.
+   Expect: =threads.db= bounded (no longer drifting up by GB/day);
+   eviction-blob disk usage scales with research-heavy traffic.  If
+   blobs balloon past, say, 1 GB total, consider a per-thread cap
+   (currently un-bounded; punted as v1 non-goal in the original
+   design).
+4. *Threshold tuning.*  Default =ASSIST_EVICT_THRESHOLD_KB=20= is a
+   guess.  After a week of prod data, if observation shows that
+   typical tool-result sizes cluster either much higher or much
+   lower, consider adjusting via =.deploy.env=.  No code change
+   required.
 
 ** Kill switch (if Layer 3 misbehaves in prod)
 Add to =/home/pierre/deploy/assist/code/.deploy.env= on the prod

--- a/docs/2026-05-04-threads-db-layer-3-tool-result-eviction.org
+++ b/docs/2026-05-04-threads-db-layer-3-tool-result-eviction.org
@@ -38,6 +38,20 @@ unchanged below.
   writes to via =StateBackend=; without draining, the middleware
   merely moves bytes from =messages= to =files= inside the same
   checkpoint, leaving DB size untouched.
+- *=put_writes= overridden too.*  Each tool node's output flows
+  through =put_writes= before it lands in a checkpoint.  Without an
+  override, the =writes= table accumulates full tool-result content
+  per super-step until Layer 2's retention sweep removes the parent
+  checkpoint.  The override applies the same per-message and
+  per-files-entry eviction; rehydration walks =CheckpointTuple.pending_writes=
+  in =get_tuple= and =list= so callers see fully-restored writes.
+- *v1 → v2 file format upgrade is one-way.*  If an evicted files
+  entry was in the legacy =content: list[str]= (v1) shape, on
+  rehydration it comes back as the modern =content: str= (v2) shape.
+  The on-disk blob carries no format metadata and =StateBackend._normalize_content=
+  smooths the difference at read time, so callers don't notice.
+  Documented here so the next session doesn't chase the format
+  divergence as a bug.
 - *Rehydration in =get_tuple= / =list=, NOT in =RollbackRunnable=.*
   Every read path (rollback, =agent.get_state=, web UI rendering)
   goes through the saver, so the saver is the single place to
@@ -52,8 +66,11 @@ unchanged below.
   to surface clean than half-rehydrate.
 
 ** Test status
-=24/24= passing in =tests/test_eviction_saver.py=, =311/311= in the
-full suite.  Run from =~/src/assist=:
+=31/31= passing in =tests/test_eviction_saver.py= (24 from the
+initial commit + 7 from the reviewer-driven follow-up: =put_writes=
+eviction, =pending_writes= rehydration, files-channel writes,
+kill-switch in =put_writes=, idempotency-skip on messages and on
+files).  Full suite passes.  Run from =~/src/assist=:
 #+begin_src
 .venv/bin/python -m pytest tests/test_eviction_saver.py
 .venv/bin/python -m pytest tests/  # full suite

--- a/edd/eval/eval_large_tool_results.py
+++ b/edd/eval/eval_large_tool_results.py
@@ -4,10 +4,20 @@ This eval tests that the agent can handle tool results exceeding the context lim
 by using FilesystemMiddleware to evict large results to files.
 
 The test mocks the internet search tool to return a payload >78k tokens, then verifies:
-1. The agent doesn't crash with a context overflow error
-2. Large tool results are written to /large_tool_results/
-3. The agent can still complete the research task
-4. Context management middleware is working correctly
+1. The agent invokes ``search_internet`` (precondition; otherwise INCONCLUSIVE).
+2. The agent doesn't crash with a context overflow error.
+3. Large tool results are evicted somewhere — either:
+   - the existing path: ``/large_tool_results/`` entries in agent state (the
+     ``ContextAwareToolEvictionMiddleware`` writes here via ``StateBackend``), or
+   - the new path: on-disk blobs under ``<tmpdir>/<tid>/large_tool_results/``
+     that Layer 3 (``EvictionSaver``) writes at checkpoint-write time.
+4. The agent can still complete the research task.
+
+The model under test is small enough to answer many factual queries from
+training memory and skip search entirely.  The prompt is engineered to be
+unanswerable without the search result (it asks for the title of the first
+search result, which is only known via the mock) and is explicit that the
+tool MUST be used.
 """
 import os
 import sys
@@ -82,22 +92,38 @@ class EvalMetrics:
         self.agent_response = ""
         self.error_message = ""
         self.large_result_files = []
+        # Did the model actually invoke the mocked search?  When 0 the
+        # eviction path was never exercised — the eval is INCONCLUSIVE,
+        # not a fail.
+        self.mock_search_invoked = 0
+        # Layer 3 (EvictionSaver) writes evicted blobs to disk under
+        # <tmpdir>/<tid>/large_tool_results/<sha256_16>.  Independent
+        # signal from the in-state files-channel check.
+        self.layer3_disk_blobs: list[str] = []
 
     def print_summary(self):
         """Print evaluation summary."""
         print("\n" + "=" * 80)
         print("LARGE TOOL RESULTS EVAL SUMMARY")
         print("=" * 80)
+        print(f"Mock Search Invoked: {self.mock_search_invoked} time(s)")
         print(f"Task Completed: {'✅ YES' if self.completed else '❌ NO'}")
         print(f"Context Overflow Error: {'❌ YES' if self.context_overflow_error else '✅ NO'}")
-        print(f"Large Results Evicted: {'✅ YES' if self.large_tool_results_created else '❌ NO'}")
+        print(f"Large Results Evicted (state): {'✅ YES' if self.large_tool_results_created else '❌ NO'}")
+        print(f"Layer 3 Disk Blobs: {len(self.layer3_disk_blobs)}")
 
         if self.large_result_files:
-            print(f"\nLarge Result Files Created: {len(self.large_result_files)}")
+            print(f"\nLarge Result Files Created (state): {len(self.large_result_files)}")
             for filepath in self.large_result_files:
                 if Path(filepath).exists():
                     size = Path(filepath).stat().st_size
                     print(f"  - {filepath} ({size:,} bytes)")
+
+        if self.layer3_disk_blobs:
+            print(f"\nLayer 3 Eviction Blobs ({len(self.layer3_disk_blobs)}):")
+            for blob in self.layer3_disk_blobs[:3]:
+                size = Path(blob).stat().st_size if Path(blob).exists() else 0
+                print(f"  - {blob} ({size:,} bytes)")
 
         if self.agent_response:
             print(f"\nAgent Response Length: {len(self.agent_response)} characters")
@@ -108,13 +134,19 @@ class EvalMetrics:
 
         print("=" * 80)
 
-        # Determine pass/fail
-        if self.completed and not self.context_overflow_error and self.large_tool_results_created:
+        if self.context_overflow_error:
+            print("❌ EVAL FAILED: Context overflow error")
+            return 1
+        if self.mock_search_invoked == 0:
+            print("⚠️  EVAL INCONCLUSIVE: model did not invoke search tool — "
+                  "eviction path not exercised")
+            return 2
+        evicted = self.large_tool_results_created or bool(self.layer3_disk_blobs)
+        if self.completed and evicted:
             print("✅ EVAL PASSED: Context management working correctly")
             return 0
-        else:
-            print("❌ EVAL FAILED: Context management not working as expected")
-            return 1
+        print("❌ EVAL FAILED: Context management not working as expected")
+        return 1
 
 
 def run_eval(verbose: bool = True) -> EvalMetrics:
@@ -129,14 +161,29 @@ def run_eval(verbose: bool = True) -> EvalMetrics:
     logger.info("Starting large tool results eval")
 
     metrics = EvalMetrics()
+    mock_invocations = [0]
+    # Sentinel string buried inside the mocked search result.  The
+    # eval prompt asks the agent to find this, which it can only do by
+    # actually invoking the search tool (no model would emit a random
+    # 12-character token from training).  Keeps the eval honest even
+    # if a future model decides to confidently fabricate.
+    SENTINEL = "MOCK-RESULT-7K3F9P"
 
-    # Create mock that returns very large payload
     def mock_ddg_search(query: str, **kwargs):
-        logger.info(f"Mock DDG search invoked with query: '{query}'")
+        mock_invocations[0] += 1
+        logger.info(
+            f"Mock DDG search invoked (#{mock_invocations[0]}) with query: '{query}'"
+        )
         large_payload = create_large_payload(target_tokens=80000)
-        logger.info(f"Returning large payload: {len(large_payload)} characters (~{len(large_payload)//4} tokens)")
-        # Return a list of dicts matching DDG's text() return format
-        # but with a huge body so str() produces a large payload
+        # Inject the sentinel near the top of the body so the agent
+        # finds it after a single read.
+        large_payload = (
+            f"SEARCH-VERIFICATION-CODE: {SENTINEL}\n\n" + large_payload
+        )
+        logger.info(
+            f"Returning large payload: {len(large_payload)} characters "
+            f"(~{len(large_payload)//4} tokens) with sentinel {SENTINEL}"
+        )
         return [{"title": "Mock Result", "href": "https://example.com", "body": large_payload}]
 
     # Patch the DDGS.text method BEFORE creating the agent
@@ -160,9 +207,22 @@ def run_eval(verbose: bool = True) -> EvalMetrics:
                     print("📝 Asking agent to research president of France...")
                     print("   (This will trigger a search returning ~80k tokens)\n")
 
-                # Ask the agent to do research
-                # Make it explicit that internet research is needed
-                query = "Who is the current president of France? Please search the internet for this information and provide their full name, term in office, and recent achievements."
+                # Force the model into the search path.  Past runs
+                # showed Qwen3.6-27B answers factual questions from
+                # training memory and skips ``search_internet``
+                # entirely, so the eviction path was never exercised.
+                # The query below is unanswerable without invoking
+                # the mocked tool: it asks for a verification code
+                # buried in the mock's response body.
+                query = (
+                    "I need you to use the search_internet tool to look "
+                    "up information about France's government.  The search "
+                    "result will contain a SEARCH-VERIFICATION-CODE near "
+                    "the top of the body.  Find the code and report it "
+                    "back to me verbatim along with a brief summary of "
+                    "what was returned.  You MUST use search_internet — "
+                    "do not answer from your training data."
+                )
 
                 try:
                     response = thread.message(query)
@@ -194,22 +254,26 @@ def run_eval(verbose: bool = True) -> EvalMetrics:
                             print(f"   {error_str}")
                         raise
 
-                # Check if large_tool_results files were created in agent state
-                # FilesystemMiddleware writes to state["files"], not physical filesystem
+                # Record mock invocations for the precondition check.
+                metrics.mock_search_invoked = mock_invocations[0]
+                if verbose:
+                    print(f"\nMock search invocations: {metrics.mock_search_invoked}")
+
+                # Check if large_tool_results files were created in agent state.
+                # ContextAwareToolEvictionMiddleware writes to state["files"]
+                # via StateBackend; entries land under /large_tool_results/.
                 try:
-                    # Get the final state from the thread
                     final_state = thread.agent.get_state({"configurable": {"thread_id": thread.thread_id}})
                     files_in_state = final_state.values.get("files", {})
 
-                    # Look for files in /large_tool_results/
                     large_result_files = [path for path in files_in_state.keys() if path.startswith("/large_tool_results/")]
 
                     if large_result_files:
                         metrics.large_tool_results_created = True
                         metrics.large_result_files = large_result_files
                         if verbose:
-                            print(f"\n✅ {len(large_result_files)} file(s) evicted to /large_tool_results/ in agent state")
-                            for filepath in large_result_files[:3]:  # Show first 3
+                            print(f"\n✅ {len(large_result_files)} file(s) in /large_tool_results/ in agent state")
+                            for filepath in large_result_files[:3]:
                                 file_data = files_in_state[filepath]
                                 if isinstance(file_data, dict):
                                     content = file_data.get("content", [])
@@ -217,15 +281,34 @@ def run_eval(verbose: bool = True) -> EvalMetrics:
                                 else:
                                     content_len = len(str(file_data))
                                 print(f"   - {filepath}: {content_len:,} chars")
-                    else:
-                        if verbose:
-                            print(f"\n⚠️  No files in /large_tool_results/ in agent state")
-                            if files_in_state:
-                                print(f"   Files in state: {list(files_in_state.keys())[:5]}")
-                            print("   (Large tool results may not have been evicted)")
+                    elif verbose:
+                        print(f"\n⚠️  No files in /large_tool_results/ in agent state")
+                        if files_in_state:
+                            print(f"   Files in state: {list(files_in_state.keys())[:5]}")
                 except Exception as e:
                     if verbose:
                         print(f"\n⚠️  Could not check agent state for large_tool_results: {e}")
+
+                # Layer 3 (EvictionSaver) writes evicted blobs to disk under
+                # <tmpdir>/<tid>/large_tool_results/<sha256_16>.  Independent
+                # of the in-state check above — Layer 3 evicts both the
+                # messages channel and the files channel at checkpoint write
+                # time, so this directory should have at least one blob if
+                # eviction triggered.
+                try:
+                    import glob
+                    pattern = os.path.join(tmpdir, "*", "large_tool_results", "*")
+                    blobs = sorted(p for p in glob.glob(pattern) if os.path.isfile(p))
+                    metrics.layer3_disk_blobs = blobs
+                    if verbose and blobs:
+                        print(f"\n✅ Layer 3 wrote {len(blobs)} eviction blob(s) to disk:")
+                        for blob in blobs[:3]:
+                            print(f"   - {blob} ({Path(blob).stat().st_size:,} bytes)")
+                    elif verbose:
+                        print(f"\n⚠️  No Layer 3 eviction blobs on disk under {tmpdir}")
+                except Exception as e:
+                    if verbose:
+                        print(f"\n⚠️  Could not scan disk for Layer 3 blobs: {e}")
 
             except Exception as e:
                 logger.error(f"Eval failed with unexpected error: {e}", exc_info=True)

--- a/edd/eval/eval_large_tool_results.py
+++ b/edd/eval/eval_large_tool_results.py
@@ -169,7 +169,11 @@ def run_eval(verbose: bool = True) -> EvalMetrics:
     # if a future model decides to confidently fabricate.
     SENTINEL = "MOCK-RESULT-7K3F9P"
 
-    def mock_ddg_search(query: str, **kwargs):
+    def mock_ddg_search(self, query: str, **kwargs):
+        # ``self`` accepted because the patch replaces an *unbound*
+        # method on ``ddgs.ddgs.DDGS``; instance call-sites bind it as
+        # a method and pass the instance as the first arg.  Ignored
+        # otherwise.
         mock_invocations[0] += 1
         logger.info(
             f"Mock DDG search invoked (#{mock_invocations[0]}) with query: '{query}'"
@@ -186,8 +190,12 @@ def run_eval(verbose: bool = True) -> EvalMetrics:
         )
         return [{"title": "Mock Result", "href": "https://example.com", "body": large_payload}]
 
-    # Patch the DDGS.text method BEFORE creating the agent
-    with patch('ddgs.DDGS.text', mock_ddg_search):
+    # ``ddgs.DDGS`` is a proxy class (``_DDGSProxy``) that delegates to
+    # the real implementation at ``ddgs.ddgs.DDGS``.  Instances returned
+    # by ``ddgs.DDGS()`` are the real class, so patching the proxy's
+    # ``text`` attribute is a no-op — calls go straight to
+    # ``ddgs.ddgs.DDGS.text`` (the real method).  Patch the real class.
+    with patch('ddgs.ddgs.DDGS.text', mock_ddg_search):
         with tempfile.TemporaryDirectory() as tmpdir:
             if verbose:
                 print(f"\n{'=' * 80}")

--- a/tests/test_eviction_saver.py
+++ b/tests/test_eviction_saver.py
@@ -457,6 +457,149 @@ class TestEvictionFilesUnderThreadDir(TestCase):
 # ---------------------------------------------------------------------------
 
 
+class TestPutWrites(TestCase):
+    """``put_writes`` is the per-task-write hook; it must also evict
+    large content so the ``writes`` table doesn't carry full ToolMessages
+    for the duration of Layer 2's retention window."""
+
+    def _put_checkpoint(self, saver, tid="t1"):
+        """Put an empty checkpoint so the FK-ish (thread_id, ns,
+        checkpoint_id) tuple exists for put_writes to reference."""
+        saver.put(_config(tid), _ckpt(0), {}, {})
+        return _config(tid) | {"configurable": {
+            "thread_id": tid, "checkpoint_ns": "", "checkpoint_id": "00000000",
+        }}
+
+    def test_large_message_in_writes_is_evicted(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            cfg = self._put_checkpoint(saver, "t1")
+            big = "x" * 5000
+            saver.put_writes(
+                cfg, [("messages", [_tool_msg(big)])], task_id="task_1"
+            )
+            evict_dir = os.path.join(root, "t1", "large_tool_results")
+            self.assertTrue(os.path.isdir(evict_dir))
+            self.assertEqual(len(os.listdir(evict_dir)), 1)
+
+            # Raw row in the writes table does NOT contain the original.
+            cur = saver.conn.cursor()
+            cur.execute(
+                "SELECT value FROM writes WHERE thread_id='t1' AND task_id='task_1'"
+            )
+            for (raw,) in cur.fetchall():
+                self.assertNotIn(big.encode("utf-8"), bytes(raw))
+
+    def test_small_message_in_writes_passes_through(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=20, root=root)
+            cfg = self._put_checkpoint(saver, "t1")
+            saver.put_writes(
+                cfg, [("messages", [_tool_msg("hi")])], task_id="task_1"
+            )
+            self.assertFalse(
+                os.path.isdir(os.path.join(root, "t1", "large_tool_results"))
+            )
+
+    def test_pending_writes_rehydrated_in_get_tuple(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            cfg = self._put_checkpoint(saver, "t1")
+            big = "y" * 5000
+            saver.put_writes(
+                cfg, [("messages", [_tool_msg(big)])], task_id="task_1"
+            )
+            tup = saver.get_tuple(_config("t1"))
+            self.assertIsNotNone(tup.pending_writes)
+            # Find the messages-channel write and assert its content
+            # is restored.
+            found = False
+            for entry in tup.pending_writes:
+                if len(entry) != 3:
+                    continue
+                _, channel, value = entry
+                if channel != "messages":
+                    continue
+                if isinstance(value, list):
+                    self.assertEqual(value[0].content, big)
+                else:
+                    self.assertEqual(value.content, big)
+                found = True
+            self.assertTrue(found, "no messages-channel write found in pending_writes")
+
+    def test_kill_switch_skips_put_writes_eviction(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=0, root=root)
+            cfg = self._put_checkpoint(saver, "t1")
+            big = "z" * 5000
+            saver.put_writes(
+                cfg, [("messages", [_tool_msg(big)])], task_id="task_1"
+            )
+            self.assertFalse(os.path.isdir(os.path.join(root, "t1")))
+
+    def test_files_channel_in_writes_is_evicted(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            cfg = self._put_checkpoint(saver, "t1")
+            big = "w" * 5000
+            files = {
+                "/large_tool_results/abc": {"content": big, "encoding": "utf-8"},
+            }
+            saver.put_writes(cfg, [("files", files)], task_id="task_1")
+            evict_dir = os.path.join(root, "t1", "large_tool_results")
+            self.assertEqual(len(os.listdir(evict_dir)), 1)
+
+
+class TestSkipAlreadyEvictedMessage(TestCase):
+    """Pinning the idempotency contract documented in
+    ``_evict_one_message``: a ToolMessage already carrying
+    ``_evicted_to`` in ``additional_kwargs`` is skipped on re-put,
+    so disk doesn't get a duplicate file."""
+
+    def test_skip_path_message(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            big = "x" * 5000
+            # Hand-construct a stub message identical to what eviction
+            # would produce, but feed it directly into put without
+            # going through rehydration first.
+            stub = ToolMessage(
+                content="[evicted: 5000 bytes tool result, see /large_tool_results/deadbeef]",
+                tool_call_id="call_x",
+                name="t",
+                additional_kwargs={
+                    "_evicted_to": "/nonexistent/path",
+                    "_evicted_size": len(big),
+                    "_evicted_sha256": "deadbeef" * 2,
+                },
+            )
+            saver.put(_config("t1"), _ckpt(0, messages=[stub]), {}, {})
+            # No new eviction file is written (the stub points to a
+            # nonexistent path that we never touch).
+            self.assertFalse(
+                os.path.isdir(os.path.join(root, "t1", "large_tool_results"))
+            )
+
+
+class TestSkipAlreadyEvictedFile(TestCase):
+    """Same idempotency pin for the files channel."""
+
+    def test_skip_path_file(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            stub_fd = {
+                "_evicted_to": "/nonexistent/path",
+                "_evicted_size": 5000,
+                "_evicted_sha256": "deadbeef" * 2,
+                "_evicted_encoding": "utf-8",
+            }
+            files = {"/large_tool_results/abc": stub_fd}
+            saver.put(_config("t1"), _ckpt(0, files=files), {}, {})
+            self.assertFalse(
+                os.path.isdir(os.path.join(root, "t1", "large_tool_results"))
+            )
+
+
 class TestStubMetadata(TestCase):
     def test_stub_records_size_and_hash(self):
         """Inspect the in-DB checkpoint (not rehydrated) to confirm the

--- a/tests/test_eviction_saver.py
+++ b/tests/test_eviction_saver.py
@@ -1,0 +1,483 @@
+"""Tests for ``assist.eviction_saver.EvictionSaver``.
+
+Layer 3 of the threads.db growth plan
+(docs/2026-05-04-threads-db-layer-3-tool-result-eviction.org).
+
+Real sqlite + real upstream SqliteSaver behind the wrapper.  The
+on-disk eviction directory is a per-test ``tempfile.TemporaryDirectory``
+so the round-trip (write → evict → checkpoint → read → rehydrate) is
+exercised end-to-end without mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sqlite3
+import tempfile
+from unittest import TestCase
+from unittest.mock import patch
+
+from langchain_core.messages import HumanMessage, ToolMessage
+from langgraph.checkpoint.base import empty_checkpoint
+
+from assist.eviction_saver import (
+    DEFAULT_EVICT_THRESHOLD_KB,
+    EVICT_HASH_KEY,
+    EVICT_PATH_KEY,
+    EVICT_SIZE_KEY,
+    EvictionFileMissingError,
+    EvictionSaver,
+    _resolve_evict_threshold_kb,
+)
+
+
+def _config(thread_id: str, ns: str = "") -> dict:
+    return {"configurable": {"thread_id": thread_id, "checkpoint_ns": ns}}
+
+
+def _ckpt(seq: int, *, messages=None, files=None) -> dict:
+    """Build a Checkpoint with deterministic id and the given channel values."""
+    c = empty_checkpoint()
+    c["id"] = f"{seq:08d}"
+    cv = c.get("channel_values") or {}
+    if messages is not None:
+        cv["messages"] = messages
+    if files is not None:
+        cv["files"] = files
+    c["channel_values"] = cv
+    return c
+
+
+def _tool_msg(content: str, tool_call_id: str = "call_x") -> ToolMessage:
+    return ToolMessage(content=content, tool_call_id=tool_call_id, name="t")
+
+
+def _new_saver(
+    *, threshold_kb: int = 20, root: str | None = None
+) -> tuple[EvictionSaver, str]:
+    """Return (saver, eviction_root).  Caller is responsible for cleaning
+    up ``eviction_root`` (use ``TemporaryDirectory`` in the test).
+    """
+    if root is None:
+        root = tempfile.mkdtemp()
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    return (
+        EvictionSaver(conn, evict_threshold_kb=threshold_kb, eviction_root=root),
+        root,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip(TestCase):
+    """Write a large ToolMessage; verify it goes to disk and rehydrates."""
+
+    def test_round_trip_messages(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            big = "x" * 5000  # 5 KB > 1 KB threshold
+            tm = _tool_msg(big)
+            saver.put(_config("t1"), _ckpt(0, messages=[tm]), {}, {})
+
+            # Eviction file written under <root>/<tid>/large_tool_results/
+            evict_dir = os.path.join(root, "t1", "large_tool_results")
+            self.assertTrue(os.path.isdir(evict_dir))
+            files = os.listdir(evict_dir)
+            self.assertEqual(len(files), 1)
+            with open(os.path.join(evict_dir, files[0]), "rb") as f:
+                self.assertEqual(f.read(), big.encode("utf-8"))
+
+            # Checkpoint in DB has stub content (does NOT contain the
+            # original 5 KB).  Smoking gun is byte count.
+            cur = saver.conn.cursor()
+            cur.execute("SELECT checkpoint FROM checkpoints WHERE thread_id='t1'")
+            blob = cur.fetchone()[0]
+            self.assertNotIn(big.encode("utf-8"), bytes(blob))
+
+            # get_tuple rehydrates back to the original content.
+            tup = saver.get_tuple(_config("t1"))
+            self.assertIsNotNone(tup)
+            messages = tup.checkpoint["channel_values"]["messages"]
+            self.assertEqual(len(messages), 1)
+            self.assertEqual(messages[0].content, big)
+            # Sentinel keys are scrubbed from rehydrated messages.
+            self.assertNotIn(EVICT_PATH_KEY, messages[0].additional_kwargs)
+
+    def test_round_trip_files_channel(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            big = "y" * 5000
+            files = {
+                "/large_tool_results/abc": {
+                    "content": big, "encoding": "utf-8",
+                },
+            }
+            saver.put(_config("t1"), _ckpt(0, files=files), {}, {})
+
+            tup = saver.get_tuple(_config("t1"))
+            restored = tup.checkpoint["channel_values"]["files"]
+            self.assertEqual(restored["/large_tool_results/abc"]["content"], big)
+
+    def test_unevicted_messages_unchanged(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=20, root=root)
+            small = "hello"
+            tm = _tool_msg(small)
+            saver.put(_config("t1"), _ckpt(0, messages=[tm]), {}, {})
+            self.assertFalse(
+                os.path.isdir(os.path.join(root, "t1", "large_tool_results"))
+            )
+            tup = saver.get_tuple(_config("t1"))
+            self.assertEqual(
+                tup.checkpoint["channel_values"]["messages"][0].content, small
+            )
+
+
+# ---------------------------------------------------------------------------
+# Threshold semantics
+# ---------------------------------------------------------------------------
+
+
+class TestThresholdBoundary(TestCase):
+    """Exactly-at-threshold is NOT evicted; threshold+1 is."""
+
+    def test_exact_boundary_not_evicted(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            content = "x" * 1024  # exactly 1 KB
+            tm = _tool_msg(content)
+            saver.put(_config("t1"), _ckpt(0, messages=[tm]), {}, {})
+            self.assertFalse(
+                os.path.isdir(os.path.join(root, "t1", "large_tool_results"))
+            )
+
+    def test_threshold_plus_one_evicted(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            content = "x" * 1025  # 1 KB + 1 byte
+            tm = _tool_msg(content)
+            saver.put(_config("t1"), _ckpt(0, messages=[tm]), {}, {})
+            evict_dir = os.path.join(root, "t1", "large_tool_results")
+            self.assertTrue(os.path.isdir(evict_dir))
+            self.assertEqual(len(os.listdir(evict_dir)), 1)
+
+    def test_files_channel_only_under_large_tool_results_prefix(self):
+        """Only ``/large_tool_results/`` entries are eligible for eviction."""
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            big = "z" * 5000
+            files = {
+                "/large_tool_results/should_evict": {
+                    "content": big, "encoding": "utf-8",
+                },
+                "/other_path/should_keep": {
+                    "content": big, "encoding": "utf-8",
+                },
+            }
+            saver.put(_config("t1"), _ckpt(0, files=files), {}, {})
+            evict_dir = os.path.join(root, "t1", "large_tool_results")
+            # Only one file evicted (the /large_tool_results/ one).
+            self.assertEqual(len(os.listdir(evict_dir)), 1)
+
+
+# ---------------------------------------------------------------------------
+# Kill switch
+# ---------------------------------------------------------------------------
+
+
+class TestKillSwitch(TestCase):
+    def test_threshold_zero_disables_eviction(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=0, root=root)
+            big = "x" * 100_000
+            tm = _tool_msg(big)
+            saver.put(_config("t1"), _ckpt(0, messages=[tm]), {}, {})
+            # No eviction dir.
+            self.assertFalse(os.path.isdir(os.path.join(root, "t1")))
+            # Content survives in DB unchanged.
+            tup = saver.get_tuple(_config("t1"))
+            self.assertEqual(
+                tup.checkpoint["channel_values"]["messages"][0].content, big
+            )
+
+    def test_no_eviction_root_disables_eviction(self):
+        """If eviction_root is None but threshold > 0, eviction still
+        gets disabled (no place to write) and pass-through works."""
+        conn = sqlite3.connect(":memory:", check_same_thread=False)
+        saver = EvictionSaver(conn, evict_threshold_kb=1, eviction_root=None)
+        self.assertEqual(saver.evict_threshold_kb, 0)
+        big = "x" * 5000
+        tm = _tool_msg(big)
+        saver.put(_config("t1"), _ckpt(0, messages=[tm]), {}, {})
+        tup = saver.get_tuple(_config("t1"))
+        self.assertEqual(
+            tup.checkpoint["channel_values"]["messages"][0].content, big
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dedup
+# ---------------------------------------------------------------------------
+
+
+class TestContentHashDedup(TestCase):
+    def test_same_content_two_threads_one_file(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            big = "shared content " * 1000  # > 1 KB, identical bytes
+            tm_a = _tool_msg(big, tool_call_id="call_a")
+            tm_b = _tool_msg(big, tool_call_id="call_b")
+            saver.put(_config("ta"), _ckpt(0, messages=[tm_a]), {}, {})
+            saver.put(_config("tb"), _ckpt(0, messages=[tm_b]), {}, {})
+
+            # Each thread has its own dir; files have the same hash.
+            ta_dir = os.path.join(root, "ta", "large_tool_results")
+            tb_dir = os.path.join(root, "tb", "large_tool_results")
+            self.assertEqual(os.listdir(ta_dir), os.listdir(tb_dir))
+
+            # Both rehydrate correctly.
+            for tid in ("ta", "tb"):
+                tup = saver.get_tuple(_config(tid))
+                self.assertEqual(
+                    tup.checkpoint["channel_values"]["messages"][0].content, big
+                )
+
+    def test_two_puts_same_thread_same_content_dedup(self):
+        """Putting the same content twice in one thread reuses the file
+        (O_EXCL hits, treated as success)."""
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            big = "dup " * 1000
+            for seq in range(2):
+                saver.put(
+                    _config("t1"),
+                    _ckpt(seq, messages=[_tool_msg(big)]),
+                    {}, {},
+                )
+            evict_dir = os.path.join(root, "t1", "large_tool_results")
+            self.assertEqual(len(os.listdir(evict_dir)), 1)
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: a checkpoint with already-evicted stubs is a no-op.
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency(TestCase):
+    def test_already_evicted_message_skipped(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            big = "x" * 5000
+            saver.put(
+                _config("t1"),
+                _ckpt(0, messages=[_tool_msg(big)]),
+                {}, {},
+            )
+            evict_dir = os.path.join(root, "t1", "large_tool_results")
+            files_before = sorted(os.listdir(evict_dir))
+
+            # Read back and put again — the rehydrated message goes
+            # back to full content, gets re-evicted to the same hash.
+            tup = saver.get_tuple(_config("t1"))
+            saver.put(
+                _config("t1"),
+                _ckpt(1, messages=tup.checkpoint["channel_values"]["messages"]),
+                {}, {},
+            )
+            files_after = sorted(os.listdir(evict_dir))
+            self.assertEqual(files_before, files_after)
+
+
+# ---------------------------------------------------------------------------
+# Failure modes
+# ---------------------------------------------------------------------------
+
+
+class TestRehydrationFailure(TestCase):
+    def test_missing_eviction_file_raises(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            big = "x" * 5000
+            saver.put(
+                _config("t1"),
+                _ckpt(0, messages=[_tool_msg(big)]),
+                {}, {},
+            )
+            evict_dir = os.path.join(root, "t1", "large_tool_results")
+            for f in os.listdir(evict_dir):
+                os.unlink(os.path.join(evict_dir, f))
+            with self.assertRaises(EvictionFileMissingError):
+                saver.get_tuple(_config("t1"))
+
+
+class TestDiskWriteFallback(TestCase):
+    """Disk failure during put() falls back to writing un-evicted checkpoint."""
+
+    def test_makedirs_failure_falls_back(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            big = "x" * 5000
+            tm = _tool_msg(big)
+            with patch("os.makedirs", side_effect=OSError("ENOSPC")):
+                saver.put(_config("t1"), _ckpt(0, messages=[tm]), {}, {})
+            # Eviction dir was never created.
+            self.assertFalse(
+                os.path.isdir(os.path.join(root, "t1", "large_tool_results"))
+            )
+            # But the checkpoint did get persisted (un-evicted).
+            tup = saver.get_tuple(_config("t1"))
+            self.assertEqual(
+                tup.checkpoint["channel_values"]["messages"][0].content, big
+            )
+
+
+# ---------------------------------------------------------------------------
+# Compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestNonToolMessagesUnchanged(TestCase):
+    def test_human_message_with_huge_content_not_evicted(self):
+        """Eviction targets ToolMessage only; HumanMessage / AIMessage
+        with large content stays in the DB.  The threshold protects
+        against tool-result blowup, not against user pasting a novel."""
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            big = "x" * 5000
+            hm = HumanMessage(content=big)
+            saver.put(_config("t1"), _ckpt(0, messages=[hm]), {}, {})
+            self.assertFalse(
+                os.path.isdir(os.path.join(root, "t1", "large_tool_results"))
+            )
+            tup = saver.get_tuple(_config("t1"))
+            self.assertEqual(
+                tup.checkpoint["channel_values"]["messages"][0].content, big
+            )
+
+
+class TestListWrapsRehydration(TestCase):
+    def test_list_returns_rehydrated_checkpoints(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            big = "x" * 5000
+            for seq in range(3):
+                saver.put(
+                    _config("t1"),
+                    _ckpt(seq, messages=[_tool_msg(big + str(seq))]),
+                    {}, {},
+                )
+            tuples = list(saver.list(_config("t1")))
+            self.assertEqual(len(tuples), 3)
+            for tup in tuples:
+                content = tup.checkpoint["channel_values"]["messages"][0].content
+                self.assertTrue(content.startswith("x"))
+                self.assertGreater(len(content), 4000)
+
+
+class TestAputStillRaises(TestCase):
+    """The async path is intentionally not enabled by Layer 3."""
+
+    def test_aput_raises_not_implemented(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(root=root)
+            with self.assertRaises(NotImplementedError):
+                asyncio.run(saver.aput(_config("t"), _ckpt(0), {}, {}))
+
+
+# ---------------------------------------------------------------------------
+# Env var parser
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEvictThresholdKb(TestCase):
+    def test_unset_uses_default(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ASSIST_EVICT_THRESHOLD_KB", None)
+            self.assertEqual(
+                _resolve_evict_threshold_kb(), DEFAULT_EVICT_THRESHOLD_KB
+            )
+
+    def test_zero_disables(self):
+        with patch.dict(os.environ, {"ASSIST_EVICT_THRESHOLD_KB": "0"}):
+            self.assertEqual(_resolve_evict_threshold_kb(), 0)
+
+    def test_disabled_keyword(self):
+        for v in ("disabled", "off", "false", ""):
+            with patch.dict(os.environ, {"ASSIST_EVICT_THRESHOLD_KB": v}):
+                self.assertEqual(_resolve_evict_threshold_kb(), 0)
+
+    def test_positive_int(self):
+        with patch.dict(os.environ, {"ASSIST_EVICT_THRESHOLD_KB": "50"}):
+            self.assertEqual(_resolve_evict_threshold_kb(), 50)
+
+    def test_negative_int_falls_back_to_default(self):
+        with patch.dict(os.environ, {"ASSIST_EVICT_THRESHOLD_KB": "-5"}):
+            self.assertEqual(
+                _resolve_evict_threshold_kb(), DEFAULT_EVICT_THRESHOLD_KB
+            )
+
+    def test_garbage_falls_back_to_default(self):
+        with patch.dict(os.environ, {"ASSIST_EVICT_THRESHOLD_KB": "abc"}):
+            self.assertEqual(
+                _resolve_evict_threshold_kb(), DEFAULT_EVICT_THRESHOLD_KB
+            )
+
+
+# ---------------------------------------------------------------------------
+# Compatibility with Layer 0's hard_delete (smoke).  Eviction files live
+# inside the per-thread dir so an rmtree on the dir takes them with it.
+# ---------------------------------------------------------------------------
+
+
+class TestEvictionFilesUnderThreadDir(TestCase):
+    def test_eviction_path_is_under_root(self):
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            saver.put(
+                _config("tid_xyz"),
+                _ckpt(0, messages=[_tool_msg("x" * 5000)]),
+                {}, {},
+            )
+            evict_dir = os.path.join(root, "tid_xyz", "large_tool_results")
+            self.assertTrue(os.path.isdir(evict_dir))
+            # Every eviction file is under <root>/<tid>/.
+            for f in os.listdir(evict_dir):
+                full = os.path.join(evict_dir, f)
+                self.assertTrue(
+                    os.path.commonpath([full, os.path.join(root, "tid_xyz")])
+                    == os.path.join(root, "tid_xyz")
+                )
+
+
+# ---------------------------------------------------------------------------
+# Stub-message metadata: stubs carry size + hash for forensics.
+# ---------------------------------------------------------------------------
+
+
+class TestStubMetadata(TestCase):
+    def test_stub_records_size_and_hash(self):
+        """Inspect the in-DB checkpoint (not rehydrated) to confirm the
+        stub message carries the size + hash that Layer 0 / VACUUM
+        observability can later inspect."""
+        with tempfile.TemporaryDirectory() as root:
+            saver, _ = _new_saver(threshold_kb=1, root=root)
+            big = "x" * 5000
+            saver.put(
+                _config("t1"),
+                _ckpt(0, messages=[_tool_msg(big)]),
+                {}, {},
+            )
+            # Use the upstream get_tuple via a parallel SqliteSaver so
+            # we see the un-rehydrated checkpoint.  Any saver pointed
+            # at the same conn works.
+            from langgraph.checkpoint.sqlite import SqliteSaver
+            raw = SqliteSaver(saver.conn).get_tuple(_config("t1"))
+            stub = raw.checkpoint["channel_values"]["messages"][0]
+            ak = stub.additional_kwargs
+            self.assertIn(EVICT_PATH_KEY, ak)
+            self.assertEqual(ak[EVICT_SIZE_KEY], 5000)
+            self.assertEqual(len(ak[EVICT_HASH_KEY]), 16)
+            self.assertNotIn("x" * 5000, str(stub.content))

--- a/tests/test_eviction_saver_integration.py
+++ b/tests/test_eviction_saver_integration.py
@@ -1,0 +1,133 @@
+"""Integration test: EvictionSaver wired into a real ThreadManager.
+
+Layer 3 of the threads.db growth plan
+(docs/2026-05-04-threads-db-layer-3-tool-result-eviction.org).
+
+The unit tests in ``test_eviction_saver.py`` exercise eviction with
+synthetic checkpoints constructed via ``empty_checkpoint()``.  This
+test covers the wiring: that a ``ThreadManager`` instantiated normally
+gets an ``EvictionSaver``, and that the round-trip works against a
+real ``threads.db`` SQLite file (not ``:memory:``) the same way prod
+will use it.
+
+No LLM calls — the saver is exercised directly via its public
+``put`` / ``get_tuple`` API, so this test is fast and doesn't depend
+on a running model.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+from unittest import TestCase
+
+from langchain_core.messages import ToolMessage
+from langgraph.checkpoint.base import empty_checkpoint
+
+from assist.eviction_saver import EvictionSaver
+from assist.thread import ThreadManager
+
+
+def _config(tid: str) -> dict:
+    return {"configurable": {"thread_id": tid, "checkpoint_ns": ""}}
+
+
+class TestThreadManagerWiring(TestCase):
+    def test_thread_manager_uses_eviction_saver(self):
+        with tempfile.TemporaryDirectory() as root:
+            tm = ThreadManager(root_dir=root)
+            try:
+                self.assertIsInstance(tm.checkpointer, EvictionSaver)
+                # eviction_root must be ThreadManager.root_dir so Layer 0's
+                # rmtree(thread_dir) cleans up eviction blobs for free.
+                self.assertEqual(tm.checkpointer.eviction_root, tm.root_dir)
+                # default threshold is 20 KB (env var unset in test process).
+                self.assertEqual(tm.checkpointer.evict_threshold_kb, 20)
+            finally:
+                tm.close()
+
+    def test_real_db_round_trip(self):
+        """Drive a real ``threads.db`` (file-backed, not in-memory) through
+        a put + get_tuple cycle with a 100 KB ``ToolMessage``.  Asserts:
+
+        - The eviction blob lands at ``<root>/<tid>/large_tool_results/<sha256_16>``.
+        - The serialized checkpoint row in ``threads.db`` does NOT contain
+          the original 100 KB bytes (the load-bearing DB-bytes claim).
+        - ``get_tuple`` rehydrates the message back to its full content.
+        """
+        with tempfile.TemporaryDirectory() as root:
+            tm = ThreadManager(root_dir=root)
+            try:
+                tid = "tid_int_test"
+                big = "Z" * 100_000  # 100 KB > 20 KB threshold
+
+                tm.checkpointer.put(
+                    _config(tid),
+                    self._build_checkpoint(big),
+                    {}, {},
+                )
+
+                # Eviction blob on disk, under per-thread dir.
+                evict_dir = os.path.join(root, tid, "large_tool_results")
+                self.assertTrue(os.path.isdir(evict_dir))
+                files = os.listdir(evict_dir)
+                self.assertEqual(len(files), 1)
+                with open(os.path.join(evict_dir, files[0]), "rb") as f:
+                    self.assertEqual(f.read(), big.encode("utf-8"))
+
+                # threads.db row does NOT contain the 100 KB original.
+                # This is the load-bearing claim — Layer 3's reason to exist.
+                db_path = os.path.join(root, "threads.db")
+                self.assertTrue(os.path.exists(db_path))
+                with sqlite3.connect(db_path) as conn:
+                    cur = conn.cursor()
+                    cur.execute(
+                        "SELECT checkpoint FROM checkpoints WHERE thread_id = ?",
+                        (tid,),
+                    )
+                    blob = cur.fetchone()[0]
+                self.assertNotIn(big.encode("utf-8"), bytes(blob))
+
+                # get_tuple rehydrates back to full content.
+                tup = tm.checkpointer.get_tuple(_config(tid))
+                self.assertIsNotNone(tup)
+                msgs = tup.checkpoint["channel_values"]["messages"]
+                self.assertEqual(msgs[0].content, big)
+            finally:
+                tm.close()
+
+    def test_hard_delete_cascades_to_eviction_blobs(self):
+        """Layer 0's ``hard_delete`` rmtrees the per-thread directory.
+        Eviction blobs live INSIDE that directory, so they go too —
+        no separate cleanup path needed."""
+        with tempfile.TemporaryDirectory() as root:
+            tm = ThreadManager(root_dir=root)
+            try:
+                tid = "tid_for_hard_delete"
+                # Bootstrap a thread directory the way ``ThreadManager.new()``
+                # would, then put a checkpoint with eviction.
+                os.makedirs(os.path.join(root, tid), exist_ok=True)
+                tm.checkpointer.put(
+                    _config(tid),
+                    self._build_checkpoint("X" * 100_000),
+                    {}, {},
+                )
+                evict_dir = os.path.join(root, tid, "large_tool_results")
+                self.assertTrue(os.path.isdir(evict_dir))
+
+                tm.hard_delete(tid)
+
+                # The whole thread dir is gone; eviction blobs with it.
+                self.assertFalse(os.path.exists(os.path.join(root, tid)))
+            finally:
+                tm.close()
+
+    def _build_checkpoint(self, content: str) -> dict:
+        c = empty_checkpoint()
+        c["id"] = "00000001"
+        c["channel_values"] = {
+            "messages": [
+                ToolMessage(content=content, tool_call_id="call_int", name="t")
+            ],
+        }
+        return c


### PR DESCRIPTION
## Summary
Layer 3 of the prod `threads.db` growth plan ([overview](docs/2026-05-03-prod-threads-db-growth.org), [Layer 3 design](docs/2026-05-04-threads-db-layer-3-tool-result-eviction.org)). Caps per-checkpoint size by moving large tool-result content out of the DB onto the filesystem at write time, and rehydrating on read.

- `assist/eviction_saver.py` (new) — `EvictionSaver(SqliteSaver)` subclass; overrides `put`, `put_writes`, `get_tuple`, `list`. Walks `channel_values["messages"]` (large `ToolMessage` content) and `channel_values["files"]` (entries under `/large_tool_results/`); evicts anything over `ASSIST_EVICT_THRESHOLD_KB` (default 20) to `<root_dir>/<tid>/large_tool_results/<sha256_16>`. Rehydration on `get_tuple`/`list` covers both the checkpoint and `pending_writes`.
- Wired into `ThreadManager.__init__` with `eviction_root=self.root_dir` so eviction blobs live inside the per-thread directory and Layer 0's `hard_delete` rmtree cleans them up for free.
- Kill switch: `ASSIST_EVICT_THRESHOLD_KB=0` (or `disabled` / `off` / `false`) in `.deploy.env` flips to no-op pass-through. Already-evicted checkpoints continue to rehydrate correctly.
- `EvictionFileMissingError` raised when a stub points to a missing on-disk file — no silent half-rehydration.

## Reviewer findings addressed (commit `e0813d3`)
1. **`put_writes` not overridden** → now overridden, evicts on every per-task-write. Walks `(channel, value)` pairs; rehydrates `pending_writes` on read.
2. **Skip-already-evicted path was reachable but untested** → added direct tests that hand-construct stub messages/files-entries and feed them through `put`, asserting no duplicate disk write.
3. **v1 → v2 silent FileData format upgrade on rehydration** → documented in `_rehydrate_one_file` docstring and the session-handoff. `StateBackend._normalize_content` smooths the difference at read time.

## Compatibility with Layer 2 (PR #88)
Branched from `main` so this PR has no conflict with PR #88's `assist/checkpointer.py`. After both merge, fold `EvictionSaver` to subclass `CheckpointRetentionSaver` instead of `SqliteSaver` and pass both env kwargs through — single one-line edit. Tests stay split.

## Test plan + actual results
- [x] **Unit tests:** `tests/test_eviction_saver.py` — 31/31 passing (round-trip on messages and files channels, threshold boundaries, kill switch, content-hash dedup, idempotency, missing-file failure mode, disk-write fallback, `put_writes` eviction, `pending_writes` rehydration, files-channel writes, idempotency-skip on messages and files, list rehydration, aput-still-raises, env-var parser × 6, eviction-files-under-thread-dir invariant, stub metadata).
- [x] **Integration tests:** `tests/test_eviction_saver_integration.py` — 3/3 passing. Covers what the eval was meant to prove without depending on agent behavior: `ThreadManager` correctly wires `EvictionSaver` with `eviction_root=root_dir`; real file-backed `threads.db` round-trip evicts 100 KB out of the DB blob and rehydrates on read; Layer 0's `hard_delete` rmtree cascades to wipe eviction blobs.
- [x] **Full suite:** `tests/` — 321/321 passing.
- [x] **`eval_large_tool_results.py` N=3:** 3/3 returned `Large Results Evicted: NO`. **Not a Layer 3 regression** — Qwen3.6-27B answers "who is the president of France?" from training memory and never invokes `search_internet`, so the mocked DDG payload is never produced; no large tool result enters the messages or files channels for either the middleware or Layer 3 to act on. The integration test above proves the mechanism works on a real `threads.db`. A future eval-reliability PR should mock the LLM or use a query the model demonstrably cannot answer from training.
- [ ] **`test_research_multi_turn_token_regression`:** ran for 600s without completing trial 1 — network-bound real DDG searches stalled. Independent of Layer 3.
- [ ] **Smoke + observe in prod after merge** — pending operator action.

## Files
- `assist/eviction_saver.py` (new, ~480 lines)
- `assist/thread.py` — `ThreadManager.__init__` wires `EvictionSaver`
- `tests/test_eviction_saver.py` (new, 31 tests)
- `tests/test_eviction_saver_integration.py` (new, 3 tests)
- `.deploy.env.example` — adds `ASSIST_EVICT_THRESHOLD_KB=20`
- `docs/2026-05-04-threads-db-layer-3-tool-result-eviction.org` — session-handoff block at top

🤖 Generated with [Claude Code](https://claude.com/claude-code)