### PR TITLE
Fix streamed sub-agent wedge + langgraph 1.2 chunk parsing

### DIFF
--- a/assist/stream_chunks.py
+++ b/assist/stream_chunks.py
@@ -1,0 +1,37 @@
+"""Defensive normalization of langgraph stream-chunk payloads.
+
+Shared by every consumer of `Thread.stream_message` — the assist CLI
+(`manage/cli.py`) and the emacsos-server NDJSON gateway (`emacsos_server`,
+which installs assist editable) — so langgraph-version-specific chunk shapes
+are handled in exactly one place rather than re-discovered per consumer.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from langgraph.types import Overwrite
+
+
+def unwrap_messages(value: Any) -> list:
+    """Return the messages carried by a node's ``messages`` channel update,
+    regardless of how langgraph wrapped them.
+
+    Under ``stream_mode=["messages", "updates"]`` an ``updates`` chunk's
+    per-node ``messages`` value is normally a list.  langgraph 1.2 may instead
+    deliver an ``Overwrite`` wrapper (a node *replacing* the channel rather
+    than appending).  ``Overwrite`` is truthy and not iterable, so the naive
+    ``for m in value or []`` raises ``TypeError: 'Overwrite' object is not
+    iterable``.  This unwraps the known shapes and returns ``[]`` for anything
+    unexpected — it never raises.
+    """
+    if isinstance(value, Overwrite):
+        value = value.value
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    if value is None:
+        return []
+    # A lone message-like object: the messages channel is normally a list,
+    # but tolerate a single message so a stray shape isn't silently dropped.
+    if hasattr(value, "content") or hasattr(value, "type"):
+        return [value]
+    return []

--- a/assist/stream_chunks.py
+++ b/assist/stream_chunks.py
@@ -32,6 +32,8 @@ def unwrap_messages(value: Any) -> list:
         return []
     # A lone message-like object: the messages channel is normally a list,
     # but tolerate a single message so a stray shape isn't silently dropped.
-    if hasattr(value, "content") or hasattr(value, "type"):
+    # Key on `.content` (every langchain message has it) — not `.type`, which
+    # is a common attribute name that would wrap unrelated objects.
+    if hasattr(value, "content"):
         return [value]
     return []

--- a/assist/stream_chunks.py
+++ b/assist/stream_chunks.py
@@ -12,7 +12,7 @@ from typing import Any
 from langgraph.types import Overwrite
 
 
-def unwrap_messages(value: Any) -> list:
+def unwrap_messages(value: Any) -> list[Any]:
     """Return the messages carried by a node's ``messages`` channel update,
     regardless of how langgraph wrapped them.
 
@@ -22,7 +22,8 @@ def unwrap_messages(value: Any) -> list:
     than appending).  ``Overwrite`` is truthy and not iterable, so the naive
     ``for m in value or []`` raises ``TypeError: 'Overwrite' object is not
     iterable``.  This unwraps the known shapes and returns ``[]`` for anything
-    unexpected — it never raises.
+    unexpected; it does not raise on the channel-value shapes langgraph
+    produces (lists, ``Overwrite``, ``None``, or a message object).
     """
     if isinstance(value, Overwrite):
         value = value.value

--- a/assist/thread.py
+++ b/assist/thread.py
@@ -204,7 +204,22 @@ class Thread:
                 yield from self.agent.stream(
                     {"messages": [{"role": "user", "content": text}]},
                     self.runconfig,
-                    stream_mode=["messages", "updates"]
+                    stream_mode=["messages", "updates"],
+                    # durability="sync": persist each checkpoint synchronously
+                    # before the next step instead of langgraph's default
+                    # "async" background writes.  The async path submits every
+                    # checkpoint put to a BackgroundExecutor and chains them via
+                    # futures (`_checkpointer_put_after_previous`); under the
+                    # streamed agent's deep nesting (general.stream → sub-agent
+                    # .invoke → nested trio + concurrent tools) that pool gets
+                    # exhausted — every worker blocks on the previous put's
+                    # future with none left to complete them, deadlocking the
+                    # turn (confirmed by py-spy, 2026-05-25).  "sync" keeps one
+                    # put in flight at a time, so the pool can't pile up, while
+                    # still writing per-step checkpoints (RollbackRunnable needs
+                    # them).  langgraph propagates this to the task-tool
+                    # sub-agents via the config, so the whole tree is covered.
+                    durability="sync",
                 )
         return _gen()
 

--- a/assist/thread_queue.py
+++ b/assist/thread_queue.py
@@ -103,12 +103,14 @@ class ThreadAffinityQueue:
     ) -> Iterator[_Handle]:
         """Acquire this thread's single-flight slot for the ``with`` block.
 
