### PR TITLE
LoopDetection: relaxed Pattern-C threshold for exploration tools

### DIFF
--- a/assist/agent.py
+++ b/assist/agent.py
@@ -110,6 +110,7 @@ def create_agent(model: BaseChatModel,
                  sandbox_backend=None,
                  extra_skill_sources: dict[str, BackendProtocol] | None = None,
                  extra_tools: Sequence[BaseTool | Callable | dict[str, Any]] | None = None,
+                 loop_exploration_tools: frozenset[str] | None = None,
                  ) -> CompiledStateGraph:
     """Build the general-purpose agent.
 
@@ -132,6 +133,15 @@ def create_agent(model: BaseChatModel,
     general-purpose subagent; the bespoke ``context`` / ``research`` /
     ``critique`` subagents are built separately and do not see these
     tools (correctly, given their roles).  Default ``None`` is empty.
+
+    ``loop_exploration_tools`` is forwarded to the MAIN agent's
+    ``LoopDetectionMiddleware(exploration_tools=...)``: tool names whose
+    distinct-args breadth gets a higher Pattern-C threshold (they probe
+    many forms legitimately — e.g. emacsos's ``eval_elisp``).  They are
+    NOT exempt from loop detection (still subject to Patterns A/B and a
+    finite Pattern-C cap).  Only the main agent gets it — the bespoke
+    subagents don't receive ``extra_tools`` so the exploration tool can't
+    reach them.  Default ``None`` leaves the dev/code agent unchanged.
     """
     # Core middleware: retry, tool call limiting, JSON validation, and logging.
     # See `_make_retry_middleware` for the retry-on tuple rationale.
@@ -154,7 +164,7 @@ def create_agent(model: BaseChatModel,
     # of `loop_detection_mw` so the rejection is what the loop
     # detector sees if the model retries.
     git_push_blocker_mw = GitPushBlockerMiddleware()
-    loop_detection_mw = LoopDetectionMiddleware()
+    loop_detection_mw = LoopDetectionMiddleware(exploration_tools=loop_exploration_tools)
     # Innermost wrap_model_call middleware — recovers from empty terminal
     # AIMessages after every outer retry/sanitization layer has had its turn.
     empty_response_recovery_mw = EmptyResponseRecoveryMiddleware()

--- a/assist/middleware/loop_detection.py
+++ b/assist/middleware/loop_detection.py
@@ -28,7 +28,10 @@ C. Same tool + >= ``distinct_args_threshold`` distinct arg sets within
    error → ``foo2.py`` → error → ``foo_new.py``) even when individual
    error strings differ. Read-only tools (``read_file``, ``ls``,
    ``grep``, etc.) are exempt because distinct-args usage is the
