### PR TITLE
Bind Thread.stream_message generator to its construction Context (May-28 cause fix)

### DIFF
--- a/assist/thread.py
+++ b/assist/thread.py
@@ -1,3 +1,4 @@
+import contextvars
 import logging
 import os
 import shutil
@@ -44,6 +45,32 @@ def render_tool_call(call: dict) -> str:
         return f"Calling subagent {subagent} with {args}"
     else:
         return f"Calling {name} with {args}"
+
+
+class _ContextBoundIterator:
+    """Iterator that routes every step through a captured ``contextvars.Context``.
+
+    Used by :meth:`Thread.stream_message` to keep its generator's
+    ``__enter__`` / ``__exit__`` (and the THREAD_QUEUE contextvar token
+    they bind) on the same Context, even when ``__next__`` / ``close`` are
+    called from a different OS thread.  See the comment in
+    ``stream_message`` for the failure mode this closes.
+    """
+    __slots__ = ("_ctx", "_gen")
+
+    def __init__(self, ctx: contextvars.Context, gen: Iterator) -> None:
+        self._ctx = ctx
+        self._gen = gen
+
+    def __iter__(self) -> "_ContextBoundIterator":
+        return self
+
+    def __next__(self):
+        return self._ctx.run(self._gen.__next__)
+
+    def close(self) -> None:
+        self._ctx.run(self._gen.close)
+
 
 class Thread:
     """Reusable chat-like interface that mimics the CLI back-and-forth.
@@ -208,6 +235,18 @@ class Thread:
         # Continue the thread by sending only the latest human message; prior state is in the checkpointer.
         # Wrap the iterator in a generator so the queue is held for the
         # full streaming lifetime, not just the call to .stream().
+        #
+        # The iterator is bound to a captured contextvars.Context (see
+        # _ContextBoundIterator below).  Without that, a consumer that
+        # drives `next()` / `close()` from a different OS thread (e.g.
+        # the emacsos-server's `run_in_executor` → `next()` pump, or
+        # any FastAPI streaming response handler) exits THREAD_QUEUE's
+        # `with` block in a different Context than it entered — and
+        # `_active_handle.reset(token)` raises ValueError, leaking
+        # `_holder` until the watchdog (see assist/thread_queue.py)
+        # force-releases it.  The binding makes that bug structurally
+        # impossible: every step runs in the construction context.
+        ctx = contextvars.copy_context()
         def _gen():
             with THREAD_QUEUE.acquire(self.thread_id, on_state_change=self.on_queue_state):
                 yield from self.agent.stream(
@@ -230,7 +269,7 @@ class Thread:
                     # sub-agents via the config, so the whole tree is covered.
                     durability="sync",
                 )
-        return _gen()
+        return _ContextBoundIterator(ctx, _gen())
 
     def get_messages(self) -> list[dict]:
         """Return user/assistant messages from checkpointer state as role/content dicts."""

--- a/docs/2026-05-30-stream-message-context-binding.org
+++ b/docs/2026-05-30-stream-message-context-binding.org
@@ -1,0 +1,96 @@
+#+TITLE: Bind Thread.stream_message generator to its construction Context
+#+DATE: 2026-05-30
+State: In review (PR pending)
+
+The cause-side fix for the 2026-05-28 queue holder leak (the symptom
+of which is bounded by the watchdog in
+[[file:2026-05-29-queue-holder-leak-fix.org]]).
+
+* Problem
+=Thread.stream_message= returns a generator that holds =THREAD_QUEUE=
+via a ~with~ block.  The block captures a =_active_handle.set(handle)=
+token bound to whichever =contextvars.Context= was current at
+=__enter__=.  Python's contextvar contract: =reset(token)= must run
+in the SAME Context, else =ValueError=.
+
+In production a streaming consumer drives iteration from a different
+OS thread (the emacsos-server's =run_in_executor= → =next()= pump;
+FastAPI streaming response handlers; any caller using a worker pool
+for backpressure).  Each =next()= / =close()= lands in that thread's
+default Context — which differs from the Context active when the
+generator was constructed.  On exit, =_active_handle.reset(token)=
+sees the mismatch and raises =ValueError=.
+
+Pre-PR #111: the =ValueError= aborted the rest of =finally=, leaving
+=_holder= set.  17h leak on 2026-05-28.
+Post-PR #111: the watchdog catches the leak within =hold_timeout_s=
+(default 2h) — better but still wrong.  PR #111's design doc
+acknowledged this as the cause to fix here.
+
+* Solution
+Wrap the generator in a tiny iterator class that routes every step
+through a captured Context:
+
+#+BEGIN_SRC python
+class _ContextBoundIterator:
+    __slots__ = ("_ctx", "_gen")
+    def __init__(self, ctx, gen):
+        self._ctx = ctx
+        self._gen = gen
+    def __iter__(self):
+        return self
+    def __next__(self):
+        return self._ctx.run(self._gen.__next__)
+    def close(self):
+        self._ctx.run(self._gen.close)
+#+END_SRC
+
+=stream_message= captures =ctx = contextvars.copy_context()= before
+returning the wrapper.  Every =next()= and =close()= the consumer
+calls runs the underlying generator's step inside =ctx= — so
+=__enter__=, every yield, and =__exit__= all see the same Context.
+The token's Context matches.  Reset works.  No leak.
+
+** What this class deliberately does NOT have
+- *No =__del__=.*  Observed failure modes are explicit iteration
+  (=for chunk in iter=) and explicit =close()=; both covered.  A
+  GC-induced =close= on a different thread is theoretically possible
+  but has not been observed, and adding =__del__= would add a code
+  path that the next reader has to reason about.  If it bites, we
+  add it then.
+- *No =throw= / =send=.*  Neither is called by current consumers.
+- *No fallback for an empty =copy_context()= edge case.*  An empty
+  Context is fine for our purposes; the contextvar set on entry
+  works the same way.
+
+* Tests
+=tests/test_thread_queue_integration.py= — one new test:
+
+- =test_iterator_can_be_driven_from_different_os_thread= — constructs
+  the iterator in the main thread, iterates it from a worker thread,
+  asserts no exception + queue released cleanly.  Pre-fix this would
+  trigger the =ValueError= and leak the holder; post-fix it works.
+
+The existing four =TestThreadStreamMessageHoldsAndReleasesQueue=
+tests still pass (the wrapper is transparent on the same-thread
+happy path).
+
+* Risks
+- *R1 — =ctx.run= cost.*  One Python-level function call per
+  =next()= for the Context switch.  Negligible compared to LLM
+  inference latency.
+- *R2 — The wrapper hides nothing.*  =__next__= surfaces the same
+  exceptions =gen.__next__= would (=StopIteration=, agent errors,
+  etc.) because =ctx.run= re-raises.  Caller-visible behavior is
+  identical.
+
+* Eval cadence
+Unit tests only.  Single integration test pins the cross-thread
+contract.
+
+* Relationship to other PRs
+- PR #111 (=fix-queue-holder-leak=) — bounds the *symptom* of this
+  bug to =hold_timeout_s= via the watchdog.  This PR fixes the
+  *cause*.  Land order doesn't matter; the two are complementary.
+- PR #113 (=fix-message-checkpoint-deadlock=) — already merged-and-
+  deployed; unrelated bug class (langgraph deadlock).

--- a/tests/test_thread_queue_integration.py
+++ b/tests/test_thread_queue_integration.py
@@ -152,6 +152,12 @@ class TestThreadStreamMessageHoldsAndReleasesQueue(_ThreadQueueIntegrationBase):
             t.start()
             t.join(timeout=2.0)
 
+        # Worker must have finished — without this guard a hang inside
+        # `ctx.run` would let `join` return on timeout with empty errors,
+        # a partial `chunks`, and a released `current_handle()` (because
+        # the holder hasn't been touched yet), masking the very bug this
+        # test is supposed to catch.
+        self.assertFalse(t.is_alive(), "consumer thread did not finish")
         self.assertFalse(errors, f"cross-thread iteration raised: {errors}")
         self.assertEqual(chunks, ["a", "b", "c"])
         # Queue released cleanly — no ValueError on with-exit means no leak.

--- a/tests/test_thread_queue_integration.py
+++ b/tests/test_thread_queue_integration.py
@@ -125,3 +125,34 @@ class TestThreadStreamMessageHoldsAndReleasesQueue(_ThreadQueueIntegrationBase):
             gen.close()
         # Generator close runs the finally → exits the `with` → releases queue.
         self.assertIsNone(THREAD_QUEUE.current_handle())
+
+    def test_iterator_can_be_driven_from_different_os_thread(self):
+        # The streaming iterator binds to a captured contextvars.Context at
+        # construction time, so iterating from a different OS thread does NOT
+        # trigger a ValueError on THREAD_QUEUE's `_active_handle.reset(token)`.
+        # Without that binding, a consumer using `run_in_executor → next()`
+        # (or any cross-thread iteration) exits the with-block in a different
+        # Context than entered — and the queue holder leaks until the
+        # watchdog catches it.  The 2026-05-28 incident was this exact bug.
+        chat = self.tm.new()
+        chunks: list = []
+        errors: list = []
+
+        with patch.object(chat.agent, "stream", self._patch_stream(["a", "b", "c"])):
+            stream_iter = chat.stream_message("hello")
+
+            def consumer():
+                try:
+                    for chunk in stream_iter:
+                        chunks.append(chunk)
+                except Exception as e:
+                    errors.append(e)
+
+            t = threading.Thread(target=consumer)
+            t.start()
+            t.join(timeout=2.0)
+
+        self.assertFalse(errors, f"cross-thread iteration raised: {errors}")
+        self.assertEqual(chunks, ["a", "b", "c"])
+        # Queue released cleanly — no ValueError on with-exit means no leak.
+        self.assertIsNone(THREAD_QUEUE.current_handle())


### PR DESCRIPTION
## What this PR does

Closes the **cause** of the 2026-05-28 queue holder leak. PR #111 bounds the **symptom** via the watchdog (force-release after `hold_timeout_s`); this PR makes the failure mode structurally impossible.

## The bug

`Thread.stream_message` returned a bare generator that holds `THREAD_QUEUE` via a `with` block. The block's `_active_handle.set(handle)` captures a token bound to whichever `contextvars.Context` is current at `__enter__`. Python's contract: `reset(token)` must run in the **same** Context, else `ValueError`.

When a consumer drives `next()`/`close()` from a different OS thread (the emacsos-server's `run_in_executor → next()` pump; FastAPI streaming response handlers; any worker-pool consumer), each call lands in that thread's default Context. On exit, `reset(token)` sees the mismatch and raises — leaking `_holder`. The 2026-05-28 incident (17-hour wedge) was this exact bug.

## The fix

A tiny `_ContextBoundIterator` class in `assist/thread.py` that routes every `__next__`/`close` through a captured Context:

```python
class _ContextBoundIterator:
    __slots__ = ("_ctx", "_gen")
    def __init__(self, ctx, gen):
        self._ctx = ctx
        self._gen = gen
    def __iter__(self):
        return self
    def __next__(self):
        return self._ctx.run(self._gen.__next__)
    def close(self):
        self._ctx.run(self._gen.close)
```

`stream_message` captures `ctx = contextvars.copy_context()` before returning the wrapper. Every step the consumer triggers runs the underlying generator inside `ctx` — so `__enter__` and `__exit__` always see the same Context. No mismatch.

## Deliberately minimal

Per the user's saved guidance, no theoretical-only code:
- **No `__del__`** — GC-induced close on a different thread is theoretically possible but not observed.
- **No `throw` / `send`** — not used by current consumers.

If either becomes a real problem, we add then.

## Tests

`tests/test_thread_queue_integration.py` — one new test:
- `test_iterator_can_be_driven_from_different_os_thread` — pins the cross-thread contract: construct iterator in main thread, drive iteration from a worker thread, assert no exception + queue released.

The existing 4 stream_message tests still pass (the wrapper is transparent on the same-thread happy path). 522/522 broader suite.

## Relationship to other PRs

- **PR #111** (queue holder leak watchdog) — bounds the symptom of this bug. Land order doesn't matter; complementary.
- **PR #113** (durability="sync") — already merged-and-deployed; unrelated bug class.

## Design doc

`docs/2026-05-30-stream-message-context-binding.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)