### PR TITLE
Post-merge cleanup — integrated-review findings (BLOCKER: GC-cross-thread leak)

### DIFF
--- a/assist/thread.py
+++ b/assist/thread.py
@@ -55,6 +55,14 @@ class _ContextBoundIterator:
     they bind) on the same Context, even when ``__next__`` / ``close`` are
     called from a different OS thread.  See the comment in
     ``stream_message`` for the failure mode this closes.
+
+    ``__del__`` routes the GC-driven generator finalization through
+    ``ctx.run`` too: CPython's generator finalizer (``_PyGen_Finalize``)
+    runs on whichever thread the collector happens to be on, which
+    typically isn't the construction thread.  Without this, a consumer
+    that drops the iterator without calling ``close()`` (e.g. emacsos-
+    server client disconnect) re-introduces the contextvar-mismatch
+    leak that PR #114 closed for the explicit-iteration path.
     """
     __slots__ = ("_ctx", "_gen")
 
@@ -70,6 +78,15 @@ class _ContextBoundIterator:
 
     def close(self) -> None:
         self._ctx.run(self._gen.close)
+
+    def __del__(self) -> None:
+        # GC-driven finalization.  Errors are swallowed because Python
+        # routes them to sys.unraisablehook anyway; raising here just
+        # pollutes the unraisable channel without any caller to handle it.
+        try:
+            self._ctx.run(self._gen.close)
+        except Exception:
+            pass
 
 
 class Thread:

--- a/assist/thread_queue.py
+++ b/assist/thread_queue.py
@@ -187,21 +187,15 @@ class ThreadAffinityQueue:
         try:
             yield handle
         finally:
-            # NOTE: `_active_handle.reset(token)` raises ValueError when
-            # this with-block exits in a different contextvars.Context
-            # than it was entered (the case the docstring above warns
-            # about).  Today we let it propagate — the cause lives in
-            # the caller (a generator iterated across thread boundaries)
-            # and the fix belongs there, NOT in a try/except around the
-            # reset that would hide the bug.  The watchdog below bounds
-            # the resulting `_holder` leak to ``hold_timeout_s`` so the
-            # queue stays serving other threads while the underlying
-            # contract violation gets fixed in a follow-up.
+            # `_active_handle.reset(token)` requires same-Context exit
+            # (the docstring above defines the contract).  Callers that
+            # iterate across thread boundaries must bind via
+            # ``contextvars.Context.run`` — see `Thread.stream_message`'s
+            # `_ContextBoundIterator` for the in-tree pattern.  If the
+            # contract is violated, the watchdog bounds the resulting
+            # `_holder` leak to ``hold_timeout_s``.
             _active_handle.reset(token)
-            try:
-                watchdog.cancel()
-            except Exception:
-                pass
+            watchdog.cancel()
             self._release_if_holder(handle)
 
     def _release_if_holder(self, handle: _Handle) -> bool:
@@ -223,21 +217,15 @@ class ThreadAffinityQueue:
         """Watchdog callback: flag holder ``expired`` and force-release the slot.
 
         ``expired = True`` is read by :class:`ThreadQueueMiddleware`'s