-   normal shape of legitimate exploration.
+   normal shape of legitimate exploration. Embedder-declared
+   ``exploration_tools`` (e.g. emacsos's ``eval_elisp``) are not exempt
+   but get a HIGHER breadth threshold (``_EXPLORATION_DISTINCT_ARGS_
+   THRESHOLD``); they remain fully subject to A and B.
 """
 
 import hashlib

--- a/assist/middleware/loop_detection.py
+++ b/assist/middleware/loop_detection.py
@@ -30,8 +30,9 @@ C. Same tool + >= ``distinct_args_threshold`` distinct arg sets within
    ``grep``, etc.) are exempt because distinct-args usage is the
    normal shape of legitimate exploration. Embedder-declared
    ``exploration_tools`` (e.g. emacsos's ``eval_elisp``) are not exempt
-   but get a HIGHER breadth threshold (``_EXPLORATION_DISTINCT_ARGS_
-   THRESHOLD``); they remain fully subject to A and B.
+   but get a HIGHER breadth threshold
+   (``_EXPLORATION_DISTINCT_ARGS_THRESHOLD``); they remain fully subject
+   to A and B.
 """
 
 import hashlib
@@ -452,8 +453,9 @@ class LoopDetectionMiddleware(AgentMiddleware):
         distinct_args_window: Sliding window for the distinct-args
             check. Default 10.
         exploration_tools: Tool names whose distinct-args *breadth* gets a
-            higher Pattern-C threshold (``_EXPLORATION_DISTINCT_ARGS_
-            THRESHOLD``) because probing many distinct forms is their normal
+            higher Pattern-C threshold
+            (``_EXPLORATION_DISTINCT_ARGS_THRESHOLD``) because probing many
+            distinct forms is their normal
             shape (e.g. emacsos's ``eval_elisp``).  They are NOT exempt from
             Pattern C (a sustained flail is still caught) and remain fully
             subject to Patterns A/B (repetition).  Default ``None`` → empty,
@@ -476,7 +478,9 @@ class LoopDetectionMiddleware(AgentMiddleware):
         self.args_repeat_threshold = args_repeat_threshold
         self.distinct_args_threshold = distinct_args_threshold
         self.distinct_args_window = distinct_args_window
-        self.exploration_tools = exploration_tools or frozenset()
+        # Normalise to frozenset so a caller passing a mutable set still
+        # yields an immutable attribute (matches the type annotation).
+        self.exploration_tools = frozenset(exploration_tools or ())
         self.tools = []
         self._intervention_count = 0
 

--- a/assist/middleware/loop_detection.py
+++ b/assist/middleware/loop_detection.py
@@ -69,6 +69,20 @@ _READ_ONLY_TOOLS: frozenset[str] = frozenset({
     "search_internet",
 })
 
+# Pattern C distinct-args threshold for tools an embedder marks as
+# "exploration" (e.g. emacsos's `eval_elisp`, which probes a live emacs and
+# is the agent's primary inspection tool).  Such tools legitimately fire
+# many distinct forms, and the small local model fumbles the API as it goes
+# — so a few distinct erroring probes are normal trial-and-error, not yet a
+# loop.  Exploration tools get this HIGHER breadth threshold than ordinary
+# mutating tools (default 3), so legitimate exploration isn't terminated;
+# but they are NOT exempt — a sustained flail of this many distinct erroring
+# forms is still caught (faster + with a clearer message than the recursion
+# limit).  They ALSO stay fully subject to Patterns A/B (repetition), which
+# is why `_mutating_only` below intentionally keeps using `_READ_ONLY_TOOLS`
+# only.  Tune against the live exploration shape in the evals.
+_EXPLORATION_DISTINCT_ARGS_THRESHOLD = 6
+
 
 def _looks_like_error(content: str) -> bool:
     head = content.lstrip().lower()[:120]
@@ -179,6 +193,8 @@ def _detect_loop(
     args_repeat_threshold: int,
     distinct_args_threshold: int,
     distinct_args_window: int,
+    exploration_tools: frozenset[str] = frozenset(),
+    exploration_args_threshold: int = _EXPLORATION_DISTINCT_ARGS_THRESHOLD,
 ) -> dict | None:
     """Return loop-detection info or ``None`` if no loop.
 
@@ -205,6 +221,14 @@ def _detect_loop(
     # exploration and do not trigger detection (Pattern A needs at
     # least one error event; Pattern B needs the same MUTATING tool
     # repeating).
+    #
+    # NOTE: this intentionally filters on `_READ_ONLY_TOOLS` ONLY — NOT the
+    # caller's `exploration_tools`.  Exploration tools (eg. eval_elisp) get a
+    # relaxed *Pattern C* breadth threshold below, but they must stay
+    # "mutating" here so Patterns A/B still catch a genuine repetition loop
+    # in them (same error / same form repeated).  Folding `exploration_tools`
+    # into this filter would disable A/B for them and remove their only
+    # remaining loop protection.
     def _mutating_only(events):
         return [e for e in events if e["tool_name"] not in _READ_ONLY_TOOLS]
 
@@ -269,7 +293,13 @@ def _detect_loop(
         if e["is_error"]:
             tool_errored[e["tool_name"]] = True
     for tool_name, sigs in by_tool.items():
-        if len(sigs) >= distinct_args_threshold and tool_errored.get(tool_name):
+        # Exploration tools (eg. eval_elisp) probe many distinct forms
+        # legitimately, so they get a higher breadth threshold — but still a
+        # finite one, so a sustained flail is caught.
+        threshold = (exploration_args_threshold
+                     if tool_name in exploration_tools
+                     else distinct_args_threshold)
+        if len(sigs) >= threshold and tool_errored.get(tool_name):
             return {
                 "pattern": "distinct-args-thrash",
                 "reason": (f"distinct-args-thrash: {tool_name} "
@@ -418,6 +448,14 @@ class LoopDetectionMiddleware(AgentMiddleware):
             exempt. Default 3.
         distinct_args_window: Sliding window for the distinct-args
             check. Default 10.
+        exploration_tools: Tool names whose distinct-args *breadth* gets a
+            higher Pattern-C threshold (``_EXPLORATION_DISTINCT_ARGS_
+            THRESHOLD``) because probing many distinct forms is their normal
+            shape (e.g. emacsos's ``eval_elisp``).  They are NOT exempt from
+            Pattern C (a sustained flail is still caught) and remain fully
+            subject to Patterns A/B (repetition).  Default ``None`` → empty,
+            so the dev/code agent is unaffected; an embedder opts in per
+            agent.
     """
 
     def __init__(
@@ -427,6 +465,7 @@ class LoopDetectionMiddleware(AgentMiddleware):
         args_repeat_threshold: int = 3,
         distinct_args_threshold: int = 3,
         distinct_args_window: int = 10,
+        exploration_tools: frozenset[str] | None = None,
     ):
         super().__init__()
         self.window = window
@@ -434,6 +473,7 @@ class LoopDetectionMiddleware(AgentMiddleware):
         self.args_repeat_threshold = args_repeat_threshold
         self.distinct_args_threshold = distinct_args_threshold
         self.distinct_args_window = distinct_args_window
+        self.exploration_tools = exploration_tools or frozenset()
         self.tools = []
         self._intervention_count = 0
 
@@ -457,6 +497,7 @@ class LoopDetectionMiddleware(AgentMiddleware):
             args_repeat_threshold=self.args_repeat_threshold,
             distinct_args_threshold=self.distinct_args_threshold,
             distinct_args_window=self.distinct_args_window,
+            exploration_tools=self.exploration_tools,
         )
         if detection is None:
             return None

--- a/assist/thread.py
+++ b/assist/thread.py
@@ -60,11 +60,18 @@ class Thread:
                  sandbox_backend=None,
                  on_queue_state: Callable[[str], None] | None = None,
                  extra_tools: Sequence[BaseTool | Callable | dict[str, Any]] | None = None,
+                 loop_exploration_tools: frozenset[str] | None = None,
                  extra_config: dict[str, Any] | None = None):
         """`extra_tools` is forwarded to ``create_agent(extra_tools=...)``
         — embedder-supplied tools the main agent can call.  See
         ``assist.agent.create_agent`` docstring for the subagent
         scope.
+
+        `loop_exploration_tools` is forwarded to
+        ``create_agent(loop_exploration_tools=...)`` — tool names whose
+        distinct-args breadth gets a relaxed (but still finite) loop-
+        detection threshold because probing many forms is their normal
+        shape (eg. an embedder's ``eval_elisp``).  Default ``None``.
 
         `extra_config` is merged into ``self.runconfig`` so per-Thread
         embedder context (eg. langgraph ``configurable`` values that
@@ -152,7 +159,8 @@ class Thread:
                                   working_dir=working_dir,
                                   checkpointer=checkpointer,
                                   sandbox_backend=sandbox_backend,
-                                  extra_tools=extra_tools)
+                                  extra_tools=extra_tools,
+                                  loop_exploration_tools=loop_exploration_tools)
 
     def message(self, text: str) -> str:
         """Continue the thread and return the last response.

