### PR TITLE
Align eval harness with prod (reasoning-off) + timeout headroom for heavy eval files

### DIFF
--- a/assist/model_manager.py
+++ b/assist/model_manager.py
@@ -331,9 +331,12 @@ def select_chat_model(
     and we don't actually want a quiet fallback to a remote API.
 
     ``enable_thinking`` (default ``None``): see
-    ``_build_openai_chat_model``.  Used by the reasoning-impact eval
-    in ``edd/eval/test_reasoning_impact.py`` to A/B Qwen3 thinking
-    mode against latency.  Production callers leave it unset.
+    ``_build_openai_chat_model``.  Most callers should use
+    :func:`select_assistant_model` instead, which defaults Qwen3
+    reasoning OFF to match production; this lower-level entry point
+    leaves the upstream behavior alone unless told otherwise and is for
+    callers that need that (e.g. the reasoning-impact A/B eval, which
+    passes an explicit flag).
     """
 
     config = _get_config()
@@ -352,3 +355,22 @@ def select_chat_model(
     )
     llm.profile = {"max_input_tokens": config.context_len}
     return llm
+
+
+def select_assistant_model(
+    temperature: float,
+    *,
+    enable_thinking: bool = False,
+) -> BaseChatModel:
+    """Chat model configured the way assist actually runs it.
+
+    Thin wrapper over :func:`select_chat_model` that defaults Qwen3
+    reasoning OFF — the production configuration (see ``Thread`` and the
+    web summary flow).  Both prod and the eval harness build their models
+    through here so the reasoning setting can't drift apart as new call
+    sites are added: the eval/prod mismatch this consolidates cost a full
+    night of NO-XML eval timeouts before it was found.
+
+    Pass ``enable_thinking=True`` for the rare reasoning-on path.
+    """
+    return select_chat_model(temperature, enable_thinking=enable_thinking)

--- a/assist/thread.py
+++ b/assist/thread.py
@@ -18,7 +18,7 @@ from langchain_core.language_models.chat_models import BaseChatModel
 from deepagents.backends.protocol import BackendProtocol
 
 from assist.promptable import base_prompt_for
-from assist.model_manager import select_chat_model
+from assist.model_manager import select_assistant_model
 from assist.agent import create_research_agent, create_agent
 from assist.checkpoint_rollback import invoke_with_rollback
 from assist.sandbox_manager import SandboxManager
@@ -162,7 +162,7 @@ class Thread:
         self.working_dir = working_dir
         ts = datetime.now().strftime("%Y%m%d%H%M%S")
         self.thread_id = thread_id or f"{working_dir}:{ts}"
-        self.model = model or select_chat_model(0.1, enable_thinking=False)
+        self.model = model or select_assistant_model(0.1)
         self.max_concurrency = max_concurrency
         # Notified with "queued" if another thread is holding the LLM
         # queue when this Thread.message() runs, then "running" once
@@ -376,7 +376,7 @@ n    checkpointing via SqliteSaver.
         if self._model is None:
             with self._model_lock:
                 if self._model is None:
-                    self._model = select_chat_model(0.1, enable_thinking=False)
+                    self._model = select_assistant_model(0.1)
         return self._model
 
     def list(self) -> list[str]:

--- a/edd/eval/test_agent.py
+++ b/edd/eval/test_agent.py
@@ -27,7 +27,7 @@ class TestAgent(AgentTestMixin, TestCase):
                                          root)), root
 
     def setUp(self):
-        self.model = select_chat_model(0.1)
+        self.model = select_chat_model(0.1, enable_thinking=False)
 
     def test_adds_item_correctly(self):
         agent, root = self.create_agent({"README.org": "All of my todos are in gtd/inbox.org",
@@ -244,7 +244,7 @@ class TestAgentSandboxIntegration(AgentTestMixin, TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = select_chat_model(0.1)
+        cls.model = select_chat_model(0.1, enable_thinking=False)
 
     def setUp(self):
         self.workspace = tempfile.mkdtemp(prefix="agent_integration_eval_")
@@ -468,7 +468,7 @@ class TestResearchRateLimitHandoff(AgentTestMixin, TestCase):
     """
 
     def setUp(self):
-        self.model = select_chat_model(0.1)
+        self.model = select_chat_model(0.1, enable_thinking=False)
 
     def _run_with_blocked_search(self, prompt: str):
         """Build the general agent with search/fetch forced to report

--- a/edd/eval/test_agent.py
+++ b/edd/eval/test_agent.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 from langchain_core.messages import AIMessage
 
-from assist.model_manager import select_chat_model
+from assist.model_manager import select_assistant_model
 from assist.agent import create_agent, AgentHarness
 from assist.sandbox_manager import SandboxManager
 from assist.tools import _CIRCUIT_OPEN_MESSAGE
@@ -27,7 +27,7 @@ class TestAgent(AgentTestMixin, TestCase):
                                          root)), root
 
     def setUp(self):
-        self.model = select_chat_model(0.1, enable_thinking=False)
+        self.model = select_assistant_model(0.1)
 
     def test_adds_item_correctly(self):
         agent, root = self.create_agent({"README.org": "All of my todos are in gtd/inbox.org",
@@ -244,7 +244,7 @@ class TestAgentSandboxIntegration(AgentTestMixin, TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = select_chat_model(0.1, enable_thinking=False)
+        cls.model = select_assistant_model(0.1)
 
     def setUp(self):
         self.workspace = tempfile.mkdtemp(prefix="agent_integration_eval_")
@@ -468,7 +468,7 @@ class TestResearchRateLimitHandoff(AgentTestMixin, TestCase):
     """
 
     def setUp(self):
-        self.model = select_chat_model(0.1, enable_thinking=False)
+        self.model = select_assistant_model(0.1)
 
     def _run_with_blocked_search(self, prompt: str):
         """Build the general agent with search/fetch forced to report

--- a/edd/eval/test_calculate_skill.py
+++ b/edd/eval/test_calculate_skill.py
@@ -78,7 +78,7 @@ class TestCalculateSkill(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = select_chat_model(0.1)
+        cls.model = select_chat_model(0.1, enable_thinking=False)
 
     def setUp(self):
         self.workspace = tempfile.mkdtemp(prefix="calculate_skill_eval_")

--- a/edd/eval/test_calculate_skill.py
+++ b/edd/eval/test_calculate_skill.py
@@ -40,7 +40,7 @@ from unittest import TestCase
 from langchain_core.messages import AIMessage, ToolMessage
 
 from assist.agent import create_agent, AgentHarness
-from assist.model_manager import select_chat_model
+from assist.model_manager import select_assistant_model
 from assist.sandbox_manager import SandboxManager
 
 from .utils import create_filesystem
@@ -78,7 +78,7 @@ class TestCalculateSkill(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = select_chat_model(0.1, enable_thinking=False)
+        cls.model = select_assistant_model(0.1)
 
     def setUp(self):
         self.workspace = tempfile.mkdtemp(prefix="calculate_skill_eval_")

--- a/edd/eval/test_context_agent.py
+++ b/edd/eval/test_context_agent.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 from assist.agent import create_context_agent, AgentHarness
 
-from assist.model_manager import select_chat_model
+from assist.model_manager import select_assistant_model
 
 from .utils import create_filesystem
 
@@ -22,7 +22,7 @@ class TestContextAgent(TestCase):
                                                   root)), root
 
     def setUp(self):
-        self.model = select_chat_model(0.1, enable_thinking=False)
+        self.model = select_assistant_model(0.1)
 
     def test_surfaces_todo_files_for_task_request(self):
         """When the query implies a task, surface the task files directly."""

--- a/edd/eval/test_context_agent.py
+++ b/edd/eval/test_context_agent.py
@@ -22,7 +22,7 @@ class TestContextAgent(TestCase):
                                                   root)), root
 
     def setUp(self):
-        self.model = select_chat_model(0.1)
+        self.model = select_chat_model(0.1, enable_thinking=False)
 
     def test_surfaces_todo_files_for_task_request(self):
         """When the query implies a task, surface the task files directly."""

--- a/edd/eval/test_dev_agent.py
+++ b/edd/eval/test_dev_agent.py
@@ -21,7 +21,7 @@ from unittest import TestCase
 
 from langchain_core.messages import AIMessage, ToolMessage
 
-from assist.model_manager import select_chat_model
+from assist.model_manager import select_assistant_model
 from assist.agent import create_agent, AgentHarness
 from assist.sandbox_manager import SandboxManager
 
@@ -89,7 +89,7 @@ class TestDevAgent(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = select_chat_model(0.1, enable_thinking=False)
+        cls.model = select_assistant_model(0.1)
 
     def setUp(self):
         self.workspace = tempfile.mkdtemp(prefix="dev_agent_eval_")

--- a/edd/eval/test_dev_agent.py
+++ b/edd/eval/test_dev_agent.py
@@ -89,7 +89,7 @@ class TestDevAgent(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = select_chat_model(0.1)
+        cls.model = select_chat_model(0.1, enable_thinking=False)
 
     def setUp(self):
         self.workspace = tempfile.mkdtemp(prefix="dev_agent_eval_")

--- a/edd/eval/test_dev_agent_planning_flow.py
+++ b/edd/eval/test_dev_agent_planning_flow.py
@@ -86,7 +86,7 @@ class TestDevAgentPlanningFlow(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = select_chat_model(0.1)
+        cls.model = select_chat_model(0.1, enable_thinking=False)
 
     def setUp(self):
         self.workspace = tempfile.mkdtemp(prefix="dev_agent_planning_eval_")

--- a/edd/eval/test_dev_agent_planning_flow.py
+++ b/edd/eval/test_dev_agent_planning_flow.py
@@ -19,7 +19,7 @@ from unittest import TestCase
 
 from langchain_core.messages import AIMessage
 
-from assist.model_manager import select_chat_model
+from assist.model_manager import select_assistant_model
 from assist.agent import create_agent, AgentHarness
 from assist.sandbox_manager import SandboxManager
 
@@ -86,7 +86,7 @@ class TestDevAgentPlanningFlow(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = select_chat_model(0.1, enable_thinking=False)
+        cls.model = select_assistant_model(0.1)
 
     def setUp(self):
         self.workspace = tempfile.mkdtemp(prefix="dev_agent_planning_eval_")

--- a/edd/eval/test_dev_agent_runs_eval.py
+++ b/edd/eval/test_dev_agent_runs_eval.py
@@ -59,7 +59,7 @@ class TestDevAgentRunsEval(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = select_chat_model(0.1)
+        cls.model = select_chat_model(0.1, enable_thinking=False)
         cls.workspace = tempfile.mkdtemp(prefix="dev_agent_eval_runs_eval_")
         _rsync_project(cls.workspace)
 

--- a/edd/eval/test_dev_agent_runs_eval.py
+++ b/edd/eval/test_dev_agent_runs_eval.py
@@ -17,7 +17,7 @@ from unittest import TestCase
 from langchain_core.messages import AIMessage, ToolMessage
 from langgraph.errors import GraphRecursionError
 
-from assist.model_manager import select_chat_model
+from assist.model_manager import select_assistant_model
 from assist.agent import create_agent, AgentHarness
 from assist.sandbox_manager import SandboxManager
 
@@ -59,7 +59,7 @@ class TestDevAgentRunsEval(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = select_chat_model(0.1, enable_thinking=False)
+        cls.model = select_assistant_model(0.1)
         cls.workspace = tempfile.mkdtemp(prefix="dev_agent_eval_runs_eval_")
         _rsync_project(cls.workspace)
 

--- a/edd/eval/test_dev_skill_loading.py
+++ b/edd/eval/test_dev_skill_loading.py
@@ -42,7 +42,7 @@ from langchain_core.messages import AIMessage
 from langchain_core.tools import tool
 
 from assist.agent import create_agent, AgentHarness
-from assist.model_manager import select_chat_model
+from assist.model_manager import select_assistant_model
 
 from .utils import create_filesystem
 
@@ -108,7 +108,7 @@ class TestDevSkillLoading(TestCase):
     of prompt implicitness levels — without the hard-inject path."""
 
     def setUp(self):
-        self.model = select_chat_model(0.1, enable_thinking=False)
+        self.model = select_assistant_model(0.1)
 
     def _make_agent(self):
         """Create an agent rooted at a temp dir that looks like a Python

--- a/edd/eval/test_dev_skill_loading.py
+++ b/edd/eval/test_dev_skill_loading.py
@@ -108,7 +108,7 @@ class TestDevSkillLoading(TestCase):
     of prompt implicitness levels — without the hard-inject path."""
 
     def setUp(self):
-        self.model = select_chat_model(0.1)
+        self.model = select_chat_model(0.1, enable_thinking=False)
 
     def _make_agent(self):
         """Create an agent rooted at a temp dir that looks like a Python

--- a/edd/eval/test_git_push_blocker_agent.py
+++ b/edd/eval/test_git_push_blocker_agent.py
@@ -30,7 +30,7 @@ from unittest import TestCase
 from langchain_core.messages import AIMessage, ToolMessage
 
 from assist.agent import AgentHarness, create_agent
-from assist.model_manager import select_chat_model
+from assist.model_manager import select_assistant_model
 from assist.sandbox_manager import SandboxManager
 
 
@@ -81,7 +81,7 @@ class TestGitPushBlockerAgent(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = select_chat_model(0.1, enable_thinking=False)
+        cls.model = select_assistant_model(0.1)
 
     def setUp(self):
         # Workspace = a brand-new working clone with a bare remote

--- a/edd/eval/test_git_push_blocker_agent.py
+++ b/edd/eval/test_git_push_blocker_agent.py
@@ -81,7 +81,7 @@ class TestGitPushBlockerAgent(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = select_chat_model(0.1)
+        cls.model = select_chat_model(0.1, enable_thinking=False)
 
     def setUp(self):
         # Workspace = a brand-new working clone with a bare remote

--- a/edd/eval/test_memory.py
+++ b/edd/eval/test_memory.py
@@ -19,7 +19,7 @@ class TestMemory(AgentTestMixin, TestCase):
                                          root)), root
 
     def setUp(self):
-        self.model = select_chat_model(0.1)
+        self.model = select_chat_model(0.1, enable_thinking=False)
 
     def test_reads_memory(self):
         agent, root = self.create_agent({"AGENTS.md": "I have 3 cats"})

--- a/edd/eval/test_memory.py
+++ b/edd/eval/test_memory.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 
 from unittest import TestCase
 
-from assist.model_manager import select_chat_model
+from assist.model_manager import select_assistant_model
 from assist.agent import create_agent, AgentHarness
 
 from .utils import read_file, create_filesystem, AgentTestMixin
@@ -19,7 +19,7 @@ class TestMemory(AgentTestMixin, TestCase):
                                          root)), root
 
     def setUp(self):
-        self.model = select_chat_model(0.1, enable_thinking=False)
+        self.model = select_assistant_model(0.1)
 
     def test_reads_memory(self):
         agent, root = self.create_agent({"AGENTS.md": "I have 3 cats"})

--- a/edd/eval/test_org_format_skill.py
+++ b/edd/eval/test_org_format_skill.py
@@ -32,7 +32,7 @@ class TestOrgFormatSkill(TestCase):
         return AgentHarness(create_agent(self.model, root)), root
 
     def setUp(self):
-        self.model = select_chat_model(0.1)
+        self.model = select_chat_model(0.1, enable_thinking=False)
 
     def test_inserts_heading_without_orphaning_previous_body(self):
         """Insert a new top-level heading between two existing top-level

--- a/edd/eval/test_org_format_skill.py
+++ b/edd/eval/test_org_format_skill.py
@@ -17,7 +17,7 @@ from textwrap import dedent
 from unittest import TestCase
 
 from assist.agent import create_agent, AgentHarness
-from assist.model_manager import select_chat_model
+from assist.model_manager import select_assistant_model
 
 from .utils import create_filesystem, read_file
 
@@ -32,7 +32,7 @@ class TestOrgFormatSkill(TestCase):
         return AgentHarness(create_agent(self.model, root)), root
 
     def setUp(self):
-        self.model = select_chat_model(0.1, enable_thinking=False)
+        self.model = select_assistant_model(0.1)
 
     def test_inserts_heading_without_orphaning_previous_body(self):
         """Insert a new top-level heading between two existing top-level

--- a/edd/eval/test_pdf_reading.py
+++ b/edd/eval/test_pdf_reading.py
@@ -63,7 +63,7 @@ class TestPdfReading(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = select_chat_model(0.1)
+        cls.model = select_chat_model(0.1, enable_thinking=False)
 
     def setUp(self):
         self.workspace = tempfile.mkdtemp(prefix="pdf_reading_eval_")

--- a/edd/eval/test_pdf_reading.py
+++ b/edd/eval/test_pdf_reading.py
@@ -30,7 +30,7 @@ from unittest import TestCase
 from langchain_core.messages import AIMessage
 
 from assist.agent import AgentHarness, create_agent
-from assist.model_manager import select_chat_model
+from assist.model_manager import select_assistant_model
 from assist.sandbox_manager import SandboxManager
 
 
@@ -63,7 +63,7 @@ class TestPdfReading(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = select_chat_model(0.1, enable_thinking=False)
+        cls.model = select_assistant_model(0.1)
 
     def setUp(self):
         self.workspace = tempfile.mkdtemp(prefix="pdf_reading_eval_")

--- a/edd/eval/test_research_agent.py
+++ b/edd/eval/test_research_agent.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 from unittest import TestCase
 
 from assist.agent import create_research_agent, AgentHarness
-from assist.model_manager import select_chat_model
+from assist.model_manager import select_assistant_model
 
 from .utils import read_file, create_filesystem, files_in_directory
 
@@ -24,7 +24,7 @@ class TestResearchAgent(TestCase):
                                                   root)), root
     
     def setUp(self):
-        self.model = select_chat_model(0.1, enable_thinking=False)
+        self.model = select_assistant_model(0.1)
         
     def test_follows_result_guidance(self):
         # research-agent is confined to <root>/references/, so the

--- a/edd/eval/test_research_agent.py
+++ b/edd/eval/test_research_agent.py
@@ -24,7 +24,7 @@ class TestResearchAgent(TestCase):
                                                   root)), root
     
     def setUp(self):
-        self.model = select_chat_model(0.1)
+        self.model = select_chat_model(0.1, enable_thinking=False)
         
     def test_follows_result_guidance(self):
         # research-agent is confined to <root>/references/, so the

--- a/edd/eval/test_skill_loading.py
+++ b/edd/eval/test_skill_loading.py
@@ -34,7 +34,7 @@ from unittest import TestCase
 from langchain_core.messages import AIMessage
 
 from assist.agent import create_agent, AgentHarness
-from assist.model_manager import select_chat_model
+from assist.model_manager import select_assistant_model
 
 from .utils import create_filesystem, read_file
 
@@ -58,7 +58,7 @@ class TestSkillLoading(TestCase):
     range of prompt implicitness levels."""
 
     def setUp(self):
-        self.model = select_chat_model(0.1, enable_thinking=False)
+        self.model = select_assistant_model(0.1)
 
     def _make_agent(self):
         root = tempfile.mkdtemp()

--- a/edd/eval/test_skill_loading.py
+++ b/edd/eval/test_skill_loading.py
@@ -58,7 +58,7 @@ class TestSkillLoading(TestCase):
     range of prompt implicitness levels."""
 
     def setUp(self):
-        self.model = select_chat_model(0.1)
+        self.model = select_chat_model(0.1, enable_thinking=False)
 
     def _make_agent(self):
         root = tempfile.mkdtemp()

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -755,9 +755,9 @@ async def merge_thread(tid: str):
         raise HTTPException(status_code=400, detail="No git repository configured for this thread")
 
     # Get a model for summarizing
-    from assist.model_manager import select_chat_model
+    from assist.model_manager import select_assistant_model
     try:
-        summary_model = select_chat_model(temperature=0.1, enable_thinking=False)
+        summary_model = select_assistant_model(temperature=0.1)
     except Exception:
         # If model fails to load, pass None and use fallback summary
         summary_model = None

--- a/scripts/run-evals.sh
+++ b/scripts/run-evals.sh
@@ -11,9 +11,10 @@
 # session.  Running pytest one file at a time bounds the blast radius:
 # we lose at most one file's XML, not the entire night.
 #
-# Each file gets:
-#   - per-test cap: 600s (pytest-timeout, thread method)
-#   - per-file cap: 1800s (outer `timeout`)
+# Each file gets (DEFAULT caps; a few "heavy" files override — see
+# HEAVY_FILES below):
+#   - per-test cap: 600s (pytest-timeout, thread method) [heavy: 1200s]
+#   - per-file cap: 1800s (outer `timeout`)              [heavy: 3600s]
 #   - own JUnit XML at edd/history/<base>-<ts>.xml
 #
 # A summary line lands in edd/history/eval-summary-<ts>.txt as each file
@@ -79,7 +80,8 @@ mkdir -p "$HISTORY_DIR"
 SUMMARY="$HISTORY_DIR/eval-summary-$TS.txt"
 
 echo "=== eval suite starting at $(date -Iseconds) ===" | tee -a "$SUMMARY"
-echo "  per-test timeout: ${PER_TEST_TIMEOUT}s, per-file timeout: ${PER_FILE_TIMEOUT}s" | tee -a "$SUMMARY"
+echo "  default per-test timeout: ${PER_TEST_TIMEOUT}s, per-file timeout: ${PER_FILE_TIMEOUT}s" | tee -a "$SUMMARY"
+echo "  heavy files (${HEAVY_TEST_TIMEOUT}s/${HEAVY_FILE_TIMEOUT}s): ${HEAVY_FILES}" | tee -a "$SUMMARY"
 echo "  TMPDIR: $TMPDIR (wiped, $(df -h "$TMPDIR" | awk 'NR==2 {print $4 " free"}'))" | tee -a "$SUMMARY"
 
 for f in edd/eval/test_*.py; do

--- a/scripts/run-evals.sh
+++ b/scripts/run-evals.sh
@@ -11,11 +11,20 @@
 # session.  Running pytest one file at a time bounds the blast radius:
 # we lose at most one file's XML, not the entire night.
 #
-# Each file gets (DEFAULT caps; a few "heavy" files override — see
-# HEAVY_FILES below):
-#   - per-test cap: 600s (pytest-timeout, thread method) [heavy: 1200s]
-#   - per-file cap: 1800s (outer `timeout`)              [heavy: 3600s]
+# Each file gets:
+#   - per-test cap: 1200s (pytest-timeout, thread method)
+#   - per-file cap: 3600s (outer `timeout`)
 #   - own JUnit XML at edd/history/<base>-<ts>.xml
+#
+# One timeout for every file, deliberately generous.  A few files
+# (test_agent, test_dev_agent, test_research_multi_turn) legitimately
+# run for many minutes — many sequential LLM calls / simulated turns on
+# the slow local model — and the 2026-06-03 slot-trace investigation
+# confirmed the model generates normally throughout (busy ~88% of the
+# window, no frozen decode, no runaway), so the long runs are real work,
+# not hangs.  Rather than special-case those files, every file gets the
+# same headroom: simpler, and per-file isolation still bounds the blast
+# radius if one ever does hang.
 #
 # A summary line lands in edd/history/eval-summary-<ts>.txt as each file
 # completes, so partial progress is visible during long runs.
@@ -23,20 +32,8 @@ set -u
 
 PYTEST="${PYTEST:-.venv/bin/pytest}"
 HISTORY_DIR="edd/history"
-PER_TEST_TIMEOUT="${PER_TEST_TIMEOUT:-600}"
-PER_FILE_TIMEOUT="${PER_FILE_TIMEOUT:-1800}"
-
-# A few eval files are legitimately long — many sequential LLM calls or
-# many simulated turns on the slow local model — and were hitting the
-# default caps as NO-XML even though nothing is hung.  The 2026-06-03
-# slot-trace investigation confirmed the model generates normally
-# throughout (busy ~88% of the window, no frozen decode, no runaway
-# generation); these files just do a lot of real work.  Give them
-# headroom so they produce JUnit XML instead of timing out.  See
-# HEAVY_FILES below.
-HEAVY_TEST_TIMEOUT="${HEAVY_TEST_TIMEOUT:-1200}"
-HEAVY_FILE_TIMEOUT="${HEAVY_FILE_TIMEOUT:-3600}"
-HEAVY_FILES="test_agent test_dev_agent test_research_multi_turn_token_regression"
+PER_TEST_TIMEOUT="${PER_TEST_TIMEOUT:-1200}"
+PER_FILE_TIMEOUT="${PER_FILE_TIMEOUT:-3600}"
 TS="$(date +%Y%m%d-%H%M)"
 
 # All eval-time tempfile activity (test workspaces, langgraph SqliteSaver
@@ -80,8 +77,7 @@ mkdir -p "$HISTORY_DIR"
 SUMMARY="$HISTORY_DIR/eval-summary-$TS.txt"
 
 echo "=== eval suite starting at $(date -Iseconds) ===" | tee -a "$SUMMARY"
-echo "  default per-test timeout: ${PER_TEST_TIMEOUT}s, per-file timeout: ${PER_FILE_TIMEOUT}s" | tee -a "$SUMMARY"
-echo "  heavy files (${HEAVY_TEST_TIMEOUT}s/${HEAVY_FILE_TIMEOUT}s): ${HEAVY_FILES}" | tee -a "$SUMMARY"
+echo "  per-test timeout: ${PER_TEST_TIMEOUT}s, per-file timeout: ${PER_FILE_TIMEOUT}s" | tee -a "$SUMMARY"
 echo "  TMPDIR: $TMPDIR (wiped, $(df -h "$TMPDIR" | awk 'NR==2 {print $4 " free"}'))" | tee -a "$SUMMARY"
 
 for f in edd/eval/test_*.py; do
@@ -89,16 +85,10 @@ for f in edd/eval/test_*.py; do
     xml="$HISTORY_DIR/${base}-${TS}.xml"
     log="$HISTORY_DIR/${base}-${TS}.log"
 
-    # Heavy files get the larger caps; everything else the defaults.
-    pt="$PER_TEST_TIMEOUT"; pf="$PER_FILE_TIMEOUT"
-    case " $HEAVY_FILES " in
-        *" $base "*) pt="$HEAVY_TEST_TIMEOUT"; pf="$HEAVY_FILE_TIMEOUT" ;;
-    esac
-
-    echo "===> $base (per-test ${pt}s, per-file ${pf}s)" | tee -a "$SUMMARY"
+    echo "===> $base" | tee -a "$SUMMARY"
     start=$(date +%s)
-    timeout "$pf" "$PYTEST" \
-        --timeout="$pt" \
+    timeout "$PER_FILE_TIMEOUT" "$PYTEST" \
+        --timeout="$PER_TEST_TIMEOUT" \
         --timeout-method=thread \
         --junit-xml="$xml" \
         "$f" \

--- a/scripts/run-evals.sh
+++ b/scripts/run-evals.sh
@@ -24,6 +24,18 @@ PYTEST="${PYTEST:-.venv/bin/pytest}"
 HISTORY_DIR="edd/history"
 PER_TEST_TIMEOUT="${PER_TEST_TIMEOUT:-600}"
 PER_FILE_TIMEOUT="${PER_FILE_TIMEOUT:-1800}"
+
+# A few eval files are legitimately long — many sequential LLM calls or
+# many simulated turns on the slow local model — and were hitting the
+# default caps as NO-XML even though nothing is hung.  The 2026-06-03
+# slot-trace investigation confirmed the model generates normally
+# throughout (busy ~88% of the window, no frozen decode, no runaway
+# generation); these files just do a lot of real work.  Give them
+# headroom so they produce JUnit XML instead of timing out.  See
+# HEAVY_FILES below.
+HEAVY_TEST_TIMEOUT="${HEAVY_TEST_TIMEOUT:-1200}"
+HEAVY_FILE_TIMEOUT="${HEAVY_FILE_TIMEOUT:-3600}"
+HEAVY_FILES="test_agent test_dev_agent test_research_multi_turn_token_regression"
 TS="$(date +%Y%m%d-%H%M)"
 
 # All eval-time tempfile activity (test workspaces, langgraph SqliteSaver
@@ -75,10 +87,16 @@ for f in edd/eval/test_*.py; do
     xml="$HISTORY_DIR/${base}-${TS}.xml"
     log="$HISTORY_DIR/${base}-${TS}.log"
 
-    echo "===> $base" | tee -a "$SUMMARY"
+    # Heavy files get the larger caps; everything else the defaults.
+    pt="$PER_TEST_TIMEOUT"; pf="$PER_FILE_TIMEOUT"
+    case " $HEAVY_FILES " in
+        *" $base "*) pt="$HEAVY_TEST_TIMEOUT"; pf="$HEAVY_FILE_TIMEOUT" ;;
+    esac
+
+    echo "===> $base (per-test ${pt}s, per-file ${pf}s)" | tee -a "$SUMMARY"
     start=$(date +%s)
-    timeout "$PER_FILE_TIMEOUT" "$PYTEST" \
-        --timeout="$PER_TEST_TIMEOUT" \
+    timeout "$pf" "$PYTEST" \
+        --timeout="$pt" \
         --timeout-method=thread \
         --junit-xml="$xml" \
         "$f" \

--- a/tests/model_manager/test_dynamic_model.py
+++ b/tests/model_manager/test_dynamic_model.py
@@ -380,6 +380,37 @@ class TestSelectChatModel(TestCase):
         self.assertFalse(eb, f"Expected no extra_body for True; got {eb!r}")
 
 
+class TestSelectAssistantModel(TestCase):
+    """``select_assistant_model`` is the prod/eval-shared constructor.
+
+    Its contract: reasoning OFF by default, overrideable to on.  The
+    whole point is that prod and the eval harness can't drift apart on
+    the reasoning setting, so these tests pin the default.
+    """
+
+    def test_defaults_thinking_off(self):
+        """No flag -> reasoning off (``chat_template_kwargs`` payload),
+        matching the production ``Thread`` config.
+        """
+        with patch.dict("os.environ", {"ASSIST_MODEL_URL": "http://x/v1"}):
+            llm = model_manager.select_assistant_model(0.1)
+        eb = getattr(llm, "extra_body", None) or {}
+        self.assertEqual(
+            eb.get("chat_template_kwargs"),
+            {"enable_thinking": False},
+            f"default should disable thinking; got {eb!r}",
+        )
+
+    def test_enable_thinking_true_opts_back_in(self):
+        """``enable_thinking=True`` is the rare reasoning-on path; it
+        defers to Qwen3's own default and sends no payload.
+        """
+        with patch.dict("os.environ", {"ASSIST_MODEL_URL": "http://x/v1"}):
+            llm = model_manager.select_assistant_model(0.1, enable_thinking=True)
+        eb = getattr(llm, "extra_body", None)
+        self.assertFalse(eb, f"Expected no extra_body for True; got {eb!r}")
+
+
 class TestRequestTimeoutAndRetries(TestCase):
     """Pin the per-phase httpx Timeout shape and the OpenAI client's
     ``max_retries=0`` invariant.  Both are construction-time config —

--- a/tests/test_create_agent_default_backend.py
+++ b/tests/test_create_agent_default_backend.py
@@ -163,7 +163,7 @@ class TestThreadDefaultBackend:
         from assist.thread import Thread
 
         with patch("assist.thread.create_agent") as fake_ca, \
-             patch("assist.thread.select_chat_model") as fake_model:
+             patch("assist.thread.select_assistant_model") as fake_model:
             fake_ca.return_value = MagicMock()
             fake_model.return_value = MagicMock()
             with tempfile.TemporaryDirectory() as wd:
@@ -182,7 +182,7 @@ class TestThreadDefaultBackend:
         # guard runs (it raises on the first statement, before any heavy work).
         from assist.thread import Thread
 
-        with patch("assist.thread.select_chat_model") as fake_model:
+        with patch("assist.thread.select_assistant_model") as fake_model:
             fake_model.return_value = MagicMock()
             with tempfile.TemporaryDirectory() as wd:
                 with pytest.raises(ValueError):

--- a/tests/test_create_agent_extra_tools.py
+++ b/tests/test_create_agent_extra_tools.py
@@ -110,7 +110,7 @@ class TestThreadExtraTools:
     def _build(self, **kwargs):
         from assist.thread import Thread
         with patch("assist.thread.create_agent") as fake_ca, \
-             patch("assist.thread.select_chat_model") as fake_model:
+             patch("assist.thread.select_assistant_model") as fake_model:
             fake_ca.return_value = MagicMock()
             fake_model.return_value = MagicMock()
             with tempfile.TemporaryDirectory() as wd:
@@ -153,7 +153,7 @@ class TestThreadExtraConfig:
     def _build(self, **kwargs):
         from assist.thread import Thread
         with patch("assist.thread.create_agent") as fake_ca, \
-             patch("assist.thread.select_chat_model") as fake_model:
+             patch("assist.thread.select_assistant_model") as fake_model:
             fake_ca.return_value = MagicMock()
             fake_model.return_value = MagicMock()
             with tempfile.TemporaryDirectory() as wd:

--- a/tests/test_thread_manager_lazy.py
+++ b/tests/test_thread_manager_lazy.py
@@ -28,8 +28,8 @@ class TestThreadManagerLazy(TestCase):
     def test_init_does_not_call_select_chat_model(self):
         """Constructing a ``ThreadManager`` must not touch the model."""
         with patch(
-            "assist.thread.select_chat_model",
-            side_effect=AssertionError("select_chat_model called at init"),
+            "assist.thread.select_assistant_model",
+            side_effect=AssertionError("select_assistant_model called at init"),
         ):
             with tempfile.TemporaryDirectory() as tmp:
                 ThreadManager(root_dir=tmp)
@@ -39,7 +39,7 @@ class TestThreadManagerLazy(TestCase):
         result is cached for subsequent reads."""
         sentinel = object()
         with patch(
-            "assist.thread.select_chat_model", return_value=sentinel
+            "assist.thread.select_assistant_model", return_value=sentinel
         ) as fake_select:
             with tempfile.TemporaryDirectory() as tmp:
                 manager = ThreadManager(root_dir=tmp)
@@ -73,7 +73,7 @@ class TestThreadManagerLazy(TestCase):
         # init_chat_model() which requires a real model string.  We
         # don't care about the agent itself here; we care about the
         # filesystem side effects of the wiring around it.
-        with patch("assist.thread.select_chat_model", return_value=MagicMock()), \
+        with patch("assist.thread.select_assistant_model", return_value=MagicMock()), \
              patch("assist.agent.create_deep_agent", return_value=MagicMock()):
             with tempfile.TemporaryDirectory() as tmp:
                 manager = ThreadManager(root_dir=tmp)

--- a/tests/test_thread_manager_lazy.py
+++ b/tests/test_thread_manager_lazy.py
@@ -25,7 +25,7 @@ from assist.thread import ThreadManager
 
 
 class TestThreadManagerLazy(TestCase):
-    def test_init_does_not_call_select_chat_model(self):
+    def test_init_does_not_call_select_assistant_model(self):
         """Constructing a ``ThreadManager`` must not touch the model."""
         with patch(
             "assist.thread.select_assistant_model",
@@ -35,8 +35,8 @@ class TestThreadManagerLazy(TestCase):
                 ThreadManager(root_dir=tmp)
 
     def test_first_model_access_calls_select(self):
-        """First read of ``.model`` triggers ``select_chat_model``; the
-        result is cached for subsequent reads."""
+        """First read of ``.model`` triggers ``select_assistant_model``;
+        the result is cached for subsequent reads."""
         sentinel = object()
         with patch(
             "assist.thread.select_assistant_model", return_value=sentinel


### PR DESCRIPTION
## What

Two eval-harness fixes (surfaced by the 2026-06-03 "slow research evals" investigation), plus a small prod/eval refactor added during review:

1. **Align the eval harness with production's reasoning setting.** Prod has run **reasoning-off** since 2026-05-01 (commit `30608e4`), but the eval harness built its agent models with bare `select_chat_model(0.1)` → reasoning **on**. So the nightly was testing a config prod never runs — ~2.8×/call slower (9× on short prompts), which manifested as research-eval *timeouts*. Aligned all 15 agent-under-test eval models to reasoning-off.

2. **Unify the per-file eval timeout (generous, for every file).** A few files (`test_agent`, `test_dev_agent`, `test_research_multi_turn`) legitimately run for many minutes — many sequential LLM calls / simulated turns on the slow local model — and were hitting the old 600s/1800s caps as NO-XML. A live slot-trace of the server during the nightly confirmed this is **real work, not a hang** (model busy ~88% of the window, no frozen decode, max single generation ~9k tokens, no runaway). Rather than special-case those files, **every** eval file now gets the same 1200s per-test / 3600s per-file caps. Simpler harness, and per-file isolation still bounds the blast radius if one ever does hang.

3. **`select_assistant_model` helper (added in review).** Rather than repeat `enable_thinking=False` at every call site (which drifts as new tests are added), there's now one helper that defaults Qwen3 reasoning **off** and is overrideable to on. Both prod and the eval harness build their models through it, so the reasoning config can't diverge again.

**Not touched:** the multi-turn *driver* model (temp 0.7, simulated user) and the low-level `select_chat_model` (kept for tests that exercise it directly, and as the non-Qwen-safe `enable_thinking=None` path).

## Evidence it works

Tonight's nightly ran this branch's config (reasoning-off). Three files that **timed out (NO-XML) every prior night** now complete:

| file | prior nights | this branch |
|---|---|---|
| `test_research_agent` | 602s NO-XML (0 tests ran) | **136s, xml-ok (all 3 ran)** |
| `test_thread_e2e` | 602s NO-XML | **159s, PASS** |
| `test_calculate_skill` | 642s NO-XML | **200s, PASS** |

Several others got faster (`test_memory` 85→58s, `test_dev_skill_loading` 102→18s). Model-level proof of the reasoning toggle: a sample call dropped **9.0s/326 tok → 1.0s/34 tok** (the 326-token default *was* the hidden `<think>`). 576 unit tests pass.

## Scope / notes

- **This is a behavior-preserving refactor, not a behavior change.** It does touch production code (`assist/thread.py`, `manage/web/threads.py`), but only to route existing reasoning-off calls through the new `select_assistant_model` helper — prod already ran reasoning-off, so runtime behavior is unchanged.
- Pass rates may shift vs the old reasoning-on runs — that's the point: the nightly now reflects what prod actually runs.
- Separate from the over-search hardening (`#120`); this PR is just the eval/prod alignment + uniform timeout + the shared-helper refactor.

## Design changes from review

- Introduced `select_assistant_model` (reasoning-off default, overrideable) at the user's request, replacing the per-call-site `enable_thinking=False` across prod (×3) and all 15 eval sites — to stop the eval/prod config from drifting as new tests land. Pinned the off-by-default contract in `TestSelectAssistantModel`.
- Unified the eval timeout to one value for all files (1200s/3600s) instead of a `HEAVY_FILES` special-case list — simpler harness, at the user's request. The slot-trace proved there are no hangs, so the generous cap costs nothing real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