-        cooperative cancel (via :func:`active_handle` — per-call-stack);
-        the force-release through :meth:`_release_if_holder` bounds the
-        leak window when ``acquire``'s ``finally`` is skipped (the
-        2026-05-28 incident).  Logs WARNING when the release actually
-        fired — should be cold in steady state, a hit means the
-        cooperative path didn't clean up in time.
+        cooperative cancel (via :func:`active_handle` — per-call-stack).
+        The force-release through :meth:`_release_if_holder` is
+        defense-in-depth: it bounds the leak window for any cleanup
+        failure that leaves ``_holder`` set, regardless of cause.
+        Logs WARNING when the release actually fired — should be cold
+        in steady state.
         """
         handle.expired = True
         if self._release_if_holder(handle):
-            # We can't tell from here why the slot was still held: the
-            # cooperative cancel may never have fired, may have fired but
-            # the holder is mid-unwind, or `finally` ran partially and left
-            # `_holder` set (the 2026-05-28 incident shape).  Log the fact
-            # we can observe — the slot needed force-release — and leave
-            # the why to the investigator.
             logger.warning(
                 "force-released wedged holder %s after %.1fs hold",
                 handle.thread_id,

--- a/docs/2026-05-29-queue-holder-leak-fix.org
+++ b/docs/2026-05-29-queue-holder-leak-fix.org
@@ -1,6 +1,6 @@
 #+TITLE: ThreadAffinityQueue holder-slot leak fix
 #+DATE: 2026-05-29
-State: In review (PR #111)
+State: Shipped (PR #111, commit =c233062=, merged to main 2026-05-30)
 
 Follow-up to =2026-05-06-thread-affinity-queue.org=.  That PR shipped the
 queue; this one fixes a leak that bit prod on 2026-05-28.
@@ -74,11 +74,12 @@ thread).  The fix lives in =assist/thread.py= — bind the generator
 to a captured =contextvars.copy_context()= — NOT in a defensive
 swallow inside the queue.
 
-Tracked as the next PR, separate from this one.  Until that PR lands,
-the contextvar-reset ValueError propagates out of =finally= and leaks
-=_holder= momentarily; the watchdog catches it within
-=hold_timeout_s=.  See the pinned-contract test
-=test_cross_context_exit_leaks_holder_until_watchdog_recovers=.
+Shipped as PR #114 (=bind-stream-message-context=, commit =030572e=,
+merged 2026-05-30).  See
+[[file:2026-05-30-stream-message-context-binding.org]].  The pinned-
+contract test =test_cross_context_exit_leaks_holder_until_watchdog_recovers=
+still covers the queue-level recovery semantics for any future caller
+that might violate the same-Context-exit contract.
 
 ** Rejected alternatives
 1. *Heartbeat-based holder.*  Requires a background poller; the Timer
@@ -95,10 +96,9 @@ the contextvar-reset ValueError propagates out of =finally= and leaks
    for legitimately long agent runs.  The bug isn't the cap; it's the
    watchdog not actually freeing the slot.
 
-** Out of scope
+** Out of scope (deferred to later PRs)
 - =Thread.stream_message= generator close-on-disconnect — the *cause*
-  of the contextvar-reset case.  This is the NEXT PR, separately
-  scoped; the watchdog bounds the leak in the meantime.
+  of the contextvar-reset case.  Shipped as PR #114; see [[file:2026-05-30-stream-message-context-binding.org]].
 - Metrics dashboard for force-release counts.
 - =_Handle= → =@dataclass= refactor (=__slots__= is load-bearing).
 
@@ -128,9 +128,10 @@ the contextvar-reset ValueError propagates out of =finally= and leaks
 Unit tests only — this is queue plumbing, not agent behavior.
 =tests/test_thread_queue.py=: 3 new tests + 1 modified.
 
-* Next PR (the cause fix)
-Bind =Thread.stream_message='s generator to a captured
+* Cause fix (shipped separately)
+PR #114 (=bind-stream-message-context=, commit =030572e=, merged
+2026-05-30) binds =Thread.stream_message='s generator to a captured
 =contextvars.copy_context()= so =__enter__= and =__exit__= always run
 in the same context.  Makes the contextvar-reset ValueError
-structurally impossible.  Lives in =assist/thread.py=; separate scope
-from this queue-plumbing fix.
+structurally impossible from the only known caller.  See
+[[file:2026-05-30-stream-message-context-binding.org]].

--- a/docs/2026-05-30-incidents-postmortem.org
+++ b/docs/2026-05-30-incidents-postmortem.org
@@ -1,0 +1,237 @@
+#+TITLE: Postmortem — 2026-05-28 and 2026-05-29 queue wedges
+#+DATE: 2026-05-30
+State: Closed
+
+Two production incidents in 26 hours, both surfacing as "thread stuck
+in =processing= forever."  Initially I conflated them; investigation
+showed they're different bugs in different layers.  This doc captures
+the timeline, the root causes, the fixes shipped, the mistakes I made
+along the way, and the lessons saved to memory.
+
+* TL;DR
+
+| Incident | Root cause | Fix (PR) | Status |
+|----------+-----------+----------+--------|
+| 2026-05-28 (17h leak) | =_active_handle.reset()= raises =ValueError= on cross-context exit; finally aborts; =_holder= leaks. | PR #114 (cause) + PR #111 (symptom bound) | Both deployed |
+| 2026-05-29 (5h26m wedge) | langgraph =BackgroundExecutor= chained-futures pool exhaustion under nested + concurrent tools.  Same bug class as 2026-05-25 streaming wedge; fix didn't reach the blocking entry point. | PR #113 (=durability="sync"= mirror) | Deployed |
+
+* Incident 1 — 2026-05-28 queue =_holder= leak (17h)
+
+** Timeline
+
+| Time      | Event                                                             |
+|-----------+-------------------------------------------------------------------|
+| ~14:48    | A holder thread's =finally= ran =_active_handle.reset(token)=, which raised =ValueError= (cross-context exit; the docstring already warned this could happen).  The raise aborted the rest of =finally= — watchdog cancel + =_holder= clear + =notify_all()= all skipped.  =_holder= stayed pointing at a dead handle. |
+| 18:48:44  | Thread =20260527085157-77ceb1f1= errored out with =QueueWaitTimeout: waited 14400.0s for queue= — the full =ASSIST_THREAD_QUEUE_WAIT_S= ceiling.  17h after the leak began. |
+| 2026-05-29 08:17 / 08:19 | Two new threads (=20260528073914-cbd6a4cb=, =df64e49f-...=) hit the still-held queue and went to =queued=.  They would have errored out around 12:17 / 12:19 the same way. |
+| 2026-05-29 ~08:30 | =make restart= recovered.  Lifespan handler marked the queued threads =error= with =pending_message= preserved. |
+
+** Root cause
+
+The queue's reentrancy mechanism uses a =contextvars.ContextVar=.  On
+=acquire= entry, =_active_handle.set(handle)= returns a =Token= bound
+to the current =contextvars.Context=.  On exit, =reset(token)= must
+run in the SAME Context — else =ValueError=.
+
+In =Thread.stream_message=, the returned generator is iterated by the
+consumer in whichever thread/Context the consumer drives =next()= /
+=close()= from.  Known consumers that drive iteration from a different
+OS thread:
+
+- the emacsos-server's =run_in_executor= → =next()= pump (each
+  executor worker has its own default Context)
+- FastAPI streaming response handlers
+- GC-driven generator close from a collector thread
+
+When the consumer's thread isn't the construction thread, =__enter__=
+ran in Context A and =__exit__= runs in Context B.  =reset(token)=
+raises.  Pre-fix, the raise was the FIRST line of =finally= — the
+rest of cleanup skipped — and =_holder= leaked.
+
+** Fixes
+
+*** Cause — PR #114 (=bind-stream-message-context=)
+=Thread.stream_message= now captures =ctx = contextvars.copy_context()=
+and wraps the inner generator in a tiny =_ContextBoundIterator= that
+routes every =__next__= / =close= through =ctx.run=.  =__enter__= and
+=__exit__= always see the same Context.  The =ValueError= becomes
+structurally impossible.  Design doc:
+[[file:2026-05-30-stream-message-context-binding.org]].
+
+*** Symptom bound — PR #111 (=fix-queue-holder-leak=)
+The watchdog's =_on_hold_timeout= callback now forcibly releases
+=_holder= (in addition to setting =handle.expired = True=) and logs a
+=WARNING= when force-release fires.  Bounds the leak to
+=hold_timeout_s= (2h) regardless of how cleanup failed.  Catches not
+just contextvar mismatches but any future cleanup path that leaves
+=_holder= set.  Design doc:
+[[file:2026-05-29-queue-holder-leak-fix.org]].
+
+PR #111 went through 4 Copilot rounds.  An earlier draft included a
+"Change A" — wrap =reset(token)= in =try/except ValueError= inside
+=finally= — that the user pushed back on:
+
+#+BEGIN_QUOTE
+Why would this happen?  Seems like fixing the cause of this is more
+important than placing these assurances *around* it.
+#+END_QUOTE
+
+That feedback was right.  Change A was dropped on 2026-05-30; the
+cause fix moved to its own PR (#114).  See
+[[feedback_no_theoretical_only_code]] in memory.
+
+* Incident 2 — 2026-05-29 langgraph deadlock (5h26m)
+
+** Timeline
+
+| Time      | Event                                                             |
+|-----------+-------------------------------------------------------------------|
+| 10:52:45  | Thread =20260528073914-cbd6a4cb= acquired the LLM queue; sandbox started. |
+| 10:53:36  | =[research-agent] Model Call #2 completed with 4 concurrent tool call(s).= |
+| 10:53:36 → 12:52:45 | Two hours of silence in the journal.  All 38 Python threads in the process were in =futex_wait= (lock waits), not socket I/O. |
+| 12:52:45  | PR #111's watchdog (which had been deployed earlier that morning) fired: =force-released wedged holder ... after 7200.0s hold=.  Queue slot freed for other threads.  But the holder thread itself stayed wedged. |
+| ~16:18    | User reported "stuck again."  I observed the thread still in =processing=. |
+| ~17:00    | =make restart= recovered. |
+
+** Root cause
+
+Same chained-futures pool exhaustion as the 2026-05-25 streaming
+wedge.  When langgraph's Pregel loop runs with =durability="async"=
+(the default), every superstep submits a checkpoint =put= to a per-loop
+=BackgroundExecutor= and chains them via futures
+(=_checkpointer_put_after_previous=).  Under deep nesting (general
+→ research subagent → 4 concurrent tool calls) the pool's workers all
+park on =prev.result()= waiting for the previous put's future, with
+no free worker left to complete any.  Self-deadlocked.
+
+The 2026-05-25 fix passed =durability="sync"= to =agent.stream()= in
+=Thread.stream_message=.  =Thread.message= → =invoke_with_rollback=
+→ =agent.invoke= was NOT covered.  =roadmap.org= line 51 explicitly
+claimed the blocking path "does NOT hit it."  That claim was wrong —
+the deadlock is =durability=-mode-dependent, not entry-point-dependent.
+
+** Fix — PR #113 (=fix-message-checkpoint-deadlock=)
+One-line change in =assist/checkpoint_rollback.py=:
+=agent.invoke(input, config, durability="sync")=.  Two more
+production-adjacent sites a scope audit found
+(=edd/capture.py:228=, =edd/eval/test_dev_agent_runs_eval.py:116=).
+=roadmap.org= line 51's wrong claim retracted.  Design doc:
+[[file:2026-05-30-message-path-durability-sync.org]].
+
+* What I got wrong
+
+** Misdiagnosed Incident 2 as a CLOSE_WAIT socket hang
+
+My initial investigation of the 2026-05-29 wedge found a single
+=CLOSE_WAIT= socket from the assist-web process to llama.cpp at
+=127.0.0.1:8000= with 1 byte buffered.  I attributed the wedge to
+"openai/httpx blocked on =recv()=" and proposed PR #112 — TCP
+keepalive on the httpx client.
+
+Copilot reviewer caught the framing problem.  Re-reading my own
+diagnostic confirmed Copilot was right:
+
+- llama.cpp logs at incident time: =done request: POST
+  /v1/chat/completions 127.0.0.1 200= — the call had COMPLETED cleanly.
+- No ESTABLISHED connections to llama.cpp existed on the wedged PID.
+- All 38 Python threads were in =futex_wait= — not socket I/O.
+- The =CLOSE_WAIT= socket was a stale pool connection from a
+  COMPLETED request, not the wedge cause.
+
+Plus a structural error in my proposed fix: TCP keepalive only probes
+ESTABLISHED connections — it does nothing for a CLOSE_WAIT socket
+where the FIN has already arrived.
+
+PR #112 was closed.  Lesson saved to memory:
+[[feedback_diagnose_wedge_thread_states_first]] — check =wchan= per
+thread (and ideally =py-spy=) BEFORE attributing a wedge to any open
+socket.  =ss -tnp= output for a stuck process is mostly noise.
+
+** Added defensive code "around" a symptom instead of fixing the cause
+
+PR #111 initially had two changes: the watchdog (Change B) AND a
+=try/except ValueError= wrapper around =_active_handle.reset(token)=
+(Change A).  Reviewer-justified at the time.  User pushed back: that
+hides the bug in =stream_message=.  Dropped Change A; moved the cause
+fix to PR #114.
+
+Lesson saved to memory:
+[[feedback_no_theoretical_only_code]] — fix root causes, don't paper
+over with try/except, helpers, or defensive branches.  Every line
+adds maintenance cost; theoretical robustness isn't free.
+
+** Used =git add -A= in assist
+
+Once, on the durability-fix PR (#113).  Picked up =.claude/=,
+=improvements/=, =edd/eval-history/=, =roadmap.org_archive= — all
+intentionally-untracked operator data.  Caught it before push; reset
+and re-staged specifically.
+
+Lesson saved to memory:
+[[feedback_no_git_add_dash_a_in_assist]] — always =git add
+<specific-files>=; the assist repo has multiple uncommitted
+top-level dirs that must stay out.
+
+** Created prod-state confusion with branch-deploys
+
+Deployed PR #113's branch at ~11:30 — =rsync --delete= overwrote
+PR #111's watchdog deployment from earlier that morning.  Didn't
+flag.  User asked the wrap-up "deploy PR #114 paired with the
+already-deployed PR #113" — I had to correct: prod had PR #113 but
+NOT PR #111 (my fault).  Built a =prod-restore-2026-05-30= branch
+combining all three and redeployed.
+
+No saved lesson on this one because the underlying mechanism is well
+known (=rsync --delete= replaces operator state).  Next time I deploy
+from a feature branch, I should explicitly check whether other
+unmerged-but-deployed branches are about to be lost.
+
+* What I got right
+
+- The investigation of Incident 2 (after the misdiagnosis correction)
+  found the langgraph deadlock fast — journal showed "Model Call #2
+  completed with 4 concurrent tool call(s)" right before 2h of
+  silence, which matched the 2026-05-25 wedge shape exactly.
+- PR #111's watchdog WAS valuable independent of the cause fix.  Its
+  =WARNING= log at 12:52:45 was the diagnostic anchor that let me
+  identify the wedge as different-class-from-leak (queue released
+  cleanly per the log; the wedge had to be in the holder thread's own
+  code).
+- The 4-lens code review on PR #111 caught real issues pre-Copilot
+  (BLOCKER on async coverage, IMPORTANTs on finalizer, naming, etc.).
+- Pushed back on Copilot re-flags on PR #111 round 4 (the
+  "State: In review" marker had been flagged in rounds 1, 3, 4 with
+  different framings each time).  CLAUDE.md predicted this pattern;
+  the cap saved cycles.
+
+* Memory artifacts saved this session
+
+- =feedback_diagnose_wedge_thread_states_first.md= — =wchan= per
+  thread first, not =ss=.
+- =feedback_no_theoretical_only_code.md= — fix causes, don't paper
+  over with defensive code.
+- =feedback_no_git_add_dash_a_in_assist.md= — stage specific files.
+
+* Open follow-ups (NOT done this session)
+
+- *Task #6 — refresh sandbox container TTL on activity.*  Real
+  roadmap item; would have prevented the 2026-05-27
+  =SandboxContainerLostError= that fed into Incident 1's
+  precondition.  Unblocked, not started.
+- *Investigate the langgraph BackgroundExecutor pattern itself.*  Two
+  bugs of the same class (2026-05-25 streaming + 2026-05-29 blocking)
+  in two months.  Worth a deeper conversation about whether the
+  =durability="sync"= workaround is the right long-term shape, or
+  whether the executor needs replacing.  Out of scope for the incident
+  response; on the roadmap as design work.
+
+* PRs
+
+| PR  | Branch                            | Status                                     |
+|-----+-----------------------------------+--------------------------------------------|
+| #111 | =fix-queue-holder-leak=          | Merged 2026-05-30 (commit =c233062=)       |
+| #112 | =llm-client-tcp-keepalive=       | Closed (misdiagnosed)                      |
+| #113 | =fix-message-checkpoint-deadlock= | Merged 2026-05-30 (commit =cc106b3=)      |
+| #114 | =bind-stream-message-context=    | Merged 2026-05-30 (commit =030572e=)       |
+| #?  | =post-merge-cleanup=              | This PR — integrated-review findings (BLOCKER: =_ContextBoundIterator.__del__=; dead-code drop; doc state markers; postmortem to main) |
+| n/a | =prod-restore-2026-05-30=         | Temp combined branch; deleted after individual PRs merged |

--- a/docs/2026-05-30-message-path-durability-sync.org
+++ b/docs/2026-05-30-message-path-durability-sync.org
@@ -1,6 +1,6 @@
 #+TITLE: Mirror durability="sync" into Thread.message (langgraph BackgroundExecutor wedge)
 #+DATE: 2026-05-30
-State: In review (PR pending)
+State: Shipped (PR #113, commit =cc106b3=, merged to main 2026-05-30)
 
 * Problem
 On 2026-05-29 thread =20260528073914-cbd6a4cb= sat in =processing= for

--- a/docs/2026-05-30-stream-message-context-binding.org
+++ b/docs/2026-05-30-stream-message-context-binding.org
@@ -1,6 +1,6 @@
 #+TITLE: Bind Thread.stream_message generator to its construction Context
 #+DATE: 2026-05-30
-State: In review (PR pending)
+State: Shipped (PR #114, commit =030572e=, merged to main 2026-05-30).  Follow-up: PR (this branch) adds =__del__= to close the GC-on-different-thread path.
 
 The cause-side fix for the 2026-05-28 queue holder leak (the symptom
 of which is bounded by the watchdog in

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -297,12 +297,14 @@ def test_cross_context_exit_leaks_holder_until_watchdog_recovers():
     # Pins the failure-mode-and-recovery for the 2026-05-28 prod incident:
     # the with-block is entered in one `contextvars.Context` and exited in
     # another, so `_active_handle.reset(token)` raises `ValueError` at the
-    # top of `finally`, aborting the rest of cleanup.  This PR's policy is
-    # NOT to swallow the ValueError (that hides the bug in the caller);
+    # top of `finally`, aborting the rest of cleanup.  The queue's policy
+    # is NOT to swallow the ValueError (that hides the bug in the caller);
     # instead, the watchdog bounds the resulting `_holder` leak to
-    # `hold_timeout_s`.  The cause itself (a generator iterated across
-    # thread boundaries — see `Thread.stream_message`) gets fixed in a
-    # follow-up.
+    # `hold_timeout_s`.  The known caller (`Thread.stream_message`) binds
+    # its generator to a captured Context via `_ContextBoundIterator`, so
+    # this path is no longer reachable from in-tree code; the test still
+    # pins the queue-level recovery contract for any future caller that
+    # might violate the same-Context-exit contract.
     q = ThreadAffinityQueue()
     cm = q.acquire("A", hold_timeout_s=0.1)
     ctx = contextvars.copy_context()

--- a/tests/test_thread_queue_integration.py
+++ b/tests/test_thread_queue_integration.py
@@ -162,3 +162,80 @@ class TestThreadStreamMessageHoldsAndReleasesQueue(_ThreadQueueIntegrationBase):
         self.assertEqual(chunks, ["a", "b", "c"])
         # Queue released cleanly — no ValueError on with-exit means no leak.
         self.assertIsNone(THREAD_QUEUE.current_handle())
+
+    def test_iterator_gc_on_different_thread_does_not_leak(self):
+        # Consumer abandons the iterator without calling `close()` — Python
+        # GC eventually finalizes it on the collector thread.  Without
+        # `_ContextBoundIterator.__del__`, the underlying generator's
+        # finalization runs `gen.close()` on the GC thread, the with-block's
+        # `_active_handle.reset(token)` raises ValueError, and `_holder`
+        # leaks until the watchdog catches it.  This test pins the __del__
+        # behavior: even GC-driven cleanup runs in the captured context.
+        import gc
+        chat = self.tm.new()
+        with patch.object(chat.agent, "stream", self._patch_stream(["a", "b", "c"])):
+            stream_iter = chat.stream_message("hello")
+            # Advance once so the queue is acquired; then drop the reference.
+            next(stream_iter)
+            self.assertIsNotNone(THREAD_QUEUE.current_handle())
+            del stream_iter
+            gc.collect()
+        # GC ran the iterator's __del__ → routed close through ctx.run →
+        # with-exit ran in the captured Context → reset succeeded → slot
+        # released.  If __del__ is missing or routes through the wrong
+        # context, this assertion fails.
+        self.assertIsNone(THREAD_QUEUE.current_handle())
+
+    def test_iterator_holds_queue_when_watchdog_fires_mid_stream(self):
+        # A stream_message iterator is mid-flight when the watchdog fires.
+        # PR #114 binds iteration to a captured context; PR #111's watchdog
+        # force-releases _holder when hold_timeout_s elapses.  The two
+        # interact: watchdog clears _holder mid-`with`; iteration eventually
+        # completes; holder's __exit__ runs in the captured ctx and calls
+        # `_release_if_holder(handle)` which finds `_holder is None` and
+        # no-ops via the identity guard.  Assert clean release.
+        import time
+        chat = self.tm.new()
+
+        # Override the model's hold_timeout via a generator that yields
+        # the first chunk fast, then stalls past hold_timeout_s, then
+        # yields the rest.
+        slow_event = threading.Event()
+
+        def slow_stream(*args, **kwargs):
+            yield "a"
+            slow_event.wait(timeout=2.0)
+            yield "b"
+            yield "c"
+
+        # Tight hold_timeout so the watchdog fires during the stall.
+        with patch.object(chat.agent, "stream", slow_stream):
+            with patch.object(
+                THREAD_QUEUE,
+                "_default_hold_timeout",
+                0.1,
+            ):
+                stream_iter = chat.stream_message("hello")
+                # First chunk acquires the queue.
+                first = next(stream_iter)
+                self.assertEqual(first, "a")
+                self.assertIsNotNone(THREAD_QUEUE.current_handle())
+
+                # Wait past hold_timeout_s — watchdog fires, _holder cleared.
+                time.sleep(0.25)
+                self.assertIsNone(
+                    THREAD_QUEUE.current_handle(),
+                    "watchdog did not force-release the stalled holder",
+                )
+
+                # Unstick the stream; iteration completes; holder's
+                # finally runs `_release_if_holder` which is a no-op
+                # because `_holder` is already None (identity guard).
+                slow_event.set()
+                rest = list(stream_iter)
+                self.assertEqual(rest, ["b", "c"])
+
+        # After full exhaustion, slot is still None — the holder's
+        # late finally did not clobber, and no waiter was promoted
+        # so nothing's there.
+        self.assertIsNone(THREAD_QUEUE.current_handle())


### PR DESCRIPTION
After PR #111, #113, #114 all landed together, a 4-lens integrated code review surfaced one BLOCKER + several smaller cleanups. All in one PR per direct ask.

## The BLOCKER

`_ContextBoundIterator` (added in PR #114) has no `__del__`. When a consumer drops the iterator without explicit `close()`, CPython's `_PyGen_Finalize` runs `gen.close()` on the GC thread — bypassing the `ctx.run` routing. The integrated reviewer reproduced it:

```
del iter; gc.collect()
→ Exception ignored while closing generator
→ ValueError: <Token …> was created in a different Context
→ force-released wedged holder A after 0.2s hold
```

**Real production scenario:** emacsos-server consumer drops the iterator (client disconnect) → GC eventually calls close on a different thread → ValueError on contextvar reset → `_holder` leaks until the watchdog catches it (default 2h).

When I wrote PR #114 I said "GC-induced close on a different thread is theoretically possible but has not been observed" and skipped `__del__`. **The reviewer observed it.** Fix: add `__del__` that routes the close through `self._ctx.run`. Errors swallowed because Python routes unraisable errors to `sys.unraisablehook` anyway.

New regression test: `test_iterator_gc_on_different_thread_does_not_leak`.

## Dead-code removal

`try: watchdog.cancel() except Exception: pass` in `acquire()`'s finally. `threading.Timer.cancel()` doesn't raise. Same anti-pattern as Change A (dropped on 2026-05-30 per the saved feedback rule: don't paper over with try/except unless there's an observed failure). Bare `watchdog.cancel()` is clearer.

## Two integration tests pinned

- `test_iterator_holds_queue_when_watchdog_fires_mid_stream` — exactly the May-28 incident shape on the streaming path; works by construction but no test pinned it.
- `test_iterator_gc_on_different_thread_does_not_leak` — pins the `__del__` fix above.

(Skipped a third potential test from the review — RollbackRunnable subagent durability propagation — works by construction and a test there would be theoretical-only-coverage per the saved rule.)

## NIT cleanups

- `_on_hold_timeout` docstring reframed as cause-agnostic defense-in-depth (was overanchoring on the May-28 contextvar incident, which is now fixed at cause by PR #114).
- `acquire` finally-block comment dropped the "fix in a follow-up" past-tense framing; restated the contract + pointer to `_ContextBoundIterator` as the in-tree binding pattern.
- Three design doc state markers bumped from "In review" to "Shipped (PR #N, commit X, merged YYYY-MM-DD)".
- `docs/2026-05-29-queue-holder-leak-fix.org` "Next PR" / "Out of scope" sections updated past-tense to reference the shipped PR #114.
- Test comment dropped "follow-up" framing.

## Postmortem doc moved to main

`docs/2026-05-30-incidents-postmortem.org` was on the temp `prod-restore-2026-05-30` branch (where it stayed together with the deployed combined state). Now brought onto main as the canonical record; PRs table updated to past-tense with merge commits, this PR's row added. Temp branch can be deleted after this lands.

## Verification

- 529 broader test suite passes
- 94 affected tests pass at N=5
- Manual repro of the BLOCKER (before/after the `__del__` fix) confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)