--- a/tests/middleware/test_loop_detection.py
+++ b/tests/middleware/test_loop_detection.py
@@ -262,6 +262,83 @@ class TestDetectLoop:
         ]
         assert _detect_loop(events, 2, 3, 3, 10) is None
 
+    # ------------------------------------------------------------------
+    # Exploration tools (eg. emacsos's eval_elisp): relaxed Pattern-C
+    # breadth threshold, but NOT exempt and still subject to A/B.
+    # ------------------------------------------------------------------
+
+    def test_pattern_c_exploration_tool_gets_higher_threshold(self):
+        # The live emacsos shape: a few distinct eval_elisp probes, one
+        # erroring (the small model fumbles the API).  With eval_elisp
+        # marked as an exploration tool, the higher threshold (default 6)
+        # means this legitimate exploration is NOT terminated.
+        events = [
+            self._evt(tool="eval_elisp", args={"code": "(cursor-type)"}, content="box"),
+            self._evt(tool="eval_elisp",
+                      args={"code": "(frame-parameter nil 'cursor-color)"},
+                      content="nil"),
+            self._evt(tool="eval_elisp", args={"code": "(load-path)"},
+                      content="error: void-function load-path", is_error=True),
+        ]
+        assert _detect_loop(events, 2, 3, 3, 10,
+                            exploration_tools=frozenset({"eval_elisp"})) is None
+
+    def test_pattern_c_fires_for_eval_elisp_when_not_an_exploration_tool(self):
+        # Opt-in: with NO exploration_tools (the dev/code agent's config),
+        # the same 3 distinct erroring probes trip Pattern C at threshold 3.
+        events = [
+            self._evt(tool="eval_elisp", args={"code": "(cursor-type)"}, content="box"),
+            self._evt(tool="eval_elisp",
+                      args={"code": "(frame-parameter nil 'cursor-color)"},
+                      content="nil"),
+            self._evt(tool="eval_elisp", args={"code": "(load-path)"},
+                      content="error: void-function load-path", is_error=True),
+        ]
+        result = _detect_loop(events, 2, 3, 3, 10)
+        assert result is not None
+        assert result["pattern"] == "distinct-args-thrash"
+
+    def test_pattern_c_still_catches_sustained_exploration_flail(self):
+        # A sustained flail (>= the higher threshold of distinct erroring
+        # forms, with DISTINCT errors so A/B don't fire) IS still caught,
+        # faster than the recursion limit.
+        errs = ["void-function foo", "void-variable bar", "wrong-type baz",
+                "args-out-of-range qux", "scan-error quux", "no-catch corge"]
+        events = [
+            self._evt(tool="eval_elisp", args={"code": f"(probe-{i})"},
+                      content=f"error: {errs[i]}", is_error=True)
+            for i in range(6)
+        ]
+        result = _detect_loop(events, 2, 3, 3, 10,
+                              exploration_tools=frozenset({"eval_elisp"}))
+        assert result is not None
+        assert result["pattern"] == "distinct-args-thrash"
+        assert result["run_length"] == 6
+
+    def test_exploration_tool_still_subject_to_pattern_a(self):
+        # The SAME error repeated is a real loop — Pattern A still fires for
+        # an exploration tool (it stays "mutating" for A/B).
+        events = [
+            self._evt(tool="eval_elisp", args={"code": "(a)"},
+                      content="error: void-function frobnicate", is_error=True),
+            self._evt(tool="eval_elisp", args={"code": "(b)"},
+                      content="error: void-function frobnicate", is_error=True),
+        ]
+        result = _detect_loop(events, 2, 3, 3, 10,
+                              exploration_tools=frozenset({"eval_elisp"}))
+        assert result is not None
+        assert result["pattern"] == "same-tool-same-error"
+
+    def test_exploration_tool_still_subject_to_pattern_b(self):
+        # The IDENTICAL form repeated 3x is a real loop — Pattern B still
+        # fires for an exploration tool.
+        evt = self._evt(tool="eval_elisp", args={"code": "(stuck)"}, content="nil")
+        events = [evt, evt.copy(), evt.copy()]
+        result = _detect_loop(events, 2, 3, 3, 10,
+                              exploration_tools=frozenset({"eval_elisp"}))
+        assert result is not None
+        assert result["pattern"] == "same-tool-same-args"
+
     def test_different_tools_do_not_interleave(self):
         # Pattern C identifies the offending tool name when 3 distinct
         # mutating calls share the same name. Custom tool name avoids the