-        Thread-affine: holds a ``threading.Condition`` and sets a
-        ``ContextVar`` token, so it must be entered, resumed across ``yield``,
-        and exited on the same OS thread.  Advancing the wrapped generator
-        across threads (e.g. ``run_in_executor`` on the default pool) releases
-        the lock from a non-owning thread and raises ``RuntimeError: cannot
-        release un-acquired lock``; drive it from a single thread.
+        Thread-affine: the context manager sets a ``ContextVar`` token on entry
+        and resets it on exit, and re-acquires a ``threading.Condition`` in its
+        finally — so it must be entered, resumed across ``yield``, and exited on
+        the same OS thread.  If the wrapped generator is advanced/closed across
+        threads (e.g. ``run_in_executor`` on the default pool), the exit runs in
+        a different context and the token reset raises ``ValueError: <token>
+        was created in a different Context`` (and the Condition is likewise
+        unsafe to touch from a non-owning thread).  Drive it from one thread.
         """
         cb = on_state_change or (lambda _: None)
         wait_timeout = (

--- a/assist/thread_queue.py
+++ b/assist/thread_queue.py
@@ -101,6 +101,15 @@ class ThreadAffinityQueue:
         wait_timeout_s: float | None = None,
         hold_timeout_s: float | None = None,
     ) -> Iterator[_Handle]:
+        """Acquire this thread's single-flight slot for the ``with`` block.
+
+        Thread-affine: holds a ``threading.Condition`` and sets a
+        ``ContextVar`` token, so it must be entered, resumed across ``yield``,
+        and exited on the same OS thread.  Advancing the wrapped generator
+        across threads (e.g. ``run_in_executor`` on the default pool) releases
+        the lock from a non-owning thread and raises ``RuntimeError: cannot
+        release un-acquired lock``; drive it from a single thread.
+        """
         cb = on_state_change or (lambda _: None)
         wait_timeout = (
             self._default_wait_timeout if wait_timeout_s is None else wait_timeout_s

--- a/assist/thread_queue.py
+++ b/assist/thread_queue.py
@@ -103,14 +103,15 @@ class ThreadAffinityQueue:
     ) -> Iterator[_Handle]:
         """Acquire this thread's single-flight slot for the ``with`` block.
 
