### PR TITLE
Thread: forward extra_skill_sources to create_agent

### DIFF
--- a/assist/thread.py
+++ b/assist/thread.py
@@ -14,6 +14,8 @@ from langchain_core.tools import BaseTool
 from langgraph.checkpoint.sqlite import SqliteSaver
 from langchain_core.language_models.chat_models import BaseChatModel
 
+from deepagents.backends.protocol import BackendProtocol
+
 from assist.promptable import base_prompt_for
 from assist.model_manager import select_chat_model
 from assist.agent import create_research_agent, create_agent
@@ -61,6 +63,7 @@ class Thread:
                  on_queue_state: Callable[[str], None] | None = None,
                  extra_tools: Sequence[BaseTool | Callable | dict[str, Any]] | None = None,
                  loop_exploration_tools: frozenset[str] | None = None,
+                 extra_skill_sources: dict[str, BackendProtocol] | None = None,
                  extra_config: dict[str, Any] | None = None):
         """`extra_tools` is forwarded to ``create_agent(extra_tools=...)``
         — embedder-supplied tools the main agent can call.  See
@@ -72,6 +75,12 @@ class Thread:
         distinct-args breadth gets a relaxed (but still finite) loop-
         detection threshold because probing many forms is their normal
         shape (eg. an embedder's ``eval_elisp``).  Default ``None``.
+
+        `extra_skill_sources` is forwarded to
+        ``create_agent(extra_skill_sources=...)`` — a mapping of additional
+        virtual-path routes to backends that hold ``SKILL.md`` files, so an
+        embedder can ship skills that live outside the assist repo (see
+        ``assist.agent.create_agent``).  Default ``None``.
 
         `extra_config` is merged into ``self.runconfig`` so per-Thread
         embedder context (eg. langgraph ``configurable`` values that
@@ -160,7 +169,8 @@ class Thread:
                                   checkpointer=checkpointer,
                                   sandbox_backend=sandbox_backend,
                                   extra_tools=extra_tools,
-                                  loop_exploration_tools=loop_exploration_tools)
+                                  loop_exploration_tools=loop_exploration_tools,
+                                  extra_skill_sources=extra_skill_sources)
 
     def message(self, text: str) -> str:
         """Continue the thread and return the last response.

--- a/tests/test_create_agent_extra_tools.py
+++ b/tests/test_create_agent_extra_tools.py
@@ -139,7 +139,8 @@ class TestThreadExtraTools:
         assert ca_kwargs["extra_skill_sources"] is None
 
     def test_extra_skill_sources_forwarded_to_create_agent(self):
-        sentinel = {"/emacsos-skills/": object()}
+        from deepagents.backends.protocol import BackendProtocol
+        sentinel = {"/emacsos-skills/": MagicMock(spec=BackendProtocol)}
         _, ca_kwargs = self._build(extra_skill_sources=sentinel)
         assert ca_kwargs["extra_skill_sources"] is sentinel
 

--- a/tests/test_create_agent_extra_tools.py
+++ b/tests/test_create_agent_extra_tools.py
@@ -134,6 +134,15 @@ class TestThreadExtraTools:
         _, ca_kwargs = self._build(loop_exploration_tools=frozenset({"eval_elisp"}))
         assert ca_kwargs["loop_exploration_tools"] == frozenset({"eval_elisp"})
 
+    def test_default_extra_skill_sources_none_passed_through(self):
+        _, ca_kwargs = self._build()
+        assert ca_kwargs["extra_skill_sources"] is None
+
+    def test_extra_skill_sources_forwarded_to_create_agent(self):
+        sentinel = {"/emacsos-skills/": object()}
+        _, ca_kwargs = self._build(extra_skill_sources=sentinel)
+        assert ca_kwargs["extra_skill_sources"] is sentinel
+
 
 class TestThreadExtraConfig:
     """`Thread.__init__(extra_config=...)` merges into `self.runconfig`.


### PR DESCRIPTION
`create_agent` already accepts `extra_skill_sources` (embedder-supplied virtual-path routes holding `SKILL.md` files), but `assist.Thread` didn't forward it — only `extra_tools` and `loop_exploration_tools`. This adds the param and forwards it, mirroring the existing passthroughs.

Enables emacsos-server to ship a `config-apply` skill (#2 — the fix for the agent *wandering* on config requests). Default `None` preserves current behavior. 501 assist tests pass (+2 forwarding tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)