--- a/tests/middleware/test_loop_detection.py
+++ b/tests/middleware/test_loop_detection.py
@@ -298,6 +298,19 @@ class TestDetectLoop:
         assert result is not None
         assert result["pattern"] == "distinct-args-thrash"
 
+    def test_pattern_c_exploration_tool_boundary_just_below_threshold(self):
+        # 5 distinct erroring forms (one below the exploration threshold of
+        # 6, with DISTINCT errors so A/B don't fire) → not yet a flail.
+        errs = ["void-function a", "void-variable b", "wrong-type c",
+                "args-range d", "scan-error e"]
+        events = [
+            self._evt(tool="eval_elisp", args={"code": f"(p{i})"},
+                      content=f"error: {errs[i]}", is_error=True)
+            for i in range(5)
+        ]
+        assert _detect_loop(events, 2, 3, 3, 10,
+                            exploration_tools=frozenset({"eval_elisp"})) is None
+
     def test_pattern_c_still_catches_sustained_exploration_flail(self):
         # A sustained flail (>= the higher threshold of distinct erroring
         # forms, with DISTINCT errors so A/B don't fire) IS still caught,

--- a/tests/test_create_agent_extra_tools.py
+++ b/tests/test_create_agent_extra_tools.py
@@ -72,6 +72,37 @@ class TestCreateAgentExtraTools:
         assert kwargs["tools"] == [t1, t2]
 
 
