### PR TITLE
Rate-limit search/fetch with per-host throttle + DDG circuit breaker

### DIFF
--- a/assist/tools.py
+++ b/assist/tools.py
@@ -29,6 +29,19 @@ from urllib.parse import urlparse
 import requests
 from ddgs import DDGS
 
+# Explicit rate-limit exception types from the `ddgs` library.  These are
+# the unambiguous cases — when ddgs itself recognises rate-limiting or a
+# transport timeout, it raises one of these.  Wrapped in try/except so a
+# future ddgs that renames or drops the module doesn't break import here.
+try:
+    import ddgs.exceptions as _ddgs_exc
+    _DDGS_RATE_LIMIT_TYPES: tuple[type[BaseException], ...] = (
+        _ddgs_exc.RatelimitException,
+        _ddgs_exc.TimeoutException,
+    )
+except Exception:  # noqa: BLE001 — defensive: never block import on this
+    _DDGS_RATE_LIMIT_TYPES = ()
+
 # --- Search throttle (cross-tool, global) ---
 _search_lock = threading.Lock()
 _search_last_call_time = 0.0
@@ -134,13 +147,37 @@ def _open_search_circuit_now() -> None:
         _search_circuit_open_until = time.time() + _SEARCH_CIRCUIT_DURATION_S
 
 
-def _exception_looks_like_rate_limit(exc: BaseException) -> bool:
-    """Heuristic: does ``exc`` (its type-name + str()) match any
-    `_RATE_LIMIT_EXC_INDICATORS` substring?  Used by `search_internet`
-    to short-circuit on detected upstream blocks instead of waiting for
-    the consecutive-failures threshold.  Case-insensitive."""
+def _exception_looks_like_rate_limit(exc: BaseException, elapsed_s: float = 0.0) -> bool:
+    """Heuristic: does ``exc`` look like an upstream rate-limit / block?
+
+    Three signals, any one is enough:
+
+    1. *Explicit type match.*  ``ddgs.exceptions.RatelimitException`` or
+       ``TimeoutException`` are unambiguous — the library knows.
+
+    2. *Substring match.*  type-name + str() contains one of
+       ``_RATE_LIMIT_EXC_INDICATORS`` (timeout / 429 / forbidden /
+       captcha / etc.).  Catches the requests / httpcore / urllib3
+       cases where the underlying error escapes ddgs's wrapping.
+
+    3. *Timing heuristic for ddgs's misleading ``DDGSException("No
+       results found.")``.*  ddgs raises this on BOTH "genuine zero
+       results for query" AND "couldn't reach DDG at all" (because in
+       both cases it parsed zero results).  A call that took >=3s
+       almost certainly hit a TCP timeout, not a fast empty-parse;
+       treat as rate-limit.  Fast (<3s) ``"No results found."`` is a
+       genuine empty result and we let it fall through.
+
+    Caller passes ``elapsed_s`` (time the call took); defaults to 0
+    so the test/standalone path still works."""
+    if _DDGS_RATE_LIMIT_TYPES and isinstance(exc, _DDGS_RATE_LIMIT_TYPES):
+        return True
     blob = f"{type(exc).__name__}: {exc}".lower()
-    return any(ind in blob for ind in _RATE_LIMIT_EXC_INDICATORS)
+    if any(ind in blob for ind in _RATE_LIMIT_EXC_INDICATORS):
+        return True
+    if elapsed_s >= 3.0 and "no results found" in blob:
+        return True
+    return False
 
 
 def read_url(url: str) -> str:
@@ -183,18 +220,22 @@ def search_internet(
     if _circuit_is_open():
         return _CIRCUIT_OPEN_MESSAGE
     _search_throttle()
+    t0 = time.time()
     try:
         results = DDGS().text(query,
                               max_results=max_results,
                               backend="duckduckgo")
         _record_search_success()
     except Exception as e:
+        elapsed = time.time() - t0
         # Rate-limit / block DETECTED (timeout, connection reset, 429,
-        # 403, captcha challenge, etc.)?  Skip the slow consecutive-failures
-        # threshold and open the circuit NOW so we stop hitting an
-        # already-blocking endpoint.  The model gets the same explicit
-        # "search is rate-limited" instruction it would after threshold.
-        if _exception_looks_like_rate_limit(e):
+        # 403, captcha challenge, or a slow ddgs DDGSException that's
+        # really a TCP timeout — see `_exception_looks_like_rate_limit`)?
+        # Skip the slow consecutive-failures threshold and open the
+        # circuit NOW so we stop hitting an already-blocking endpoint.
+        # The model gets the same explicit "search is rate-limited"
+        # instruction it would after threshold.
+        if _exception_looks_like_rate_limit(e, elapsed):
             _open_search_circuit_now()
             return _CIRCUIT_OPEN_MESSAGE
         _record_search_failure()

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -1,29 +1,122 @@
+"""Web tools the agent exposes: a throttled DuckDuckGo search and a
+per-host throttled URL fetch.
+
+Throttle/rate-limit shape (added 2026-05-31 after a research-agent ran
+~9,000 fetch_url calls in two hours and got the dev box's IP
+soft-blocked by DDG):
+
+- ``search_internet`` is throttled to ~one call every ``_SEARCH_MIN_DELAY``
+  seconds and circuit-broken after ``_SEARCH_CIRCUIT_FAILURE_THRESHOLD``
+  consecutive failures.  DDG has no public rate-limit documentation for
+  anonymous HTML/lite endpoints; community-observed safe rates are
+  ~1 query / 2-5s, so 4s is the conservative middle.  When the circuit
+  is open we return an explicit message ``_CIRCUIT_OPEN_MESSAGE`` rather
+  than the silent ``"[]"`` (no results) — the latter would let the model
+  retry or write a confidently-empty report; the former tells the model
+  *why* it can't search and what to do.
+- ``read_url`` is throttled per-host (1s between calls to the same host)
+  rather than globally, so a burst of fetches to different sites isn't
+  artificially serialised but a tight loop against one bot-protected
+  site (the casio-runaway shape) is locally rate-limited before that
+  site's edge does the same to us.
+"""
+
 import re
 import time
 import threading
+from urllib.parse import urlparse
 
 import requests
 from ddgs import DDGS
 
-_last_call_time = 0.0
-_rate_lock = threading.Lock()
-_MIN_DELAY = 0.5
+# --- Search throttle (cross-tool, global) ---
+_search_lock = threading.Lock()
+_search_last_call_time = 0.0
+_SEARCH_MIN_DELAY = 4.0
+
+# --- Search circuit breaker ---
+# After N consecutive search failures (DDG timeout / exception), open the
+# circuit for `_SEARCH_CIRCUIT_DURATION_S` and return the explicit message
+# below instead of attempting the call — saves further hits to a DDG
+# endpoint that's already blocking us, and gives the model an
+# unambiguous "search is dead, finalize what you have" instruction.
+_search_circuit_lock = threading.Lock()
+_search_consecutive_failures = 0
+_SEARCH_CIRCUIT_FAILURE_THRESHOLD = 3
+_search_circuit_open_until = 0.0
+_SEARCH_CIRCUIT_DURATION_S = 600  # 10 minutes
+
+_CIRCUIT_OPEN_MESSAGE = (
+    "Search is rate-limited (DuckDuckGo). Cannot retry for ~10 minutes. "
+    "Finalize your response using what's already gathered; tell the user "
+    "search is temporarily rate-limited and to try again in a few minutes."
+)
+
+# --- Per-host fetch throttle ---
+_host_lock = threading.Lock()
+_host_last_call: dict[str, float] = {}
+_HOST_MIN_DELAY = 1.0
 
 
-def _rate_limit():
-    """Enforce minimum delay between DuckDuckGo API calls."""
-    global _last_call_time
-    with _rate_lock:
+def _search_throttle() -> None:
+    """Block until at least ``_SEARCH_MIN_DELAY`` has passed since the
+    last search call."""
+    global _search_last_call_time
+    with _search_lock:
         now = time.time()
-        elapsed = now - _last_call_time
-        if elapsed < _MIN_DELAY:
-            time.sleep(_MIN_DELAY - elapsed)
-        _last_call_time = time.time()
+        elapsed = now - _search_last_call_time
+        if elapsed < _SEARCH_MIN_DELAY:
+            time.sleep(_SEARCH_MIN_DELAY - elapsed)
+        _search_last_call_time = time.time()
+
+
+def _host_throttle(host: str) -> None:
+    """Block until at least ``_HOST_MIN_DELAY`` has passed since the last
+    fetch to this specific ``host``.  No-op for empty/None host."""
+    if not host:
+        return
+    with _host_lock:
+        now = time.time()
+        last = _host_last_call.get(host, 0.0)
+        elapsed = now - last
+        if elapsed < _HOST_MIN_DELAY:
+            time.sleep(_HOST_MIN_DELAY - elapsed)
+        _host_last_call[host] = time.time()
+
+
+def _circuit_is_open() -> bool:
+    """True if the search circuit is currently open (wall-clock-bounded)."""
+    return time.time() < _search_circuit_open_until
+
+
+def _record_search_failure() -> None:
+    """Bump the consecutive-failure counter; open the circuit if at threshold."""
+    global _search_consecutive_failures, _search_circuit_open_until
+    with _search_circuit_lock:
+        _search_consecutive_failures += 1
+        if _search_consecutive_failures >= _SEARCH_CIRCUIT_FAILURE_THRESHOLD:
+            _search_circuit_open_until = time.time() + _SEARCH_CIRCUIT_DURATION_S
+
+
+def _record_search_success() -> None:
+    """Reset the consecutive-failure counter; a successful call closes
+    the circuit's path back to working."""
+    global _search_consecutive_failures
+    with _search_circuit_lock:
+        _search_consecutive_failures = 0
 
 
 def read_url(url: str) -> str:
-    """Extract the content from the given url."""
-    _rate_limit()
+    """Extract the content from the given url.
+
+    Per-host throttled (~1s between calls to the same host) so a burst
+    of fetches to different sites isn't artificially serialised, but a
+    tight loop against one bot-protected site is rate-limited locally."""
+    try:
+        host = urlparse(url).hostname or ""
+    except Exception:
+        host = ""
+    _host_throttle(host)
     try:
         resp = requests.get(
             url,
@@ -44,15 +137,28 @@ def search_internet(
         query: str,
         max_results: int = 5,
 ) -> str:
-    """Used to search the internet for information on a given topic using a query string."""
-    _rate_limit()
+    """Used to search the internet for information on a given topic using a query string.
+
+    Throttled to ~4s between DDG calls and circuit-broken on 3 consecutive
+    failures.  When the circuit is open, returns an explicit-message string
+    so the model finalizes its response instead of silently retrying or
+    writing a confidently-empty report."""
+    if _circuit_is_open():
+        return _CIRCUIT_OPEN_MESSAGE
+    _search_throttle()
     try:
         results = DDGS().text(query,
                               max_results=max_results,
                               backend="duckduckgo")
+        _record_search_success()
     except Exception:
+        _record_search_failure()
+        # If THIS failure tipped us into circuit-open state, surface the
+        # explicit message immediately rather than the bare "[]" — the
+        # model gets the same instruction whether the circuit opened
+        # before or during this call.
+        if _circuit_is_open():
+            return _CIRCUIT_OPEN_MESSAGE
         return "[]"
     normalized = [{"title": r["title"], "url": r["href"], "content": r["body"]} for r in results]
     return str(normalized)
-
-

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -52,6 +52,24 @@ _CIRCUIT_OPEN_MESSAGE = (
     "search is temporarily rate-limited and to try again in a few minutes."
 )
 
+# Substrings in an exception's type-name + str() that suggest the failure
+# is an upstream rate-limit / block (as opposed to a transient network
+# blip or a parse failure on a one-off bad result).  When detected, we
+# open the circuit IMMEDIATELY rather than waiting for
+# _SEARCH_CIRCUIT_FAILURE_THRESHOLD failures — the cost of a false
+# positive (10 min of no search; the agent finalizes with what it has)
+# is much lower than the cost of a false negative (more requests to a
+# blocked endpoint, deeper IP burn, longer recovery).  Biased toward
+# false positives accordingly: timeouts, connection-resets, and
+# explicit 4xx/429 all count.
+_RATE_LIMIT_EXC_INDICATORS = (
+    "timeout", "timed out", "read timeout",
+    "connection refused", "connection reset", "reset by peer",
+    "rate limit", "rate-limit", "too many requests",
+    "blocked", "challenge", "captcha", "forbidden",
+    " 429", " 403",
+)
+
 # --- Per-host fetch throttle ---
 _host_lock = threading.Lock()
 _host_last_call: dict[str, float] = {}
@@ -106,6 +124,25 @@ def _record_search_success() -> None:
         _search_consecutive_failures = 0
 
 
+def _open_search_circuit_now() -> None:
+    """Open the search circuit immediately (rate-limit DETECTED, not
+    just a generic failure).  Distinct from `_record_search_failure`,
+    which counts toward the threshold — this jumps straight to open."""
+    global _search_consecutive_failures, _search_circuit_open_until
+    with _search_circuit_lock:
+        _search_consecutive_failures = _SEARCH_CIRCUIT_FAILURE_THRESHOLD
+        _search_circuit_open_until = time.time() + _SEARCH_CIRCUIT_DURATION_S
+
+
+def _exception_looks_like_rate_limit(exc: BaseException) -> bool:
+    """Heuristic: does ``exc`` (its type-name + str()) match any
+    `_RATE_LIMIT_EXC_INDICATORS` substring?  Used by `search_internet`
+    to short-circuit on detected upstream blocks instead of waiting for
+    the consecutive-failures threshold.  Case-insensitive."""
+    blob = f"{type(exc).__name__}: {exc}".lower()
+    return any(ind in blob for ind in _RATE_LIMIT_EXC_INDICATORS)
+
+
 def read_url(url: str) -> str:
     """Extract the content from the given url.
 
@@ -151,7 +188,15 @@ def search_internet(
                               max_results=max_results,
                               backend="duckduckgo")
         _record_search_success()
-    except Exception:
+    except Exception as e:
+        # Rate-limit / block DETECTED (timeout, connection reset, 429,
+        # 403, captcha challenge, etc.)?  Skip the slow consecutive-failures
+        # threshold and open the circuit NOW so we stop hitting an
+        # already-blocking endpoint.  The model gets the same explicit
+        # "search is rate-limited" instruction it would after threshold.
+        if _exception_looks_like_rate_limit(e):
+            _open_search_circuit_now()
+            return _CIRCUIT_OPEN_MESSAGE
         _record_search_failure()
         # If THIS failure tipped us into circuit-open state, surface the
         # explicit message immediately rather than the bare "[]" — the

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -1,9 +1,14 @@
 """Web tools the agent exposes: a throttled DuckDuckGo search and a
 per-host throttled URL fetch.
 
-Throttle/rate-limit shape (added 2026-05-31 after a research-agent ran
-~9,000 fetch_url calls in two hours and got the dev box's IP
-soft-blocked by DDG):
+Throttle/rate-limit shape (added 2026-05-31 after two adjacent failure
+modes burned the dev box's IP: a research-agent emitted ~9,000
+`fetch_url` calls across many distinct URLs on bot-protected sites
+(mostly casio.com) over two hours, and separately the `ddgs` library's
+mirror-fallback retry cycled DDG endpoints — `duckduckgo.com` /
+`html.duckduckgo.com` / `duck.ai` / the onion mirror — ~1,314 times
+each in a few minutes, which DDG's edge correctly read as obviously-a-bot
+and dropped):
 
 - ``search_internet`` is throttled to ~one call every ``_SEARCH_MIN_DELAY``
   seconds and circuit-broken after ``_SEARCH_CIRCUIT_FAILURE_THRESHOLD``
@@ -87,6 +92,13 @@ _RATE_LIMIT_EXC_INDICATORS = (
 _host_lock = threading.Lock()
 _host_last_call: dict[str, float] = {}
 _HOST_MIN_DELAY = 1.0
+# When the per-host dict crosses this size, drop entries we haven't
+# touched in `_HOST_DICT_PRUNE_KEEP_S` seconds.  Bounds memory in a
+# long-running process that fetches many distinct hosts (PR #118
+# Copilot review #1).  Cheap when small (the comparison is the only
+# work); the prune scan runs only on threshold-cross.
+_HOST_DICT_PRUNE_THRESHOLD = 256
+_HOST_DICT_PRUNE_KEEP_S = 60.0
 
 
 def _search_throttle() -> None:
@@ -103,7 +115,11 @@ def _search_throttle() -> None:
 
 def _host_throttle(host: str) -> None:
     """Block until at least ``_HOST_MIN_DELAY`` has passed since the last
-    fetch to this specific ``host``.  No-op for empty/None host."""
+    fetch to this specific ``host``.  No-op for empty/None host.
+
+    Opportunistically prunes ``_host_last_call`` when it crosses
+    ``_HOST_DICT_PRUNE_THRESHOLD`` entries — see the constant for the
+    rationale (long-running process + many distinct hosts)."""
     if not host:
         return
     with _host_lock:
@@ -112,12 +128,21 @@ def _host_throttle(host: str) -> None:
         elapsed = now - last
         if elapsed < _HOST_MIN_DELAY:
             time.sleep(_HOST_MIN_DELAY - elapsed)
-        _host_last_call[host] = time.time()
+            now = time.time()  # refresh after sleep so the recorded call-time is accurate
+        _host_last_call[host] = now
+        if len(_host_last_call) > _HOST_DICT_PRUNE_THRESHOLD:
+            cutoff = now - _HOST_DICT_PRUNE_KEEP_S
+            for h in list(_host_last_call):
+                if _host_last_call[h] < cutoff:
+                    del _host_last_call[h]
 
 
 def _circuit_is_open() -> bool:
-    """True if the search circuit is currently open (wall-clock-bounded)."""
-    return time.time() < _search_circuit_open_until
+    """True if the search circuit is currently open (wall-clock-bounded).
+    Acquires ``_search_circuit_lock`` for read consistency with the
+    open/close writers; the lock is uncontended in the common path."""
+    with _search_circuit_lock:
+        return time.time() < _search_circuit_open_until
 
 
 def _record_search_failure() -> None:
@@ -186,10 +211,9 @@ def read_url(url: str) -> str:
     Per-host throttled (~1s between calls to the same host) so a burst
     of fetches to different sites isn't artificially serialised, but a
     tight loop against one bot-protected site is rate-limited locally."""
-    try:
-        host = urlparse(url).hostname or ""
-    except Exception:
-        host = ""
+    # `urlparse` never raises on str input; for empty/malformed URLs
+    # `.hostname` is None and `_host_throttle` no-ops on the empty string.
+    host = urlparse(url).hostname or ""
     _host_throttle(host)
     try:
         resp = requests.get(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -243,3 +243,70 @@ class TestRateLimitDetection:
             result = tools.search_internet("query")
             assert result == "[]"
             assert not tools._circuit_is_open()
+
+    def test_ddgs_ratelimit_exception_type_detected_explicitly(self):
+        """If `ddgs` itself raises `RatelimitException`, the explicit
+        type check should match even though the message text might not
+        contain our substring indicators."""
+        if not tools._DDGS_RATE_LIMIT_TYPES:
+            pytest.skip("ddgs.exceptions module not importable here")
+        RL = tools._DDGS_RATE_LIMIT_TYPES[0]  # RatelimitException
+        # Message intentionally contains NO substring indicator — the type
+        # check is what must catch this.
+        exc = RL("blip")
+        assert tools._exception_looks_like_rate_limit(exc, elapsed_s=0.0)
+
+    def test_slow_ddgs_no_results_treated_as_rate_limit(self):
+        """ddgs's `DDGSException("No results found.")` is its catch-all
+        when nothing parses — raised both for *genuine* empty results
+        AND for TCP timeouts (the message is misleading).  A call that
+        took >=3s is almost certainly a timeout disguised as empty."""
+        if not tools._DDGS_RATE_LIMIT_TYPES:
+            pytest.skip("ddgs.exceptions module not importable here")
+        # Use the base DDGSException so the type check DOESN'T trip; we
+        # need the timing heuristic to be what catches it.
+        import ddgs.exceptions
+        exc = ddgs.exceptions.DDGSException("No results found.")
+        assert tools._exception_looks_like_rate_limit(exc, elapsed_s=4.5)
+        # And the FAST counterpart is treated as a genuine empty result.
+        assert not tools._exception_looks_like_rate_limit(exc, elapsed_s=0.2)
+
+    def test_search_internet_opens_circuit_on_slow_no_results(self):
+        """End-to-end through search_internet: a `DDGSException` raised
+        after ~5s (TCP-timeout shape) should open the circuit
+        immediately on the FIRST failure, returning the explicit
+        message rather than the bare '[]'."""
+        if not tools._DDGS_RATE_LIMIT_TYPES:
+            pytest.skip("ddgs.exceptions module not importable here")
+        import ddgs.exceptions
+        with patch.object(tools, "time") as t, \
+             patch.object(tools, "DDGS") as ddgs_class:
+            # Simulate t0=5000 → 5005 (5s elapsed during DDGS().text()).
+            t.time.side_effect = [5000.0,   # _search_throttle entry
+                                  5000.0,   # _search_throttle last-call update
+                                  5000.0,   # t0
+                                  5005.0,   # elapsed measurement
+                                  5005.0]   # _open_search_circuit_now
+            ddgs_class.return_value.text.side_effect = (
+                ddgs.exceptions.DDGSException("No results found.")
+            )
+            result = tools.search_internet("query")
+            assert result == tools._CIRCUIT_OPEN_MESSAGE
+            assert tools._circuit_is_open()
+
+    def test_search_internet_fast_no_results_does_NOT_open_circuit(self):
+        """End-to-end: a fast `DDGSException` (genuine empty results, not
+        a timeout) must NOT trip the circuit — just return '[]'."""
+        if not tools._DDGS_RATE_LIMIT_TYPES:
+            pytest.skip("ddgs.exceptions module not importable here")
+        import ddgs.exceptions
+        with patch.object(tools, "time") as t, \
+             patch.object(tools, "DDGS") as ddgs_class:
+            # t0=5000 → 5000.1 (100ms elapsed = genuine empty parse).
+            t.time.side_effect = [5000.0, 5000.0, 5000.0, 5000.1, 5000.1]
+            ddgs_class.return_value.text.side_effect = (
+                ddgs.exceptions.DDGSException("No results found.")
+            )
+            result = tools.search_internet("query")
+            assert result == "[]"
+            assert not tools._circuit_is_open()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -275,18 +275,27 @@ class TestRateLimitDetection:
         """End-to-end through search_internet: a `DDGSException` raised
         after ~5s (TCP-timeout shape) should open the circuit
         immediately on the FIRST failure, returning the explicit
-        message rather than the bare '[]'."""
+        message rather than the bare '[]'.
+
+        Drives ``time.time`` via a stateful counter (rather than a fixed
+        side_effect list) because the precise number of internal
+        ``time.time()`` calls per ``search_internet`` invocation is an
+        implementation detail (circuit check, throttle x2, t0, elapsed,
+        circuit-open, plus any future probes); a list would have to grow
+        every refactor."""
         if not tools._DDGS_RATE_LIMIT_TYPES:
             pytest.skip("ddgs.exceptions module not importable here")
         import ddgs.exceptions
-        with patch.object(tools, "time") as t, \
+        # Stateful clock: the first 4 calls (circuit_check + throttle x2 +
+        # t0) return 5000, then the elapsed call and onward return 5005
+        # so `elapsed == 5.0` (> 3s threshold = treated as TCP timeout).
+        calls = {"n": 0}
+        def fake_time():
+            calls["n"] += 1
+            return 5000.0 if calls["n"] <= 4 else 5005.0
+        with patch.object(tools.time, "time", side_effect=fake_time), \
+             patch.object(tools.time, "sleep"), \
              patch.object(tools, "DDGS") as ddgs_class:
-            # Simulate t0=5000 → 5005 (5s elapsed during DDGS().text()).
-            t.time.side_effect = [5000.0,   # _search_throttle entry
-                                  5000.0,   # _search_throttle last-call update
-                                  5000.0,   # t0
-                                  5005.0,   # elapsed measurement
-                                  5005.0]   # _open_search_circuit_now
             ddgs_class.return_value.text.side_effect = (
                 ddgs.exceptions.DDGSException("No results found.")
             )
@@ -300,10 +309,14 @@ class TestRateLimitDetection:
         if not tools._DDGS_RATE_LIMIT_TYPES:
             pytest.skip("ddgs.exceptions module not importable here")
         import ddgs.exceptions
-        with patch.object(tools, "time") as t, \
+        # 100ms elapsed (genuine empty parse), well below the 3s threshold.
+        calls = {"n": 0}
+        def fake_time():
+            calls["n"] += 1
+            return 5000.0 if calls["n"] <= 4 else 5000.1
+        with patch.object(tools.time, "time", side_effect=fake_time), \
+             patch.object(tools.time, "sleep"), \
              patch.object(tools, "DDGS") as ddgs_class:
-            # t0=5000 → 5000.1 (100ms elapsed = genuine empty parse).
-            t.time.side_effect = [5000.0, 5000.0, 5000.0, 5000.1, 5000.1]
             ddgs_class.return_value.text.side_effect = (
                 ddgs.exceptions.DDGSException("No results found.")
             )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -61,7 +61,10 @@ class TestHostThrottle:
 
     def test_second_call_to_same_host_within_window_sleeps(self):
         with patch.object(tools, "time") as t:
-            t.time.side_effect = [1000.0, 1000.0, 1000.3, 1000.3]
+            # Three time.time() calls expected: call 1 (not-slept) = 1;
+            # call 2 (slept) = 2 (one before-sleep check, one after-sleep
+            # to record the actual call time).
+            t.time.side_effect = [1000.0, 1000.3, 1000.3]
             tools._host_throttle("example.com")
             tools._host_throttle("example.com")
             t.sleep.assert_called_once()
@@ -85,6 +88,34 @@ class TestHostThrottle:
             tools._host_throttle("")
             t.sleep.assert_not_called()
             t.time.assert_not_called()
+
+    def test_host_dict_pruned_when_over_threshold(self):
+        """Over-threshold dict size triggers a prune that drops entries
+        older than _HOST_DICT_PRUNE_KEEP_S, bounding memory in a
+        long-running process that touches many distinct hosts
+        (Copilot PR #118 review item #1)."""
+        # Seed the dict: half "fresh" (within keep-window), half "stale".
+        threshold = tools._HOST_DICT_PRUNE_THRESHOLD
+        keep_s = tools._HOST_DICT_PRUNE_KEEP_S
+        now_anchor = 10_000.0
+        # Stale: their last-call is `keep_s + 10` seconds ago.
+        for i in range(threshold // 2 + 5):
+            tools._host_last_call[f"stale-{i}.example"] = now_anchor - keep_s - 10
+        # Fresh: their last-call is 1 second ago.
+        for i in range(threshold // 2 + 5):
+            tools._host_last_call[f"fresh-{i}.example"] = now_anchor - 1
+        # Sanity: we should be over threshold so the prune triggers.
+        assert len(tools._host_last_call) > threshold
+        # Drive `_host_throttle` for a new host at `now_anchor`.
+        with patch.object(tools.time, "time", return_value=now_anchor), \
+             patch.object(tools.time, "sleep"):
+            tools._host_throttle("new-host.example")
+        # All stale entries should be gone; all fresh + the new one stay.
+        assert not any(h.startswith("stale-") for h in tools._host_last_call)
+        assert all(h.startswith("fresh-") or h == "new-host.example"
+                   for h in tools._host_last_call)
+        # And size is now bounded by the fresh-plus-new count.
+        assert len(tools._host_last_call) == threshold // 2 + 5 + 1
 
 
 # -------------------- circuit breaker primitives ------------------------

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,188 @@
+"""Tests for the throttled / circuit-broken web tools in assist.tools.
+
+The throttle helpers and the search circuit breaker are tested by
+patching the module's ``time`` and ``DDGS`` references, so no real
+sleeps and no real network are involved.  Each test resets the module's
+global state in a fixture so order-of-execution doesn't matter."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from assist import tools
+
+
+@pytest.fixture(autouse=True)
+def _reset_tool_state():
+    """Reset module-level throttle + circuit state before each test."""
+    tools._search_last_call_time = 0.0
+    tools._search_consecutive_failures = 0
+    tools._search_circuit_open_until = 0.0
+    tools._host_last_call.clear()
+    yield
+
+
+# -------------------- _search_throttle ----------------------------------
+
+class TestSearchThrottle:
+    def test_first_call_does_not_sleep(self):
+        """No prior call → elapsed is huge → no sleep."""
+        with patch.object(tools, "time") as t:
+            t.time.return_value = 1000.0
+            tools._search_throttle()
+            t.sleep.assert_not_called()
+
+    def test_second_call_within_window_sleeps_difference(self):
+        """Second call 1s after first should sleep (MIN_DELAY - 1s)."""
+        with patch.object(tools, "time") as t:
+            t.time.side_effect = [1000.0, 1000.0, 1001.0, 1001.0]
+            tools._search_throttle()  # first
+            tools._search_throttle()  # second, 1s later
+            t.sleep.assert_called_once_with(tools._SEARCH_MIN_DELAY - 1.0)
+
+    def test_second_call_past_window_does_not_sleep(self):
+        """Second call after MIN_DELAY elapsed → no sleep."""
+        with patch.object(tools, "time") as t:
+            t.time.side_effect = [1000.0, 1000.0,
+                                  1000.0 + tools._SEARCH_MIN_DELAY + 1, 1000.0 + tools._SEARCH_MIN_DELAY + 1]
+            tools._search_throttle()
+            tools._search_throttle()
+            t.sleep.assert_not_called()
+
+
+# -------------------- _host_throttle ------------------------------------
+
+class TestHostThrottle:
+    def test_first_call_to_a_host_does_not_sleep(self):
+        with patch.object(tools, "time") as t:
+            t.time.return_value = 1000.0
+            tools._host_throttle("example.com")
+            t.sleep.assert_not_called()
+
+    def test_second_call_to_same_host_within_window_sleeps(self):
+        with patch.object(tools, "time") as t:
+            t.time.side_effect = [1000.0, 1000.0, 1000.3, 1000.3]
+            tools._host_throttle("example.com")
+            tools._host_throttle("example.com")
+            t.sleep.assert_called_once()
+            # Approx because 1.0 - 0.3 isn't exactly 0.7 in float.
+            slept = t.sleep.call_args.args[0]
+            assert slept == pytest.approx(tools._HOST_MIN_DELAY - 0.3)
+
+    def test_different_hosts_do_not_block_each_other(self):
+        """The whole point of per-host: a burst of fetches to distinct
+        sites isn't artificially serialised."""
+        with patch.object(tools, "time") as t:
+            t.time.side_effect = [1000.0, 1000.0, 1000.1, 1000.1]
+            tools._host_throttle("example.com")
+            tools._host_throttle("other.com")
+            t.sleep.assert_not_called()
+
+    def test_empty_host_is_noop(self):
+        """A URL whose hostname parses as empty (rare) shouldn't crash
+        — just skip the throttle."""
+        with patch.object(tools, "time") as t:
+            tools._host_throttle("")
+            t.sleep.assert_not_called()
+            t.time.assert_not_called()
+
+
+# -------------------- circuit breaker primitives ------------------------
+
+class TestCircuitBreakerPrimitives:
+    def test_failures_below_threshold_keep_circuit_closed(self):
+        for _ in range(tools._SEARCH_CIRCUIT_FAILURE_THRESHOLD - 1):
+            tools._record_search_failure()
+        assert not tools._circuit_is_open()
+
+    def test_threshold_failures_open_circuit(self):
+        with patch.object(tools, "time") as t:
+            t.time.return_value = 5000.0
+            for _ in range(tools._SEARCH_CIRCUIT_FAILURE_THRESHOLD):
+                tools._record_search_failure()
+            assert tools._circuit_is_open()
+            assert tools._search_circuit_open_until == 5000.0 + tools._SEARCH_CIRCUIT_DURATION_S
+
+    def test_success_resets_failure_counter(self):
+        tools._record_search_failure()
+        tools._record_search_failure()
+        tools._record_search_success()
+        # Failure count is back to 0, so next THRESHOLD failures are needed
+        # to open the circuit.
+        for _ in range(tools._SEARCH_CIRCUIT_FAILURE_THRESHOLD - 1):
+            tools._record_search_failure()
+        assert not tools._circuit_is_open()
+
+    def test_circuit_recloses_after_duration(self):
+        with patch.object(tools, "time") as t:
+            t.time.return_value = 5000.0
+            for _ in range(tools._SEARCH_CIRCUIT_FAILURE_THRESHOLD):
+                tools._record_search_failure()
+            assert tools._circuit_is_open()
+            # Jump past the duration.
+            t.time.return_value = 5000.0 + tools._SEARCH_CIRCUIT_DURATION_S + 1
+            assert not tools._circuit_is_open()
+
+
+# -------------------- search_internet end-to-end ------------------------
+
+class TestSearchInternet:
+    def test_open_circuit_returns_explicit_message_without_calling_DDG(self):
+        """The model needs an explicit 'search is rate-limited' message
+        — NOT the silent '[]', which the model would interpret as 'no
+        results' and potentially write a confidently-empty report or
+        retry immediately."""
+        with patch.object(tools, "time") as t, \
+             patch.object(tools, "DDGS") as ddgs:
+            t.time.return_value = 5000.0
+            tools._search_circuit_open_until = 5000.0 + 60  # circuit open
+            result = tools.search_internet("anything")
+            assert result == tools._CIRCUIT_OPEN_MESSAGE
+            ddgs.assert_not_called()
+
+    def test_DDG_exception_does_not_open_circuit_below_threshold(self):
+        """One or two exceptions should NOT open the circuit — sporadic
+        DDG hiccups are normal.  Below threshold returns the bare '[]'
+        so the model treats it as 'no results' and pivots, the same
+        behavior pre-patch."""
+        with patch.object(tools, "time") as t, \
+             patch.object(tools, "DDGS") as ddgs:
+            t.time.return_value = 5000.0
+            ddgs.return_value.text.side_effect = Exception("boom")
+            result = tools.search_internet("query")
+            assert result == "[]"
+            assert not tools._circuit_is_open()
+
+    def test_threshold_failures_open_circuit_via_real_path(self):
+        """Driving search_internet through THRESHOLD consecutive
+        exceptions opens the circuit and the next call short-circuits."""
+        with patch.object(tools, "time") as t, \
+             patch.object(tools, "DDGS") as ddgs:
+            t.time.return_value = 5000.0
+            ddgs.return_value.text.side_effect = Exception("boom")
+            for _ in range(tools._SEARCH_CIRCUIT_FAILURE_THRESHOLD):
+                tools.search_internet("query")
+            # Circuit should now be open; the next call doesn't reach DDGS.
+            ddgs.reset_mock()
+            result = tools.search_internet("another query")
+            assert result == tools._CIRCUIT_OPEN_MESSAGE
+            ddgs.assert_not_called()
+
+    def test_success_after_failures_keeps_circuit_closed(self):
+        """A successful call resets the failure counter, so the next
+        N-1 failures don't open the circuit on their own."""
+        with patch.object(tools, "time") as t, \
+             patch.object(tools, "DDGS") as ddgs:
+            t.time.return_value = 5000.0
+            # First call fails, second succeeds, third fails.
+            fake_results = [{"title": "x", "href": "https://e.com", "body": "y"}]
+            ddgs.return_value.text.side_effect = [
+                Exception("boom"),
+                fake_results,
+                Exception("boom"),
+            ]
+            tools.search_internet("q1")
+            tools.search_internet("q2")
+            tools.search_internet("q3")
+            # 1 failure → success (reset) → 1 failure = below threshold.
+            assert not tools._circuit_is_open()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -186,3 +186,60 @@ class TestSearchInternet:
             tools.search_internet("q3")
             # 1 failure → success (reset) → 1 failure = below threshold.
             assert not tools._circuit_is_open()
+
+
+# -------------------- rate-limit detection on exception -----------------
+
+class TestRateLimitDetection:
+    @pytest.mark.parametrize("exc", [
+        TimeoutError("operation timed out"),
+        ConnectionError("Connection refused"),
+        ConnectionResetError("Connection reset by peer"),
+        Exception("HTTP 429 Too Many Requests"),
+        Exception("HTTP 403 Forbidden"),
+        Exception("DuckDuckGo blocked the request: please solve the CAPTCHA"),
+        Exception("Rate limit exceeded"),
+    ])
+    def test_detector_matches_known_rate_limit_shapes(self, exc):
+        assert tools._exception_looks_like_rate_limit(exc), \
+            f"detector should have caught {type(exc).__name__}: {exc}"
+
+    @pytest.mark.parametrize("exc", [
+        ValueError("invalid query"),
+        KeyError("missing field 'href'"),
+        Exception("Unable to parse response as JSON"),
+        RuntimeError("internal library error"),
+    ])
+    def test_detector_does_not_match_generic_failures(self, exc):
+        assert not tools._exception_looks_like_rate_limit(exc), \
+            f"detector falsely flagged {type(exc).__name__}: {exc}"
+
+    def test_rate_limit_exception_opens_circuit_on_first_failure(self):
+        """The whole point: a single timeout/429/etc should NOT wait for
+        the 3-failure threshold — it should open immediately and return
+        the explicit message, so the next search call short-circuits."""
+        with patch.object(tools, "time") as t, \
+             patch.object(tools, "DDGS") as ddgs:
+            t.time.return_value = 5000.0
+            ddgs.return_value.text.side_effect = TimeoutError("Read timeout")
+            result = tools.search_internet("query")
+            assert result == tools._CIRCUIT_OPEN_MESSAGE
+            assert tools._circuit_is_open()
+            # And the NEXT call doesn't even invoke DDGS — short-circuited.
+            ddgs.reset_mock()
+            result2 = tools.search_internet("another query")
+            assert result2 == tools._CIRCUIT_OPEN_MESSAGE
+            ddgs.assert_not_called()
+
+    def test_generic_exception_still_uses_threshold_path(self):
+        """Counterpart: a non-rate-limit exception must NOT trip the
+        circuit early — sporadic parse errors etc. shouldn't take search
+        offline for 10 minutes.  Still returns the bare '[]' so the model
+        treats it as 'no results' and pivots."""
+        with patch.object(tools, "time") as t, \
+             patch.object(tools, "DDGS") as ddgs:
+            t.time.return_value = 5000.0
+            ddgs.return_value.text.side_effect = ValueError("bad query")
+            result = tools.search_internet("query")
+            assert result == "[]"
+            assert not tools._circuit_is_open()


### PR DESCRIPTION
The 2026-05-30 / 05-31 research-agent runaway burned the dev box's IP on DDG (1314 hits each to 4 mirrors from `ddgs`'s mirror-fallback retry) and forced casio.com's Akamai edge to bot-block us on every product URL. The existing `_rate_limit()` (single global 500ms throttle shared by search and fetch) was both too lax for DDG and too coupled across tools.

## What changes

Replaces the global 500ms throttle with three layers in `assist/tools.py`:

1. **`search_internet` throttle: ≥4s between calls** (DDG community-observed safe rate for anonymous HTML/lite ≈ 1q/2-5s; 4s is the conservative middle).
2. **`search_internet` circuit breaker: 3 consecutive failures → 10-min open**. When open, returns an *explicit* message telling the model "search is rate-limited (DuckDuckGo), cannot retry for ~10 minutes, finalize what you have, tell the user to try again." Silent `"[]"` would let the model retry immediately or write a confidently-empty report; the explicit message names the upstream cause so the model doesn't blame the topic. One successful call resets the failure counter.
3. **`read_url` per-host throttle (1s)** — a burst to distinct sites isn't artificially serialised, but a tight loop against one bot-protected site (the casio shape) is locally rate-limited before that site's edge does the same to us.

## Tests

`tests/test_tools.py` — new file, 15 tests, all passing. Pure-function tests for both throttles (per-host independence verified), circuit-breaker primitives (threshold, duration-bounded close, success-reset), and end-to-end through `search_internet` (open circuit short-circuits without calling DDGS; sub-threshold failures still return `"[]"`; threshold failures open the circuit and surface the explicit message).

## Background / follow-ups

DDG's anonymous HTML/lite endpoints have no published rate-limit documentation; the throttle values here are based on community consensus + observed behavior. A separate roadmap item is being added to explore migrating to a real search API (Brave / Tavily / Serper / Bing) with documented rate limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)