### PR TITLE
Heed the research-agent's "search unavailable" signal (prompt-only)

### DIFF
--- a/assist/templates/deepagents/general_instructions.md.j2
+++ b/assist/templates/deepagents/general_instructions.md.j2
@@ -69,6 +69,10 @@ Once the sub-agents return, pick the action pattern that fits.
 → Follow the exact heading/formatting conventions already in the file
 → Always write results into files — do not just respond verbally
 
+**A sub-agent reports it could NOT complete because an external dependency is unavailable** — e.g. the research-agent says search is rate-limited, "try again in a few minutes", or "couldn't search":
+→ STOP. Do NOT re-dispatch that sub-agent, and do NOT fall back to answering from your own knowledge. A confident answer from memory is worse than no answer here — the user asked you to look it up precisely because they don't want a guess.
+→ Tell the user plainly that you couldn't retrieve the information right now, relay the wait the sub-agent reported (e.g. "search is temporarily rate-limited — try again in a few minutes"), and end the turn. Offer to retry later if they'd like.
+
 ### Step 4: Clean Up
 - Mark your internal todos as complete
 - Respond to the user summarizing what you did
@@ -80,6 +84,7 @@ Once the sub-agents return, pick the action pattern that fits.
 - By DEFAULT, call the context-agent AND the research-agent in parallel for non-skill tasks. Only skip the research-agent when the request is purely about the user's own data or a trivial local action. If in doubt, call both.
 - Call each sub-agent ONCE per user request, then proceed to action. Do not call them in a loop.
 - NEVER answer questions from your own knowledge when the research-agent could answer them instead.
+- If a sub-agent reports an external dependency is unavailable (e.g. search is rate-limited), relay that to the user with the wait time and STOP. Do NOT re-dispatch it, and do NOT substitute your own knowledge — "I couldn't look this up right now, please try again in a few minutes" is the correct answer.
 - ALWAYS write results into files when creating plans, researching, or generating content
 - When adding entries to existing files, append new content — never remove or overwrite existing entries
 - Be concise and direct

--- a/assist/templates/deepagents/general_instructions.md.j2
+++ b/assist/templates/deepagents/general_instructions.md.j2
@@ -71,7 +71,7 @@ Once the sub-agents return, pick the action pattern that fits.
 
 **A sub-agent reports it could NOT complete because an external dependency is unavailable** — e.g. the research-agent says search is rate-limited, "try again in a few minutes", or "couldn't search":
 → STOP. Do NOT re-dispatch that sub-agent, and do NOT fall back to answering from your own knowledge. A confident answer from memory is worse than no answer here — the user asked you to look it up precisely because they don't want a guess.
-→ Tell the user plainly that you couldn't retrieve the information right now, relay the wait the sub-agent reported (e.g. "search is temporarily rate-limited — try again in a few minutes"), and end the turn. Offer to retry later if they'd like.
+→ Tell the user plainly that you couldn't retrieve the information right now, relay the wait the sub-agent reported (e.g. "search is temporarily rate-limited — try again in a few minutes"), and end the turn.
 
 ### Step 4: Clean Up
 - Mark your internal todos as complete
@@ -84,7 +84,7 @@ Once the sub-agents return, pick the action pattern that fits.
 - By DEFAULT, call the context-agent AND the research-agent in parallel for non-skill tasks. Only skip the research-agent when the request is purely about the user's own data or a trivial local action. If in doubt, call both.
 - Call each sub-agent ONCE per user request, then proceed to action. Do not call them in a loop.
 - NEVER answer questions from your own knowledge when the research-agent could answer them instead.
-- If a sub-agent reports an external dependency is unavailable (e.g. search is rate-limited), relay that to the user with the wait time and STOP. Do NOT re-dispatch it, and do NOT substitute your own knowledge — "I couldn't look this up right now, please try again in a few minutes" is the correct answer.
+- If a sub-agent reports an external dependency is unavailable, relay the wait to the user and STOP — do not re-dispatch it or answer from memory.
 - ALWAYS write results into files when creating plans, researching, or generating content
 - When adding entries to existing files, append new content — never remove or overwrite existing entries
 - Be concise and direct

--- a/assist/templates/deepagents/research_instructions.txt.j2
+++ b/assist/templates/deepagents/research_instructions.txt.j2
@@ -138,4 +138,4 @@ You have access to a few tools.
 
 Use this to run an internet search for a given query. You can specify the number of results, the topic, and whether raw content should be included.
 
-REMEMBER: Your last message MUST end with `FINAL_REPORT: <filename>` so the system can identify the final report file.
+REMEMBER: Your last message MUST end with `FINAL_REPORT: <filename>` so the system can identify the final report file — UNLESS search was unavailable/rate-limited, in which case you relay that status and omit the `FINAL_REPORT:` line (see above).

--- a/assist/templates/deepagents/research_instructions.txt.j2
+++ b/assist/templates/deepagents/research_instructions.txt.j2
@@ -15,6 +15,8 @@ Only proceed to dispatching the research-agent if no existing report covers the 
 
 Use the research-agent to conduct deep research. It will respond to your questions/topics with a detailed answer.
 
+If the research-agent (or a search/fetch tool) reports that search is unavailable or rate-limited (e.g. "rate-limited", "try again in a few minutes"), do NOT write a report from your own knowledge. Make your final message relay that status — including the wait time — and stop. In this case skip writing a report file and omit the `FINAL_REPORT:` line; relaying the rate-limit status verbatim is the correct outcome.
+
 When you think you have enough information to write a final report, write it to an appropriately-named file (e.g. `<topic>.org`) — or use the exact filename the caller requested. Only write the report to a single file. You will use this filename when requesting critiques and fact-checking.
 
 After you finish, your last message MUST end with a single line in this exact format so the system can identify the final report:

--- a/assist/templates/deepagents/research_instructions.txt.j2
+++ b/assist/templates/deepagents/research_instructions.txt.j2
@@ -25,6 +25,8 @@ After you finish, your last message MUST end with a single line in this exact fo
 
 where `<filename>` is the report's basename (no path prefix, no quotes).
 
+(The only exception is the search-unavailable case above: when you are relaying a rate-limit status instead of a report, there is no report file, so do not emit a `FINAL_REPORT:` line.)
+
 You may call the critique-agent zero or one time to get a critique of the final report.  If you do call it, address the most important critiques in a single edit and move on — do not re-critique.
 You may call the fact-check-agent zero or one time to verify your references support your claims.  If you do call it, address any mismatches in a single edit and move on — do not re-fact-check.
 

--- a/assist/templates/deepagents/sub_research.txt.j2
+++ b/assist/templates/deepagents/sub_research.txt.j2
@@ -4,4 +4,6 @@ Current date/time: {{ current_datetime() }}
 
 Conduct thorough research and then reply to the user with a detailed answer to their question.
 
+If a search or fetch tool reports it is unavailable or rate-limited (e.g. "rate-limited", "try again in a few minutes"), do NOT answer from your own knowledge. Make your final message relay that status — including the wait time — and stop. A guess from memory is worse than an honest "I couldn't look this up right now."
+
 Only your FINAL answer will be passed on to the user. They will have NO knowledge of anything except your final message, so your final report should be your final message!

--- a/docs/2026-05-31-heed-research-agent-rate-limit-signal.org
+++ b/docs/2026-05-31-heed-research-agent-rate-limit-signal.org
@@ -323,9 +323,16 @@ What landed, and the code-review findings folded in:
 - *Helper de-dup.*  Hoisted the =task=-dispatch counting into
   =AgentTestMixin.subagent_calls()=; deleted the duplicate
   =_task_subagents_called= and pointed its caller (+ =assertSubAgentCall=)
