### PR TITLE
LoopDetection: skip read-only tools in Pattern A/B trailing-run walks

### DIFF
--- a/assist/middleware/loop_detection.py
+++ b/assist/middleware/loop_detection.py
@@ -193,11 +193,28 @@ def _detect_loop(
     if not completed_events:
         return None
 
-    # Pattern A: trailing run of same tool + same normalised error.
+    # Patterns A and B walk the trailing run of "mutating" tool events;
+    # read-only events (ls, read_file, grep, glob, read_url,
+    # search_internet) are TRANSPARENT to the walk — neither extending
+    # the run nor breaking it.  Rationale: a read-only call between two
+    # failing mutating calls is "let me check what's there" — the agent
+    # is observing state but not changing approach.  Treating that as
+    # progress-resetting would let "[ls, write_file_err] x N" loops
+    # escape detection (which is exactly the 2026-05-16 winged-horse-
+    # flag thread).  Read-only sequences alone are still pure
+    # exploration and do not trigger detection (Pattern A needs at
+    # least one error event; Pattern B needs the same MUTATING tool
+    # repeating).
+    def _mutating_only(events):
+        return [e for e in events if e["tool_name"] not in _READ_ONLY_TOOLS]
+
+    mutating_events = _mutating_only(completed_events)
+
+    # Pattern A: trailing run of same mutating tool + same normalised error.
     run_tool = None
     run_err = None
     run_len = 0
-    for e in reversed(completed_events):
+    for e in reversed(mutating_events):
         if not e["is_error"]:
             break
         err_sig = _normalise_error(e["result_content"])
@@ -217,11 +234,11 @@ def _detect_loop(
             "run_length": run_len,
         }
 
-    # Pattern B: trailing run of same tool + same args.
+    # Pattern B: trailing run of same mutating tool + same args.
     run_tool = None
     run_args = None
     run_len = 0
-    for e in reversed(completed_events):
+    for e in reversed(mutating_events):
         if run_tool is None:
             run_tool = e["tool_name"]
             run_args = e["args_sig"]

--- a/tests/middleware/test_loop_detection.py
+++ b/tests/middleware/test_loop_detection.py
@@ -278,6 +278,110 @@ class TestDetectLoop:
         assert result is not None
         assert result["tools"] == {"custom_mutator"}
 
+    # ------------------------------------------------------------------
+    # Read-only-interleaved trailing-run detection
+    # Regression: 2026-05-16 thread 20260516165139-36e38c0a ("winged-
+    # horse flag") oscillated 70+ times in
+    # `[ls, write_file_err, ls, write_file_err, ...]` for ~1 hour
+    # before the sandbox container was lost.  Pattern A trailing-run
+    # walk used to break on the interleaved `ls` (non-error), so the
+    # loop escaped detection.  Read-only events are now transparent
+    # to the Pattern A and B walks.
+    # ------------------------------------------------------------------
+
+    def test_pattern_a_catches_loop_through_interleaved_ls(self):
+        """Two write_file errors with `ls` in between — the flag-thread
+        shape — must trigger Pattern A.  `ls` is read-only so it
+        neither extends nor breaks the trailing mutating-tool error
+        run."""
+        events = [
+            self._evt(tool="ls", args={"path": "/workspace"}, content="[]"),
+            self._evt(
+                tool="write_file",
+                args={"file_path": "report.org", "content": "..."},
+                content=("OCI runtime exec failed: exec failed: unable to "
+                         "start container process: chdir to cwd "
+                         "(\"/workspace/references\")"),
+                is_error=True,
+            ),
+            self._evt(tool="ls", args={"path": "/workspace"}, content="[]"),
+            self._evt(
+                tool="write_file",
+                args={"file_path": "report.org", "content": "..."},
+                content=("OCI runtime exec failed: exec failed: unable to "
+                         "start container process: chdir to cwd "
+                         "(\"/workspace/references\")"),
+                is_error=True,
+            ),
+        ]
+        result = _detect_loop(events, 2, 3, 3, 10)
+        assert result is not None, "Pattern A should fire on ls-interleaved write_file errors"
+        assert result["pattern"] == "same-tool-same-error"
+        assert result["tools"] == {"write_file"}
+        assert result["run_length"] == 2
+
+    def test_pattern_a_catches_long_alternating_pathology(self):
+        """Full 8-event alternation (4 ls + 4 wf_err) — the exact
+        N=4 mutating-error run we'd want to catch as early as
+        possible.  Asserts run_length counts only the mutating
+        events (4), not the interleaved ls."""
+        events = []
+        for _ in range(4):
+            events.append(self._evt(tool="ls", args={"path": "/"}, content="[]"))
+            events.append(self._evt(
+                tool="write_file",
+                args={"file_path": "x.org"},
+                content="OCI runtime exec failed: chdir to cwd",
+                is_error=True,
+            ))
+        result = _detect_loop(events, 2, 3, 3, 10)
+        assert result is not None
+        assert result["pattern"] == "same-tool-same-error"
+        assert result["run_length"] == 4
+
+    def test_pattern_b_catches_same_args_through_interleaved_glob(self):
+        """Same-args trailing-run also tolerates read-only interleaving.
+        Three identical write_file calls with `glob` in between count
+        as Pattern B at threshold 3."""
+        wf = self._evt(
+            tool="write_file",
+            args={"file_path": "/x.org", "content": "data"},
+            content="ok",
+        )
+        gl = self._evt(tool="glob", args={"pattern": "*.org"}, content="[]")
+        events = [wf, gl, wf.copy(), gl.copy(), wf.copy()]
+        result = _detect_loop(events, 2, 3, 3, 10)
+        assert result is not None
+        assert result["pattern"] == "same-tool-same-args"
+        assert result["tools"] == {"write_file"}
+        assert result["run_length"] == 3
+
+    def test_no_false_positive_legitimate_write_read_write(self):
+        """Sanity counter-check: a real workflow of `write_file(/a) →
+        ls → write_file(/b)` (different files, no errors) must NOT
+        trigger any pattern.  The ls is transparent to A/B walks but
+        without errors there's no Pattern A; and the two writes have
+        different args so Pattern B's trailing-same-args-run is 1."""
+        events = [
+            self._evt(tool="write_file", args={"file_path": "/a.org"}, content="Wrote /a.org"),
+            self._evt(tool="ls", args={"path": "/"}, content="['a.org']"),
+            self._evt(tool="write_file", args={"file_path": "/b.org"}, content="Wrote /b.org"),
+        ]
+        assert _detect_loop(events, 2, 3, 3, 10) is None
+
+    def test_no_false_positive_pure_exploration(self):
+        """A run of read-only tools alone (no mutating) must NOT
+        trigger any pattern.  After filtering out read-only events
+        the mutating-events list is empty, so all three patterns
+        short-circuit."""
+        events = [
+            self._evt(tool="ls", args={"path": "/"}, content="[]"),
+            self._evt(tool="read_file", args={"file_path": "/x"}, content="hi"),
+            self._evt(tool="grep", args={"pattern": "foo"}, content="[]"),
+            self._evt(tool="search_internet", args={"query": "x"}, content="[]"),
+        ]
+        assert _detect_loop(events, 2, 3, 3, 10) is None
+
 
 class TestLastSuccessfulArtifact:
     def test_returns_path_of_last_success(self):


### PR DESCRIPTION
## Summary

Fix for the 2026-05-16 winged-horse-flag thread (`20260516165139-36e38c0a`) which oscillated `[ls, write_file_err] × 70+` for ~1 hour before the sandbox container vanished and the agent died with 155 tool calls accumulated.  None of LoopDetection's three patterns caught it.

## Root cause

`_detect_loop`'s Patterns A and B walk `reversed(completed_events)` looking for a trailing run.  Each read-only `ls → []` between failing `write_file` calls broke the run:

- **Pattern A** (same tool + same normalised error, ≥2): `if not e["is_error"]: break` on line 201 — the `ls` (non-error) reset the trailing run to zero.
- **Pattern B** (same tool + same args, ≥3): trailing tool alternated `ls / write_file / ls / write_file`, so the trailing-same-tool run was always 1.
- **Pattern C** (distinct mutating args, ≥3): already excludes read-only tools, but the model kept calling `write_file` with effectively the same file path each time → distinct-args set stayed at 1.

## Fix

Patterns A and B now walk a `_mutating_only(completed_events)` filtered list — read-only tools (`ls`, `read_file`, `grep`, `glob`, `read_url`, `search_internet`) are **transparent** to the walk, neither extending the trailing run nor breaking it.

Rationale: a read-only call between two failing mutating calls is *"let me check what's there"* — the agent is observing state but not changing approach.  Treating that as progress-resetting lets `[ls, write_file_err] × N` loops escape detection forever, which is the failure mode we just hit.  Pattern C unchanged (already had the right filter).

## Coverage

Before: 51 loop_detection tests, all passing.  After: 56 (+5 new), all passing.  457 total unit tests pass.

New tests:

| Test | Asserts |
|---|---|
| `test_pattern_a_catches_loop_through_interleaved_ls` | exact flag-thread shape — 2 wf_err + 2 ls interleaved → Pattern A fires |
| `test_pattern_a_catches_long_alternating_pathology` | 4 ls + 4 wf_err → run_length counts only the 4 mutating events |
| `test_pattern_b_catches_same_args_through_interleaved_glob` | 3 identical write_file with glob between → Pattern B fires |
| `test_no_false_positive_legitimate_write_read_write` | real workflow (write /a → ls → write /b, no errors, different args) → NO trigger |
| `test_no_false_positive_pure_exploration` | sequence of pure read-only tools → NO trigger (filtered list is empty) |

## Test plan

- [x] All 51 pre-existing loop_detection tests pass unchanged.
- [x] 5 new regression tests pass.
- [x] Full unit suite passes (457).
- [ ] Post-merge: monitor that the next research thread with a path-related write failure now surfaces a LoopDetection intervention within ~6 events instead of running for an hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)