### PR TITLE
Per-thread LLM affinity queue + UI queued state

### DIFF
--- a/assist/agent.py
+++ b/assist/agent.py
@@ -27,6 +27,7 @@ from assist.middleware.read_only_enforcer import ReadOnlyEnforcerMiddleware
 from assist.middleware.skills_middleware import SmallModelSkillsMiddleware
 from assist.middleware.memory_middleware import SmallModelMemoryMiddleware
 from assist.middleware.write_collision import WriteCollisionMiddleware
+from assist.middleware.thread_queue_middleware import ThreadQueueMiddleware
 
 
 logger = logging.getLogger(__name__)
@@ -118,7 +119,7 @@ def create_agent(model: BaseChatModel,
 
     mw = [retry_middle, bad_request_mw, json_validation_mw, tool_name_mw,
           context_eviction_mw, write_collision_mw, loop_detection_mw,
-          empty_response_recovery_mw]
+          ThreadQueueMiddleware(), empty_response_recovery_mw]
 
     workspace_dir = sandbox_backend.work_dir if sandbox_backend else "/"
     # Single-slashed path that's safe to interpolate without producing
@@ -220,6 +221,7 @@ def create_context_agent(model: BaseChatModel,
     )
     base_mw.append(context_eviction_mw)
     base_mw.append(LoopDetectionMiddleware())
+    base_mw.append(ThreadQueueMiddleware())
     base_mw.append(EmptyResponseRecoveryMiddleware())
     # Enforce the read-only contract at the tool layer.
     base_mw.append(ReadOnlyEnforcerMiddleware())
@@ -280,6 +282,7 @@ def create_research_agent(model: BaseChatModel,
     # write_file).
     base_mw.append(WriteCollisionMiddleware())
     base_mw.append(LoopDetectionMiddleware())
+    base_mw.append(ThreadQueueMiddleware())
     base_mw.append(EmptyResponseRecoveryMiddleware())
 
     # Confine the research agent's filesystem reach to <working_dir>/references/.
@@ -321,6 +324,7 @@ def create_research_agent(model: BaseChatModel,
         return [_make_retry_middleware(),
                 BadRequestRetryMiddleware(max_retries=3),
                 LoopDetectionMiddleware(),
+                ThreadQueueMiddleware(),
                 EmptyResponseRecoveryMiddleware()]
 
     research_sub_agent = {

--- a/assist/middleware/thread_queue_middleware.py
+++ b/assist/middleware/thread_queue_middleware.py
@@ -1,0 +1,27 @@
+"""Cooperative cancellation for :class:`ThreadAffinityQueue`.
+
+The queue's watchdog flips ``handle.expired`` after ``hold_timeout_s``.
+This middleware reads that flag in ``after_model`` and raises
+:class:`ThreadHoldExpired` between LLM calls so the holder yields the
+queue without corrupting an in-flight slot.
+"""
+
+from typing import Any
+
+from langchain.agents.middleware import AgentMiddleware, AgentState
+from langgraph.runtime import Runtime
+
+from assist.thread_queue import ThreadHoldExpired, active_handle
+
+
+class ThreadQueueMiddleware(AgentMiddleware):
+    def after_model(
+        self, state: AgentState, runtime: Runtime
+    ) -> dict[str, Any] | None:
+        handle = active_handle()
+        if handle is not None and handle.expired:
+            raise ThreadHoldExpired(
+                f"thread {handle.thread_id} held the LLM queue past its cap; "
+                "killed to avoid starving other threads"
+            )
+        return None

--- a/assist/thread.py
+++ b/assist/thread.py
@@ -18,6 +18,7 @@ from assist.model_manager import select_chat_model
 from assist.agent import create_research_agent, create_agent
 from assist.checkpoint_rollback import invoke_with_rollback
 from assist.sandbox_manager import SandboxManager
+from assist.thread_queue import THREAD_QUEUE
 
 logger = logging.getLogger(__name__)
 
@@ -55,12 +56,18 @@ class Thread:
                  checkpointer=None,
                  model: BaseChatModel | None = None,
                  max_concurrency: int = 5,
-                 sandbox_backend=None):
+                 sandbox_backend=None,
+                 on_queue_state: Callable[[str], None] | None = None):
         self.working_dir = working_dir
         ts = datetime.now().strftime("%Y%m%d%H%M%S")
         self.thread_id = thread_id or f"{working_dir}:{ts}"
         self.model = model or select_chat_model(0.1, enable_thinking=False)
         self.max_concurrency = max_concurrency
+        # Notified with "queued" if another thread is holding the LLM
+        # queue when this Thread.message() runs, then "running" once
+        # acquired.  Callers (e.g. manage.web) wire this to the
+        # status.json so the UI can show "queued".
+        self.on_queue_state = on_queue_state
         self.runconfig = {
             "configurable": {"thread_id": self.thread_id},
             "max_concurrency": self.max_concurrency
@@ -72,12 +79,18 @@ class Thread:
                                   sandbox_backend=sandbox_backend)
 
     def message(self, text: str) -> str:
-        """Continue the thread and return the last response"""
-        result = invoke_with_rollback(
-            self.agent,
-            {"messages": [{"role": "user", "content": text}]},
-            self.runconfig,
-        )
+        """Continue the thread and return the last response.
+
+        Acquires the per-thread LLM affinity queue for the duration of
+        the agent loop so concurrent threads don't thrash llama.cpp's
+        single KV-cache slot.  See ``assist/thread_queue.py``.
+        """
+        with THREAD_QUEUE.acquire(self.thread_id, on_state_change=self.on_queue_state):
+            result = invoke_with_rollback(
+                self.agent,
+                {"messages": [{"role": "user", "content": text}]},
+                self.runconfig,
+            )
         # Extract content from the last AIMessage
         messages = result.get("messages", [])
         if messages:
@@ -90,11 +103,16 @@ class Thread:
         if not isinstance(text, str):
             raise TypeError("text must be a string")
         # Continue the thread by sending only the latest human message; prior state is in the checkpointer.
-        return self.agent.stream(
-            {"messages": [{"role": "user", "content": text}]},
-            self.runconfig,
-            stream_mode=["messages", "updates"]
-        )
+        # Wrap the iterator in a generator so the queue is held for the
+        # full streaming lifetime, not just the call to .stream().
+        def _gen():
+            with THREAD_QUEUE.acquire(self.thread_id, on_state_change=self.on_queue_state):
+                yield from self.agent.stream(
+                    {"messages": [{"role": "user", "content": text}]},
+                    self.runconfig,
+                    stream_mode=["messages", "updates"]
+                )
+        return _gen()
 
     def get_messages(self) -> list[dict]:
         """Return user/assistant messages from checkpointer state as role/content dicts."""
@@ -312,7 +330,8 @@ n    checkpointing via SqliteSaver.
     def get(self,
             thread_id: str,
             working_dir: str | None = None,
-            sandbox_backend=None) -> Thread:
+            sandbox_backend=None,
+            on_queue_state: Callable[[str], None] | None = None) -> Thread:
         tdir = os.path.join(self.root_dir, thread_id)
         if not os.path.isdir(tdir):
             raise FileNotFoundError(f"thread directory not found: {thread_id}, {tdir}")