+class TestCreateAgentLoopExplorationTools:
+    """`loop_exploration_tools` reaches the MAIN agent's
+    `LoopDetectionMiddleware(exploration_tools=...)`; default leaves the
+    dev/code agent unchanged (empty set)."""
+
+    def _main_loop_mw(self, **kwargs):
+        from assist.agent import create_agent
+        from assist.middleware.loop_detection import LoopDetectionMiddleware
+        from langgraph.checkpoint.memory import InMemorySaver
+
+        with patch("assist.agent.create_deep_agent") as fake, \
+             patch("assist.agent.create_context_agent") as fake_ctx, \
+             patch("assist.agent.create_research_agent") as fake_res:
+            fake.return_value = MagicMock()
+            fake_ctx.return_value = MagicMock()
+            fake_res.return_value = MagicMock()
+            with tempfile.TemporaryDirectory() as wd:
+                create_agent(MagicMock(), wd, checkpointer=InMemorySaver(),
+                             sandbox_backend=None, **kwargs)
+            mws = fake.call_args.kwargs["middleware"]
+            return next(m for m in mws if isinstance(m, LoopDetectionMiddleware))
+
+    def test_default_exploration_tools_is_empty(self):
+        # The dev/code agent (no exploration tools) is unchanged.
+        assert self._main_loop_mw().exploration_tools == frozenset()
+
+    def test_loop_exploration_tools_forwarded_to_middleware(self):
+        mw = self._main_loop_mw(loop_exploration_tools=frozenset({"eval_elisp"}))
+        assert mw.exploration_tools == frozenset({"eval_elisp"})
+
+
 class TestThreadExtraTools:
     """`Thread.__init__` is heavy too; patch `create_agent` and verify
     the wiring through to `create_agent` + `self.runconfig`."""
@@ -94,6 +125,14 @@ class TestThreadExtraTools:
         def my_tool(x: str) -> str: return x
         _, ca_kwargs = self._build(extra_tools=[my_tool])
         assert ca_kwargs["extra_tools"] == [my_tool]
+
+    def test_default_loop_exploration_tools_none_passed_through(self):
+        _, ca_kwargs = self._build()
+        assert ca_kwargs["loop_exploration_tools"] is None
+
+    def test_loop_exploration_tools_forwarded_to_create_agent(self):
+        _, ca_kwargs = self._build(loop_exploration_tools=frozenset({"eval_elisp"}))
+        assert ca_kwargs["loop_exploration_tools"] == frozenset({"eval_elisp"})
 
 
 class TestThreadExtraConfig:


### PR DESCRIPTION
## What

`LoopDetectionMiddleware`'s **Pattern C** (distinct-args-thrash) terminates a run when a *mutating* tool fires ≥3 distinct arg-sets (one erroring) in a window. emacsos drives the agent via **`eval_elisp`** — its primary *exploration* tool (probe/modify a live emacs, mostly read-only probes) — but it's treated as mutating, so 3 distinct probes (one erroring, as the small Qwen model fumbles the elisp API) terminated the run **before it could finish**. Observed live on "make my cursor blue".

## How

An **opt-in** `exploration_tools` set whose distinct-args *breadth* gets a **higher, finite** Pattern-C threshold (`_EXPLORATION_DISTINCT_ARGS_THRESHOLD = 6`) — **not** full exemption:
- legitimate exploration (a few probes) is no longer terminated;
- a **sustained flail (≥6 distinct erroring forms) is still caught** — faster + clearer than the recursion limit;
- exploration tools **stay subject to Patterns A/B** (repetition loops) — `_mutating_only` deliberately keeps using `_READ_ONLY_TOOLS` only (load-bearing; commented in code).

Opt-in per agent, default-off so the dev/code agent is unchanged:
`Thread(loop_exploration_tools=)` → `create_agent(loop_exploration_tools=)` → MAIN-agent `LoopDetectionMiddleware(exploration_tools=)` (subagents stay bare; `eval_elisp` can't reach them). emacsos-server will pass `frozenset({"eval_elisp"})` (a separate one-line change in that repo).

## Design note — redirected during design review

The original plan was to *fully exempt* `eval_elisp` from Pattern C. Design review redirected to a **finite threshold** because: (a) the production flail shape (distinct erroring forms, **no** repetition) escapes Patterns A & B, so full exemption would let that exact flail run unchecked; (b) the emacsos agent runs at langgraph's **default recursion limit (25)**, not the harness's 5000 — a finite Pattern-C cap gives a faster, clearer termination. The `6` is an evidence-grounded constant ("a few probes" = legit; ≥6 distinct erroring = flail), to be tuned against the live shape.

## Process / tests

Three-phase workflow: design + 2-lens design review (which drove the redirect), implementation + 2-lens code review (**ship it, zero blockers**). Tests: legit exploration not terminated; opt-in (dev agent unchanged); **sustained flail still caught**; **A/B still fire** for exploration tools; boundary (5 distinct = no fire); `create_agent` + `Thread` forwarding. **498 assist tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)