-  at the shared method.  Dropped the speculative =args.get("agent")/
-  ("name")= fallback keys — deepagents only emits =subagent_type=
-  (no-theoretical-code rule).
+  at the shared method.  Round 2 dropped the =args.get("agent")/("name")=
+  fallback keys on a code-reviewer's "no-theoretical-code" advice — but
+  *Copilot round 3 reversed this*, correctly: two existing eval files
+  (=test_dev_agent.py:167=, =test_dev_agent_planning_flow.py:157=) carry
+  the same fallback against an *observed* small-model shape (it sometimes
+  emits the target under =agent=/=name=, not =subagent_type=), and
+  =SubagentTypeInferenceMiddleware= repairs a missing =subagent_type= only
+  by inferring from =description= (defaulting to =general-purpose=), not
+  by reading =agent=/=name=.  So the fallback is grounded, not
+  speculative; restored it for a robust, repo-consistent shared helper.
 
 - *Eval numbers.*  Baseline (current agent, pre-fix): fails — observed
   both predicted failure modes (answer-from-training-data once; 3×

--- a/docs/2026-05-31-heed-research-agent-rate-limit-signal.org
+++ b/docs/2026-05-31-heed-research-agent-rate-limit-signal.org
@@ -1,0 +1,187 @@
+#+TITLE: General agent must heed the research-agent's rate-limit signal
+#+DATE: 2026-05-31
+State: Design.  Eval-first — write the eval, watch it fail on the
+current general agent, then iterate the prompt (and only the prompt,
+hopefully) until it passes.
+
+* Problem
+PR #118 added a search-circuit-breaker with an *explicit* return
+message (=_CIRCUIT_OPEN_MESSAGE= in =assist/tools.py:67=):
+
+#+BEGIN_QUOTE
+Search is rate-limited (DuckDuckGo).  Cannot retry for ~10 minutes.
+Finalize your response using what's already gathered; tell the user
+search is temporarily rate-limited and to try again in a few minutes.
+#+END_QUOTE
+
+Validation on a live request showed the search layer itself behaves
+correctly: 128 short-circuit returns served, zero retries against DDG
+after the circuit opened.  But the *general agent* (=create_agent= in
+=assist/agent.py:112=) does NOT propagate the signal to the user.  It
+re-dispatches =task("research-agent", ...)= — the research subagent
+runs again, hits the circuit, returns "I couldn't search" — and the
+parent dispatches a *third* time.  The thread wedges in a meta-loop
+that =LoopDetectionMiddleware= (Pattern D) doesn't catch because each
+sub-agent dispatch gets fresh middleware state, so the failure streak
+never accumulates at the parent layer.
+
+The root cause is in the prompt, not the middleware.  The general
+agent prompt (=assist/templates/deepagents/general_instructions.md.j2=)
+hammers "ALWAYS call research-agent", "NEVER answer from your own
+knowledge when research-agent could answer".  Nothing tells it what
+"the research-agent returned but says it couldn't search" means or how
+to respond.  In that ambiguity the model defaults to its prior
+("retry; you must research"), so it keeps spawning.
+
+A meta-loop detector at the parent layer was considered and rejected:
+it papers over the prompt gap, adds another bespoke pattern to
+=LoopDetectionMiddleware=, and trains the model to expect the system to
+catch it rather than learning to read its tools' output.  The cheaper,
+more general fix is to teach the agent to read.
+
+* Solution outline (eval-first; fix lands after the eval pins the
+  contract)
+
+** Phase A — Eval (this design doc)
+New test in =edd/eval/test_agent.py= (or a new file
+=test_agent_rate_limit_handoff.py= if =test_agent.py= is getting
+crowded — judgment call at implementation time).  Shape:
+
+1. Patch =assist.tools.search_internet= AND =assist.tools._circuit_is_open=
+   so every search returns =_CIRCUIT_OPEN_MESSAGE= and the circuit
+   reads as open.  Patch at the =assist.tools.= import site so both
+   the parent agent's tool list and the research subagent's tool list
+   pick up the mock (both import from =assist.tools=).
+2. Track =task= tool dispatches.  Two cheap ways:
+   - Spy on the underlying tool function — wrap =task= in a counter
+     in the parent agent's tool registry before the agent is built.
+   - Or count =AIMessage.tool_calls= for =name == "task"= after the
+     run by walking the returned message history.
+   Prefer the second — it's a black-box assertion on what the model
+   actually decided, no monkey-patching of the deepagents internals.
+3. Issue a clearly-research-shaped prompt that, on a healthy system,
+   would dispatch =research-agent= exactly once.  Candidate:
+   ="What's the latest LangGraph release and what changed?"=  (Pure
+   external lookup; no local-file ambiguity to muddy the dispatch
+   decision.)
+4. Assert:
+   - *=task= dispatches to research-agent ≤ 1.*  Zero is also fine
+     — a model that reads the message before dispatching is even
+     better.  Two or more is the failure.
+   - *Final response surfaces the rate-limit signal to the user.*
+     A regex over the final assistant message: =/(rate.?limit|try
+     again|temporarily|few minutes)/i= AND NOT a fabricated
+     research answer.  The "NOT a fabricated answer" check is the
+     hard half — the cheap proxy is asserting the response is
+     *short* (≤ ~600 chars) and contains the apology+wait shape;
+     the model is unlikely to both apologize for rate-limiting AND
+     fabricate a long langgraph release note in the same turn.
+   - *No infinite loop fallback.*  Bound the run with the
+     agent's existing recursion limit (=300=) and assert it didn't
+     hit the limit (=res= is non-empty and the harness returned
+     cleanly).  A hit means we're back in the runaway shape.
+5. *N=3 baseline before any fix*, expecting failures (that's the
+   point).  Captures the current general agent's behavior so we know
+   what we're moving off of.
+
+** Phase B — Fix (separate doc / separate branch)
+Pick up after the eval is green-red.  Hypothesis: a few lines added
+to =general_instructions.md.j2= are enough.  Sketch:
+
+#+BEGIN_QUOTE
+*When the research-agent returns a message saying it's rate-limited
+or cannot search* (look for "rate-limited", "try again", "cannot
+retry"), DO NOT call research-agent again this turn.  Apologize to
+the user, relay the wait time the research-agent gave you, and end
+the turn.  Do NOT fabricate research findings.
+#+END_QUOTE
+
+If the prompt alone doesn't move the eval, fall back to (in order of
+preference):
+
+1. *Tool-level signaling.*  Have the =research-agent= subagent
+   return a structured marker (e.g., prefix =[RATE_LIMITED]=) that
+   the prompt can pattern-match more reliably than free-text.
+   Cheap, no middleware code.
+2. *Parent-side post-processing.*  In the =CompiledSubAgent= wrapper
+   for =research_sub=, detect the circuit-open shape in the
+   sub-agent's output and inject a tool-result instruction the
+   parent will read.  More plumbing, no prompt dependency.
+3. *Parent =LoopDetectionMiddleware= rule.*  Treat repeated
+   =task("research-agent", ...)= calls whose results contain the
+   circuit-open shape as a Pattern-D-equivalent at the parent layer.
+   Last resort: this re-introduces the meta-loop detector this
+   design explicitly rejected, but if the prompt and structured-
+   signal approaches both fail, the safety net is justified.
+
+The eval pins the contract independent of which mechanism we
+end up using.
+
+* Tests
+- New eval (above).  N=3 baseline, then N=5 after the fix lands,
+  then N=10 stability per the project's eval cadence.
+- =tests/test_tools.py= — unchanged; the circuit-breaker primitives
+  already have their own coverage.  This work is one layer up.
+- Existing =edd/eval/test_agent.py= cases — must still pass.  The
+  fix prompt addition is *conditional* ("when the research-agent
+  returns a rate-limited message"), so the healthy-path dispatch
+  decisions should be unchanged.  Run a small re-validation on
+  =test_finds_and_updates_relevant_files_direct= and
+  =test_adds_item_correctly= at N=3 to confirm.
+
+* Risks
+- *R1 — Mocking pattern is new in =edd/eval/=.*  Existing evals hit
+  real LLM + real tools deliberately ("Eval-first contracts" in
+  CLAUDE.md).  This eval departs because the failure mode is
+  unobservable without forcing the circuit open.  Justification:
+  we're testing the model's *reaction to a specific tool output*,
+  not the tool itself; the tool is well-covered.  Document the
+  monkey-patch clearly at the test class level.
+- *R2 — Small-model brittleness on the regex assertion.*  Qwen3.6-27B
+  Q4 can spell "rate-limited" with or without the hyphen, in
+  different casings, sometimes as "rate limited" or "rate-limiting".
+  Regex is broad =(rate.?limit|try again|temporarily|few minutes)/i=
+  on purpose.  If it false-passes on some unrelated phrasing, tighten
+  to require BOTH "rate" AND ("try" OR "minute").
+- *R3 — Eval cost.*  One additional LLM-call-heavy eval per run.
+  The general agent's research-shaped prompts are 5-15 turns; at N=10
+  this is non-trivial.  Schedule it outside the 11p-3a nightly window
+  per =reference_nightly_eval_window.md=.
+- *R4 — The fix may need more than a prompt tweak.*  Phase B lists
+  fallbacks.  If the prompt alone doesn't move the eval after two
+  iterations, escalate to the structured-marker approach rather than
+  thrashing the prompt indefinitely.
+
+* What this design deliberately does NOT do
+- *Does NOT add a parent-layer meta-loop detector.*  Considered and
+  rejected: papers over a prompt gap, adds a bespoke pattern to
+  =LoopDetectionMiddleware=, doesn't teach the agent the general
+  skill of reading sub-agent output.  Phase B fallback (3) is the
+  only path back to this option.
+- *Does NOT change the =_CIRCUIT_OPEN_MESSAGE= wording.*  Live
+  validation showed it works at the search layer; the user-facing
+  language ("temporarily rate-limited", "try again in a few minutes")
+  is exactly what we want the general agent to echo, so the message
+  doubles as the answer template.
+- *Does NOT widen the eval to cover read_url rate-limiting.*
+  =read_url= has its own per-host throttle but no circuit-breaker
+  message; the symptom shape (URL fetch fails) is different and the
+  agent already handles per-fetch failures.  Out of scope.
+- *Does NOT add a structured marker yet.*  Phase B fallback (1).
+  Try the cheap prompt fix first; the marker is a fix-side decision
+  that doesn't change the eval contract.
+
+* Relationship to other work
+- PR #116 (=loop-detection-pattern-d=) — Pattern D catches HTTP-failure
+  streaks *within a single agent run*.  It does not (and should not)
+  catch this case, which spans multiple sub-agent dispatches.  The
+  Phase A eval validates the layer Pattern D was never meant to cover.
+- PR #118 (=search-rate-limit-throttle=) — produces the
+  =_CIRCUIT_OPEN_MESSAGE= this eval depends on.  Must be merged before
+  the eval can run.
+- =roadmap.org= item "Explore a real Search API to replace the
+  scraped DDG endpoints" — independent.  A real search API would
+  reduce the *frequency* of circuit-open, not change the contract:
+  the general agent still needs to handle "search is unavailable"
+  gracefully.  This eval pins that contract regardless of the
+  underlying transport.

--- a/docs/2026-05-31-heed-research-agent-rate-limit-signal.org
+++ b/docs/2026-05-31-heed-research-agent-rate-limit-signal.org
@@ -1,8 +1,11 @@
 #+TITLE: General agent must heed the research-agent's "search unavailable" signal
 #+DATE: 2026-05-31
-State: Design (design-review team round 1 incorporated).  Eval-first —
-write the eval, watch it fail on the current general agent, then move
-the agent's behavior until it passes.
+State: Implemented (design-review + code-review rounds incorporated).
+Eval-first — wrote the eval, confirmed it fails on the current general
+agent, then moved the agent's behavior until it passes.  Per the user's
+direction to do evals + code + review in one pass, Phase A (eval) and
+the Phase B prompt-only probe landed together on this branch rather
+than as separate branches.
 
 * Problem
 PR #118 added a search-circuit-breaker with an *explicit* return
@@ -250,9 +253,9 @@ The eval pins the contract independent of which mechanism wins.
   catch this cross-dispatch case.  The Phase A eval validates the layer
   Pattern D was never meant to cover.
 - PR #118 (=search-rate-limit-throttle=) — produces
-  =_CIRCUIT_OPEN_MESSAGE= this eval depends on.  Must be merged to =main=
-  before the eval can run (this branch is off =main=; #118 is not yet
-  merged, so =_CIRCUIT_OPEN_MESSAGE= is not present here yet).
+  =_CIRCUIT_OPEN_MESSAGE= this eval depends on.  *Merged to =main= on
+  2026-06-01* (rebase merge); this branch was cut from =main= and then
+  rebased onto it, so the constant is present and the eval imports it.
 - =roadmap.org= item "Explore a real Search API to replace the scraped
   DDG endpoints" — independent.  A real search API reduces the
   *frequency* of unavailability, not the contract: the general agent
@@ -281,3 +284,51 @@ not an internal token.  The same lens wanted the marker as the
 (cheapest, and the user framed this as "teach the agent to listen"),
 with the eval — not a priori reasoning — deciding whether the sentinel
 is needed.
+
+* Implementation + code-review changes (round 2)
+What landed, and the code-review findings folded in:
+
+- *The fix is prompt-only, three prompts.*  The parent
+  (=general_instructions.md.j2=) gets a Step-3 action pattern + one Rule
+  line.  Code review (bugs lens) flagged that the rate-limit signal must
+  survive *two* research-agent summarization hops before it reaches the
+  parent — the inner research-agent (=sub_research.txt.j2=) and the outer
+  research orchestrator (=research_instructions.txt.j2=), both of which
+  are instructed to "write a polished report".  A parent-only fix is
+  fragile because either hop can launder the signal into a
+  knowledge-based report.  So the same prompt-only change also adds a
+  conditional relay line to *both* research prompts: "if a search/fetch
+  tool reports unavailable/rate-limited, do NOT answer from your own
+  knowledge — relay that status (incl. wait time) and stop."  The outer
+  prompt additionally says to skip the report file and omit the
+  =FINAL_REPORT:= line in that case (=research_cleanup.py='s missing-line
+  path leaves files untouched and passes the relay text through — safe).
+
+- *Eval =read_url= patch.*  The eval patches =read_url= too (returns a
+  rate-limit-flavoured error) so a model that ignores the blocked search
+  and hallucinates a URL can't hit the live network and re-burn the IP.
+  This widens the doc's "single monkey-patch" wording from round 1 — kept
+  deliberately, documented in the test; the eval still *asserts* nothing
+  about =read_url=.
+
+- *Second eval prompt.*  Code review (eval-alignment lens) flagged that
+  the fix prompt now contains "rate-limited"/"try again", and the eval
+  greps for those — a lexical-proximity risk.  Mitigations: the
+  dispatch-==1 assertion is pure behavior (un-parrotable), and the
+  baseline fails (fabricates / dispatches >1).  Added a second,
+  differently-shaped prompt (a non-technical news lookup) asserting the
+  same contract, so a pass shows the agent heeds the *signal*, not one
+  LangGraph-shaped prompt.
+
+- *Helper de-dup.*  Hoisted the =task=-dispatch counting into
+  =AgentTestMixin.subagent_calls()=; deleted the duplicate
+  =_task_subagents_called= and pointed its caller (+ =assertSubAgentCall=)
+  at the shared method.  Dropped the speculative =args.get("agent")/
+  ("name")= fallback keys — deepagents only emits =subagent_type=
+  (no-theoretical-code rule).
+
+- *Eval numbers.*  Baseline (current agent, pre-fix): fails — observed
+  both predicted failure modes (answer-from-training-data once; 3×
+  research-agent re-dispatch once).  Post-fix tech prompt: 4/4 pass
+  (1 standalone + N=3).  Post-review N=5 (both prompts) + N=10 stability:
+  see the PR description.

--- a/docs/2026-05-31-heed-research-agent-rate-limit-signal.org
+++ b/docs/2026-05-31-heed-research-agent-rate-limit-signal.org
@@ -1,8 +1,8 @@
-#+TITLE: General agent must heed the research-agent's rate-limit signal
+#+TITLE: General agent must heed the research-agent's "search unavailable" signal
 #+DATE: 2026-05-31
-State: Design.  Eval-first — write the eval, watch it fail on the
-current general agent, then iterate the prompt (and only the prompt,
-hopefully) until it passes.
+State: Design (design-review team round 1 incorporated).  Eval-first —
+write the eval, watch it fail on the current general agent, then move
+the agent's behavior until it passes.
 
 * Problem
 PR #118 added a search-circuit-breaker with an *explicit* return
@@ -14,30 +14,45 @@ Finalize your response using what's already gathered; tell the user
 search is temporarily rate-limited and to try again in a few minutes.
 #+END_QUOTE
 
-Validation on a live request showed the search layer itself behaves
-correctly: 128 short-circuit returns served, zero retries against DDG
-after the circuit opened.  But the *general agent* (=create_agent= in
-=assist/agent.py:112=) does NOT propagate the signal to the user.  It
-re-dispatches =task("research-agent", ...)= — the research subagent
-runs again, hits the circuit, returns "I couldn't search" — and the
-parent dispatches a *third* time.  The thread wedges in a meta-loop
-that =LoopDetectionMiddleware= (Pattern D) doesn't catch because each
-sub-agent dispatch gets fresh middleware state, so the failure streak
-never accumulates at the parent layer.
+Live validation confirmed the *search layer* behaves correctly: 128
+short-circuit returns served, zero retries against DDG after the
+circuit opened.  What was *also* observed on that run was an orphaned
+thread wedged with =status.json= stuck at "processing" — and the
+diagnosed mechanism is that the *general agent* (=create_agent= in
+=assist/agent.py:112=) does not relay the signal to the user.  It
+re-dispatches =task("research-agent", ...)=; the research subagent
+runs, hits the open circuit, returns the message; the parent reads it
+as "research failed, and I must research", and dispatches again.
+
+=LoopDetectionMiddleware= (Pattern D) does not catch this, and
+correctly so: the middleware is stateless and scoped to a *single
+agent graph's* message tail (=loop_detection.py:608=,
+=_current_turn_slice=).  Each =task("research-agent", …)= dispatch runs
+the research subagent's *own* compiled graph with its *own* middleware
+over its *own* message list.  In the parent's stream each dispatch
+collapses to one =AIMessage(tool_calls=[task])= + one =ToolMessage=,
+and since each dispatch carries a different prompt arg, neither the
+http-failure streak (Pattern D) nor the args-repeat run (Pattern B)
+accumulates at the parent layer.  This is a gap *between* agent runs,
+which the within-run loop detector was never meant to cover.
 
 The root cause is in the prompt, not the middleware.  The general
 agent prompt (=assist/templates/deepagents/general_instructions.md.j2=)
-hammers "ALWAYS call research-agent", "NEVER answer from your own
-knowledge when research-agent could answer".  Nothing tells it what
-"the research-agent returned but says it couldn't search" means or how
-to respond.  In that ambiguity the model defaults to its prior
-("retry; you must research"), so it keeps spawning.
+hammers "ALWAYS call research-agent" and "NEVER answer from your own
+knowledge when research-agent could answer" (lines 22, 63, 78, 82).
+Nothing tells it what "the research-agent returned but says it couldn't
+search" means or how to respond.  In that ambiguity the small model
+defaults to its heavily-repeated prior ("retry; you must research"),
+so it keeps spawning.
 
-A meta-loop detector at the parent layer was considered and rejected:
-it papers over the prompt gap, adds another bespoke pattern to
-=LoopDetectionMiddleware=, and trains the model to expect the system to
-catch it rather than learning to read its tools' output.  The cheaper,
-more general fix is to teach the agent to read.
+A meta-loop detector at the parent layer was considered and rejected
+(this is also the user's explicit instruction: "I don't think we need
+a meta-loop detector … we just need the top-level agent to listen to
+the research agent and heed its results").  It would paper over the
+prompt gap, add another bespoke pattern to =LoopDetectionMiddleware=,
+and train the model to expect the system to catch it rather than
+learning to read its tools' output.  The cheaper, more general fix is
+to teach the agent to read.
 
 * Solution outline (eval-first; fix lands after the eval pins the
   contract)
@@ -47,141 +62,222 @@ New test in =edd/eval/test_agent.py= (or a new file
 =test_agent_rate_limit_handoff.py= if =test_agent.py= is getting
 crowded — judgment call at implementation time).  Shape:
 
-1. Patch =assist.tools.search_internet= AND =assist.tools._circuit_is_open=
-   so every search returns =_CIRCUIT_OPEN_MESSAGE= and the circuit
-   reads as open.  Patch at the =assist.tools.= import site so both
-   the parent agent's tool list and the research subagent's tool list
-   pick up the mock (both import from =assist.tools=).
-2. Track =task= tool dispatches.  Two cheap ways:
-   - Spy on the underlying tool function — wrap =task= in a counter
-     in the parent agent's tool registry before the agent is built.
-   - Or count =AIMessage.tool_calls= for =name == "task"= after the
-     run by walking the returned message history.
-   Prefer the second — it's a black-box assertion on what the model
-   actually decided, no monkey-patching of the deepagents internals.
-3. Issue a clearly-research-shaped prompt that, on a healthy system,
-   would dispatch =research-agent= exactly once.  Candidate:
-   ="What's the latest LangGraph release and what changed?"=  (Pure
-   external lookup; no local-file ambiguity to muddy the dispatch
-   decision.)
-4. Assert:
-   - *=task= dispatches to research-agent ≤ 1.*  Zero is also fine
-     — a model that reads the message before dispatching is even
-     better.  Two or more is the failure.
-   - *Final response surfaces the rate-limit signal to the user.*
-     A regex over the final assistant message: =/(rate.?limit|try
-     again|temporarily|few minutes)/i= AND NOT a fabricated
-     research answer.  The "NOT a fabricated answer" check is the
-     hard half — the cheap proxy is asserting the response is
-     *short* (≤ ~600 chars) and contains the apology+wait shape;
-     the model is unlikely to both apologize for rate-limiting AND
-     fabricate a long langgraph release note in the same turn.
-   - *No infinite loop fallback.*  Bound the run with the
-     agent's existing recursion limit (=300=) and assert it didn't
-     hit the limit (=res= is non-empty and the harness returned
-     cleanly).  A hit means we're back in the runaway shape.
+1. *Force the "search unavailable" condition.*  Patch
+   =assist.agent.search_internet= (NOT =assist.tools.search_internet=)
+   to a stub that returns =_CIRCUIT_OPEN_MESSAGE= on every call.  The
+   patch target matters: =assist/agent.py:17= does
+   =from assist.tools import search_internet=, which binds the name
+   into the =assist.agent= namespace at import time — patching
+   =assist.tools.search_internet= would NOT rebind the reference the
+   research subagent's tool list already captured.  Mocking
+   =search_internet= wholesale also makes a separate =_circuit_is_open=
+   patch unnecessary (the circuit check lives *inside* the real
+   =search_internet=; the stub bypasses it).  This is the only
+   monkey-patch the eval needs — keep the surface minimal and document
+   it at the test-class level (see R1).
+2. *Count research-agent dispatches via the existing helper.*  Reuse
+   =_task_subagents_called= (=edd/eval/test_agent.py:283=), which walks
+   the returned message history for =task= tool calls and extracts the
+   subagent name from =args.subagent_type / .agent / .name=.  Assert on
+   the count of dispatches whose subagent is =research-agent=
+   specifically — the general agent dispatches =context-agent= in
+   parallel by default (=general_instructions.md.j2:80=), so a bare
+   =task=-call count would conflate the two.  This is a black-box
+   assertion on what the model actually decided; no patching of
+   deepagents internals.
+3. *Issue a clearly-research-shaped prompt* that, on a healthy system,
+   dispatches =research-agent= exactly once.  Candidate: ="What's the
+   latest LangGraph release and what changed?"=  (Pure external lookup;
+   no local-file ambiguity to muddy the dispatch decision.)
+4. *Assert:*
+   - *research-agent dispatched exactly once.*  Not =≤ 1=: zero
+     dispatches would mean the parent answered a research question from
+     its own knowledge, which the prompt forbids elsewhere — a
+     *different* failure we don't want to reward as a pass.  The
+     contract is: dispatch once, read the signal, stop.  Two or more is
+     the runaway failure; zero is the answer-from-knowledge failure.
+   - *Final response relays "search unavailable, wait" to the user.*
+     Regex over the final assistant message requiring BOTH a
+     rate-limit token AND a wait-time token:
+     =/rate.?limit|temporarily|unavailable/i= AND
+     =/try again|few minutes|10 ?min|later/i=.  The user specifically
+     asked that the agent "ask that the user wait ~10m", so the
+     wait-time half is required, not optional.
+   - *Did not hit the recursion ceiling.*  Belt-and-suspenders: assert
+     the harness returned cleanly (=res= non-empty, no recursion-limit
+     hit at =300=).  The dispatch-==1 assertion already makes a runaway
+     impossible to pass; this is a cheap sanity guard, not the primary
+     contract.
+   - *No char-count proxy.*  An earlier draft asserted the response is
+     "short (≤600 chars)" as a proxy for "didn't fabricate".  Cut: with
+     search mocked to always return the unavailable message and
+     dispatch pinned at exactly 1, the agent has no research data to
+     fabricate from without re-dispatching — already caught by the
+     dispatch assertion.  The proxy added a flaky knob coupled to model
+     verbosity for no new coverage.
+   The eval asserts *behavior* (dispatch count) and *user-facing
+   meaning* (the relay), deliberately NOT any internal signal token.
+   This keeps it mechanism-agnostic: it must run *before* the Phase B
+   fix exists, and whatever mechanism Phase B picks (prompt-only,
+   structured marker, …) the marker should be *stripped* from
+   user-facing text anyway, so asserting on it would be wrong.
 5. *N=3 baseline before any fix*, expecting failures (that's the
    point).  Captures the current general agent's behavior so we know
    what we're moving off of.
 
 ** Phase B — Fix (separate doc / separate branch)
-Pick up after the eval is green-red.  Hypothesis: a few lines added
-to =general_instructions.md.j2= are enough.  Sketch:
+Pick up after the eval is green-red.  The eval is the arbiter of which
+mechanism is needed; start with the cheapest and let the result decide.
+
+*First probe — prompt only.*  Add a conditional to
+=general_instructions.md.j2=.  The salience challenge is real: the same
+file asserts the opposite prior eight times, so one buried sentence may
+lose to "NEVER answer from your own knowledge."  Sketch:
 
 #+BEGIN_QUOTE
-*When the research-agent returns a message saying it's rate-limited
-or cannot search* (look for "rate-limited", "try again", "cannot
-retry"), DO NOT call research-agent again this turn.  Apologize to
-the user, relay the wait time the research-agent gave you, and end
-the turn.  Do NOT fabricate research findings.
+*When a sub-agent reports it could not complete the work because a
+dependency is unavailable* (e.g. the research-agent says search is
+rate-limited / "try again later"), DO NOT re-dispatch that sub-agent
+this turn.  Relay the situation and the wait time to the user, then end
+the turn.  Do NOT fabricate findings.
 #+END_QUOTE
 
-If the prompt alone doesn't move the eval, fall back to (in order of
-preference):
+*Recommended mechanism if the prompt-only probe is unstable — a
+structured sentinel.*  R2 predicts the small model will paraphrase the
+free-text message unreliably, making a prose match fragile.  The clean
+fix is a structured sentinel emitted by the research-agent, and the
+repo *already has this exact pattern at this exact boundary*: the
+research-agent ends its final message with =FINAL_REPORT: <filename>=,
+matched by =_FINAL_REPORT_LINE = re.compile(r"^FINAL_REPORT:\s*(\S+)…")=
+in =assist/research_cleanup.py:54= and instructed in
+=research_instructions.txt.j2:20-24,137=.  A sibling sentinel (e.g.
+=SEARCH_UNAVAILABLE=) defined next to =_CIRCUIT_OPEN_MESSAGE= in
+=assist/tools.py=, instructed in the research-agent prompts the same way
+=FINAL_REPORT:= is, and keyed off by the general-agent prompt, is
+*consistency with an existing contract*, not new machinery.  This is
+still "teach the agent to heed" — it just gives the agent a stable
+signal to heed instead of fragile prose.  Frame the sentinel and the
+parent rule *generically* ("a sub-agent reports a dependency is
+unavailable"), not specifically around rate-limiting: =read_url=
+throttling and a future real-search-API outage are the same shape, and
+generic framing costs nothing extra now (the eval still exercises only
+the search-rate-limit instance).
 
-1. *Tool-level signaling.*  Have the =research-agent= subagent
-   return a structured marker (e.g., prefix =[RATE_LIMITED]=) that
-   the prompt can pattern-match more reliably than free-text.
-   Cheap, no middleware code.
-2. *Parent-side post-processing.*  In the =CompiledSubAgent= wrapper
-   for =research_sub=, detect the circuit-open shape in the
-   sub-agent's output and inject a tool-result instruction the
-   parent will read.  More plumbing, no prompt dependency.
+*Mechanisms deliberately deferred / gated, in order:*
+1. *Framework-idiomatic structured output (=response_format=).*  In
+   deepagents a subagent that sets =response_format= has its
+   =structured_response= JSON-serialized into the =ToolMessage= the
+   parent reads (=subagents.py:495-502=) — the blessed channel for
+   "make a subagent's status legible to the parent".  Deferred, not
+   ignored: =research_sub= is a =CompiledSubAgent= wrapping
+   =ReferencesCleanupRunnable= → =RollbackRunnable= → deep-agent
+   (=agent.py:253-266,537=), not a vanilla =create_deep_agent= with a
+   =response_format=, so adopting it means threading a format through
+   three wrapper layers.  The string sentinel above gets the same
+   legibility for far less plumbing; revisit =response_format= only if
+   the sentinel proves insufficient.
+2. *Shape the subagent's terminal message in the wrapper.*  The
+   =ReferencesCleanupRunnable= wrapper (already the seam that interprets
+   =FINAL_REPORT:=) can ensure the research subagent's *final AIMessage*
+   carries the sentinel when search was unavailable.  Note: the wrapper
+   returns a *state dict* and the framework derives the =ToolMessage=
+   from the last non-empty AIMessage (=subagents.py:509-520=) — so the
+   wrapper can shape the *terminal message*, it cannot "inject a
+   tool-result" after the fact.  This nearly collapses into mechanism
+   (the sentinel) above; it's the enforcement point if the prompt can't
+   be trusted to make the subagent emit the sentinel.
 3. *Parent =LoopDetectionMiddleware= rule.*  Treat repeated
-   =task("research-agent", ...)= calls whose results contain the
-   circuit-open shape as a Pattern-D-equivalent at the parent layer.
-   Last resort: this re-introduces the meta-loop detector this
-   design explicitly rejected, but if the prompt and structured-
-   signal approaches both fail, the safety net is justified.
+   =task("research-agent", …)= calls whose results contain the
+   unavailable shape as a parent-layer pattern.  *Last resort, and NOT
+   to be implemented without checking back with the user* — it reverses
+   the user's explicit "we don't need a meta-loop detector" decision.
+   Listed only so the escape hatch and its cost are on record; an
+   implementer must not reach it autonomously.
 
-The eval pins the contract independent of which mechanism we
-end up using.
+The eval pins the contract independent of which mechanism wins.
 
 * Tests
-- New eval (above).  N=3 baseline, then N=5 after the fix lands,
-  then N=10 stability per the project's eval cadence.
-- =tests/test_tools.py= — unchanged; the circuit-breaker primitives
-  already have their own coverage.  This work is one layer up.
-- Existing =edd/eval/test_agent.py= cases — must still pass.  The
-  fix prompt addition is *conditional* ("when the research-agent
-  returns a rate-limited message"), so the healthy-path dispatch
-  decisions should be unchanged.  Run a small re-validation on
+- New eval (above).  N=3 baseline, then N=5 after the fix lands, then
+  N=10 stability per the project's eval cadence.  Schedule outside the
+  11p-3a nightly window (=reference_nightly_eval_window.md=).
+- =tests/test_tools.py= — unchanged; the circuit-breaker primitives have
+  their own coverage.  This work is one layer up.
+- Existing =edd/eval/test_agent.py= cases — must still pass.  The fix is
+  *conditional* (only fires when a sub-agent reports unavailable), so
+  healthy-path dispatch decisions should be unchanged.  Re-validate
   =test_finds_and_updates_relevant_files_direct= and
-  =test_adds_item_correctly= at N=3 to confirm.
+  =test_adds_item_correctly= at N=3 to confirm no regression.
 
 * Risks
-- *R1 — Mocking pattern is new in =edd/eval/=.*  Existing evals hit
-  real LLM + real tools deliberately ("Eval-first contracts" in
-  CLAUDE.md).  This eval departs because the failure mode is
-  unobservable without forcing the circuit open.  Justification:
-  we're testing the model's *reaction to a specific tool output*,
-  not the tool itself; the tool is well-covered.  Document the
-  monkey-patch clearly at the test class level.
-- *R2 — Small-model brittleness on the regex assertion.*  Qwen3.6-27B
-  Q4 can spell "rate-limited" with or without the hyphen, in
-  different casings, sometimes as "rate limited" or "rate-limiting".
-  Regex is broad =(rate.?limit|try again|temporarily|few minutes)/i=
-  on purpose.  If it false-passes on some unrelated phrasing, tighten
-  to require BOTH "rate" AND ("try" OR "minute").
-- *R3 — Eval cost.*  One additional LLM-call-heavy eval per run.
-  The general agent's research-shaped prompts are 5-15 turns; at N=10
-  this is non-trivial.  Schedule it outside the 11p-3a nightly window
-  per =reference_nightly_eval_window.md=.
-- *R4 — The fix may need more than a prompt tweak.*  Phase B lists
-  fallbacks.  If the prompt alone doesn't move the eval after two
-  iterations, escalate to the structured-marker approach rather than
-  thrashing the prompt indefinitely.
+- *R1 — Mocking is new in =edd/eval/=.*  Existing evals hit real LLM +
+  real tools deliberately ("Eval-first contracts" in CLAUDE.md).  This
+  eval departs because the failure mode is unobservable without forcing
+  search-unavailable.  Justification: we test the model's *reaction to a
+  specific tool output*, not the tool (which =test_tools.py= covers).
+  Document the single monkey-patch at the test-class level.
+- *R2 — Small-model brittleness on the relay regex.*  Qwen3.6-27B Q4
+  spells "rate-limited" / "rate limited" / "rate-limiting" inconsistently
+  and may relay the wait time loosely.  The assertion requires a
+  rate-limit/unavailable token AND a wait-time token to pin the part the
+  user cared about, while staying broad on spelling.  If it false-passes
+  on unrelated phrasing, tighten the wait-time branch.  This same
+  brittleness is the argument for the structured sentinel in Phase B.
+- *R3 — Eval cost.*  One LLM-heavy eval (5-15 turns) per run; at N=10
+  non-trivial.  Run outside the nightly window.
+- *R4 — The fix may need more than a prompt tweak.*  If the prompt-only
+  probe doesn't move the eval after *two* iterations, escalate to the
+  structured sentinel rather than thrashing the prompt — do not iterate
+  the prompt indefinitely.
 
 * What this design deliberately does NOT do
-- *Does NOT add a parent-layer meta-loop detector.*  Considered and
-  rejected: papers over a prompt gap, adds a bespoke pattern to
-  =LoopDetectionMiddleware=, doesn't teach the agent the general
-  skill of reading sub-agent output.  Phase B fallback (3) is the
-  only path back to this option.
-- *Does NOT change the =_CIRCUIT_OPEN_MESSAGE= wording.*  Live
-  validation showed it works at the search layer; the user-facing
-  language ("temporarily rate-limited", "try again in a few minutes")
-  is exactly what we want the general agent to echo, so the message
-  doubles as the answer template.
-- *Does NOT widen the eval to cover read_url rate-limiting.*
-  =read_url= has its own per-host throttle but no circuit-breaker
-  message; the symptom shape (URL fetch fails) is different and the
-  agent already handles per-fetch failures.  Out of scope.
-- *Does NOT add a structured marker yet.*  Phase B fallback (1).
-  Try the cheap prompt fix first; the marker is a fix-side decision
-  that doesn't change the eval contract.
+- *Does NOT add a parent-layer meta-loop detector* (Phase B mechanism 3
+  is the only path back, and it is user-sign-off-gated).  Honors the
+  user's explicit instruction.
+- *Does NOT change =_CIRCUIT_OPEN_MESSAGE= wording.*  Live validation
+  showed it works at the search layer; its user-facing language is the
+  template we want the general agent to relay.
+- *Does NOT widen the eval to cover =read_url= rate-limiting.*  Same
+  generic shape (Phase B frames the contract to include it), but
+  =read_url= has no circuit message and the agent already handles
+  per-fetch failures; out of scope for the eval.
+- *Does NOT build the structured sentinel in Phase A.*  Phase A is the
+  eval only; the sentinel is a Phase B mechanism the eval will or won't
+  call for.
 
 * Relationship to other work
 - PR #116 (=loop-detection-pattern-d=) — Pattern D catches HTTP-failure
   streaks *within a single agent run*.  It does not (and should not)
-  catch this case, which spans multiple sub-agent dispatches.  The
-  Phase A eval validates the layer Pattern D was never meant to cover.
-- PR #118 (=search-rate-limit-throttle=) — produces the
-  =_CIRCUIT_OPEN_MESSAGE= this eval depends on.  Must be merged before
-  the eval can run.
-- =roadmap.org= item "Explore a real Search API to replace the
-  scraped DDG endpoints" — independent.  A real search API would
-  reduce the *frequency* of circuit-open, not change the contract:
-  the general agent still needs to handle "search is unavailable"
-  gracefully.  This eval pins that contract regardless of the
-  underlying transport.
+  catch this cross-dispatch case.  The Phase A eval validates the layer
+  Pattern D was never meant to cover.
+- PR #118 (=search-rate-limit-throttle=) — produces
+  =_CIRCUIT_OPEN_MESSAGE= this eval depends on.  Must be merged to =main=
+  before the eval can run (this branch is off =main=; #118 is not yet
+  merged, so =_CIRCUIT_OPEN_MESSAGE= is not present here yet).
+- =roadmap.org= item "Explore a real Search API to replace the scraped
+  DDG endpoints" — independent.  A real search API reduces the
+  *frequency* of unavailability, not the contract: the general agent
+  still must relay "search is unavailable" gracefully.  This eval pins
+  that contract regardless of transport.
+
+* Design changes from review (round 1)
+Folded in: assert dispatch =exactly 1= (not =≤1=); reuse
+=_task_subagents_called= and filter on =research-agent=; cut the
+=≤600 char= "not fabricated" proxy; patch =assist.agent.search_internet=
+(not =assist.tools=) and drop the redundant =_circuit_is_open= patch;
+require a wait-time token in the relay regex; reword Phase B mechanism 2
+to "shape the terminal message" (the wrapper can't inject a ToolMessage);
+elevate the structured sentinel from a fallback to the recommended
+mechanism, grounded in the existing =FINAL_REPORT:= precedent
+(=research_cleanup.py:54=); frame the sentinel/parent-rule generically;
+gate the parent-middleware option behind explicit user sign-off.
+
+Pushed back (rejected reviewer suggestions, with rationale): the
+clean-interfaces lens wanted the eval to assert on the structured
+marker.  Declined — the eval must run before the fix and stay
+mechanism-agnostic, and the marker must be stripped from user-facing
+text, so the correct observable is dispatch-count + user-facing relay,
+not an internal token.  The same lens wanted the marker as the
+*primary* fix mechanism; kept the prompt-only probe as the first step
+(cheapest, and the user framed this as "teach the agent to listen"),
+with the eval — not a priori reasoning — deciding whether the sentinel
+is needed.

--- a/edd/eval/test_agent.py
+++ b/edd/eval/test_agent.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import re
 import subprocess
@@ -6,12 +7,14 @@ import shutil
 from textwrap import dedent
 
 from unittest import TestCase
+from unittest.mock import patch
 
 from langchain_core.messages import AIMessage
 
 from assist.model_manager import select_chat_model
 from assist.agent import create_agent, AgentHarness
 from assist.sandbox_manager import SandboxManager
+from assist.tools import _CIRCUIT_OPEN_MESSAGE
 
 from .utils import read_file, create_filesystem, AgentTestMixin
 
@@ -448,3 +451,91 @@ class TestAgentSandboxIntegration(TestCase):
             f"Response amounts: {response_amounts}.  "
             f"Response: {res[:500]}",
         )
+
+
+class TestResearchRateLimitHandoff(AgentTestMixin, TestCase):
+    """The general agent must HEED a research-agent that reports search
+    is unavailable — relay the wait to the user, not re-dispatch.
+
+    Background: PR #118 gave ``search_internet`` a circuit breaker that
+    returns ``_CIRCUIT_OPEN_MESSAGE`` ("rate-limited … try again in a
+    few minutes") instead of silently failing.  The search layer works,
+    but the *general agent* was observed re-dispatching the
+    research-agent on the blocked result — a cross-dispatch meta-loop
+    that ``LoopDetectionMiddleware`` (a within-run detector) cannot and
+    should not catch.  The contract this eval pins: dispatch
+    research-agent once, read the blocked signal, relay it, stop.
+
+    MOCKING NOTE — this is the one eval in ``edd/eval/`` that
+    monkey-patches a tool.  Existing evals hit the real LLM + real tools
+    on purpose ("eval-first contracts"), but this failure mode is
+    unobservable without forcing search to report unavailable, and
+    hitting live DDG to *induce* a real rate-limit is exactly the IP
+    burn we're trying to prevent.  We patch ``assist.agent.search_internet``
+    (NOT ``assist.tools.search_internet``): ``assist/agent.py`` binds the
+    name at import via ``from assist.tools import search_internet``, so
+    the research subagent's tool list captured that module-level
+    reference — patching the ``assist.tools`` attribute would not rebind
+    it.  ``read_url`` is patched too, purely so a model that ignores the
+    blocked search and hallucinates a URL can't reach the live network
+    and re-burn the IP; the eval asserts nothing about ``read_url``.
+    """
+
+    def setUp(self):
+        self.model = select_chat_model(0.1)
+
+    def _create_agent(self, filesystem: dict):
+        root = tempfile.mkdtemp(prefix="rate_limit_handoff_eval_")
+        create_filesystem(root, filesystem)
+        return AgentHarness(create_agent(self.model, root)), root
+
+    def test_relays_unavailable_instead_of_redispatching(self):
+        # Build the search/fetch stubs with the real functions' metadata
+        # (name, docstring, signature) so deepagents wraps them as the
+        # same-named tools the prompts reference.
+        import assist.tools as _tools
+
+        @functools.wraps(_tools.search_internet)
+        def _blocked_search(query, max_results=5):
+            return _CIRCUIT_OPEN_MESSAGE
+
+        # read_url returns a rate-limit-flavoured error too, so the whole
+        # external surface speaks with one voice ("rate-limited, retry in
+        # a few minutes") and the model can't read eval-awareness into a
+        # bespoke "unavailable in this environment" string.  Mirrors
+        # read_url's real "Error fetching URL: <e>" shape.
+        @functools.wraps(_tools.read_url)
+        def _blocked_fetch(url):
+            return ("Error fetching URL: rate-limited; cannot retry for "
+                    "~10 minutes. Try again in a few minutes.")
+
+        # Patch BEFORE building the agent so create_research_agent's tool
+        # list (built inside create_agent) captures the stubs.
+        with patch("assist.agent.search_internet", _blocked_search), \
+             patch("assist.agent.read_url", _blocked_fetch):
+            agent, _root = self._create_agent(
+                {"README.org": "My notes live in notes/.",
+                 "notes": {"misc.org": "Personal notes."}})
+            res = agent.message(
+                "What's the latest LangGraph release and what changed?")
+
+        # 1. research-agent dispatched EXACTLY once.  Zero would mean the
+        #    parent answered from its own knowledge (a different failure
+        #    the prompt forbids); two-or-more is the runaway meta-loop.
+        research_dispatches = [s for s in self.subagent_calls(agent)
+                               if s == "research-agent"]
+        self.assertEqual(
+            len(research_dispatches), 1,
+            "Expected research-agent dispatched exactly once (dispatch, "
+            "read the blocked signal, stop).  Dispatches seen: "
+            f"{self.subagent_calls(agent)}")
+
+        # 2. Final response relays BOTH that search is unavailable AND a
+        #    wait — the user asked to be told to wait ~10m.  Broad on
+        #    spelling, but the wait token is required, not optional.
+        self.assertRegex(
+            res, r"(?i)rate.?limit|temporarily|unavailable|couldn'?t search",
+            f"Response should tell the user search is unavailable.  Got: {res[:600]}")
+        self.assertRegex(
+            res, r"(?i)try again|few minutes|10 ?min|moment|shortly|later",
+            f"Response should tell the user to wait and retry.  Got: {res[:600]}")

--- a/edd/eval/test_agent.py
+++ b/edd/eval/test_agent.py
@@ -454,12 +454,13 @@ class TestResearchRateLimitHandoff(AgentTestMixin, TestCase):
     research-agent once, read the blocked signal, relay it, stop.
 
     MOCKING NOTE — this is the one eval in ``edd/eval/`` that
-    monkey-patches a tool.  Existing evals hit the real LLM + real tools
-    on purpose ("eval-first contracts"), but this failure mode is
-    unobservable without forcing search to report unavailable, and
-    hitting live DDG to *induce* a real rate-limit is exactly the IP
-    burn we're trying to prevent.  We patch ``assist.agent.search_internet``
-    (NOT ``assist.tools.search_internet``): ``assist/agent.py`` binds the
+    monkey-patches tools (``search_internet`` and ``read_url``).  Existing
+    evals hit the real LLM + real tools on purpose ("eval-first
+    contracts"), but this failure mode is unobservable without forcing
+    search to report unavailable, and hitting live DDG to *induce* a real
+    rate-limit is exactly the IP burn we're trying to prevent.  We patch
+    ``assist.agent.search_internet`` (NOT ``assist.tools.search_internet``):
+    ``assist/agent.py`` binds the
     name at import via ``from assist.tools import search_internet``, so
     the research subagent's tool list captured that module-level
     reference — patching the ``assist.tools`` attribute would not rebind
@@ -523,13 +524,20 @@ class TestResearchRateLimitHandoff(AgentTestMixin, TestCase):
             f"{self.subagent_calls(agent)}")
 
         # 2. Final response relays BOTH that search is unavailable AND a
-        #    wait — the user asked to be told to wait ~10m.  Broad on
-        #    spelling, but the wait token is required, not optional.
+        #    wait — the user asked to be told to wait ~10m.  The
+        #    unavailable token + dispatch==1 carry the discrimination
+        #    (a fabricated answer won't say "rate-limited"), so the wait
+        #    token is broad: the small model phrases the wait many ways
+        #    ("~10 minutes", "10–15 minutes", "in a bit", "shortly",
+        #    "ask again soon") and an N=10 run flapped on a too-narrow
+        #    pattern that only matched "few minutes"/"10 min".
         self.assertRegex(
             res, r"(?i)rate.?limit|temporarily|unavailable|couldn'?t search",
             f"Response should tell the user search is unavailable.  Got: {res[:600]}")
         self.assertRegex(
-            res, r"(?i)try again|few minutes|10 ?min|moment|shortly|later",
+            res,
+            r"(?i)\bmins?\b|minute|try again|ask again|in a bit|in a moment"
+            r"|in a while|shortly|soon|later|moment",
             f"Response should tell the user to wait and retry.  Got: {res[:600]}")
 
     def test_relays_unavailable_tech_lookup(self):

--- a/edd/eval/test_agent.py
+++ b/edd/eval/test_agent.py
@@ -233,7 +233,7 @@ def _cleanup_workspace(path: str) -> None:
     shutil.rmtree(path, ignore_errors=True)
 
 
-class TestAgentSandboxIntegration(TestCase):
+class TestAgentSandboxIntegration(AgentTestMixin, TestCase):
     """Integration evals that need a real sandbox.
 
     Lives alongside ``TestAgent`` because the user thinks of these as
@@ -282,19 +282,6 @@ class TestAgentSandboxIntegration(TestCase):
                     if isinstance(v, str) and path_needle in v:
                         return True
         return False
-
-    def _task_subagents_called(self, agent) -> list[str]:
-        out = []
-        for m in agent.all_messages():
-            if not isinstance(m, AIMessage) or not m.tool_calls:
-                continue
-            for tc in m.tool_calls:
-                if tc.get("name") == "task":
-                    args = tc.get("args") or {}
-                    sa = args.get("subagent_type") or args.get("agent") or args.get("name") or ""
-                    if sa:
-                        out.append(sa)
-        return out
 
     def _ran_python_via_execute(self, agent) -> bool:
         """True iff at least one `execute` tool call invoked Python.
@@ -368,7 +355,7 @@ class TestAgentSandboxIntegration(TestCase):
         )
 
         # 1. Research delegation happened.
-        subagents = self._task_subagents_called(agent)
+        subagents = self.subagent_calls(agent)
         self.assertIn(
             "research-agent", subagents,
             f"Should have delegated strategy research to research-agent. "
@@ -476,23 +463,22 @@ class TestResearchRateLimitHandoff(AgentTestMixin, TestCase):
     name at import via ``from assist.tools import search_internet``, so
     the research subagent's tool list captured that module-level
     reference — patching the ``assist.tools`` attribute would not rebind
-    it.  ``read_url`` is patched too, purely so a model that ignores the
-    blocked search and hallucinates a URL can't reach the live network
-    and re-burn the IP; the eval asserts nothing about ``read_url``.
+    it.  See ``_run_with_blocked_search`` for the mock details.
     """
 
     def setUp(self):
         self.model = select_chat_model(0.1)
 
-    def _create_agent(self, filesystem: dict):
-        root = tempfile.mkdtemp(prefix="rate_limit_handoff_eval_")
-        create_filesystem(root, filesystem)
-        return AgentHarness(create_agent(self.model, root)), root
+    def _run_with_blocked_search(self, prompt: str):
+        """Build the general agent with search/fetch forced to report
+        rate-limited, send ``prompt``, and return ``(agent, response)``.
 
-    def test_relays_unavailable_instead_of_redispatching(self):
-        # Build the search/fetch stubs with the real functions' metadata
-        # (name, docstring, signature) so deepagents wraps them as the
-        # same-named tools the prompts reference.
+        Stubs carry the real functions' metadata (name, docstring,
+        signature) via ``functools.wraps`` so deepagents wraps them as the
+        same-named tools the prompts reference.  The agent is built INSIDE
+        the patch so ``create_research_agent``'s tool list (constructed by
+        ``create_agent``) captures the stubs.
+        """
         import assist.tools as _tools
 
         @functools.wraps(_tools.search_internet)
@@ -503,21 +489,27 @@ class TestResearchRateLimitHandoff(AgentTestMixin, TestCase):
         # external surface speaks with one voice ("rate-limited, retry in
         # a few minutes") and the model can't read eval-awareness into a
         # bespoke "unavailable in this environment" string.  Mirrors
-        # read_url's real "Error fetching URL: <e>" shape.
+        # read_url's real "Error fetching URL: <e>" shape.  The eval
+        # asserts nothing about read_url; this is purely network safety.
         @functools.wraps(_tools.read_url)
         def _blocked_fetch(url):
             return ("Error fetching URL: rate-limited; cannot retry for "
                     "~10 minutes. Try again in a few minutes.")
 
-        # Patch BEFORE building the agent so create_research_agent's tool
-        # list (built inside create_agent) captures the stubs.
+        root = tempfile.mkdtemp(prefix="rate_limit_handoff_eval_")
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        create_filesystem(root, {"README.org": "My notes live in notes/.",
+                                 "notes": {"misc.org": "Personal notes."}})
         with patch("assist.agent.search_internet", _blocked_search), \
              patch("assist.agent.read_url", _blocked_fetch):
-            agent, _root = self._create_agent(
-                {"README.org": "My notes live in notes/.",
-                 "notes": {"misc.org": "Personal notes."}})
-            res = agent.message(
-                "What's the latest LangGraph release and what changed?")
+            agent = AgentHarness(create_agent(self.model, root))
+            res = agent.message(prompt)
+        return agent, res
+
+    def _assert_relays_unavailable(self, agent, res):
+        # Belt-and-suspenders: a recursion-killed / empty turn fails here
+        # with a clearer message than the regexes' "didn't match".
+        self.assertTrue(res, "Agent returned an empty response")
 
         # 1. research-agent dispatched EXACTLY once.  Zero would mean the
         #    parent answered from its own knowledge (a different failure
@@ -539,3 +531,17 @@ class TestResearchRateLimitHandoff(AgentTestMixin, TestCase):
         self.assertRegex(
             res, r"(?i)try again|few minutes|10 ?min|moment|shortly|later",
             f"Response should tell the user to wait and retry.  Got: {res[:600]}")
+
+    def test_relays_unavailable_tech_lookup(self):
+        agent, res = self._run_with_blocked_search(
+            "What's the latest LangGraph release and what changed?")
+        self._assert_relays_unavailable(agent, res)
+
+    def test_relays_unavailable_news_lookup(self):
+        # A differently-shaped, non-technical lookup.  Same contract — if
+        # the agent heeds the blocked signal here too, it's reading the
+        # signal, not pattern-matching one LangGraph-shaped prompt.
+        agent, res = self._run_with_blocked_search(
+            "What were the headlines from the Federal Reserve's most "
+            "recent interest-rate decision?")
+        self._assert_relays_unavailable(agent, res)

--- a/edd/eval/test_agent.py
+++ b/edd/eval/test_agent.py
@@ -536,8 +536,11 @@ class TestResearchRateLimitHandoff(AgentTestMixin, TestCase):
             f"Response should tell the user search is unavailable.  Got: {res[:600]}")
         self.assertRegex(
             res,
+            # Explicit retry phrase OR a time reference.  Deliberately no
+            # bare "moment" — it matches "at the moment", which isn't a
+            # wait/retry instruction and would let a fabrication pass.
             r"(?i)\bmins?\b|minute|try again|ask again|in a bit|in a moment"
-            r"|in a while|shortly|soon|later|moment",
+            r"|in a while|shortly|soon|later",
             f"Response should tell the user to wait and retry.  Got: {res[:600]}")
 
     def test_relays_unavailable_tech_lookup(self):

--- a/edd/eval/utils.py
+++ b/edd/eval/utils.py
@@ -31,6 +31,27 @@ class AgentTestMixin:
 
         self.assertIn(tool_name, tool_calls, msg)
 
+    def subagent_calls(self, agent) -> list[str]:
+        """Names of every subagent dispatched via the `task` tool, in order.
+
+        Reads AIMessage tool_calls (outgoing) rather than ToolMessages
+        (results), so a dispatch counts even if the subagent errored.
+        Returns a list (not a set) so callers can assert on *how many*
+        times a subagent was dispatched, not just whether it was.
+        """
+        calls = []
+        for m in agent.all_messages():
+            if isinstance(m, AIMessage) and m.tool_calls:
+                for tc in m.tool_calls:
+                    if tc.get("name") == "task":
+                        args = tc.get("args") or {}
+                        sa = (args.get("subagent_type")
+                              or args.get("agent")
+                              or args.get("name") or "")
+                        if sa:
+                            calls.append(sa)
+        return calls
+
     def assertSubAgentCall(self, agent, subagent_name: str, msg: str = None):
         """
         Assert that a specific subagent was called by the agent via the task tool.
@@ -43,18 +64,12 @@ class AgentTestMixin:
             subagent_name: The subagent_type value to look for (e.g. "dev-agent")
             msg: Optional custom assertion message
         """
-        subagent_calls = []
-        for m in agent.all_messages():
-            if isinstance(m, AIMessage) and m.tool_calls:
-                for tc in m.tool_calls:
-                    if tc.get("name") == "task":
-                        subagent = tc.get("args", {}).get("subagent_type", "")
-                        subagent_calls.append(subagent)
+        calls = self.subagent_calls(agent)
 
         if msg is None:
-            msg = f"Subagent '{subagent_name}' should have been called via task tool. Called subagents: {subagent_calls}"
+            msg = f"Subagent '{subagent_name}' should have been called via task tool. Called subagents: {calls}"
 
-        self.assertIn(subagent_name, subagent_calls, msg)
+        self.assertIn(subagent_name, calls, msg)
 
 
 def assertToolCall(test_case, agent, tool_name: str, msg: str = None):

--- a/edd/eval/utils.py
+++ b/edd/eval/utils.py
@@ -44,9 +44,20 @@ class AgentTestMixin:
             if isinstance(m, AIMessage) and m.tool_calls:
                 for tc in m.tool_calls:
                     if tc.get("name") == "task":
-                        # deepagents' task tool always names the target via
-                        # `subagent_type` — no other key is emitted.
-                        sa = (tc.get("args") or {}).get("subagent_type", "")
+                        # deepagents' task tool names the target via
+                        # `subagent_type`, but the small model sometimes
+                        # emits it under `agent`/`name` instead — the
+                        # dev-agent evals (test_dev_agent.py:167,
+                        # test_dev_agent_planning_flow.py:157) carry the
+                        # same fallback against that observed shape, so
+                        # match it here for consistent counting.  The
+                        # `or` chain also recovers an empty `subagent_type`
+                        # (which SubagentTypeInferenceMiddleware would
+                        # otherwise default to general-purpose).
+                        args = tc.get("args") or {}
+                        sa = (args.get("subagent_type")
+                              or args.get("agent")
+                              or args.get("name") or "")
                         if sa:
                             calls.append(sa)
         return calls

--- a/edd/eval/utils.py
+++ b/edd/eval/utils.py
@@ -44,10 +44,9 @@ class AgentTestMixin:
             if isinstance(m, AIMessage) and m.tool_calls:
                 for tc in m.tool_calls:
                     if tc.get("name") == "task":
-                        args = tc.get("args") or {}
-                        sa = (args.get("subagent_type")
-                              or args.get("agent")
-                              or args.get("name") or "")
+                        # deepagents' task tool always names the target via
+                        # `subagent_type` — no other key is emitted.
+                        sa = (tc.get("args") or {}).get("subagent_type", "")
                         if sa:
                             calls.append(sa)
         return calls


### PR DESCRIPTION
## What

When DuckDuckGo rate-limits search, `search_internet`'s circuit breaker (PR #118) returns an explicit `_CIRCUIT_OPEN_MESSAGE` ("rate-limited … try again in a few minutes"). The search layer works — but the **general agent** didn't *heed* it: it either re-dispatched the research-agent (cross-dispatch meta-loop) or fabricated an answer from its own training data. `LoopDetectionMiddleware` can't catch this — it's a within-run detector, and this gap is *between* sub-agent dispatches.

This teaches the agent to read the signal: dispatch research-agent once, see "unavailable", relay the wait to the user, and stop. **No meta-loop detector** (per the design + the user's explicit instruction) — the fix is prompt-only.

## How

- **Parent prompt** (`general_instructions.md.j2`): a Step-3 action pattern + one Rule for "a sub-agent reports an external dependency is unavailable" → relay the wait, don't re-dispatch, don't answer from memory.
- **Research prompts** (`sub_research.txt.j2`, `research_instructions.txt.j2`): the signal must survive two research-agent summarization hops, both of which say "write a polished report". Both now have a conditional: if a search/fetch tool reports unavailable/rate-limited, relay that verbatim (incl. wait time) and stop — don't report from knowledge. The outer orchestrator also skips the report file + `FINAL_REPORT:` line in that case (cleanup leaves files untouched and passes the relay text through).
- **Eval** (`edd/eval/test_agent.py::TestResearchRateLimitHandoff`): mocks `search_internet` (+ `read_url`, for network safety) to report rate-limited, then asserts the general agent dispatches research-agent **exactly once** and relays "unavailable + wait" to the user. Two differently-shaped prompts (a LangGraph lookup and a Fed-news lookup) so a pass proves the agent heeds the *signal*, not one prompt's wording.

## Eval-first evidence

- **Baseline (pre-fix, current agent):** fails — observed both predicted failure modes across runs: answered from training data once; re-dispatched research-agent 3× once.
- **Post-fix tech prompt:** 4/4 pass (1 standalone + N=3).
- **Post-review N=5 (both prompts):** 10/10 pass.
- **Stability N=10 (both prompts):** 20/20 pass (10 rounds × {tech, news} lookups), clean run on the final committed code.

An N=10 round initially flapped on a *correct* response ("rate-limited … clear in about 10–15 minutes … ask again in a bit") that a too-narrow wait-token regex didn't match — broadened the regex (the unavailable-token assertion + dispatch==1 still carry the discrimination), then re-ran clean.

## Design / review trail

Design doc: `docs/2026-05-31-heed-research-agent-rate-limit-signal.org` (carries the design-review round-1 changes, the round-2 code-review changes, and the rationale for what was pushed back on).

Notable design decisions captured there:
- Eval stays **mechanism-agnostic** — asserts behavior (dispatch count) + user-facing relay, *not* an internal marker — so it survives whichever Phase-B mechanism is needed.
- Structured sentinel (mirroring the existing `FINAL_REPORT:` contract) is the documented escalation if the prompt-only probe proves unstable at higher N; a parent-layer meta-loop detector is gated behind explicit user sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