-        Thread-affine: the context manager sets a ``ContextVar`` token on entry
-        and resets it on exit, and re-acquires a ``threading.Condition`` in its
-        finally — so it must be entered, resumed across ``yield``, and exited on
-        the same OS thread.  If the wrapped generator is advanced/closed across
-        threads (e.g. ``run_in_executor`` on the default pool), the exit runs in
-        a different context and the token reset raises ``ValueError: <token>
-        was created in a different Context`` (and the Condition is likewise
-        unsafe to touch from a non-owning thread).  Drive it from one thread.
+        Context-affine: the context manager sets a ``ContextVar`` token on entry
+        and resets it on exit, so it must be entered, resumed across ``yield``,
+        and exited in the SAME execution context.  If the wrapped generator is
+        advanced/closed in a different context — e.g. driven across threads via
+        ``run_in_executor`` on the default pool, since each thread has its own
+        context — the token reset raises ``ValueError: <token> was created in a
+        different Context``.  Drive it from a single thread/context.  (The
+        ``threading.Condition`` is always used under its own lock, so it is safe
+        across threads; the contextvar token is the hard constraint.)
         """
         cb = on_state_change or (lambda _: None)
         wait_timeout = (

--- a/manage/cli.py
+++ b/manage/cli.py
@@ -47,8 +47,7 @@ def stream_message(thread: Thread, message: str):
             print_update(chunk)
         elif ch_type == 'messages':
             # A `messages`-mode item is an `(AIMessageChunk, metadata)`
-            # tuple — print the message, not the metadata. (Mirrors
-            # stream.py's `_tool_messages` / `extract_content_text`.)
+            # tuple — print the message, not the metadata.
             message_chunk = chunk[0] if isinstance(chunk, tuple) else chunk
             print_message(message_chunk)
 

--- a/manage/cli.py
+++ b/manage/cli.py
@@ -8,6 +8,7 @@ from langchain_core.messages import AIMessage, AIMessageChunk
 
 from assist.env import load_dev_env
 from assist.thread import ThreadManager, Thread, render_tool_calls
+from assist.stream_chunks import unwrap_messages
 
 # Setup logging to file
 project_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -27,7 +28,10 @@ logger = logging.getLogger("assist.model")
 def print_update(chunk) -> None:
     model_call = chunk.get('model', None)
     if model_call:
-        last_message = model_call.get("messages", [])[-1]
+        # langgraph 1.2 may wrap the `messages` value in an `Overwrite`;
+        # unwrap_messages normalizes that (and any list/empty shape).
+        messages = unwrap_messages(model_call.get("messages"))
+        last_message = messages[-1] if messages else None
         if last_message and isinstance(last_message, AIMessage):
             print(render_tool_calls(last_message))
 
@@ -42,7 +46,11 @@ def stream_message(thread: Thread, message: str):
         if ch_type == 'updates':
             print_update(chunk)
         elif ch_type == 'messages':
-            [print_message(c) for c in chunk]
+            # A `messages`-mode item is an `(AIMessageChunk, metadata)`
+            # tuple — print the message, not the metadata. (Mirrors
+            # stream.py's `_tool_messages` / `extract_content_text`.)
+            message_chunk = chunk[0] if isinstance(chunk, tuple) else chunk
+            print_message(message_chunk)
 
 
 def main():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,9 @@ dependencies = [
     "langchain",
     "langchain-core",
     "langchain-openai",
-    "langgraph",
+    # >=1.2: durability= kwarg on .stream() (Thread.stream_message) and the
+    # langgraph.types.Overwrite chunk shape (assist.stream_chunks) require it.
+    "langgraph>=1.2",
     "langgraph-checkpoint-sqlite",
     "loguru",
     "Markdown",

--- a/roadmap.org
+++ b/roadmap.org
@@ -47,12 +47,26 @@ Consider:
 2. URLs that do not corroborate the information in the final report
 3. Better ways to search
 * Reliability
-** TODO Streamed sub-agent wedge — langgraph checkpoint-put thread-pool exhaustion
+** DONE Streamed sub-agent wedge — langgraph checkpoint-put thread-pool exhaustion
 *Symptom.*  A =/chat= turn that spawns a sub-agent (=task= → research/context-agent) over the STREAMED path (emacsos-server: =Thread.stream_message= → =agent.stream()= consumed via =run_in_executor=→=next()=) hangs after the sub-agent runs, with no error, and then wedges every later turn (they block on =THREAD_QUEUE=).  The web UI's blocking =Thread.message()= → =invoke_with_rollback= → =.invoke()= path does NOT hit it.
 
 *Root cause (py-spy dump, 2026-05-25 — saved analysis).*  THREAD-POOL EXHAUSTION in langgraph's chained checkpoint put, =_checkpointer_put_after_previous= (=langgraph/pregel/_loop.py:1508/1511=).  The dump showed five =ThreadPoolExecutor-4_*= threads all parked in =result()= waiting on the *previous* put's future, with no free worker left to complete any — a self-deadlocked future chain.  Above it: =ThreadPoolExecutor-1_0= = the top-level =agent.stream()= tick (=assist/thread.py:204=) waiting; =ThreadPoolExecutor-3_0= = the =subagent.invoke()= (=deepagents/middleware/subagents.py:493=) tick waiting; =ThreadPoolExecutor-1_1= = a second turn blocked on =thread_queue.acquire= (the wedge propagating).  The streamed path adds an extra executor layer (=run_in_executor= for =next()=) on top of the nested =general.stream → research.invoke → nested trio + concurrent tools/DDGS=, and the deep nesting + concurrency exhausts the pool feeding the put chain.  Backend-independent: deadlocks the same on =InMemorySaver= or =SqliteSaver=.  Obscure research prompts make it worse (122 floundering searches → deeper nesting); test with easy topics ("when was Paris founded").
 
-*Fix direction (under investigation).*  Levers, most-promising first: (1) langgraph checkpoint *durability* / put model — write checkpoints synchronously instead of chaining through an exhaustible executor; (2) langgraph version — may be fixed upstream; (3) drop the =run_in_executor=→=next()= streaming layer for async-native streaming.
+*Fix (DONE, lever 1).*  Pass =durability="sync"= to =agent.stream()= in
+=Thread.stream_message= (=assist/thread.py=): checkpoints persist synchronously
+before the next step instead of chaining through the exhaustible
+=BackgroundExecutor=, so the put-chain can't self-deadlock.  Kept per-step
+checkpoints (so sub-agent rollback still works); did NOT need lever 2/3.
+
+Fixing the deadlock unmasked two streamed-path consumer bugs (langgraph 1.2)
+that turns never reached while they wedged: (A) an =updates= chunk's =messages=
+can be a =langgraph.types.Overwrite= wrapper, crashing the naive list-iteration
+— fixed by the shared =assist.stream_chunks.unwrap_messages= (used by the CLI
+and emacsos-server); (B) the emacsos consumer advanced this thread-affine
+generator across the default thread pool → cross-thread =THREAD_QUEUE= lock
+release → worker crash — fixed in emacsos by pinning the generator to a
+=max_workers=1= pump (branch =fix-streamed-chat-langgraph-1.2=).  Verified e2e
+2026-05-25.  assist side ships on =fix-streamed-subagent-deadlock=.
 
 *Related (hygiene, NOT the fix).*  Branch =isolate-subagent-checkpointer= (assist, pushed/unmerged, commit f93d451): gives each ephemeral sub-agent its own =InMemorySaver= instead of the parent's persistent one.  Correct on its own — merge when convenient — but it does not resolve the wedge (confirmed by the dump).
 

--- a/tests/test_stream_chunks.py
+++ b/tests/test_stream_chunks.py
@@ -1,0 +1,44 @@
+"""Tests for ``assist.stream_chunks.unwrap_messages``.
+
+Pins the real langgraph 1.2 ``Overwrite`` shape (imported, not faked) so the
+test fails loudly if a future upgrade changes the wrapper.
+"""
+from langchain_core.messages import AIMessage, ToolMessage
+from langgraph.types import Overwrite
+
+from assist.stream_chunks import unwrap_messages
+
+
+class TestUnwrapMessages:
+    def test_bare_list_passes_through(self):
+        m1, m2 = AIMessage(content="a"), AIMessage(content="b")
+        assert unwrap_messages([m1, m2]) == [m1, m2]
+
+    def test_tuple_becomes_list(self):
+        m = AIMessage(content="a")
+        assert unwrap_messages((m,)) == [m]
+
+    def test_overwrite_is_unwrapped(self):
+        # The crash shape: a node overwriting the messages channel.
+        tm = ToolMessage(content="ok", tool_call_id="t1", name="apply_config")
+        assert unwrap_messages(Overwrite(value=[tm])) == [tm]
+
+    def test_overwrite_with_empty_value(self):
+        assert unwrap_messages(Overwrite(value=[])) == []
+
+    def test_none_returns_empty(self):
+        assert unwrap_messages(None) == []
+
+    def test_single_message_is_wrapped(self):
+        m = AIMessage(content="lonely")
+        assert unwrap_messages(m) == [m]
+
+    def test_unknown_scalar_returns_empty_not_unwrapped(self):
+        # A non-message object with a `.value` must NOT be silently unwrapped
+        # (we key on `isinstance(Overwrite)`, not duck-typing on `.value`).
+        class HasValue:
+            value = "surprise"
+
+        assert unwrap_messages(HasValue()) == []
+        assert unwrap_messages(123) == []
+        assert unwrap_messages("text") == []


### PR DESCRIPTION
## What

Fixes the streamed agent path on langgraph 1.2.0. Three layered bugs, surfaced by the emacsos-server streamed `/chat` consumer (the web UI's blocking `Thread.message()` path is unaffected).

1. **Deadlock (the original wedge).** langgraph 1.2 defaults `durability="async"`, submitting every checkpoint `put` to a `BackgroundExecutor` chained via futures (`pregel/_loop.py:_checkpointer_put_after_previous`). Under deep streamed sub-agent nesting the pool exhausts and the puts self-deadlock — confirmed by a py-spy dump (workers parked in `_checkpointer_put_after_previous`), backend-independent. **Fix:** pass `durability="sync"` to `agent.stream()` in `Thread.stream_message`. Keeps per-step checkpoints, so sub-agent rollback still works.
2. **Overwrite chunk parsing.** Once turns completed, an `updates` chunk's `messages` value can be a `langgraph.types.Overwrite` wrapper (a node replacing the channel), not a list — crashing naive iteration. **Fix:** new shared `assist/stream_chunks.unwrap_messages` (the one place that knows the chunk shapes), used by both the CLI and emacsos-server. `isinstance(Overwrite)` only — no duck-typed fallback.
3. **CLI parity.** `manage/cli.py` shared the Overwrite bug (`print_update`) and iterated a `(chunk, metadata)` tuple in messages-mode. Routed through `unwrap_messages`; tuple now unpacked.

Also: a thread-affinity docstring on `thread_queue.acquire` (the emacsos consumer fix relies on it being driven from one thread).

## Verification
- Unit: `tests/test_stream_chunks.py` (real `Overwrite`, list, single message, unknown shapes); thread_queue suites green.
- e2e (against local Qwen3.6): a fresh research sub-agent turn completed `start→sub-agent→merge→end` with a references file written, no crash; CLI streams cleanly.
- Three-phase workflow: design + design-review (simplified to the minimal fix), code-review (2 reviewers, "ship it"), e2e.

Paired with emacsos PR `fix-streamed-chat-langgraph-1.2` (the single-thread pump consumer fix). emacsos installs assist editably, so it picks up `stream_chunks` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)