### PR TITLE
model_manager: TCP keepalive on ChatOpenAI httpx client (sync + async)

### DIFF
--- a/assist/model_manager.py
+++ b/assist/model_manager.py
@@ -152,7 +152,7 @@ def _build_http_client() -> httpx.Client:
     """Construct the sync httpx.Client used by every ChatOpenAI instance.
 
     Wires in TCP keepalive (see ``_TCP_KEEPALIVE_SOCKET_OPTIONS``) so a
-    half-closed peer surfaces in ~50s rather than waiting on the kernel
+    dead peer surfaces in ~60s rather than waiting on the kernel
     default ``tcp_keepalive_time`` (2h on Linux).  The per-phase
     :class:`httpx.Timeout` from :func:`_build_request_timeout` is set
     as the client default and is *also* set via ChatOpenAI's ``timeout``

--- a/assist/model_manager.py
+++ b/assist/model_manager.py
@@ -102,19 +102,80 @@ def _build_request_timeout() -> httpx.Timeout:
     )
 
 
+class _HttpClient(httpx.Client):
+    """``httpx.Client`` subclass that closes itself on GC.
+
+    Mirrors langchain_openai's own ``_SyncHttpxClientWrapper`` (which
+    subclasses ``openai.DefaultHttpxClient`` for the same reason): a
+    plain ``httpx.Client`` has no ``__del__`` finalizer, so a ChatOpenAI
+    instance going out of scope leaks its connection pool until process
+    exit.  Production hits this once per process (cached via
+    ``ThreadManager.model``), but eval sweeps construct N clients across
+    test classes — the cumulative leak adds up.
+    """
+
+    def __del__(self) -> None:
+        if self.is_closed:
+            return
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+class _AsyncHttpClient(httpx.AsyncClient):
+    """``httpx.AsyncClient`` subclass with a sync ``__del__``.
+
+    Same reason as :class:`_HttpClient`.  ``AsyncClient.close`` is
+    async; calling it from ``__del__`` (a sync context) would raise.
+    ``AsyncClient.aclose`` is also async.  The sync escape hatch is
+    ``_close_rs``-style transport close, but that's private — instead
+    we just let the OS reap the underlying sockets on process exit.
+    The pool's idle connections are bounded by httpx's defaults (5),
+    so the leak is small and the test-sweep concern doesn't apply
+    here in the same magnitude.
+    """
+
+    def __del__(self) -> None:
+        # No safe sync close path; rely on OS-level reaping.  See class
+        # docstring for the trade-off.
+        return
+
+
 def _build_http_client() -> httpx.Client:
-    """Construct the httpx.Client used by every ChatOpenAI instance.
+    """Construct the sync httpx.Client used by every ChatOpenAI instance.
 
     Wires in TCP keepalive (see ``_TCP_KEEPALIVE_SOCKET_OPTIONS``) so a
     half-closed peer surfaces in ~50s rather than waiting on the kernel
     default ``tcp_keepalive_time`` (2h on Linux).  The per-phase
     :class:`httpx.Timeout` from :func:`_build_request_timeout` is set
-    as the client default; per-call ``timeout`` on ChatOpenAI overrides
-    it when the openai SDK calls ``client.with_options(timeout=...)``.
+    as the client default and is *also* set via ChatOpenAI's ``timeout``
+    kwarg — in normal openai-SDK usage the per-call ``client.with_options(
+    timeout=...)`` always overrides the client default, so the client
+    default is the fallback for any direct httpx use.
     """
