### PR TITLE
Hotfix: add manage/web/__main__.py for systemd entry point

### DIFF
--- a/manage/web/__init__.py
+++ b/manage/web/__init__.py
@@ -73,11 +73,5 @@ from manage.web.threads import (  # noqa: E402,F401
     render_thread,
 )
 
-
-if __name__ == "__main__":
-    import os
-    import uvicorn
-
-    os.makedirs(ROOT, exist_ok=True)
-    port = int(os.getenv("ASSIST_PORT", "8000"))
-    uvicorn.run("manage.web:app", host="0.0.0.0", port=port, log_level="info", reload=False)
+# ``python -m manage.web`` resolves to ``manage/web/__main__.py``;
+# nothing here is meant to run on import.

--- a/manage/web/__main__.py
+++ b/manage/web/__main__.py
@@ -1,0 +1,26 @@
+"""Package entry point for ``python -m manage.web``.
+
+Lives in ``__main__.py`` so the systemd service (which spawns
+``python -m manage.web``) keeps working after the split from a single
+``web.py`` module.  The same code used to live inside an
+``if __name__ == "__main__":`` block at the bottom of ``web.py`` —
+that idiom only fires when a module is run directly, which a package
+isn't.
+"""
+import os
+
+import uvicorn
+
+from manage.web.state import ROOT
+
+
+if __name__ == "__main__":
+    os.makedirs(ROOT, exist_ok=True)
+    port = int(os.getenv("ASSIST_PORT", "8000"))
+    uvicorn.run(
+        "manage.web:app",
+        host="0.0.0.0",
+        port=port,
+        log_level="info",
+        reload=False,
+    )


### PR DESCRIPTION
## Summary

PR #92 split \`manage/web.py\` into a package without adding a \`__main__.py\`. The systemd unit spawns the service via \`python -m manage.web\`, which on a package looks up \`manage.web.__main__\` instead of executing \`__init__.py\` — so the previous \`if __name__ == \"__main__\":\` block at the bottom of \`__init__.py\` never fires.

After the PR #92 merge + redeploy, \`assist-web\` crash-looped 5 times with:

\`\`\`
No module named manage.web.__main__; 'manage.web' is a package and cannot be directly executed
\`\`\`

This restores the original \`python -m\` entry point with a small \`__main__.py\` that does the same \`uvicorn.run()\` the old block did, and drops the dead block from \`__init__.py\`.

## Test plan

- [x] Verify \`importlib.util.find_spec('manage.web.__main__')\` resolves locally.
- [x] Deploy from this branch + restart \`assist-web\` — service comes up in ~4s, all routes respond 200, thread page shows the new diff polish + Review button.
- [x] No code logic changed; just restoring the entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)