@@ -323,7 +342,8 @@ n    checkpointing via SqliteSaver.
                       thread_id=thread_id,
                       checkpointer=self.checkpointer,
                       model=self.model,
-                      sandbox_backend=sandbox_backend)
+                      sandbox_backend=sandbox_backend,
+                      on_queue_state=on_queue_state)
 
     def remove(self, thread_id: str) -> None:
         tdir = os.path.join(self.root_dir, thread_id)
@@ -345,7 +365,8 @@ n    checkpointing via SqliteSaver.
             except Exception:
                 pass
 
-    def new(self, working_dir: str|None = None, sandbox_backend=None) -> Thread:
+    def new(self, working_dir: str|None = None, sandbox_backend=None,
+            on_queue_state: Callable[[str], None] | None = None) -> Thread:
         # Derive a clean ID for directory: prefer timestamp+rand
         tid = datetime.now().strftime("%Y%m%d%H%M%S") + "-" + os.urandom(4).hex()
         tdir = os.path.join(self.root_dir, tid)
@@ -354,7 +375,8 @@ n    checkpointing via SqliteSaver.
             working_dir = self.make_default_working_dir(tdir)
 
         return Thread(working_dir, thread_id=tid, checkpointer=self.checkpointer,
-                      model=self.model, sandbox_backend=sandbox_backend)
+                      model=self.model, sandbox_backend=sandbox_backend,
+                      on_queue_state=on_queue_state)
 
     def close(self) -> None:
         try:

--- a/assist/thread_queue.py
+++ b/assist/thread_queue.py
@@ -1,0 +1,199 @@
+"""Per-thread LLM-affinity queue.
+
+Serializes access at the ``Thread.message()`` boundary so concurrent
+threads don't thrash llama.cpp's ``--parallel 1`` KV cache.  When two
+agents alternate turns through the slot, every turn pays a full
+prefill from scratch — prefill cost grows from O(T) to O(T²) per
+agent.  Holding the queue for one full ``Thread.message()`` keeps the
+slot's cached prefix matched, so prefill stays a per-turn delta.
+
+Affinity, not fairness:
+
+- Holder runs to completion before any waiter runs.
+- Waiters are FIFO among themselves.
+- Same ``thread_id`` re-acquiring is a no-op (re-entrant by id).
+
+Failure-fast bounds:
+
+- ``hold_timeout_s`` — a runaway holder is flagged ``expired`` so the
+  cooperative cancel point in :class:`ThreadQueueMiddleware` raises
+  :class:`ThreadHoldExpired` between LLM calls.  Honors the project
+  rule that threads die on infrastructure failure rather than
+  heal-and-retry.  The cap bounds the *detection latency*, not the
+  exact wall-clock release time — a ``wrap_model_call`` retry inside
+  :class:`EmptyResponseRecoveryMiddleware` or
+  :class:`BadRequestRetryMiddleware` can run one or two more LLM calls
+  past expiration before ``after_model`` next fires.
+- ``wait_timeout_s`` — a waiter that can't acquire raises
+  :class:`QueueWaitTimeout` and the thread errors.
+
+Single-process scope:
+
+The queue is a module-level singleton.  It coordinates background
+tasks within one ``manage.web`` process.  Eval CLIs that import
+``assist.thread`` in a separate process get their own (empty) queue
+— intentional: they're not sharing the prod LLM slot anyway.
+"""
+
+import contextvars
+import os
+import threading
+import time
+from collections import deque
+from contextlib import contextmanager
+from typing import Callable, Iterator
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+DEFAULT_HOLD_TIMEOUT_S = _env_float("ASSIST_THREAD_HOLD_TIMEOUT_S", 600.0)
+DEFAULT_WAIT_TIMEOUT_S = _env_float("ASSIST_THREAD_QUEUE_WAIT_S", 900.0)
+
+
+class QueueWaitTimeout(Exception):
+    """A waiter exceeded ``wait_timeout_s`` before reaching the head."""
+
+
+class ThreadHoldExpired(Exception):
+    """The holder exceeded ``hold_timeout_s``; cancellation is in flight."""
+
+
+class _Handle:
+    __slots__ = ("thread_id", "expired", "acquired_at", "_watchdog")
+
+    def __init__(self, thread_id: str) -> None:
+        self.thread_id = thread_id
+        self.expired = False
+        self.acquired_at = time.time()
+        self._watchdog: threading.Timer | None = None
+
+
+_active_handle: contextvars.ContextVar = contextvars.ContextVar(
+    "thread_queue_active_handle", default=None
+)
+
+
+class ThreadAffinityQueue:
+    def __init__(
+        self,
+        hold_timeout_s: float = DEFAULT_HOLD_TIMEOUT_S,
+        wait_timeout_s: float = DEFAULT_WAIT_TIMEOUT_S,
+    ) -> None:
+        self._cond = threading.Condition()
+        self._holder: _Handle | None = None
+        self._waiters: deque[str] = deque()
+        self._default_hold_timeout = hold_timeout_s
+        self._default_wait_timeout = wait_timeout_s
+
+    @contextmanager
+    def acquire(
+        self,
+        thread_id: str,
+        on_state_change: Callable[[str], None] | None = None,
+        wait_timeout_s: float | None = None,
+        hold_timeout_s: float | None = None,
+    ) -> Iterator[_Handle]:
+        cb = on_state_change or (lambda _: None)
+        wait_timeout = (
+            self._default_wait_timeout if wait_timeout_s is None else wait_timeout_s
+        )
+        hold_timeout = (
+            self._default_hold_timeout if hold_timeout_s is None else hold_timeout_s
+        )
+
+        with self._cond:
+            # Reentrant only if this caller is on the holder's own call
+            # stack — i.e. the active contextvar is the holder's handle.
+            # A second OS thread that happens to share `thread_id` (e.g.
+            # a user double-clicking Send: two background tasks for one
+            # tid) does NOT free-ride; the contextvar is unset across
+            # threads, so it falls through to the wait path.
+            if (
+                self._holder is not None
+                and self._holder.thread_id == thread_id
+                and _active_handle.get() is self._holder
+            ):
+                # No new state callback, no new watchdog.
+                yield self._holder
+                return
+
+            if self._holder is not None:
+                cb("queued")
+                self._waiters.append(thread_id)
+                deadline = time.time() + wait_timeout
+                try:
+                    while self._holder is not None or (
+                        self._waiters and self._waiters[0] != thread_id
+                    ):
+                        remaining = deadline - time.time()
+                        if remaining <= 0:
+                            raise QueueWaitTimeout(
+                                f"thread {thread_id} waited {wait_timeout}s for queue"
+                            )
+                        self._cond.wait(timeout=remaining)
+                    self._waiters.popleft()
+                except BaseException:
+                    try:
+                        self._waiters.remove(thread_id)
+                    except ValueError:
+                        pass
+                    self._cond.notify_all()
+                    raise
+
+            handle = _Handle(thread_id)
+            self._holder = handle
+            cb("running")
+
+            watchdog = threading.Timer(hold_timeout, _mark_expired, args=(handle,))
+            watchdog.daemon = True
+            handle._watchdog = watchdog
+
+        # Start the watchdog outside the lock so a near-zero timeout
+        # (used in tests) doesn't fire while we're still in __enter__.
+        watchdog.start()
+        token = _active_handle.set(handle)
+        try:
+            yield handle
+        finally:
+            _active_handle.reset(token)
+            try:
+                watchdog.cancel()
+            except Exception:
+                pass
+            with self._cond:
+                if self._holder is handle:
+                    self._holder = None
+                    self._cond.notify_all()
+
+    def current_handle(self) -> _Handle | None:
+        with self._cond:
+            return self._holder
+
+    def waiter_count(self) -> int:
+        with self._cond:
+            return len(self._waiters)
+
+
+def _mark_expired(handle: _Handle) -> None:
+    handle.expired = True
+
+
+def active_handle() -> _Handle | None:
+    """Return the holder handle visible to the current execution context.
+
+    Set by :meth:`ThreadAffinityQueue.acquire` for the duration of the
+    ``with`` block, scoped via :mod:`contextvars` so sub-agent calls in
+    the same call stack see it but unrelated background work does not.
+    """
+    return _active_handle.get()
+
+
+THREAD_QUEUE = ThreadAffinityQueue()