-    return httpx.Client(
+    return _HttpClient(
         timeout=_build_request_timeout(),
         transport=httpx.HTTPTransport(
+            socket_options=_TCP_KEEPALIVE_SOCKET_OPTIONS,
+        ),
+    )
+
+
+def _build_http_async_client() -> httpx.AsyncClient:
+    """Construct the async httpx.AsyncClient used by every ChatOpenAI.
+
+    The async client is what deepagents' subagent dispatch
+    (``await subagent.ainvoke(...)``) uses.  Without setting
+    ``http_async_client`` on ChatOpenAI, the openai SDK falls back to
+    its default async client which has no socket options, leaving
+    subagent LLM calls completely unprotected from the half-closed-peer
+    wedge that motivated this PR.  Setting both keeps sync and async
+    paths in lockstep.
+    """
+    return _AsyncHttpClient(
+        timeout=_build_request_timeout(),
+        transport=httpx.AsyncHTTPTransport(
             socket_options=_TCP_KEEPALIVE_SOCKET_OPTIONS,
         ),
     )
@@ -350,13 +411,11 @@ def _build_openai_chat_model(
         # on per-call wall-clock.
         "max_retries": 0,
         "timeout": _build_request_timeout(),
-        # http_client with TCP keepalive — see _build_http_client.
-        # Catches the half-closed-peer wedge that bit prod on
-        # 2026-05-29; without keepalive an LLM endpoint that crashes
-        # or half-closes mid-response leaves the client blocked on
-        # recv() until the queue's hold_timeout_s force-releases the
-        # slot (and even then the holder thread itself stays stuck).
+        # Both sync AND async clients carry TCP keepalive — see
+        # _build_http_client / _build_http_async_client.  Async covers
+        # the deepagents subagent dispatch path (await subagent.ainvoke).
         "http_client": _build_http_client(),
+        "http_async_client": _build_http_async_client(),
         "callbacks": [_ModelNotFoundCacheBuster()],
         "base_url": base_url,
         "api_key": api_key,

--- a/assist/model_manager.py
+++ b/assist/model_manager.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import os
+import socket
 import threading
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -43,6 +44,30 @@ logger = logging.getLogger(__name__)
 
 
 _PROBE_TIMEOUT_S = 10.0
+
+
+# TCP keepalive socket options for the ChatOpenAI httpx client.  Without
+# these, a half-closed peer (the 2026-05-29 wedge: llama.cpp half-closed
+# a socket; the client never noticed and was blocked on `recv()` for
+# 5h26m until the queue watchdog force-released the slot — but the
+# holder THREAD itself stayed stuck because no read ever completed) is
+# only detected when Linux's default `tcp_keepalive_time` (7200s = 2h)
+# fires.  With these options, the kernel surfaces a dead peer as a
+# clean ECONNRESET after roughly:
+#
+#     TCP_KEEPIDLE + (TCP_KEEPCNT - 1) * TCP_KEEPINTVL
+#   = 30          + (3            - 1) * 10
+#   = 50 seconds.
+#
+# Constants are Linux-specific (TCP_KEEPIDLE etc. are TCP_* level);
+# `SO_KEEPALIVE` itself is portable but the per-option tuning is not.
+# Production target is Linux, so this is the right scope.
+_TCP_KEEPALIVE_SOCKET_OPTIONS: list[tuple[int, int, int]] = [
+    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+    (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 30),
+    (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10),
+    (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3),
+]
 
 
 # Per-phase httpx Timeout for ChatOpenAI's underlying client.  Without
@@ -74,6 +99,24 @@ def _build_request_timeout() -> httpx.Timeout:
         read=env_float("ASSIST_LLM_READ_TIMEOUT_S", 600.0),
         write=env_float("ASSIST_LLM_WRITE_TIMEOUT_S", 60.0),
         pool=env_float("ASSIST_LLM_POOL_TIMEOUT_S", 10.0),
+    )
+
+
+def _build_http_client() -> httpx.Client:
+    """Construct the httpx.Client used by every ChatOpenAI instance.
+
+    Wires in TCP keepalive (see ``_TCP_KEEPALIVE_SOCKET_OPTIONS``) so a
+    half-closed peer surfaces in ~50s rather than waiting on the kernel
+    default ``tcp_keepalive_time`` (2h on Linux).  The per-phase
+    :class:`httpx.Timeout` from :func:`_build_request_timeout` is set
+    as the client default; per-call ``timeout`` on ChatOpenAI overrides
+    it when the openai SDK calls ``client.with_options(timeout=...)``.
+    """
+    return httpx.Client(
+        timeout=_build_request_timeout(),
+        transport=httpx.HTTPTransport(
+            socket_options=_TCP_KEEPALIVE_SOCKET_OPTIONS,
+        ),
     )
 
 
@@ -307,6 +350,13 @@ def _build_openai_chat_model(
         # on per-call wall-clock.
         "max_retries": 0,
         "timeout": _build_request_timeout(),
+        # http_client with TCP keepalive — see _build_http_client.
+        # Catches the half-closed-peer wedge that bit prod on
+        # 2026-05-29; without keepalive an LLM endpoint that crashes
+        # or half-closes mid-response leaves the client blocked on
+        # recv() until the queue's hold_timeout_s force-releases the
+        # slot (and even then the holder thread itself stays stuck).
+        "http_client": _build_http_client(),
         "callbacks": [_ModelNotFoundCacheBuster()],
         "base_url": base_url,
         "api_key": api_key,

--- a/assist/model_manager.py
+++ b/assist/model_manager.py
@@ -46,18 +46,24 @@ logger = logging.getLogger(__name__)
 _PROBE_TIMEOUT_S = 10.0
 
 
-# TCP keepalive socket options for the ChatOpenAI httpx client.  Without
-# these, a half-closed peer (the 2026-05-29 wedge: llama.cpp half-closed
-# a socket; the client never noticed and was blocked on `recv()` for
-# 5h26m until the queue watchdog force-released the slot — but the
-# holder THREAD itself stayed stuck because no read ever completed) is
-# only detected when Linux's default `tcp_keepalive_time` (7200s = 2h)
-# fires.  With these options, the kernel surfaces a dead peer as a
-# clean ECONNRESET after roughly:
+# TCP keepalive socket options for the ChatOpenAI httpx client.
+# Defense-in-depth against dead-peer scenarios where a process is
+# actively blocked on `recv()` against a connection that the peer's
+# kernel has stopped acknowledging (e.g. peer-host kernel panic with
+# no FIN/RST sent, NAT/firewall state expiry).  Without these, the
+# kernel's safety net is the default `tcp_keepalive_time` (7200s = 2h
+# on Linux).  With these, the kernel surfaces a dead peer as a clean
+# ECONNRESET after:
 #
-#     TCP_KEEPIDLE + (TCP_KEEPCNT - 1) * TCP_KEEPINTVL
-#   = 30          + (3            - 1) * 10
-#   = 50 seconds.
+#     TCP_KEEPIDLE + TCP_KEEPCNT * TCP_KEEPINTVL
+#   = 30          + 3            * 10
+#   = 60 seconds.
+#
+# What this does NOT bound: a connection that has already received FIN
+# from the peer (socket in CLOSE_WAIT) but where the application hasn't
+# called recv() since.  Keepalive only probes ESTABLISHED connections.
+# That class is bounded by the openai SDK's per-call timeout + the
+# upstream retry layer.
 #
 # Constants are Linux-specific (TCP_KEEPIDLE etc. are TCP_* level);
 # `SO_KEEPALIVE` itself is portable but the per-option tuning is not.

--- a/docs/2026-05-30-llm-client-tcp-keepalive.org
+++ b/docs/2026-05-30-llm-client-tcp-keepalive.org
@@ -118,7 +118,7 @@ the client default at call time.
 
 * Risks
 - *R1 — Keepalive probes consume tiny bandwidth.*  4 packets every
-  ~50s per idle connection.  Negligible on localhost or a LAN.
+  ~60s per idle connection.  Negligible on localhost or a LAN.
 - *R2 — A flapping network path between the client and llama.cpp
   could trigger spurious resets.*  Localhost: not applicable.  LAN:
   if probes get dropped under congestion, the connection drops and

--- a/docs/2026-05-30-llm-client-tcp-keepalive.org
+++ b/docs/2026-05-30-llm-client-tcp-keepalive.org
@@ -8,29 +8,38 @@ that motivated the sequence.
 
 * Problem
 On 2026-05-29 thread =20260528073914-cbd6a4cb= sat in =processing= for
-5h26m.  Investigation: an open TCP connection from the assist-web
-Python process to llama.cpp at =127.0.0.1:8000= in =CLOSE_WAIT= state
-with 1 byte buffered.  Llama.cpp had finished its response and
-half-closed the socket; the openai/httpx client never noticed and was
-blocked on =recv()= indefinitely.
+5h26m.  Initial diagnostic spotted a TCP connection from the assist-web
+process to llama.cpp at =127.0.0.1:8000= in =CLOSE_WAIT= state with
+1 byte (the FIN) buffered, and that shaped the original framing of
+this PR as "openai/httpx blocked on recv()".
 
-The previous fix (PR #111) bounded the *queue slot* leak to
-=hold_timeout_s= via the watchdog — but the *holder thread* itself
-stays wedged because =ThreadQueueMiddleware='s cooperative cancel
-only fires between LLM calls (in =after_model=), and the next call
-was exactly what was blocked.
+Re-examination — and the Copilot reviewer flagging the original
+framing — clarified that the CLOSE_WAIT socket was almost certainly
+*not* the wedge cause:
+- llama.cpp logs showed the request had completed cleanly
+  (=done request: POST /v1/chat/completions 127.0.0.1 200=).
+- No ESTABLISHED connections to llama.cpp existed on PID 1675100 at
+  the time of inspection.
+- All 38 Python threads in PID 1675100 were in =futex_wait= /
+  =io_sq_wait= (lock waits), not on socket =recv()=.
+- The CLOSE_WAIT was a stale pool connection from a *completed*
+  request — the actual wedge was elsewhere (langgraph executor /
+  sqlite checkpoint write / sandbox interaction; needs separate
+  investigation, tracked as a follow-up).
 
-** Why httpx didn't time out
-- =httpx.Timeout(connect=10, read=600, write=60, pool=10)= is set
-  on the ChatOpenAI client via =assist/model_manager._build_request_timeout=.
-- =read=600= is httpx's *idle-byte* timer.  It resets on every byte
-  received and only fires when no byte arrives for =read= seconds.
-  With 1 byte sitting in the kernel's recv queue, the timer may
-  never arm cleanly.
-- No TCP keepalive is configured on the underlying socket.
-- Linux's default =tcp_keepalive_time= is 7200s (2h) — so the kernel
-  safety net would only kick in well after the queue watchdog
-  already fired anyway.
+So this PR no longer claims to bound the observed wedge.  What it
+*does* do is harden the LLM client against a *related* failure-mode
+bucket — dead-peer scenarios where a process IS actively blocked on
+a network read against a peer whose kernel has stopped acknowledging
+(peer host kernel panic with no FIN/RST, NAT/firewall state expiry,
+some bridge/iptables drop).  Defense-in-depth, not the definitive
+fix for the 2026-05-29 incident.
+
+PR #111's queue watchdog still bounded the *queue slot* leak to
+=hold_timeout_s= regardless of which layer wedged.  The holder
+thread itself stays stuck — bounding that requires a different
+mechanism (subprocess termination is the structural answer; see
+follow-up #1 in [[file:2026-05-29-queue-holder-leak-fix.org]]).
 
 * Solution
 Configure TCP keepalive on the httpx client used by every ChatOpenAI
@@ -44,10 +53,10 @@ instance.
 | =TCP_KEEPINTVL=     |    10 | 10s between probes                   |
 | =TCP_KEEPCNT=       |     3 | Fail after 3 missed probes           |
 
-Total detection time = =TCP_KEEPIDLE + (TCP_KEEPCNT - 1) * TCP_KEEPINTVL=
-= =30 + 2 * 10= = **50 seconds**.  Today's CLOSE_WAIT wedge would have
-surfaced as a clean =ECONNRESET= at the openai SDK after ~50s instead of
-hanging until the 2h queue watchdog fired.
+Total detection time = =TCP_KEEPIDLE + TCP_KEEPCNT * TCP_KEEPINTVL=
+= =30 + 3 * 10= = **60 seconds**.  A peer that goes dead without a
+clean FIN/RST surfaces as =ECONNRESET= at the openai SDK after ~60s
+instead of waiting on Linux's default =tcp_keepalive_time= (2h).
 
 ** Implementation shape
 Changes in =assist/model_manager.py=:
@@ -73,12 +82,17 @@ The =timeout= kwarg on ChatOpenAI stays — it propagates to per-call
 =client.with_options(timeout=...)= in the openai SDK, which overrides
 the client default at call time.
 
-** What this does NOT change
-- =_build_request_timeout= itself — the 600s read default stays.  The
-  audit recommended lowering to 120s, but that's operator-impactful
-  (genuinely long generations could now hit it) and a separate
-  judgment call from the keepalive hardening.  Defer to a follow-up
-  if force-release WARN keeps firing on long-running threads.
+** What this does NOT bound
+- *The CLOSE_WAIT scenario specifically.*  Once a socket has received
+  FIN, keepalive doesn't probe it.  If the application has buffered
+  read data and never calls =recv()= again, the socket sits in
+  CLOSE_WAIT until the process exits.  Bounding that requires either
+  per-call deadlines higher up the stack, or fixing the application
+  pattern that left the socket unread.
+- *The actual 2026-05-29 wedge.*  As above, that thread wasn't
+  blocked on a socket at all — it was wedged elsewhere.  Separate
+  investigation pending.
+- =_build_request_timeout= itself — the 600s read default stays.
 - =ThreadQueueMiddleware= — the cooperative cancel point is unchanged.
   Earlier cancel checks (=before_model=, =wrap_tool_call=) are the
   next surgical PR.

--- a/docs/2026-05-30-llm-client-tcp-keepalive.org
+++ b/docs/2026-05-30-llm-client-tcp-keepalive.org
@@ -50,21 +50,28 @@ surfaced as a clean =ECONNRESET= at the openai SDK after ~50s instead of
 hanging until the 2h queue watchdog fired.
 
 ** Implementation shape
-One small change in =assist/model_manager.py=:
+Changes in =assist/model_manager.py=:
 
 - New constant =_TCP_KEEPALIVE_SOCKET_OPTIONS= holds the four
   =(level, optname, value)= tuples.
-- New factory =_build_http_client()= returns
-  =httpx.Client(timeout=_build_request_timeout(),
-                  transport=httpx.HTTPTransport(socket_options=...))=.
-- =_build_openai_chat_model()= passes =http_client=_build_http_client()=
-  to ChatOpenAI alongside the existing =timeout=.
+- New factories =_build_http_client()= and =_build_http_async_client()=
+  return =httpx.Client= / =httpx.AsyncClient= subclasses (=_HttpClient=,
+  =_AsyncHttpClient=) wired with =transport=HTTPTransport(socket_options=...)=
+  + the per-phase Timeout from =_build_request_timeout=.
+- The =_HttpClient= subclass adds a =__del__= finalizer that closes
+  the client on GC — matches langchain_openai's own
+  =_SyncHttpxClientWrapper= pattern.  Without it, each ChatOpenAI
+  going out of scope leaks the underlying connection pool (a real
+  cost across eval sweeps that construct N test-class clients).
+- =_build_openai_chat_model()= passes BOTH =http_client= and
+  =http_async_client= to ChatOpenAI.  The async path is what
+  deepagents' subagent dispatch (=await subagent.ainvoke(...)=) uses;
+  without async coverage, subagent LLM calls (=context= / =research=
+  / =critique=) would still hit the 2026-05-29 wedge class.
 
 The =timeout= kwarg on ChatOpenAI stays — it propagates to per-call
 =client.with_options(timeout=...)= in the openai SDK, which overrides
-the client default at call time.  Both call sites (per-call and
-client-default) carry the same per-phase Timeout, so behavior is
-consistent.
+the client default at call time.
 
 ** What this does NOT change
 - =_build_request_timeout= itself — the 600s read default stays.  The
@@ -109,19 +116,20 @@ consistent.
   the target Python.  =SO_KEEPALIVE= is portable.
 
 * Tests
-=tests/test_model_manager.py= (new file):
-- =test_tcp_keepalive_socket_options_are_set= — assert the constant
-  contains the four expected tuples with the right values.
-- =test_build_http_client_returns_client_with_keepalive= — construct
-  a client and verify its transport's =socket_options= match the
-  constant.
-- =test_build_http_client_applies_per_phase_timeout= — assert
-  =client.timeout.connect/read/write/pool= match
-  =_build_request_timeout()=.
-- =test_keepalive_actually_set_on_server_socket= (integration) —
-  spin up a local TCP server, accept a connection from the httpx
-  client, =getsockopt(SO_KEEPALIVE)= on the server side should be
-  =1=.  Confirms the option reaches the kernel.
+=tests/model_manager/test_http_client.py= (new) — see the file for
+the assertions.  Four tests: constant correctness, sync-client
+keepalive + timeout, async-client keepalive + timeout, and a
+kernel-level proof.
+
+The kernel-level proof was originally planned as
+=getsockopt(SO_KEEPALIVE)= server-side, but that wouldn't actually
+verify the client's socket — =SO_KEEPALIVE= is set per-socket on the
+endpoint that enables it, so the server's accepted socket has no
+visibility into what the client set on its outbound socket.  The
+implementation instead monkey-patches =socket.socket.setsockopt= and
+records all calls during one HTTP GET, then asserts each keepalive
+tuple appeared.  This catches an httpx upgrade silently dropping
+=socket_options= — pure introspection wouldn't.
 
 * Eval cadence
 Unit tests only — no agent-behavior change, no LLM behavior change.

--- a/docs/2026-05-30-llm-client-tcp-keepalive.org
+++ b/docs/2026-05-30-llm-client-tcp-keepalive.org
@@ -1,0 +1,134 @@
+#+TITLE: TCP keepalive on the LLM httpx client
+#+DATE: 2026-05-30
+State: In review (PR pending)
+
+First of three surgical follow-ups to the 2026-05-29 wedge incident.
+See [[file:2026-05-29-queue-holder-leak-fix.org]] and the audit findings
+that motivated the sequence.
+
+* Problem
+On 2026-05-29 thread =20260528073914-cbd6a4cb= sat in =processing= for
+5h26m.  Investigation: an open TCP connection from the assist-web
+Python process to llama.cpp at =127.0.0.1:8000= in =CLOSE_WAIT= state
+with 1 byte buffered.  Llama.cpp had finished its response and
+half-closed the socket; the openai/httpx client never noticed and was
+blocked on =recv()= indefinitely.
+
+The previous fix (PR #111) bounded the *queue slot* leak to
+=hold_timeout_s= via the watchdog — but the *holder thread* itself
+stays wedged because =ThreadQueueMiddleware='s cooperative cancel
+only fires between LLM calls (in =after_model=), and the next call
+was exactly what was blocked.
+
+** Why httpx didn't time out
+- =httpx.Timeout(connect=10, read=600, write=60, pool=10)= is set
+  on the ChatOpenAI client via =assist/model_manager._build_request_timeout=.
+- =read=600= is httpx's *idle-byte* timer.  It resets on every byte
+  received and only fires when no byte arrives for =read= seconds.
+  With 1 byte sitting in the kernel's recv queue, the timer may
+  never arm cleanly.
+- No TCP keepalive is configured on the underlying socket.
+- Linux's default =tcp_keepalive_time= is 7200s (2h) — so the kernel
+  safety net would only kick in well after the queue watchdog
+  already fired anyway.
+
+* Solution
+Configure TCP keepalive on the httpx client used by every ChatOpenAI
+instance.
+
+** Socket options
+| Option              | Value | Why                                  |
+|---------------------+-------+--------------------------------------|
+| =SO_KEEPALIVE=      |     1 | Enable keepalive at all              |
+| =TCP_KEEPIDLE=      |    30 | Probe after 30s idle                 |
+| =TCP_KEEPINTVL=     |    10 | 10s between probes                   |
+| =TCP_KEEPCNT=       |     3 | Fail after 3 missed probes           |
+
+Total detection time = =TCP_KEEPIDLE + (TCP_KEEPCNT - 1) * TCP_KEEPINTVL=
+= =30 + 2 * 10= = **50 seconds**.  Today's CLOSE_WAIT wedge would have
+surfaced as a clean =ECONNRESET= at the openai SDK after ~50s instead of
+hanging until the 2h queue watchdog fired.
+
+** Implementation shape
+One small change in =assist/model_manager.py=:
+
+- New constant =_TCP_KEEPALIVE_SOCKET_OPTIONS= holds the four
+  =(level, optname, value)= tuples.
+- New factory =_build_http_client()= returns
+  =httpx.Client(timeout=_build_request_timeout(),
+                  transport=httpx.HTTPTransport(socket_options=...))=.
+- =_build_openai_chat_model()= passes =http_client=_build_http_client()=
+  to ChatOpenAI alongside the existing =timeout=.
+
+The =timeout= kwarg on ChatOpenAI stays — it propagates to per-call
+=client.with_options(timeout=...)= in the openai SDK, which overrides
+the client default at call time.  Both call sites (per-call and
+client-default) carry the same per-phase Timeout, so behavior is
+consistent.
+
+** What this does NOT change
+- =_build_request_timeout= itself — the 600s read default stays.  The
+  audit recommended lowering to 120s, but that's operator-impactful
+  (genuinely long generations could now hit it) and a separate
+  judgment call from the keepalive hardening.  Defer to a follow-up
+  if force-release WARN keeps firing on long-running threads.
+- =ThreadQueueMiddleware= — the cooperative cancel point is unchanged.
+  Earlier cancel checks (=before_model=, =wrap_tool_call=) are the
+  next surgical PR.
+- The probe httpx calls (=_probe_endpoint=, =_probe_props_n_ctx=) —
+  these are short single-shot requests with their own 10s timeout;
+  not worth keepalive-hardening.
+
+** Rejected alternatives
+1. *Lower =read= timeout to 120s.*  Real cost (long synthesis hits
+   it) for marginal benefit when keepalive already catches the
+   half-closed peer.  Operators can still bump the env var.
+2. *Wrap the LLM call in a thread-supervisor with =signal.alarm=
+   or =threading.Timer= + =httpx.Client.close()=.*  Cross-thread
+   client close is not safe in httpx; would risk corrupting in-flight
+   requests on other threads sharing the client.  Adding a
+   per-request supervisor is more code than the kernel-level
+   keepalive that's already there.
+3. *Move LLM calls into a subprocess we can =terminate()=.*  This is
+   the "real" structural fix — covered as the long-term contingency
+   in [[file:2026-05-29-queue-holder-leak-fix.org]] follow-up #1 /
+   the audit's holistic-option-B.  Cost is high; defer until the
+   surgical fixes prove insufficient.
+
+* Risks
+- *R1 — Keepalive probes consume tiny bandwidth.*  4 packets every
+  ~50s per idle connection.  Negligible on localhost or a LAN.
+- *R2 — A flapping network path between the client and llama.cpp
+  could trigger spurious resets.*  Localhost: not applicable.  LAN:
+  if probes get dropped under congestion, the connection drops and
+  the openai SDK reconnects (which is correct — the alternative is
+  silent wedge).  =ModelRetryMiddleware= handles the transient
+  retry case.
+- *R3 — TCP keepalive constants are Linux-specific.*  Verified
+  =socket.TCP_KEEPIDLE/TCP_KEEPINTVL/TCP_KEEPCNT= are present on
+  the target Python.  =SO_KEEPALIVE= is portable.
+
+* Tests
+=tests/test_model_manager.py= (new file):
+- =test_tcp_keepalive_socket_options_are_set= — assert the constant
+  contains the four expected tuples with the right values.
+- =test_build_http_client_returns_client_with_keepalive= — construct
+  a client and verify its transport's =socket_options= match the
+  constant.
+- =test_build_http_client_applies_per_phase_timeout= — assert
+  =client.timeout.connect/read/write/pool= match
+  =_build_request_timeout()=.
+- =test_keepalive_actually_set_on_server_socket= (integration) —
+  spin up a local TCP server, accept a connection from the httpx
+  client, =getsockopt(SO_KEEPALIVE)= on the server side should be
+  =1=.  Confirms the option reaches the kernel.
+
+* Eval cadence
+Unit tests only — no agent-behavior change, no LLM behavior change.
+No edd/eval/ suite changes.
+
+* Follow-ups (sequence)
+This is fix 1 of 3 in the post-incident sweep.  Next:
+1. Refresh sandbox container TTL on activity (roadmap item).
+2. Add =before_model= + =wrap_tool_call= cancel points to
+   =ThreadQueueMiddleware=.

--- a/tests/model_manager/test_http_client.py
+++ b/tests/model_manager/test_http_client.py
@@ -1,10 +1,10 @@
-"""Tests for assist.model_manager — focused on the LLM httpx client config.
+"""TCP keepalive and httpx client wiring for the ChatOpenAI used by every
+LLM call in assist.  Closes the 2026-05-29 CLOSE_WAIT-wedge class.
 
-The wider responsibilities of model_manager (endpoint discovery, cache
-invalidation, /props fallback) are exercised by integration tests via the
-real probe.  This file pins the TCP keepalive / httpx wiring that closes
-the 2026-05-29 CLOSE_WAIT-wedge class.  Background:
-docs/2026-05-30-llm-client-tcp-keepalive.org.
+Background: docs/2026-05-30-llm-client-tcp-keepalive.org.
+
+Located under ``tests/model_manager/`` to match the existing layout
+(see ``test_dynamic_model.py`` for the endpoint-discovery tests).
 """
 import socket
 import threading
@@ -14,6 +14,9 @@ import pytest
 
 from assist.model_manager import (
     _TCP_KEEPALIVE_SOCKET_OPTIONS,
+    _AsyncHttpClient,
+    _HttpClient,
+    _build_http_async_client,
     _build_http_client,
     _build_request_timeout,
 )
@@ -35,56 +38,50 @@ def test_tcp_keepalive_socket_options_constant():
     ]
 
 
-def test_build_http_client_returns_httpx_client():
+def test_build_http_client_returns_keepalive_client():
+    # Sync client is an _HttpClient (httpx.Client subclass with __del__)
+    # and carries the per-phase Timeout.  The actual kernel-level proof
+    # that keepalive options reach the socket lives in
+    # `test_keepalive_options_actually_applied_to_kernel_socket` below.
     client = _build_http_client()
     try:
+        assert isinstance(client, _HttpClient)
         assert isinstance(client, httpx.Client)
-    finally:
-        client.close()
-
-
-def test_build_http_client_propagates_socket_options_to_transport():
-    # httpx 0.28 stores the socket_options on the underlying
-    # httpcore ConnectionPool.  This is internal, so the assertion
-    # may need updating on httpx upgrade — but it's the cheapest
-    # check that the options aren't being dropped between
-    # HTTPTransport's kwarg and the pool that will set them on a
-    # real socket.  The behavioral test below catches an upgrade
-    # that silently breaks the wiring.
-    client = _build_http_client()
-    try:
-        transport = client._transport
-        assert isinstance(transport, httpx.HTTPTransport)
-        # Compare ignoring tuple-vs-list — httpcore may normalize.
-        observed = list(transport._pool._socket_options)
-        assert observed == _TCP_KEEPALIVE_SOCKET_OPTIONS
-    finally:
-        client.close()
-
-
-def test_build_http_client_applies_per_phase_timeout():
-    # The client's default Timeout should mirror _build_request_timeout's
-    # per-phase values, so per-call timeouts have a consistent fallback.
-    client = _build_http_client()
-    try:
         expected = _build_request_timeout()
-        actual = client.timeout
-        assert actual.connect == expected.connect
-        assert actual.read == expected.read
-        assert actual.write == expected.write
-        assert actual.pool == expected.pool
+        assert client.timeout.connect == expected.connect
+        assert client.timeout.read == expected.read
+        assert client.timeout.write == expected.write
+        assert client.timeout.pool == expected.pool
     finally:
         client.close()
+
+
+def test_build_http_async_client_returns_keepalive_async_client():
+    # Async client must also have keepalive — deepagents' subagent
+    # dispatch is `await subagent.ainvoke(...)`, which routes through
+    # ChatOpenAI's `http_async_client`.  Without coverage here, the
+    # subagent LLM calls (`context`/`research`/`critique`) would still
+    # be exposed to the 2026-05-29 wedge.
+    aclient = _build_http_async_client()
+    assert isinstance(aclient, _AsyncHttpClient)
+    assert isinstance(aclient, httpx.AsyncClient)
+    expected = _build_request_timeout()
+    assert aclient.timeout.connect == expected.connect
+    assert aclient.timeout.read == expected.read
+    assert aclient.timeout.write == expected.write
+    assert aclient.timeout.pool == expected.pool
 
 
 def test_keepalive_options_actually_applied_to_kernel_socket(monkeypatch):
     """The kernel-level proof: when the httpx client opens a connection,
     the four keepalive ``setsockopt`` calls actually reach a socket.
 
-    Catches the case where httpx's internals change and silently drop
-    ``socket_options`` — the introspection test above wouldn't catch
-    that.  Records every ``setsockopt`` call against ``socket.socket``
-    during one HTTP GET, then asserts each keepalive tuple is present.
+    Records every ``setsockopt`` call against ``socket.socket`` during
+    one HTTP GET, then asserts each keepalive tuple is present.  This
+    is what catches an httpx upgrade that silently drops
+    ``socket_options`` between the client and the kernel — pure
+    introspection of ``client._transport._pool._socket_options`` would
+    pass even when the transport stopped applying them.
     """
     options_set: list[tuple[int, int, int]] = []
     real_setsockopt = socket.socket.setsockopt
@@ -106,7 +103,13 @@ def test_keepalive_options_actually_applied_to_kernel_socket(monkeypatch):
     server.listen(1)
     port = server.getsockname()[1]
 
+    serve_error: list[Exception] = []
+
     def serve_one() -> None:
+        # Narrow except: OSError covers accept/recv/send IO failures,
+        # which we want to surface (not silently swallow) so the test
+        # fails with the real cause rather than a misleading "options
+        # not applied" assertion further down.
         try:
             conn, _ = server.accept()
             try:
@@ -119,8 +122,8 @@ def test_keepalive_options_actually_applied_to_kernel_socket(monkeypatch):
                 )
             finally:
                 conn.close()
-        except Exception:
-            pass
+        except OSError as exc:
+            serve_error.append(exc)
 
     serve_thread = threading.Thread(target=serve_one, daemon=True)
     serve_thread.start()
@@ -133,10 +136,14 @@ def test_keepalive_options_actually_applied_to_kernel_socket(monkeypatch):
         server.close()
         serve_thread.join(timeout=2.0)
 
+    assert not serve_error, f"server-side IO error: {serve_error[0]!r}"
+
     # Each keepalive option must have been applied to *some* socket
     # during the connection — the client's outbound socket.  We don't
     # care which socket object specifically; the kernel-level proof is
     # that the call happened with the expected (level, optname, value).
+    # `recording_setsockopt` runs from any thread that touches a socket
+    # during the test (atomic list.append under the GIL keeps this safe).
     for expected in _TCP_KEEPALIVE_SOCKET_OPTIONS:
         assert expected in options_set, (
             f"setsockopt{expected} was not applied to any socket during "

--- a/tests/model_manager/test_http_client.py
+++ b/tests/model_manager/test_http_client.py
@@ -26,7 +26,7 @@ def test_tcp_keepalive_socket_options_constant():
     # Pin the exact (level, optname, value) tuples.  The detection-time
     # math in the module docstring depends on these specific values:
     #
-    #     30 (idle) + 2 * 10 (probes) = 50s before kernel surfaces a
+    #     30 (idle) + 3 * 10 (probes) = 60s before kernel surfaces a
     #     dead peer as ECONNRESET.
     #
     # Changing any of these without re-doing the math is a regression.

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1,0 +1,144 @@
+"""Tests for assist.model_manager — focused on the LLM httpx client config.
+
+The wider responsibilities of model_manager (endpoint discovery, cache
+invalidation, /props fallback) are exercised by integration tests via the
+real probe.  This file pins the TCP keepalive / httpx wiring that closes
+the 2026-05-29 CLOSE_WAIT-wedge class.  Background:
+docs/2026-05-30-llm-client-tcp-keepalive.org.
+"""
+import socket
+import threading
+
+import httpx
+import pytest
+
+from assist.model_manager import (
+    _TCP_KEEPALIVE_SOCKET_OPTIONS,
+    _build_http_client,
+    _build_request_timeout,
+)
+
+
+def test_tcp_keepalive_socket_options_constant():
+    # Pin the exact (level, optname, value) tuples.  The detection-time
+    # math in the module docstring depends on these specific values:
+    #
+    #     30 (idle) + 2 * 10 (probes) = 50s before kernel surfaces a
+    #     dead peer as ECONNRESET.
+    #
+    # Changing any of these without re-doing the math is a regression.
+    assert _TCP_KEEPALIVE_SOCKET_OPTIONS == [
+        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+        (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 30),
+        (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10),
+        (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3),
+    ]
+
+
+def test_build_http_client_returns_httpx_client():
+    client = _build_http_client()
+    try:
+        assert isinstance(client, httpx.Client)
+    finally:
+        client.close()
+
+
+def test_build_http_client_propagates_socket_options_to_transport():
+    # httpx 0.28 stores the socket_options on the underlying
+    # httpcore ConnectionPool.  This is internal, so the assertion
+    # may need updating on httpx upgrade — but it's the cheapest
+    # check that the options aren't being dropped between
+    # HTTPTransport's kwarg and the pool that will set them on a
+    # real socket.  The behavioral test below catches an upgrade
+    # that silently breaks the wiring.
+    client = _build_http_client()
+    try:
+        transport = client._transport
+        assert isinstance(transport, httpx.HTTPTransport)
+        # Compare ignoring tuple-vs-list — httpcore may normalize.
+        observed = list(transport._pool._socket_options)
+        assert observed == _TCP_KEEPALIVE_SOCKET_OPTIONS
+    finally:
+        client.close()
+
+
+def test_build_http_client_applies_per_phase_timeout():
+    # The client's default Timeout should mirror _build_request_timeout's
+    # per-phase values, so per-call timeouts have a consistent fallback.
+    client = _build_http_client()
+    try:
+        expected = _build_request_timeout()
+        actual = client.timeout
+        assert actual.connect == expected.connect
+        assert actual.read == expected.read
+        assert actual.write == expected.write
+        assert actual.pool == expected.pool
+    finally:
+        client.close()
+
+
+def test_keepalive_options_actually_applied_to_kernel_socket(monkeypatch):
+    """The kernel-level proof: when the httpx client opens a connection,
+    the four keepalive ``setsockopt`` calls actually reach a socket.
+
+    Catches the case where httpx's internals change and silently drop
+    ``socket_options`` — the introspection test above wouldn't catch
+    that.  Records every ``setsockopt`` call against ``socket.socket``
+    during one HTTP GET, then asserts each keepalive tuple is present.
+    """
+    options_set: list[tuple[int, int, int]] = []
+    real_setsockopt = socket.socket.setsockopt
+
+    def recording_setsockopt(self, level, optname, value):
+        # Record the int form so comparison against the constant works
+        # even if value is passed as bytes (we use int values everywhere).
+        if isinstance(value, int):
+            options_set.append((level, optname, value))
+        return real_setsockopt(self, level, optname, value)
+
+    monkeypatch.setattr(socket.socket, "setsockopt", recording_setsockopt)
+
+    # Tiny TCP server: accept one connection, send a minimal HTTP/1.1
+    # response, close.  Bound to an ephemeral port on localhost.
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+
+    def serve_one() -> None:
+        try:
+            conn, _ = server.accept()
+            try:
+                conn.recv(4096)
+                conn.send(
+                    b"HTTP/1.1 200 OK\r\n"
+                    b"Content-Length: 0\r\n"
+                    b"Connection: close\r\n"
+                    b"\r\n"
+                )
+            finally:
+                conn.close()
+        except Exception:
+            pass
+
+    serve_thread = threading.Thread(target=serve_one, daemon=True)
+    serve_thread.start()
+
+    client = _build_http_client()
+    try:
+        client.get(f"http://127.0.0.1:{port}/")
+    finally:
+        client.close()
+        server.close()
+        serve_thread.join(timeout=2.0)
+
+    # Each keepalive option must have been applied to *some* socket
+    # during the connection — the client's outbound socket.  We don't
+    # care which socket object specifically; the kernel-level proof is
+    # that the call happened with the expected (level, optname, value).
+    for expected in _TCP_KEEPALIVE_SOCKET_OPTIONS:
+        assert expected in options_set, (
+            f"setsockopt{expected} was not applied to any socket during "
+            f"the httpx client's connection — options_set={options_set}"
+        )


### PR DESCRIPTION
## What this PR does

Hardens the ChatOpenAI httpx client (both sync and async) against dead-peer scenarios by enabling TCP keepalive on the underlying sockets. Defense-in-depth, not a fix for any specific observed incident.

| Option | Value | Effect |
|---|---|---|
| `SO_KEEPALIVE` | 1 | Enable keepalive |
| `TCP_KEEPIDLE` | 30 | Probe after 30s idle |
| `TCP_KEEPINTVL` | 10 | 10s between probes |
| `TCP_KEEPCNT` | 3 | Fail after 3 missed probes |

Detection time: `30 + 3*10 = 60s` → a peer whose kernel has stopped acknowledging surfaces as `ECONNRESET` after ~60s instead of waiting on Linux's default `tcp_keepalive_time` (2h).

## What this does NOT fix

After Copilot review caught the original framing, I re-examined my own diagnostic and confirmed the 2026-05-29 wedge **wasn't** a network wedge:
- llama.cpp logs showed the request had completed cleanly (`done request: POST /v1/chat/completions 127.0.0.1 200`)
- No ESTABLISHED connections to llama.cpp existed on the wedged PID at observation time
- All 38 Python threads were in `futex_wait` / `io_sq_wait` (lock waits), not on socket recv
- The CLOSE_WAIT socket I cited was a **stale pool connection** from a completed request

The actual wedge was somewhere else (langgraph executor / sqlite checkpoint write / sandbox interaction) — separate investigation pending.

Also: keepalive only probes ESTABLISHED connections. A socket in CLOSE_WAIT with unread bytes (the misdiagnosis class) isn't bounded by this change.

## Why ship it anyway

- The kernel-default 2h `tcp_keepalive_time` is too generous for a localhost dependency.
- Adjacent dead-peer scenarios — peer host kernel panic with no FIN/RST sent, NAT/firewall state expiry, some bridge/iptables drop — are bounded by this change.
- Both sync and async clients get coverage in lockstep. Without async (`http_async_client`), deepagents' subagent dispatch (`await subagent.ainvoke`) would still be exposed — code-review caught this as a BLOCKER.

## Other changes picked up while there

- `_HttpClient` subclass with `__del__` finalizer that closes on GC. Mirrors langchain_openai's own `_SyncHttpxClientWrapper` pattern — without it, each ChatOpenAI going out of scope leaks the connection pool (cumulative cost across eval sweeps).
- Per-phase `httpx.Timeout` from `_build_request_timeout` is set as the client default too (per-call `timeout` on ChatOpenAI still wins, but the fallback is consistent).

## What this PR explicitly does NOT change

- `ASSIST_LLM_READ_TIMEOUT_S` stays at 600s.
- `ThreadQueueMiddleware` cancel surface unchanged.
- No subprocess termination machinery.

## Tests

`tests/model_manager/test_http_client.py` (new). Four tests: constant correctness, sync client, async client, kernel-level proof via `setsockopt` recording during one localhost HTTP GET.

40/40 at N=10 stability. 512-test broader suite passes.

## Process

- Phase 1 design: `docs/2026-05-30-llm-client-tcp-keepalive.org` (reframed after Copilot caught the original misdiagnosis).
- Phase 2 code review (4 lenses): 1 BLOCKER (async coverage), 4 IMPORTANTs (finalizer, narrow except, test location, drop redundant test, doc-test reconciliation), all addressed pre-Copilot.
- Phase 3 Copilot review: round 1 surfaced (1) the math off-by-one and (2) the original framing's wrong claim about CLOSE_WAIT. Both addressed; reply posted thanking for the catch on (2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)