### PR TITLE
thread_queue: fix _holder leak when finally is interrupted

### DIFF
--- a/assist/thread_queue.py
+++ b/assist/thread_queue.py
@@ -199,7 +199,7 @@ class ThreadAffinityQueue:
                 pass
             self._release_if_holder(handle)
 
-    def _release_if_holder(self, handle: "_Handle") -> bool:
+    def _release_if_holder(self, handle: _Handle) -> bool:
         """Vacate the slot iff ``handle`` is still the current holder.
 
         Idempotent across the two release paths (``acquire``'s ``finally``
@@ -214,37 +214,21 @@ class ThreadAffinityQueue:
                 return True
             return False
 
-    def _on_hold_timeout(self, handle: "_Handle") -> None:
-        """Watchdog callback: flag the holder ``expired`` AND forcibly
-        release the slot if it's still held by this handle.
+    def _on_hold_timeout(self, handle: _Handle) -> None:
+        """Watchdog callback: flag holder ``expired`` and force-release the slot.
 
-        Two consequences, two consumers:
-
-        - ``expired = True`` drives the cooperative cancel in
-          :class:`ThreadQueueMiddleware`: the holder's next ``after_model``
-          reads :func:`active_handle` (which is per-call-stack via the
-          contextvar) and raises :class:`ThreadHoldExpired`.
-        - Forcibly clearing ``_holder`` unblocks waiters NOW, instead of
-          requiring the holder's ``finally`` to run.  Bounds leak duration
-          to ``hold_timeout_s`` even when ``finally`` was skipped — the
-          2026-05-28 incident, where ``_active_handle.reset(token)`` raised
-          mid-``finally`` and the queue stayed wedged for 17h until the
-          ``wait_timeout_s`` ceiling fired.
-
-        Briefly, the contextvar still points at ``handle`` for the holder's
-        stack while ``_holder`` may point at a newly-promoted waiter —
-        intentional: the contextvar is per-call-stack identity, ``_holder``
-        is queue-wide ownership.  The cooperative cancel reads the former,
-        waiter promotion reads the latter; they converge cleanly.
-
-        Logs WARNING when force-release actually fired (i.e. the cooperative
-        path failed to clean up in time).  Should be cold in steady state;
-        a hit is a real signal worth investigating.
+        ``expired = True`` is read by :class:`ThreadQueueMiddleware`'s
+        cooperative cancel (via :func:`active_handle` — per-call-stack);
+        the force-release through :meth:`_release_if_holder` bounds the
+        leak window when ``acquire``'s ``finally`` is skipped (the
+        2026-05-28 incident).  Logs WARNING when the release actually
+        fired — should be cold in steady state, a hit means the
+        cooperative path didn't clean up in time.
         """
         handle.expired = True
         if self._release_if_holder(handle):
             logger.warning(
-                "thread_queue: forcibly released holder %s after %.1fs hold; "
+                "force-released wedged holder %s after %.1fs; "
                 "cooperative cancel did not fire",
                 handle.thread_id,
                 time.time() - handle.acquired_at,

--- a/assist/thread_queue.py
+++ b/assist/thread_queue.py
@@ -9,7 +9,13 @@ slot's cached prefix matched, so prefill stays a per-turn delta.
 
 Affinity, not fairness:
 
-- Holder runs to completion *or* its watchdog fires, before any waiter runs.
+- Waiters wait until the slot is vacated — either by the holder's
+  clean release at ``__exit__`` or by the watchdog force-releasing it
+  at ``hold_timeout_s``.  After a force-release the original holder
+  thread may still be unwinding its ``with`` block while a waiter is
+  already running; the identity guard in :meth:`_release_if_holder`
+  prevents the unwinding holder's late cleanup from clobbering the
+  new holder.
 - Waiters are FIFO among themselves.
 - Same ``thread_id`` re-acquiring is a no-op (re-entrant by id).
 

--- a/assist/thread_queue.py
+++ b/assist/thread_queue.py
@@ -181,18 +181,17 @@ class ThreadAffinityQueue:
         try:
             yield handle
         finally:
-            # The contextvar reset can raise ValueError when this with-block
-            # exits in a different contextvars.Context than it was entered
-            # (the case warned about in this method's docstring; observed
-            # in prod on 2026-05-28).  That MUST NOT abort the rest of
-            # cleanup — leaving `_holder` set wedges every subsequent
-            # waiter until `wait_timeout_s` expires (4h in prod).  The
-            # contextvar in *this* context already reads default (None),
-            # which is the state we want.
-            try:
-                _active_handle.reset(token)
-            except ValueError:
-                pass
+            # NOTE: `_active_handle.reset(token)` raises ValueError when
+            # this with-block exits in a different contextvars.Context
+            # than it was entered (the case the docstring above warns
+            # about).  Today we let it propagate — the cause lives in
+            # the caller (a generator iterated across thread boundaries)
+            # and the fix belongs there, NOT in a try/except around the
+            # reset that would hide the bug.  The watchdog below bounds
+            # the resulting `_holder` leak to ``hold_timeout_s`` so the
+            # queue stays serving other threads while the underlying
+            # contract violation gets fixed in a follow-up.
+            _active_handle.reset(token)
             try:
                 watchdog.cancel()
             except Exception:

--- a/assist/thread_queue.py
+++ b/assist/thread_queue.py
@@ -9,7 +9,7 @@ slot's cached prefix matched, so prefill stays a per-turn delta.
 
 Affinity, not fairness:
 
-- Holder runs to completion before any waiter runs.
+- Holder runs to completion *or* its watchdog fires, before any waiter runs.
 - Waiters are FIFO among themselves.
 - Same ``thread_id`` re-acquiring is a no-op (re-entrant by id).
 
@@ -17,13 +17,16 @@ Failure-fast bounds:
 
 - ``hold_timeout_s`` — a runaway holder is flagged ``expired`` so the
   cooperative cancel point in :class:`ThreadQueueMiddleware` raises
-  :class:`ThreadHoldExpired` between LLM calls.  Honors the project
-  rule that threads die on infrastructure failure rather than
-  heal-and-retry.  The cap bounds the *detection latency*, not the
-  exact wall-clock release time — a ``wrap_model_call`` retry inside
+  :class:`ThreadHoldExpired` between LLM calls, AND the slot is vacated
+  immediately so the next waiter can claim it without waiting on the
+  runaway's ``finally``.  Honors the project rule that threads die on
+  infrastructure failure rather than heal-and-retry.  The cap bounds the
+  *detection latency* of the cooperative cancel, not the exact wall-clock
+  release time — a ``wrap_model_call`` retry inside
   :class:`EmptyResponseRecoveryMiddleware` or
   :class:`BadRequestRetryMiddleware` can run one or two more LLM calls
-  past expiration before ``after_model`` next fires.
+  past expiration before ``after_model`` next fires.  Forcible slot
+  release happens at the timeout regardless, logged at WARNING.
 - ``wait_timeout_s`` — a waiter that can't acquire raises
   :class:`QueueWaitTimeout` and the thread errors.
 
@@ -36,12 +39,15 @@ tasks within one ``manage.web`` process.  Eval CLIs that import
 """
 
 import contextvars
+import logging
 import os
 import threading
 import time
 from collections import deque
 from contextlib import contextmanager
 from typing import Callable, Iterator
+
+logger = logging.getLogger(__name__)
 
 
 def _env_float(name: str, default: float) -> float:
@@ -67,13 +73,12 @@ class ThreadHoldExpired(Exception):
 
 
 class _Handle:
-    __slots__ = ("thread_id", "expired", "acquired_at", "_watchdog")
+    __slots__ = ("thread_id", "expired", "acquired_at")
 
     def __init__(self, thread_id: str) -> None:
         self.thread_id = thread_id
         self.expired = False
         self.acquired_at = time.time()
-        self._watchdog: threading.Timer | None = None
 
 
 _active_handle: contextvars.ContextVar = contextvars.ContextVar(
@@ -164,9 +169,10 @@ class ThreadAffinityQueue:
             self._holder = handle
             cb("running")
 
-            watchdog = threading.Timer(hold_timeout, _mark_expired, args=(handle,))
+            watchdog = threading.Timer(
+                hold_timeout, self._on_hold_timeout, args=(handle,)
+            )
             watchdog.daemon = True
-            handle._watchdog = watchdog
 
         # Start the watchdog outside the lock so a near-zero timeout
         # (used in tests) doesn't fire while we're still in __enter__.
@@ -175,15 +181,74 @@ class ThreadAffinityQueue:
         try:
             yield handle
         finally:
-            _active_handle.reset(token)
+            # The contextvar reset can raise ValueError when this with-block
+            # exits in a different contextvars.Context than it was entered
+            # (the case warned about in this method's docstring; observed
+            # in prod on 2026-05-28).  That MUST NOT abort the rest of
+            # cleanup — leaving `_holder` set wedges every subsequent
+            # waiter until `wait_timeout_s` expires (4h in prod).  The
+            # contextvar in *this* context already reads default (None),
+            # which is the state we want.
+            try:
+                _active_handle.reset(token)
+            except ValueError:
+                pass
             try:
                 watchdog.cancel()
             except Exception:
                 pass
-            with self._cond:
-                if self._holder is handle:
-                    self._holder = None
-                    self._cond.notify_all()
+            self._release_if_holder(handle)
+
+    def _release_if_holder(self, handle: "_Handle") -> bool:
+        """Vacate the slot iff ``handle`` is still the current holder.
+
+        Idempotent across the two release paths (``acquire``'s ``finally``
+        and the watchdog's :meth:`_on_hold_timeout`); whichever wins the
+        lock first releases, the other sees ``_holder is not handle`` and
+        returns False without clobbering a newly-promoted holder.
+        """
+        with self._cond:
+            if self._holder is handle:
+                self._holder = None
+                self._cond.notify_all()
+                return True
+            return False
+
+    def _on_hold_timeout(self, handle: "_Handle") -> None:
+        """Watchdog callback: flag the holder ``expired`` AND forcibly
+        release the slot if it's still held by this handle.
+
+        Two consequences, two consumers:
+
+        - ``expired = True`` drives the cooperative cancel in
+          :class:`ThreadQueueMiddleware`: the holder's next ``after_model``
+          reads :func:`active_handle` (which is per-call-stack via the
+          contextvar) and raises :class:`ThreadHoldExpired`.
+        - Forcibly clearing ``_holder`` unblocks waiters NOW, instead of
+          requiring the holder's ``finally`` to run.  Bounds leak duration
+          to ``hold_timeout_s`` even when ``finally`` was skipped — the
+          2026-05-28 incident, where ``_active_handle.reset(token)`` raised
+          mid-``finally`` and the queue stayed wedged for 17h until the
+          ``wait_timeout_s`` ceiling fired.
+
+        Briefly, the contextvar still points at ``handle`` for the holder's
+        stack while ``_holder`` may point at a newly-promoted waiter —
+        intentional: the contextvar is per-call-stack identity, ``_holder``
+        is queue-wide ownership.  The cooperative cancel reads the former,
+        waiter promotion reads the latter; they converge cleanly.
+
+        Logs WARNING when force-release actually fired (i.e. the cooperative
+        path failed to clean up in time).  Should be cold in steady state;
+        a hit is a real signal worth investigating.
+        """
+        handle.expired = True
+        if self._release_if_holder(handle):
+            logger.warning(
+                "thread_queue: forcibly released holder %s after %.1fs hold; "
+                "cooperative cancel did not fire",
+                handle.thread_id,
+                time.time() - handle.acquired_at,
+            )
 
     def current_handle(self) -> _Handle | None:
         with self._cond:
@@ -192,10 +257,6 @@ class ThreadAffinityQueue:
     def waiter_count(self) -> int:
         with self._cond:
             return len(self._waiters)
-
-
-def _mark_expired(handle: _Handle) -> None:
-    handle.expired = True
 
 
 def active_handle() -> _Handle | None:

--- a/assist/thread_queue.py
+++ b/assist/thread_queue.py
@@ -227,9 +227,14 @@ class ThreadAffinityQueue:
         """
         handle.expired = True
         if self._release_if_holder(handle):
+            # We can't tell from here why the slot was still held: the
+            # cooperative cancel may never have fired, may have fired but
+            # the holder is mid-unwind, or `finally` ran partially and left
+            # `_holder` set (the 2026-05-28 incident shape).  Log the fact
+            # we can observe — the slot needed force-release — and leave
+            # the why to the investigator.
             logger.warning(
-                "force-released wedged holder %s after %.1fs; "
-                "cooperative cancel did not fire",
+                "force-released wedged holder %s after %.1fs hold",
                 handle.thread_id,
                 time.time() - handle.acquired_at,
             )

--- a/docs/2026-05-29-queue-holder-leak-fix.org
+++ b/docs/2026-05-29-queue-holder-leak-fix.org
@@ -128,5 +128,34 @@ on the prod incident is exactly the operability gap this closes.
 
 * Eval cadence
 Unit tests only — this is queue plumbing, not agent behavior.
-=tests/test_thread_queue.py= already at 14 tests; adding 4 new + 1
-modified.  No edd/eval/ suite changes.
+=tests/test_thread_queue.py= already at 14 tests; adding 3 new + 1
+modified (post code-review trim from 4 → 3).  No edd/eval/ suite changes.
+
+* Follow-ups (surfaced by code review; not in this PR)
+1. *=Thread.stream_message= close-on-disconnect.*  The generator wraps
+   =acquire()=; a consumer that drops iteration without =close()= leaves
+   the with-block suspended.  Change B in THIS PR bounds the leak to
+   =hold_timeout_s=, but the structural fix lives in =assist/thread.py=:
+   either a context-manager API for the caller, or drain the generator
+   on a worker thread bound to =copy_context()= so =__enter__= and
+   =__exit__= run in the same context.
+2. *Bind the streaming generator to a captured context.*  Wrap =_gen()=
+   so it runs inside =contextvars.copy_context().run(...)=.  Makes the
+   cross-context exit case structurally impossible; the =try/except
+   ValueError= in this PR becomes defense-in-depth.
+3. *=ThreadQueueMiddleware= docstring* should reflect the two-paths-
+   converging contract (=active_handle= = per-call-stack identity,
+   =_holder= = queue-wide ownership; the watchdog can clear =_holder=
+   while the contextvar still points at the dying handle).
+4. *Reentrant fast path could skip =_cond=.*  Reading =_active_handle=
+   is lock-free; sub-agent calls currently pay a lock acquisition just
+   to check a contextvar.
+5. *Observability counter.*  =_release_if_holder= returns =bool=, ready
+   for instrumentation: =force_releases= and =cooperative_releases= as
+   separate counters, with the ratio as the SLO signal.  WARNING log
+   in this PR catches absolute count; trend lives in metrics.
+6. *=register_at_fork= hook.*  The module docstring claims separate
+   processes get their own queue — true for =spawn=, NOT for =fork=.
+   A forked child inherits a stale =_holder=.  Either add
+   =os.register_at_fork(after_in_child=...)= to reinitialize, or
+   document the fork hazard.

--- a/docs/2026-05-29-queue-holder-leak-fix.org
+++ b/docs/2026-05-29-queue-holder-leak-fix.org
@@ -1,0 +1,132 @@
+#+TITLE: ThreadAffinityQueue holder-slot leak fix
+#+DATE: 2026-05-29
+State: Phase 1 design (about to enter Phase 2 — implementation)
+
+Follow-up to =2026-05-06-thread-affinity-queue.org=.  That PR shipped the
+queue; this one fixes a leak that bit prod on 2026-05-28.
+
+* Problem
+The queue's =_holder= slot leaked.  Symptoms in prod logs:
+- 2026-05-28 18:48:44 — thread =20260527085157-77ceb1f1= errored with
+  =QueueWaitTimeout: waited 14400.0s for queue= (the full
+  =ASSIST_THREAD_QUEUE_WAIT_S= ceiling).
+- 2026-05-29 08:17 / 08:19 — user submitted two new requests, both
+  immediately went =queued= and would have hit the same 4h ceiling.
+- assist-web process (PID 742034) stayed alive the whole time —
+  no crash, no OOM, healthy event loop.  Only the in-memory
+  =_holder= slot was wedged, pointing at a dead handle.
+- Recovery: =make restart=.  Lifespan handler marked both =queued=
+  threads as =error= (preserving their =pending_message= for the user
+  to resend).
+
+** Root cause hypothesis
+=acquire()='s =finally= block at =assist/thread_queue.py:178= starts
+with =_active_handle.reset(token)=.  The docstring at lines 106-114
+already warns: if the =with= block exits in a different
+=contextvars.Context= than it was entered, =reset()= raises =ValueError=.
+The bare =reset()= call meant that =ValueError= aborted the rest of
+=finally= — watchdog cancel, =_holder= clear, and =notify_all()= all
+skipped.  The watchdog still fired and flipped =handle.expired=, but
+nothing cleared =_holder=, so waiters blocked the full =wait_timeout_s=.
+
+The =stream_message= generator path in =assist/thread.py:212= is the
+likely source of the cross-context exit (FastAPI iterates the body
+generator on a thread different from where it was constructed when
+the client disconnects mid-stream).  Not confirmed for the specific
+2026-05-28 incident, but the shape fits.
+
+* Solution
+Two changes in =assist/thread_queue.py=, both narrow.
+
+** Change A — make =finally= leak-proof
+Wrap =_active_handle.reset(token)= in =try/except ValueError=.  The
+contextvar in the current context already reads as default (=None=);
+swallowing the mismatch is correct.  The original exception that
+drove us into =finally= still propagates upward — the holder thread
+still terminates normally.
+
+** Change B — watchdog forcibly releases the slot
+Today the watchdog =_mark_expired= just flips =handle.expired = True=
+and trusts the cooperative cancel point in =ThreadQueueMiddleware= to
+unwind the holder.  That works IF the holder's call stack is still
+running.  If the holder has already unwound past =finally= without
+clearing =_holder= (Change A's failure mode, pre-fix), nothing else
+ever clears the slot.
+
+Rename to =_on_hold_timeout=, promote to a method on
+=ThreadAffinityQueue=, and have it ALSO clear =_holder= via a shared
+=_release_if_holder= helper.  Bounds the leak duration to
+=hold_timeout_s= (default 2h) regardless of which finally-path failure
+mode triggered the leak.
+
+A =logger.warning= fires when force-release actually happens — it's a
+should-never-happen path in steady state, and the 17h detection delay
+on the prod incident is exactly the operability gap this closes.
+
+** What the design-review team pushed back on
+- *Add the log line* (rejected by architect as scope creep; all three
+  reviewers — Simplicity, Clean Interfaces, Fail-fast Contract — said
+  ship it).  Accepted: one =logger.warning= when the force-release
+  branch actually fires.
+- *Narrow exception catch to =ValueError= only* (architect proposed
+  =(ValueError, LookupError)= defensively; Simplicity reviewer said
+  speculative).  Accepted: =ValueError= only.
+- *Extract =_release_if_holder= helper* (Clean Interfaces #1 — the
+  4-line release pattern is repeated in =finally= and =_mark_expired=).
+  Accepted.
+- *Rename =_mark_expired= → =_on_hold_timeout=* (Clean Interfaces #2
+  — the function does more than mark after Change B).  Accepted.
+- *Promote to method, drop unused =_Handle._watchdog= slot* (Clean
+  Interfaces #3, #6).  Accepted.
+- *Document the two-paths-converging contract* (Clean Interfaces #7,
+  Fail-fast #1).  Accepted: module docstring + comment on
+  =_on_hold_timeout=.
+
+** Rejected alternatives
+1. *Heartbeat-based holder.*  Requires a background poller; the Timer
+   we already have does the same job without polling.
+2. *Admin endpoint to forcibly clear =_holder=.*  Hands operators a
+   footgun (force-clearing a live holder corrupts mid-prefill).
+3. *Periodic cleanup pass on each =acquire()=.*  Only runs when new
+   traffic arrives; silent if the system is idle.
+4. *Switch contextvar to =threading.local= or explicit handle param.*
+   The contextvar is the right primitive for "same call stack" detection
+   (sub-agent calls free-ride; cross-thread same-tid does not).  A
+   redesign is a separate, larger PR.
+5. *Tune =DEFAULT_HOLD_TIMEOUT_S= lower.*  The 2h default is calibrated
+   for legitimately long agent runs.  The bug isn't the cap; it's the
+   watchdog not actually freeing the slot.
+
+** Out of scope
+- =Thread.stream_message= generator close-on-disconnect (real but bounded
+  to =hold_timeout_s= by Change B; proper fix belongs in =assist/thread.py=).
+- Metrics dashboard for force-release counts.
+- Force-release endpoint or =current_handle_age_s()= helper.
+- =_Handle= → =@dataclass= refactor (=__slots__= is load-bearing).
+
+* Risks
+- *R1 — Slow-but-progressing holder gets force-released.*  Already the
+  documented contract of =hold_timeout_s=; Change B just makes the kill
+  also free the slot.  At most one overlap LLM call between the dying
+  holder and the newly-promoted waiter — same window the
+  =EmptyResponseRecoveryMiddleware= retry comment already calls out.
+- *R2 — Double-release race.*  The =is handle= guard in
+  =_release_if_holder= short-circuits whichever path runs second.  No
+  clobbering of a newly-promoted holder.
+- *R3 — Cooperative cancel still works.*  =ThreadQueueMiddleware= reads
+  =active_handle()= (contextvar), not =queue._holder=.  So even after
+  the watchdog clears =_holder=, the dying holder's middleware still
+  sees =handle.expired = True= and raises =ThreadHoldExpired= at the
+  next LLM call boundary.
+- *R4 — Timer thread re-entering =_cond=.*  No deadlock: =_cond= is
+  acquired by the holder thread only inside short critical sections;
+  the Timer thread queues for the lock normally.
+- *R5 — Effective wait timeout shrinks to =min(wait, hold)=.*  A
+  waiter behind an expired holder unblocks at =hold_timeout_s= instead
+  of waiting =wait_timeout_s=.  Strictly better; matches operator
+  intuition.
+
+* Eval cadence
+Unit tests only — this is queue plumbing, not agent behavior.
+=tests/test_thread_queue.py= already at 14 tests; adding 4 new + 1
+modified.  No edd/eval/ suite changes.

--- a/docs/2026-05-29-queue-holder-leak-fix.org
+++ b/docs/2026-05-29-queue-holder-leak-fix.org
@@ -36,51 +36,49 @@ disconnects mid-stream).  Not confirmed for the specific 2026-05-28
 incident, but the shape fits.
 
 * Solution
-Two changes in =assist/thread_queue.py=, both narrow.
+*One change* in =assist/thread_queue.py=: the watchdog forcibly
+releases the slot.
 
-** Change A — make =finally= leak-proof
-Wrap =_active_handle.reset(token)= in =try/except ValueError=.  The
-contextvar in the current context already reads as default (=None=);
-swallowing the mismatch is correct.  The original exception that
-drove us into =finally= still propagates upward — the holder thread
-still terminates normally.
-
-** Change B — watchdog forcibly releases the slot
-Today the watchdog =_mark_expired= just flips =handle.expired = True=
-and trusts the cooperative cancel point in =ThreadQueueMiddleware= to
-unwind the holder.  That works IF the holder's call stack is still
-running.  If the holder has already unwound past =finally= without
-clearing =_holder= (Change A's failure mode, pre-fix), nothing else
-ever clears the slot.
+Today the watchdog only flips =handle.expired = True= and trusts the
+cooperative cancel point in =ThreadQueueMiddleware= to unwind the
+holder.  That works IF the holder's call stack is still running.  If
+the holder has already unwound past =finally= without clearing
+=_holder= (the contextvar-reset case below), nothing else clears the
+slot.
 
 Rename to =_on_hold_timeout=, promote to a method on
 =ThreadAffinityQueue=, and have it ALSO clear =_holder= via a shared
 =_release_if_holder= helper.  Bounds the leak duration to
-=hold_timeout_s= (default 2h) regardless of which finally-path failure
-mode triggered the leak.
+=hold_timeout_s= (default 2h) regardless of *which* failure mode left
+=_holder= set.
 
 A =logger.warning= fires when force-release actually happens — it's a
 should-never-happen path in steady state, and the 17h detection delay
 on the prod incident is exactly the operability gap this closes.
 
-** What the design-review team pushed back on
-- *Add the log line* (rejected by architect as scope creep; all three
-  reviewers — Simplicity, Clean Interfaces, Fail-fast Contract — said
-  ship it).  Accepted: one =logger.warning= when the force-release
-  branch actually fires.
-- *Narrow exception catch to =ValueError= only* (architect proposed
-  =(ValueError, LookupError)= defensively; Simplicity reviewer said
-  speculative).  Accepted: =ValueError= only.
-- *Extract =_release_if_holder= helper* (Clean Interfaces #1 — the
-  4-line release pattern is repeated in =finally= and =_mark_expired=).
-  Accepted.
-- *Rename =_mark_expired= → =_on_hold_timeout=* (Clean Interfaces #2
-  — the function does more than mark after Change B).  Accepted.
-- *Promote to method, drop unused =_Handle._watchdog= slot* (Clean
-  Interfaces #3, #6).  Accepted.
-- *Document the two-paths-converging contract* (Clean Interfaces #7,
-  Fail-fast #1).  Accepted: module docstring + comment on
-  =_on_hold_timeout=.
+** What this PR does NOT do
+We do NOT wrap =_active_handle.reset(token)= in a
+=try/except ValueError= to "make =finally= leak-proof."  An earlier
+draft did exactly that; the user pushed back on 2026-05-30 with:
+
+#+BEGIN_QUOTE
+Why would this happen?  Seems like fixing the cause of this is more
+important than placing these assurances *around* it.
+#+END_QUOTE
+
+The cause is that =Thread.stream_message=' generator gets iterated
+across thread boundaries (FastAPI streaming the body via
+=run_in_executor=; the emacsos consumer's =run_in_executor= → =next()=
+pump; client-disconnect GC closing the generator from the collector
+thread).  The fix lives in =assist/thread.py= — bind the generator
+to a captured =contextvars.copy_context()= — NOT in a defensive
+swallow inside the queue.
+
+Tracked as the next PR, separate from this one.  Until that PR lands,
+the contextvar-reset ValueError propagates out of =finally= and leaks
+=_holder= momentarily; the watchdog catches it within
+=hold_timeout_s=.  See the pinned-contract test
+=test_cross_context_exit_leaks_holder_until_watchdog_recovers=.
 
 ** Rejected alternatives
 1. *Heartbeat-based holder.*  Requires a background poller; the Timer
@@ -98,10 +96,10 @@ on the prod incident is exactly the operability gap this closes.
    watchdog not actually freeing the slot.
 
 ** Out of scope
-- =Thread.stream_message= generator close-on-disconnect (real but bounded
-  to =hold_timeout_s= by Change B; proper fix belongs in =assist/thread.py=).
+- =Thread.stream_message= generator close-on-disconnect — the *cause*
+  of the contextvar-reset case.  This is the NEXT PR, separately
+  scoped; the watchdog bounds the leak in the meantime.
 - Metrics dashboard for force-release counts.
-- Force-release endpoint or =current_handle_age_s()= helper.
 - =_Handle= → =@dataclass= refactor (=__slots__= is load-bearing).
 
 * Risks
@@ -128,34 +126,11 @@ on the prod incident is exactly the operability gap this closes.
 
 * Eval cadence
 Unit tests only — this is queue plumbing, not agent behavior.
-=tests/test_thread_queue.py= already at 14 tests; adding 3 new + 1
-modified (post code-review trim from 4 → 3).  No edd/eval/ suite changes.
+=tests/test_thread_queue.py=: 3 new tests + 1 modified.
 
-* Follow-ups (surfaced by code review; not in this PR)
-1. *=Thread.stream_message= close-on-disconnect.*  The generator wraps
-   =acquire()=; a consumer that drops iteration without =close()= leaves
-   the with-block suspended.  Change B in THIS PR bounds the leak to
-   =hold_timeout_s=, but the structural fix lives in =assist/thread.py=:
-   either a context-manager API for the caller, or drain the generator
-   on a worker thread bound to =copy_context()= so =__enter__= and
-   =__exit__= run in the same context.
-2. *Bind the streaming generator to a captured context.*  Wrap =_gen()=
-   so it runs inside =contextvars.copy_context().run(...)=.  Makes the
-   cross-context exit case structurally impossible; the =try/except
-   ValueError= in this PR becomes defense-in-depth.
-3. *=ThreadQueueMiddleware= docstring* should reflect the two-paths-
-   converging contract (=active_handle= = per-call-stack identity,
-   =_holder= = queue-wide ownership; the watchdog can clear =_holder=
-   while the contextvar still points at the dying handle).
-4. *Reentrant fast path could skip =_cond=.*  Reading =_active_handle=
-   is lock-free; sub-agent calls currently pay a lock acquisition just
-   to check a contextvar.
-5. *Observability counter.*  =_release_if_holder= returns =bool=, ready
-   for instrumentation: =force_releases= and =cooperative_releases= as
-   separate counters, with the ratio as the SLO signal.  WARNING log
-   in this PR catches absolute count; trend lives in metrics.
-6. *=register_at_fork= hook.*  The module docstring claims separate
-   processes get their own queue — true for =spawn=, NOT for =fork=.
-   A forked child inherits a stale =_holder=.  Either add
-   =os.register_at_fork(after_in_child=...)= to reinitialize, or
-   document the fork hazard.
+* Next PR (the cause fix)
+Bind =Thread.stream_message='s generator to a captured
+=contextvars.copy_context()= so =__enter__= and =__exit__= always run
+in the same context.  Makes the contextvar-reset ValueError
+structurally impossible.  Lives in =assist/thread.py=; separate scope
+from this queue-plumbing fix.

--- a/docs/2026-05-29-queue-holder-leak-fix.org
+++ b/docs/2026-05-29-queue-holder-leak-fix.org
@@ -1,6 +1,6 @@
 #+TITLE: ThreadAffinityQueue holder-slot leak fix
 #+DATE: 2026-05-29
-State: Shipped (PR #111)
+State: In review (PR #111)
 
 Follow-up to =2026-05-06-thread-affinity-queue.org=.  That PR shipped the
 queue; this one fixes a leak that bit prod on 2026-05-28.

--- a/docs/2026-05-29-queue-holder-leak-fix.org
+++ b/docs/2026-05-29-queue-holder-leak-fix.org
@@ -1,6 +1,6 @@
 #+TITLE: ThreadAffinityQueue holder-slot leak fix
 #+DATE: 2026-05-29
-State: Phase 1 design (about to enter Phase 2 — implementation)
+State: Shipped (PR #111)
 
 Follow-up to =2026-05-06-thread-affinity-queue.org=.  That PR shipped the
 queue; this one fixes a leak that bit prod on 2026-05-28.
@@ -19,21 +19,21 @@ The queue's =_holder= slot leaked.  Symptoms in prod logs:
   threads as =error= (preserving their =pending_message= for the user
   to resend).
 
-** Root cause hypothesis
-=acquire()='s =finally= block at =assist/thread_queue.py:178= starts
-with =_active_handle.reset(token)=.  The docstring at lines 106-114
-already warns: if the =with= block exits in a different
-=contextvars.Context= than it was entered, =reset()= raises =ValueError=.
-The bare =reset()= call meant that =ValueError= aborted the rest of
-=finally= — watchdog cancel, =_holder= clear, and =notify_all()= all
-skipped.  The watchdog still fired and flipped =handle.expired=, but
-nothing cleared =_holder=, so waiters blocked the full =wait_timeout_s=.
+** Root cause
+=ThreadAffinityQueue.acquire='s =finally= block starts with
+=_active_handle.reset(token)=.  As the method's docstring already
+warns: if the =with= block exits in a different =contextvars.Context=
+than it was entered, =reset()= raises =ValueError=.  The bare
+=reset()= call meant that =ValueError= aborted the rest of =finally=
+— watchdog cancel, =_holder= clear, and =notify_all()= all skipped.
+The watchdog still fired and flipped =handle.expired=, but nothing
+cleared =_holder=, so waiters blocked the full =wait_timeout_s=.
 
-The =stream_message= generator path in =assist/thread.py:212= is the
-likely source of the cross-context exit (FastAPI iterates the body
-generator on a thread different from where it was constructed when
-the client disconnects mid-stream).  Not confirmed for the specific
-2026-05-28 incident, but the shape fits.
+The =Thread.stream_message= generator path is the likely source of
+the cross-context exit (FastAPI iterates the body generator on a
+thread different from where it was constructed when the client
+disconnects mid-stream).  Not confirmed for the specific 2026-05-28
+incident, but the shape fits.
 
 * Solution
 Two changes in =assist/thread_queue.py=, both narrow.

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -156,12 +156,23 @@ def test_wait_timeout_raises():
     assert q.waiter_count() == 0
 
 
-def test_hold_timeout_marks_expired():
+def test_hold_timeout_marks_expired_and_force_releases():
+    # After the hold_timeout_s watchdog fires, both the cooperative-cancel
+    # flag (`expired`) AND the queue-slot release happen.  The force release
+    # is what bounds the leak window when the holder's `finally` is skipped
+    # (the 2026-05-28 prod incident — see thread_queue.py docstring).
     q = ThreadAffinityQueue()
     with q.acquire("A", hold_timeout_s=0.1) as handle:
         assert handle.expired is False
+        assert q.current_handle() is handle
         time.sleep(0.25)
         assert handle.expired is True
+        # The slot is vacated mid-`with`: a waiter could acquire RIGHT NOW.
+        assert q.current_handle() is None
+    # Holder's `finally` ran after the watchdog already released; the
+    # `is handle` guard in `_release_if_holder` made it a no-op (no
+    # exception, no double-notify).
+    assert q.current_handle() is None
 
 
 def test_reentrant_same_thread_id_is_noop():
@@ -269,3 +280,165 @@ def test_defaults_match_module_constants():
     q = ThreadAffinityQueue()
     assert q._default_hold_timeout == DEFAULT_HOLD_TIMEOUT_S
     assert q._default_wait_timeout == DEFAULT_WAIT_TIMEOUT_S
+
+
+# --- Leak-fix regression tests ----------------------------------------
+# These tests pin the contract that the queue's `_holder` slot is
+# released even when `acquire`'s `finally` is interrupted partway, AND
+# that the watchdog timer forcibly releases the slot when `finally` is
+# bypassed entirely.  Background: docs/2026-05-29-queue-holder-leak-fix.org.
+
+
+def test_finally_runs_when_contextvar_reset_raises():
+    # Reproduces the 2026-05-28 prod failure mode: the with-block is
+    # entered in one `contextvars.Context` and exited in another, so
+    # `_active_handle.reset(token)` raises `ValueError` at the top of
+    # `finally`.  Pre-fix, that aborted the rest of `finally` and left
+    # `_holder` set; waiters then blocked the full wait_timeout_s (4h
+    # in prod).  Post-fix, the ValueError is swallowed and the slot is
+    # released cleanly.
+    import contextvars
+
+    q = ThreadAffinityQueue()
+    cm = q.acquire("A")
+    ctx = contextvars.copy_context()
+    # `__enter__` binds the contextvar token to `ctx`; the subsequent
+    # `__exit__` runs in the test's outer context, so `reset(token)`
+    # sees the context mismatch and raises ValueError (the real CPython
+    # behaviour — no mocking needed).
+    ctx.run(cm.__enter__)
+    assert q.current_handle() is not None
+    cm.__exit__(None, None, None)
+
+    # The swallow guard in `finally` caught the ValueError; the rest of
+    # cleanup (watchdog cancel + `_release_if_holder`) still ran.
+    assert q.current_handle() is None
+
+    # A fresh acquire goes straight to "running" with no "queued" state.
+    states: list[str] = []
+    with q.acquire("B", on_state_change=states.append):
+        pass
+    assert states == ["running"]
+
+
+def test_watchdog_force_releases_when_holder_is_wedged():
+    # The real leak-bound: even if the holder's `with` never exits
+    # (wedged in an infinite loop, never reaches `finally`), the
+    # watchdog timer must release the slot at `hold_timeout_s` so
+    # waiters can proceed.
+    q = ThreadAffinityQueue()
+    holder_can_release = threading.Event()
+    holder_done = threading.Event()
+    waiter_states: list[str] = []
+    waiter_done = threading.Event()
+
+    def wedged_holder():
+        with q.acquire("A", hold_timeout_s=0.1):
+            holder_can_release.wait(timeout=5.0)
+        holder_done.set()
+
+    def waiter():
+        # Wait_timeout generous; the watchdog should free the slot
+        # at ~0.1s, well before wait_timeout would matter.
+        with q.acquire("B", wait_timeout_s=2.0,
+                       on_state_change=waiter_states.append):
+            pass
+        waiter_done.set()
+
+    th = threading.Thread(target=wedged_holder)
+    th.start()
+    # Give A time to enter `with` and become holder.
+    time.sleep(0.05)
+    assert q.current_handle() is not None
+    tw = threading.Thread(target=waiter)
+    tw.start()
+
+    # B is queued behind A.  Wait long enough for the watchdog to fire.
+    waiter_done.wait(timeout=2.0)
+    assert waiter_done.is_set(), "waiter never acquired — watchdog didn't release"
+    # B observed both states: queued then running.
+    assert waiter_states == ["queued", "running"]
+
+    # Let the wedged holder unblock so the test thread can finish.
+    holder_can_release.set()
+    holder_done.wait(timeout=2.0)
+    th.join(timeout=2.0)
+    tw.join(timeout=2.0)
+
+    assert q.current_handle() is None
+    assert q.waiter_count() == 0
+
+
+def test_watchdog_does_not_clobber_newly_promoted_holder():
+    # Watchdog fires on A, releasing the slot.  B is promoted and
+    # becomes the new holder.  Then A's `with` finally exits — its
+    # cleanup must NOT clobber B's slot.  The `is handle` guard in
+    # `_release_if_holder` is what protects this; this test pins it.
+    q = ThreadAffinityQueue()
+    a_can_release = threading.Event()
+    b_acquired = threading.Event()
+    b_can_release = threading.Event()
+
+    def hold_a():
+        with q.acquire("A", hold_timeout_s=0.1):
+            a_can_release.wait(timeout=5.0)
+
+    def hold_b():
+        with q.acquire("B", wait_timeout_s=2.0) as h:
+            # Mark that B is now the holder (post-watchdog promotion).
+            b_acquired.set()
+            b_can_release.wait(timeout=5.0)
+            # Save B's handle identity via closure into the outer scope.
+            hold_b.handle = h  # type: ignore[attr-defined]
+
+    ta = threading.Thread(target=hold_a)
+    ta.start()
+    time.sleep(0.05)
+    tb = threading.Thread(target=hold_b)
+    tb.start()
+
+    # Wait for B to be promoted (watchdog fires at ~0.1s).
+    assert b_acquired.wait(timeout=2.0), "B never promoted — watchdog didn't release A"
+    b_handle = q.current_handle()
+    assert b_handle is not None
+    assert b_handle.thread_id == "B"
+
+    # Now let A exit its `with` (its cleanup must be a no-op for `_holder`).
+    a_can_release.set()
+    ta.join(timeout=2.0)
+
+    # B is still the holder — A's `finally` didn't clobber it.
+    assert q.current_handle() is b_handle
+
+    b_can_release.set()
+    tb.join(timeout=2.0)
+    assert q.current_handle() is None
+
+
+def test_late_watchdog_fire_after_normal_release_is_noop():
+    # The happy path: holder releases normally before hold_timeout_s,
+    # so `watchdog.cancel()` should prevent the Timer firing.  But if
+    # the Timer fires anyway (race window between cancel and the
+    # Timer thread's tick), `_on_hold_timeout` must be a no-op:
+    # `_holder` is None, so `_release_if_holder` returns False, no
+    # exception, no spurious notify.
+    q = ThreadAffinityQueue()
+    # Acquire cleanly; record the handle for the manual fire below.
+    with q.acquire("A", hold_timeout_s=10.0) as handle:
+        pass
+    assert q.current_handle() is None
+
+    # Simulate a late Timer fire after the holder cleanly released.
+    q._on_hold_timeout(handle)
+
+    # Slot is still None; the late callback didn't crash and didn't
+    # confuse a future acquire.
+    assert q.current_handle() is None
+    # `expired` does get flipped (cheap, harmless) — but no one is reading
+    # it now since the holder's `with` already exited.
+    assert handle.expired is True
+
+    # A fresh acquire still works.
+    with q.acquire("B"):
+        pass
+    assert q.current_handle() is None

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -1,8 +1,8 @@
 """Tests for ThreadAffinityQueue (assist/thread_queue.py)."""
+import contextvars
 import os
 import threading
 import time
-from unittest.mock import patch
 
 import pytest
 
@@ -297,8 +297,6 @@ def test_finally_runs_when_contextvar_reset_raises():
     # `_holder` set; waiters then blocked the full wait_timeout_s (4h
     # in prod).  Post-fix, the ValueError is swallowed and the slot is
     # released cleanly.
-    import contextvars
-
     q = ThreadAffinityQueue()
     cm = q.acquire("A")
     ctx = contextvars.copy_context()
@@ -384,12 +382,10 @@ def test_watchdog_does_not_clobber_newly_promoted_holder():
             a_can_release.wait(timeout=5.0)
 
     def hold_b():
-        with q.acquire("B", wait_timeout_s=2.0) as h:
+        with q.acquire("B", wait_timeout_s=2.0):
             # Mark that B is now the holder (post-watchdog promotion).
             b_acquired.set()
             b_can_release.wait(timeout=5.0)
-            # Save B's handle identity via closure into the outer scope.
-            hold_b.handle = h  # type: ignore[attr-defined]
 
     ta = threading.Thread(target=hold_a)
     ta.start()
@@ -412,33 +408,4 @@ def test_watchdog_does_not_clobber_newly_promoted_holder():
 
     b_can_release.set()
     tb.join(timeout=2.0)
-    assert q.current_handle() is None
-
-
-def test_late_watchdog_fire_after_normal_release_is_noop():
-    # The happy path: holder releases normally before hold_timeout_s,
-    # so `watchdog.cancel()` should prevent the Timer firing.  But if
-    # the Timer fires anyway (race window between cancel and the
-    # Timer thread's tick), `_on_hold_timeout` must be a no-op:
-    # `_holder` is None, so `_release_if_holder` returns False, no
-    # exception, no spurious notify.
-    q = ThreadAffinityQueue()
-    # Acquire cleanly; record the handle for the manual fire below.
-    with q.acquire("A", hold_timeout_s=10.0) as handle:
-        pass
-    assert q.current_handle() is None
-
-    # Simulate a late Timer fire after the holder cleanly released.
-    q._on_hold_timeout(handle)
-
-    # Slot is still None; the late callback didn't crash and didn't
-    # confuse a future acquire.
-    assert q.current_handle() is None
-    # `expired` does get flipped (cheap, harmless) — but no one is reading
-    # it now since the holder's `with` already exited.
-    assert handle.expired is True
-
-    # A fresh acquire still works.
-    with q.acquire("B"):
-        pass
     assert q.current_handle() is None

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -1,6 +1,5 @@
 """Tests for ThreadAffinityQueue (assist/thread_queue.py)."""
 import contextvars
-import os
 import threading
 import time
 

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -343,11 +343,15 @@ def test_watchdog_force_releases_when_holder_is_wedged():
     q = ThreadAffinityQueue()
     holder_can_release = threading.Event()
     holder_done = threading.Event()
+    holder_acquired = threading.Event()
     waiter_states: list[str] = []
     waiter_done = threading.Event()
 
     def wedged_holder():
-        with q.acquire("A", hold_timeout_s=0.1):
+        with q.acquire(
+            "A", hold_timeout_s=0.1,
+            on_state_change=lambda s: holder_acquired.set() if s == "running" else None,
+        ):
             holder_can_release.wait(timeout=5.0)
         holder_done.set()
 
@@ -361,8 +365,10 @@ def test_watchdog_force_releases_when_holder_is_wedged():
 
     th = threading.Thread(target=wedged_holder)
     th.start()
-    # Give A time to enter `with` and become holder.
-    time.sleep(0.05)
+    # Deterministic wait for A to become holder (avoids time.sleep flakiness
+    # on slow/loaded CI — the on_state_change callback above flips the Event
+    # the moment A's acquire transitions to "running").
+    assert holder_acquired.wait(timeout=2.0), "holder A never acquired"
     assert q.current_handle() is not None
     tw = threading.Thread(target=waiter)
     tw.start()
@@ -379,6 +385,10 @@ def test_watchdog_force_releases_when_holder_is_wedged():
     th.join(timeout=2.0)
     tw.join(timeout=2.0)
 
+    # Assert threads actually terminated — a flaky join-on-timeout would
+    # leave them alive and silently corrupt state for the next test.
+    assert not th.is_alive(), "wedged_holder thread did not finish"
+    assert not tw.is_alive(), "waiter thread did not finish"
     assert q.current_handle() is None
     assert q.waiter_count() == 0
 
@@ -390,11 +400,15 @@ def test_watchdog_does_not_clobber_newly_promoted_holder():
     # `_release_if_holder` is what protects this; this test pins it.
     q = ThreadAffinityQueue()
     a_can_release = threading.Event()
+    a_acquired = threading.Event()
     b_acquired = threading.Event()
     b_can_release = threading.Event()
 
     def hold_a():
-        with q.acquire("A", hold_timeout_s=0.1):
+        with q.acquire(
+            "A", hold_timeout_s=0.1,
+            on_state_change=lambda s: a_acquired.set() if s == "running" else None,
+        ):
             a_can_release.wait(timeout=5.0)
 
     def hold_b():
@@ -405,7 +419,8 @@ def test_watchdog_does_not_clobber_newly_promoted_holder():
 
     ta = threading.Thread(target=hold_a)
     ta.start()
-    time.sleep(0.05)
+    # Deterministic wait for A to enter `with` and become holder.
+    assert a_acquired.wait(timeout=2.0), "holder A never acquired"
     tb = threading.Thread(target=hold_b)
     tb.start()
 
@@ -418,10 +433,12 @@ def test_watchdog_does_not_clobber_newly_promoted_holder():
     # Now let A exit its `with` (its cleanup must be a no-op for `_holder`).
     a_can_release.set()
     ta.join(timeout=2.0)
+    assert not ta.is_alive(), "hold_a thread did not finish"
 
     # B is still the holder — A's `finally` didn't clobber it.
     assert q.current_handle() is b_handle
 
     b_can_release.set()
     tb.join(timeout=2.0)
+    assert not tb.is_alive(), "hold_b thread did not finish"
     assert q.current_handle() is None

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -293,28 +293,40 @@ def test_defaults_match_module_constants():
 # bypassed entirely.  Background: docs/2026-05-29-queue-holder-leak-fix.org.
 
 
-def test_finally_runs_when_contextvar_reset_raises():
-    # Reproduces the 2026-05-28 prod failure mode: the with-block is
-    # entered in one `contextvars.Context` and exited in another, so
-    # `_active_handle.reset(token)` raises `ValueError` at the top of
-    # `finally`.  Pre-fix, that aborted the rest of `finally` and left
-    # `_holder` set; waiters then blocked the full wait_timeout_s (4h
-    # in prod).  Post-fix, the ValueError is swallowed and the slot is
-    # released cleanly.
+def test_cross_context_exit_leaks_holder_until_watchdog_recovers():
+    # Pins the failure-mode-and-recovery for the 2026-05-28 prod incident:
+    # the with-block is entered in one `contextvars.Context` and exited in
+    # another, so `_active_handle.reset(token)` raises `ValueError` at the
+    # top of `finally`, aborting the rest of cleanup.  This PR's policy is
+    # NOT to swallow the ValueError (that hides the bug in the caller);
+    # instead, the watchdog bounds the resulting `_holder` leak to
+    # `hold_timeout_s`.  The cause itself (a generator iterated across
+    # thread boundaries — see `Thread.stream_message`) gets fixed in a
+    # follow-up.
     q = ThreadAffinityQueue()
-    cm = q.acquire("A")
+    cm = q.acquire("A", hold_timeout_s=0.1)
     ctx = contextvars.copy_context()
     # `__enter__` binds the contextvar token to `ctx`; the subsequent
     # `__exit__` runs in the test's outer context, so `reset(token)`
-    # sees the context mismatch and raises ValueError (the real CPython
+    # sees the context mismatch and raises ValueError (real CPython
     # behaviour — no mocking needed).
     ctx.run(cm.__enter__)
     assert q.current_handle() is not None
-    cm.__exit__(None, None, None)
 
-    # The swallow guard in `finally` caught the ValueError; the rest of
-    # cleanup (watchdog cancel + `_release_if_holder`) still ran.
-    assert q.current_handle() is None
+    # The ValueError propagates out of `finally` — the holder leaks
+    # momentarily.  This is the documented failure mode.
+    with pytest.raises(ValueError):
+        cm.__exit__(None, None, None)
+    assert q.current_handle() is not None, "holder leaked, as expected"
+
+    # The watchdog catches the leak: `_holder` is force-released after
+    # `hold_timeout_s` so the queue stays serving other threads.
+    deadline = time.time() + 2.0
+    while q.current_handle() is not None and time.time() < deadline:
+        time.sleep(0.01)
+    assert q.current_handle() is None, (
+        "watchdog should have force-released the leaked slot"
+    )
 
     # A fresh acquire goes straight to "running" with no "queued" state.
     states: list[str] = []

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -160,11 +160,16 @@ def test_hold_timeout_marks_expired_and_force_releases():
     # flag (`expired`) AND the queue-slot release happen.  The force release
     # is what bounds the leak window when the holder's `finally` is skipped
     # (the 2026-05-28 prod incident — see thread_queue.py docstring).
+    # Poll for the watchdog's effects rather than fixed-sleep: avoids
+    # flakiness on slow/loaded CI where the Timer thread may take longer
+    # than a tight `time.sleep` margin to execute its callback.
     q = ThreadAffinityQueue()
     with q.acquire("A", hold_timeout_s=0.1) as handle:
         assert handle.expired is False
         assert q.current_handle() is handle
-        time.sleep(0.25)
+        deadline = time.time() + 2.0
+        while q.current_handle() is not None and time.time() < deadline:
+            time.sleep(0.01)
         assert handle.expired is True
         # The slot is vacated mid-`with`: a waiter could acquire RIGHT NOW.
         assert q.current_handle() is None


### PR DESCRIPTION
## Problem

A production incident on 2026-05-28 wedged the `ThreadAffinityQueue`'s `_holder` slot for ~17 hours. Symptoms:

- `2026-05-28 18:48:44 ERROR — thread 20260527085157-77ceb1f1 waited 14400.0s for queue` — that thread waited the full 4h `ASSIST_THREAD_QUEUE_WAIT_S` ceiling. Something held the queue but never released the slot.
- Two more threads (`20260528073914-cbd6a4cb` and `df64e49f-8669-4395-a78c-983e1e1894d5`) hit the still-held queue and went to `queued`.
- The web process stayed alive the whole time — no crash, no OOM. Only the in-memory `_holder` slot was wedged.
- Recovery was `make restart`; the lifespan handler marked the stuck threads as `error` and the in-memory queue reset clean.

## Root cause

`acquire()`'s `finally` block ran `_active_handle.reset(token)` first. That raises `ValueError` when the with-block exits in a different `contextvars.Context` than it was entered — a case the method's own docstring already warns about. The raise aborted the rest of `finally` (watchdog cancel + `_holder` clear + `notify_all()` all skipped), leaving the slot permanently held.

The cross-context exit happens when a streaming consumer drives `next()` / `close()` from a different OS thread (the emacsos-server's `run_in_executor → next()` pump; FastAPI streaming response handlers). The **cause** lives in `Thread.stream_message`, NOT the queue. **PR #114** fixes the cause by binding the generator to its construction Context — making the failure mode structurally impossible.

This PR (#111) is the **symptom bound**: even if the contextvar reset (or any other cleanup step) fails, the watchdog forcibly releases the slot after `hold_timeout_s`, keeping the queue serving other threads.

## What this PR does (single change)

**The watchdog forcibly releases the slot.** Rename `_mark_expired` → `_on_hold_timeout`, promote to a method on `ThreadAffinityQueue`, and have it ALSO clear `_holder` via a new `_release_if_holder` helper. Bounds the leak duration to `hold_timeout_s` (default 2h) regardless of which `finally`-path failure mode triggered it. Logs `WARNING` when force-release actually fires.

### What this PR explicitly does NOT do

Earlier drafts wrapped `_active_handle.reset(token)` in a `try/except ValueError` ("Change A") to make the `finally` block leak-proof. The user pushed back: *"Why would this happen? Seems like fixing the cause of this is more important than placing these assurances around it."* That feedback is right. Defensive try/except around a documented failure mode just hides the underlying bug in `stream_message`. So Change A is dropped. The cause fix lives in PR #114.

Refactors picked up while here:
- Drop the unused `_Handle._watchdog` slot (assigned but never read).
- Update module docstring's "Holder runs to completion" bullet to cover the watchdog-fires path.

## Tests

`tests/test_thread_queue.py`:
- `test_cross_context_exit_leaks_holder_until_watchdog_recovers` — pins the failure-mode-and-recovery: cross-context exit → ValueError propagates → holder leaks → watchdog force-releases within `hold_timeout_s`.
- `test_watchdog_force_releases_when_holder_is_wedged` — pins the watchdog catches a wedged holder.
- `test_watchdog_does_not_clobber_newly_promoted_holder` — pins the `is handle` guard.

`test_hold_timeout_marks_expired_and_force_releases` (modified) — pins that the watchdog flips `expired` AND releases the slot mid-`with`.

85/85 tests pass at N=5.

## Design doc

`docs/2026-05-29-queue-holder-leak-fix.org` — incident timeline, single-change framing, why we don't swallow.

## Relationship to other PRs

- **PR #114** (`bind-stream-message-context`) — the cause fix. Land order doesn't matter; complementary.
- **PR #113** (`fix-message-checkpoint-deadlock`) — merged-and-deployed; unrelated bug class (langgraph deadlock, the May-29 wedge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)