--- a/edd/eval/test_thread_queue.py
+++ b/edd/eval/test_thread_queue.py
@@ -1,0 +1,139 @@
+"""End-to-end eval for ThreadAffinityQueue.
+
+Spawns two real Threads concurrently, each sending one short message,
+and verifies that the queue serialized them — i.e., one thread observed
+the "queued" state for nonzero duration before acquiring the lock.
+"""
+import os
+import shutil
+import tempfile
+import threading
+import time
+
+from unittest import TestCase
+
+from assist.thread import ThreadManager
+from assist.thread_queue import THREAD_QUEUE
+
+
+class _StateRecorder:
+    """Capture (timestamp, state) tuples emitted by the queue."""
+
+    def __init__(self):
+        self.events: list[tuple[float, str]] = []
+        self._lock = threading.Lock()
+
+    def __call__(self, state: str) -> None:
+        with self._lock:
+            self.events.append((time.time(), state))
+
+    def states(self) -> list[str]:
+        with self._lock:
+            return [s for _, s in self.events]
+
+    def queued_duration(self) -> float:
+        """Seconds spent in 'queued' before observing 'running'.
+
+        0.0 if the thread never queued.
+        """
+        with self._lock:
+            queued_at = None
+            for ts, state in self.events:
+                if state == "queued":
+                    queued_at = ts
+                elif state == "running" and queued_at is not None:
+                    return ts - queued_at
+        return 0.0
+
+
+class TestThreadQueueE2E(TestCase):
+    """Concurrent Thread.message() calls must serialize through the queue."""
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.tm = ThreadManager(self.root)
+
+    def tearDown(self):
+        try:
+            self.tm.close()
+        except Exception:
+            pass
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def test_two_concurrent_threads_serialize_via_queue(self):
+        """Both threads finish; one observes a 'queued' state for >0 seconds."""
+        # Sanity: queue is empty at start.
+        self.assertIsNone(THREAD_QUEUE.current_handle())
+        self.assertEqual(THREAD_QUEUE.waiter_count(), 0)
+
+        # Two recorders, one per thread.
+        rec_a = _StateRecorder()
+        rec_b = _StateRecorder()
+
+        chat_a = self.tm.new(on_queue_state=rec_a)
+        chat_b = self.tm.new(on_queue_state=rec_b)
+
+        # Use the same prompt so cache-pressure conditions are equivalent.
+        # Short prompt keeps the eval bounded.
+        prompt = "What is 2+2? Answer in one short sentence."
+
+        results: dict[str, str] = {}
+        errors: dict[str, BaseException] = {}
+
+        def run(name: str, chat):
+            try:
+                results[name] = chat.message(prompt)
+            except BaseException as e:
+                errors[name] = e
+
+        ta = threading.Thread(target=run, args=("A", chat_a))
+        tb = threading.Thread(target=run, args=("B", chat_b))
+
+        # Start A first so its acquire wins the unloaded queue, then B
+        # right after so B has to wait on A.
+        start = time.time()
+        ta.start()
+        # Tiny delay to make A's first-acquire deterministic.
+        time.sleep(0.01)
+        tb.start()
+        ta.join(timeout=180)
+        tb.join(timeout=180)
+        wall = time.time() - start
+
+        # Both threads completed (no hangs, no exceptions).
+        self.assertFalse(ta.is_alive(), "thread A did not finish in time")
+        self.assertFalse(tb.is_alive(), "thread B did not finish in time")
+        self.assertEqual(errors, {}, f"thread errors: {errors}")
+        self.assertIn("A", results)
+        self.assertIn("B", results)
+        self.assertGreater(len(results["A"]), 0, "thread A returned empty")
+        self.assertGreater(len(results["B"]), 0, "thread B returned empty")
+
+        # The queue actually serialized something: at least one of the
+        # threads spent measurable time in 'queued' before 'running'.
+        # This proves the lock contended; if both immediately acquired,
+        # the test environment isn't exercising what it claims to.
+        a_wait = rec_a.queued_duration()
+        b_wait = rec_b.queued_duration()
+        max_wait = max(a_wait, b_wait)
+        self.assertGreater(
+            max_wait,
+            0.0,
+            f"neither thread observed a queued state; "
+            f"events A={rec_a.events!r} B={rec_b.events!r}",
+        )
+
+        # The first thread (A) saw only "running" (no queued).
+        self.assertEqual(rec_a.states(), ["running"])
+        # The second thread (B) saw "queued" then "running".
+        self.assertEqual(rec_b.states(), ["queued", "running"])
+
+        # Queue is cleaned up after both threads finish.
+        self.assertIsNone(THREAD_QUEUE.current_handle())
+        self.assertEqual(THREAD_QUEUE.waiter_count(), 0)
+
+        # Sanity ceiling: 2 short prompts on a local LLM should land in
+        # well under 3 minutes total even with full prefill cost on
+        # both. This is a generous upper bound — its job is to catch
+        # hangs, not measure throughput.
+        self.assertLess(wall, 180.0, f"wall-clock {wall:.1f}s exceeded sanity cap")

--- a/manage/web.py
+++ b/manage/web.py
@@ -145,16 +145,18 @@ def _get_sandbox_backend(tid: str):
 #   initializing      - thread row created, background task queued
 #   cloning           - git clone in progress
 #   starting_sandbox  - docker container starting
+#   queued            - waiting for another thread's LLM affinity hold
 #   processing        - agent is running on a message
 #   ready             - idle, accepting input
 #   error             - something failed; see status["error"]
 INIT_STAGES = {"initializing", "cloning", "starting_sandbox"}
