### PR TITLE
Declare assist runtime deps in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,32 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "assist"
 version = "0.1.0"
+# Runtime deps: packages actually imported under assist/, manage/, edd/.
+# Versions are NOT pinned here; requirements.txt is the lockfile that
+# pins the full transitive closure for reproducible installs.
+# Downstream consumers (eg. emacsos-server) can install with:
+#   pip install -e /path/to/assist -c /path/to/assist/requirements.txt
+# to pick up these deps while honouring assist's pinned versions.
 dependencies = [
-    "vgrep==0.1.4",
-    "Jinja2==3.1.6",
-    "typer",
-    "pyyaml",
-    "jsonschema"
+    "ddgs",
+    "deepagents",
+    "docker",
+    "fastapi",
+    "httpx",
+    "Jinja2",
+    "langchain",
+    "langchain-core",
+    "langchain-openai",
+    "langgraph",
+    "langgraph-checkpoint-sqlite",
+    "loguru",
+    "Markdown",
+    "openai",
+    "pydantic",
+    "python-dotenv",
+    "python-multipart",
+    "requests",
+    "uvicorn",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

- The existing `pyproject.toml` dependency list was vestigial — none of `vgrep`, `typer`, `pyyaml`, or `jsonschema` are imported anywhere under `assist/`, `manage/`, or `edd/`.  Meanwhile the real runtime stack (`deepagents`, `langchain*`, `langgraph`, `fastapi`, `openai`, etc.) lived only in `requirements.txt`, so `pip install assist` produced an unimportable install.
- This PR declares the actually-imported first-party packages as `dependencies`.  No version pins — `requirements.txt` continues to serve as the lockfile for the full transitive closure.
- Downstream consumers (notably emacsos-server, see [emacsos Makefile lines 74-91](https://github.com/pierrel/emacsos/blob/main/Makefile#L74-L91)) can drop the `pip install -r requirements.txt` workaround and use `pip install -e ../assist -c ../assist/requirements.txt` instead — picks up assist's runtime deps with the locked versions, skips ~50 dev-tooling packages (pytest, ipython, pylint, flake8, jupyter machinery, etc.).

## Validation

- Walk-imported every non-test module in a fresh venv built via `pip install -e . -c requirements.txt`: 1 expected failure for `edd/conftest.py` (pytest infrastructure, not a runtime concern).
- Ran `python -m pytest tests/`: **473 passed**, no regressions.

## Test plan

- [x] Walk-import succeeds against a fresh venv installed via constraints flag
- [x] Existing assist test suite passes (473 tests)
- [ ] Follow-up emacsos PR drops the `-r requirements.txt` workaround once this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)