-BUSY_STAGES = INIT_STAGES | {"processing"}
+BUSY_STAGES = INIT_STAGES | {"processing", "queued"}
 
 STAGE_LABELS = {
     "initializing": "Setting up thread...",
     "cloning": "Cloning repository...",
     "starting_sandbox": "Starting sandbox container...",
+    "queued": "Waiting for another thread to finish...",
     "processing": "Processing your message...",
 }
 
@@ -272,7 +274,16 @@ def render_index() -> str:
             status = _get_status(tid)
             stage = status.get("stage", "ready")
             badge = ""
-            if stage in BUSY_STAGES:
+            if stage == "queued":
+                # Distinguish "queued" visually from other busy stages so
+                # the user can tell their message is held behind another
+                # thread (vs. actively running).
+                badge = (
+                    f'<span style="font-size:.7rem; color:#1e3a5f; background:#e1ecf4;'
+                    f' border:1px solid #b6d4ef; padding:.1rem .4rem; border-radius:10px;'
+                    f' margin-right:.4rem;">{html.escape(STAGE_LABELS.get(stage, stage))}</span>'
+                )
+            elif stage in BUSY_STAGES:
                 badge = (
                     f'<span style="font-size:.7rem; color:#555; background:#fff3cd;'
                     f' border:1px solid #ffeeba; padding:.1rem .4rem; border-radius:10px;'
@@ -642,14 +653,25 @@ def _process_message(tid: str, text: str) -> None:
     # Carry the pending message in the status so the thread page can show
     # it as a placeholder bubble while processing (cleared once status==ready).
     pending_kwargs = {"pending_message": text}
+
+    def on_queue_state(stage: str) -> None:
+        # Called by ThreadAffinityQueue when this thread has to wait
+        # for another's hold ("queued") and again when the queue is
+        # acquired ("running" -> rewritten to "processing" for the UI).
+        ui_stage = "processing" if stage == "running" else stage
+        _set_status(tid, ui_stage, **pending_kwargs)
+
     try:
         _set_status(tid, "starting_sandbox", **pending_kwargs)
         sandbox = _get_sandbox_backend(tid)
         try:
-            chat = MANAGER.get(tid, sandbox_backend=sandbox)
+            chat = MANAGER.get(tid, sandbox_backend=sandbox,
+                               on_queue_state=on_queue_state)
         except FileNotFoundError:
             return
-        _set_status(tid, "processing", **pending_kwargs)
+        # The queue callback drives status from "starting_sandbox" through
+        # "queued" (if needed) and finally "processing" once acquired.
+        # Without the callback we'd jump straight to "processing" here.
         resp = chat.message(text)
         MANAGER.touch(tid)
 

--- a/tests/middleware/test_thread_queue_middleware.py
+++ b/tests/middleware/test_thread_queue_middleware.py
@@ -1,0 +1,38 @@
+"""Tests for ThreadQueueMiddleware."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from assist.middleware.thread_queue_middleware import ThreadQueueMiddleware
+from assist.thread_queue import ThreadHoldExpired, _Handle, _active_handle
+
+
+def test_after_model_passes_through_when_no_active_handle():
+    mw = ThreadQueueMiddleware()
+    # Default ContextVar state: no handle.
+    result = mw.after_model(MagicMock(), MagicMock())
+    assert result is None
+
+
+def test_after_model_passes_through_when_handle_not_expired():
+    mw = ThreadQueueMiddleware()
+    handle = _Handle("A")
+    token = _active_handle.set(handle)
+    try:
+        result = mw.after_model(MagicMock(), MagicMock())
+        assert result is None
+    finally:
+        _active_handle.reset(token)
+
+
+def test_after_model_raises_when_handle_expired():
+    mw = ThreadQueueMiddleware()
+    handle = _Handle("A")
+    handle.expired = True
+    token = _active_handle.set(handle)
+    try:
+        with pytest.raises(ThreadHoldExpired) as ctx:
+            mw.after_model(MagicMock(), MagicMock())
+        assert "A" in str(ctx.value)
+    finally:
+        _active_handle.reset(token)

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -1,0 +1,271 @@
+"""Tests for ThreadAffinityQueue (assist/thread_queue.py)."""
+import os
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+from assist.thread_queue import (
+    DEFAULT_HOLD_TIMEOUT_S,
+    DEFAULT_WAIT_TIMEOUT_S,
+    QueueWaitTimeout,
+    ThreadAffinityQueue,
+    active_handle,
+)
+
+
+def test_no_contention_runs_immediately_with_no_queued_callback():
+    q = ThreadAffinityQueue()
+    states = []
+    with q.acquire("A", on_state_change=states.append):
+        pass
+    # Single holder never observed "queued"; only "running" was emitted.
+    assert states == ["running"]
+    assert q.current_handle() is None
+
+
+def test_second_thread_observes_queued_then_running():
+    q = ThreadAffinityQueue()
+    holder_can_release = threading.Event()
+    waiter_states: list[str] = []
+    waiter_done = threading.Event()
+
+    def hold_a():
+        with q.acquire("A"):
+            holder_can_release.wait(timeout=5)
+
+    def waiter_b():
+        with q.acquire("B", on_state_change=waiter_states.append):
+            pass
+        waiter_done.set()
+
+    ta = threading.Thread(target=hold_a)
+    ta.start()
+    # Give A a head start so B definitely arrives second.
+    time.sleep(0.05)
+    tb = threading.Thread(target=waiter_b)
+    tb.start()
+
+    # B has not acquired yet; should be queued.
+    time.sleep(0.05)
+    assert waiter_states == ["queued"]
+    assert q.waiter_count() == 1
+
+    holder_can_release.set()
+    ta.join(timeout=5)
+    tb.join(timeout=5)
+    assert waiter_done.is_set()
+    assert waiter_states == ["queued", "running"]
+    assert q.current_handle() is None
+    assert q.waiter_count() == 0
+
+
+def test_fifo_among_waiters():
+    q = ThreadAffinityQueue()
+    holder_can_release = threading.Event()
+    completion_order: list[str] = []
+    completion_lock = threading.Lock()
+
+    def hold_a():
+        with q.acquire("A"):
+            holder_can_release.wait(timeout=5)
+        with completion_lock:
+            completion_order.append("A")
+
+    def waiter(tid: str, started: threading.Event):
+        started.set()
+        with q.acquire(tid):
+            # Tiny bit of work to force ordering to be observable.
+            time.sleep(0.01)
+        with completion_lock:
+            completion_order.append(tid)
+
+    ta = threading.Thread(target=hold_a)
+    ta.start()
+    time.sleep(0.05)
+
+    # Stagger waiter starts so FIFO order is unambiguous.
+    starts = [threading.Event() for _ in range(3)]
+    waiters = []
+    for tid, ev in zip(["B", "C", "D"], starts):
+        t = threading.Thread(target=waiter, args=(tid, ev))
+        waiters.append(t)
+        t.start()
+        ev.wait(timeout=1)
+        # Allow this waiter's acquire() to enqueue before the next one.
+        time.sleep(0.02)
+
+    holder_can_release.set()
+    ta.join(timeout=5)
+    for w in waiters:
+        w.join(timeout=5)
+
+    assert completion_order == ["A", "B", "C", "D"]
+
+
+def test_holder_exception_releases_lock():
+    q = ThreadAffinityQueue()
+    waiter_acquired = threading.Event()
+
+    def hold_a():
+        try:
+            with q.acquire("A"):
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+
+    def waiter_b():
+        with q.acquire("B"):
+            waiter_acquired.set()
+
+    ta = threading.Thread(target=hold_a)
+    tb = threading.Thread(target=waiter_b)
+    ta.start()
+    tb.start()
+    ta.join(timeout=5)
+    tb.join(timeout=5)
+    assert waiter_acquired.is_set()
+    assert q.current_handle() is None
+
+
+def test_wait_timeout_raises():
+    q = ThreadAffinityQueue()
+    holder_can_release = threading.Event()
+
+    def hold_a():
+        with q.acquire("A"):
+            holder_can_release.wait(timeout=2)
+
+    ta = threading.Thread(target=hold_a)
+    ta.start()
+    time.sleep(0.05)
+
+    with pytest.raises(QueueWaitTimeout):
+        with q.acquire("B", wait_timeout_s=0.1):
+            pytest.fail("should not have acquired")
+
+    # Holder still owns the queue; we did not steal it on timeout.
+    assert q.current_handle() is not None
+    assert q.current_handle().thread_id == "A"
+
+    holder_can_release.set()
+    ta.join(timeout=5)
+    assert q.current_handle() is None
+    # Waiter cleaned itself out of the queue.
+    assert q.waiter_count() == 0
+
+
+def test_hold_timeout_marks_expired():
+    q = ThreadAffinityQueue()
+    with q.acquire("A", hold_timeout_s=0.1) as handle:
+        assert handle.expired is False
+        time.sleep(0.25)
+        assert handle.expired is True
+
+
+def test_reentrant_same_thread_id_is_noop():
+    q = ThreadAffinityQueue()
+    states_outer: list[str] = []
+    states_inner: list[str] = []
+    with q.acquire("A", on_state_change=states_outer.append) as outer:
+        with q.acquire("A", on_state_change=states_inner.append) as inner:
+            assert inner is outer
+        # Inner exit must not release the holder.
+        assert q.current_handle() is outer
+    assert q.current_handle() is None
+    # Outer fired "running"; inner fired nothing (no "queued", no "running").
+    assert states_outer == ["running"]
+    assert states_inner == []
+
+
+def test_same_thread_id_from_different_os_thread_does_not_free_ride():
+    # Reentrancy is gated on "same call stack as the holder", not just
+    # matching thread_id.  A web double-click produces two background
+    # tasks with the same tid; the second must queue, not run alongside.
+    q = ThreadAffinityQueue()
+    holder_can_release = threading.Event()
+    waiter_states: list[str] = []
+    waiter_done = threading.Event()
+
+    def hold_a():
+        with q.acquire("A"):
+            holder_can_release.wait(timeout=5)
+
+    def waiter_same_tid():
+        with q.acquire("A", on_state_change=waiter_states.append):
+            pass
+        waiter_done.set()
+
+    ta = threading.Thread(target=hold_a)
+    ta.start()
+    time.sleep(0.05)
+    tb = threading.Thread(target=waiter_same_tid)
+    tb.start()
+    time.sleep(0.05)
+
+    # Second caller with same tid is on a different OS thread, so it
+    # must queue — NOT take the reentrant fast path.
+    assert waiter_states == ["queued"]
+    assert q.waiter_count() == 1
+
+    holder_can_release.set()
+    ta.join(timeout=5)
+    tb.join(timeout=5)
+    assert waiter_done.is_set()
+    assert waiter_states == ["queued", "running"]
+
+
+def test_active_handle_visible_inside_acquire():
+    q = ThreadAffinityQueue()
+    assert active_handle() is None
+    with q.acquire("A") as handle:
+        assert active_handle() is handle
+    assert active_handle() is None
+
+
+def test_active_handle_not_set_in_unrelated_thread():
+    q = ThreadAffinityQueue()
+    other_thread_handle: list = []
+
+    def peek():
+        other_thread_handle.append(active_handle())
+
+    with q.acquire("A"):
+        t = threading.Thread(target=peek)
+        t.start()
+        t.join(timeout=2)
+    # Spawned thread did not inherit the contextvar via threading.
+    assert other_thread_handle == [None]
+
+
+def test_env_float_parses_valid_value(monkeypatch):
+    # Test the parser directly, not via importlib.reload — reloading the
+    # module recreates the contextvar singleton and breaks any other
+    # test that imported it.
+    from assist.thread_queue import _env_float
+
+    monkeypatch.setenv("ASSIST_TESTING_FLOAT", "1.5")
+    assert _env_float("ASSIST_TESTING_FLOAT", 99.0) == 1.5
+
+
+def test_env_float_falls_back_on_unset(monkeypatch):
+    from assist.thread_queue import _env_float
+
+    monkeypatch.delenv("ASSIST_TESTING_FLOAT", raising=False)
+    assert _env_float("ASSIST_TESTING_FLOAT", 99.0) == 99.0
+
+
+def test_env_float_falls_back_on_invalid(monkeypatch):
+    from assist.thread_queue import _env_float
+
+    monkeypatch.setenv("ASSIST_TESTING_FLOAT", "notanumber")
+    assert _env_float("ASSIST_TESTING_FLOAT", 99.0) == 99.0
+
+
+def test_defaults_match_module_constants():
+    # Sanity check: the values applied to a freshly-constructed queue
+    # match the module-level defaults documented in the docstring.
+    q = ThreadAffinityQueue()
+    assert q._default_hold_timeout == DEFAULT_HOLD_TIMEOUT_S
+    assert q._default_wait_timeout == DEFAULT_WAIT_TIMEOUT_S

--- a/tests/test_thread_queue_integration.py
+++ b/tests/test_thread_queue_integration.py
@@ -1,0 +1,127 @@
+"""Integration tests for Thread.message / Thread.stream_message and the queue.
+
+Covers the reviewer's gap items #3 and #4: the queue must release on
+exceptions raised from inside the agent invocation, and the
+``stream_message`` generator must hold the queue for the duration of
+iteration (and release on iterator close / exception).
+"""
+import os
+import shutil
+import tempfile
+import threading
+from unittest import TestCase
+from unittest.mock import patch
+
+from langchain.messages import AIMessage
+
+from assist.thread import Thread, ThreadManager
+from assist.thread_queue import THREAD_QUEUE
+
+
+class _ThreadQueueIntegrationBase(TestCase):
+    def setUp(self):
+        # The conftest fixture stubs `_probe_endpoint` so model
+        # selection doesn't network, but `_get_config` first checks
+        # ASSIST_MODEL_URL and raises if unset.  Set a placeholder.
+        self._prev_url = os.environ.get("ASSIST_MODEL_URL")
+        os.environ["ASSIST_MODEL_URL"] = "http://test.local/v1"
+        self.root = tempfile.mkdtemp()
+        self.tm = ThreadManager(self.root)
+
+    def tearDown(self):
+        try:
+            self.tm.close()
+        except Exception:
+            pass
+        shutil.rmtree(self.root, ignore_errors=True)
+        if self._prev_url is None:
+            os.environ.pop("ASSIST_MODEL_URL", None)
+        else:
+            os.environ["ASSIST_MODEL_URL"] = self._prev_url
+        # Belt-and-suspenders: confirm no test leaked the queue holder.
+        self.assertIsNone(
+            THREAD_QUEUE.current_handle(),
+            "test leaked queue holder; clean-up failed",
+        )
+
+
+class TestThreadMessageReleasesQueueOnException(_ThreadQueueIntegrationBase):
+    def test_message_releases_queue_when_invoke_raises(self):
+        chat = self.tm.new()
+        with patch(
+            "assist.thread.invoke_with_rollback",
+            side_effect=RuntimeError("boom from inside the agent"),
+        ):
+            with self.assertRaises(RuntimeError):
+                chat.message("hello")
+        # Queue is empty: a subsequent thread should be free to acquire.
+        self.assertIsNone(THREAD_QUEUE.current_handle())
+        self.assertEqual(THREAD_QUEUE.waiter_count(), 0)
+
+    def test_message_releases_queue_after_normal_completion(self):
+        chat = self.tm.new()
+        fake_result = {"messages": [AIMessage(content="ok")]}
+        with patch(
+            "assist.thread.invoke_with_rollback",
+            return_value=fake_result,
+        ):
+            resp = chat.message("hello")
+        self.assertEqual(resp, "ok")
+        self.assertIsNone(THREAD_QUEUE.current_handle())
+
+
+class TestThreadStreamMessageHoldsAndReleasesQueue(_ThreadQueueIntegrationBase):
+    def _patch_stream(self, chunks, raise_on=None):
+        """Replace ``self.agent.stream`` on the thread with a generator that
+        yields ``chunks`` and optionally raises after a given index.
+        """
+
+        def fake_stream(*args, **kwargs):
+            for i, chunk in enumerate(chunks):
+                if raise_on is not None and i == raise_on:
+                    raise RuntimeError("boom mid-stream")
+                yield chunk
+
+        return fake_stream
+
+    def test_queue_acquired_only_when_iteration_starts(self):
+        chat = self.tm.new()
+        gen = None
+        with patch.object(chat.agent, "stream", self._patch_stream(["a", "b"])):
+            gen = chat.stream_message("hello")
+            # No iteration yet — the queue should be untouched.
+            self.assertIsNone(THREAD_QUEUE.current_handle())
+            chunks = list(gen)
+        self.assertEqual(chunks, ["a", "b"])
+        self.assertIsNone(THREAD_QUEUE.current_handle())
+
+    def test_queue_held_during_iteration_released_on_exhaustion(self):
+        chat = self.tm.new()
+        seen_holder: list = []
+        with patch.object(chat.agent, "stream", self._patch_stream(["a", "b", "c"])):
+            for chunk in chat.stream_message("hello"):
+                seen_holder.append(THREAD_QUEUE.current_handle())
+        # During iteration the queue had a holder for this thread.
+        self.assertTrue(all(h is not None for h in seen_holder))
+        self.assertTrue(all(h.thread_id == chat.thread_id for h in seen_holder))
+        # Released after exhaustion.
+        self.assertIsNone(THREAD_QUEUE.current_handle())
+
+    def test_queue_released_when_stream_iteration_raises(self):
+        chat = self.tm.new()
+        with patch.object(
+            chat.agent, "stream", self._patch_stream(["a", "b"], raise_on=1)
+        ):
+            with self.assertRaises(RuntimeError):
+                list(chat.stream_message("hello"))
+        self.assertIsNone(THREAD_QUEUE.current_handle())
+
+    def test_queue_released_when_iterator_is_closed_early(self):
+        chat = self.tm.new()
+        with patch.object(chat.agent, "stream", self._patch_stream(["a", "b", "c"])):
+            gen = chat.stream_message("hello")
+            next(gen)
+            self.assertIsNotNone(THREAD_QUEUE.current_handle())
+            gen.close()
+        # Generator close runs the finally → exits the `with` → releases queue.
+        self.assertIsNone(THREAD_QUEUE.current_handle())


### PR DESCRIPTION
## Summary
- Serializes `Thread.message()` at a per-thread affinity queue so concurrent threads don't thrash llama.cpp's `--parallel 1` KV cache. Without this, two agents running together took ~3× one alone (full prefill on every cross-thread turn — O(T²)). With it, ~2×.
- New `"queued"` stage and blue badge in the web UI when a thread is waiting on another's hold; uses the existing `status.json` polling, no JS changes.
- Watchdog enforces `ASSIST_THREAD_HOLD_TIMEOUT_S=600` (env-overridable). Cooperative cancel between LLM calls via `ThreadQueueMiddleware`. Honors the saved feedback rule "threads die on infrastructure failure rather than heal-and-retry."
- Reentrancy is gated on **contextvar-stack identity**, not bare `thread_id` — so a user double-clicking Send (two background tasks for one tid on different OS threads) queues rather than free-riding the holder.

## Design + review
Phase 1 plan ran through the `Plan` architect subagent (per `CLAUDE.md`'s two-phase workflow). Phase 2 review ran through a `general-purpose` reviewer; flagged 4 IMPORTANT items and 5 NITs, all addressed:
- Tightened reentry guard (was: bare tid match → bug on web double-submit; now: contextvar-stack identity).
- Added integration tests for queue release on `Thread.message` exception.
- Added 4 lifecycle tests for `Thread.stream_message` (acquire-on-iterate, release-on-exhaustion, release-on-exception, release-on-close).
- Documented in the module docstring that `hold_timeout_s` bounds detection latency, not exact wall-clock release time (a `wrap_model_call` retry can run one or two extra calls past the cap).

## Files
- New: `assist/thread_queue.py`, `assist/middleware/thread_queue_middleware.py`
- Modified: `assist/thread.py`, `assist/agent.py`, `manage/web.py`
- Tests: `tests/test_thread_queue.py` (14 unit), `tests/test_thread_queue_integration.py` (6 integration), `tests/middleware/test_thread_queue_middleware.py` (3)
- Eval: `edd/eval/test_thread_queue.py` — pins the contract end-to-end (two real concurrent threads serialize, second one observes "queued" for nonzero duration)

## Test plan
- [x] 310 pytest tests pass (zero regressions vs main)
- [x] 23 new unit + integration tests pass
- [x] Eval pinning the contract: 10/10 stability at N=10 (~1s each, ~10s total)
- [ ] Deploy to prod and observe a real concurrent-thread case in the live UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)