### PR TITLE
fix(middleware): stop re-appending id-less messages as duplicates

### DIFF
--- a/assist/middleware/json_validation_middleware.py
+++ b/assist/middleware/json_validation_middleware.py
@@ -4,6 +4,8 @@ import logging
 import re
 from typing import Any
 from langchain.agents.middleware import AgentMiddleware, AgentState
+from langchain_core.messages import RemoveMessage
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.runtime import Runtime
 
 logger = logging.getLogger(__name__)
@@ -386,7 +388,12 @@ class JsonValidationMiddleware(AgentMiddleware):
 
         if modified:
             logger.info(f"Sanitized {len(messages)} messages before sending to model")
-            return {"messages": sanitized_messages}
+            # Overwrite the whole history: clear then re-add the sanitized
+            # list.  Returning the list alone would re-append every id-less
+            # Human/Tool message as a duplicate (add_messages dedupes by id,
+            # and the checkpointer deserializes those with id=None).  See
+            # docs/2026-06-05-middleware-message-duplication.org.
+            return {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES)] + sanitized_messages}
 
         return None
 
@@ -451,8 +458,18 @@ class JsonValidationMiddleware(AgentMiddleware):
 
         # If we modified anything, update the state
         if modified:
-            # Update the tool calls in the last message
-            last_message.tool_calls = validated_calls
-            return {"messages": messages}
+            # Return ONLY the modified last message.  Copy it (don't mutate
+            # the channel's object in place) and set the validated calls; it
+            # keeps the model id, so add_messages replaces it by id.
+            # Returning the whole list would re-append id-less Human/Tool
+            # messages as duplicates — see
+            # docs/2026-06-05-middleware-message-duplication.org.
+            new_last = (
+                last_message.model_copy()
+                if hasattr(last_message, "model_copy")
+                else last_message.copy()
+            )
+            new_last.tool_calls = validated_calls
+            return {"messages": [new_last]}
 
         return None

--- a/assist/middleware/loop_detection.py
+++ b/assist/middleware/loop_detection.py
@@ -867,4 +867,11 @@ class LoopDetectionMiddleware(AgentMiddleware):
                 ak["tool_calls"] = []
             new_last.additional_kwargs = ak
 
-        return {"messages": messages[:-1] + [new_last]}
+        # Return ONLY the modified last message, not the whole list.  The
+        # `messages` channel reducer (`add_messages`) replaces by `.id`, and
+        # `new_last` keeps the model's id (model_copy preserves it), so this
+        # replaces the last AIMessage in place.  Returning `messages[:-1]`
+        # too would re-append every id-less HumanMessage/ToolMessage (the
+        # checkpointer deserializes them with id=None) as duplicates — see
+        # docs/2026-06-05-middleware-message-duplication.org.
+        return {"messages": [new_last]}

--- a/assist/middleware/subagent_type_inference.py
+++ b/assist/middleware/subagent_type_inference.py
@@ -143,4 +143,8 @@ class SubagentTypeInferenceMiddleware(AgentMiddleware):
                 new_last.additional_kwargs = dict(new_last.additional_kwargs)
                 new_last.additional_kwargs["tool_calls"] = new_ak_calls
 
-        return {"messages": messages[:-1] + [new_last]}
+        # Return ONLY the modified last message — add_messages replaces by
+        # id (new_last keeps the model id).  Returning the whole list would
+        # re-append id-less Human/Tool messages as duplicates; see
+        # docs/2026-06-05-middleware-message-duplication.org.
+        return {"messages": [new_last]}

--- a/assist/middleware/tool_name_sanitization.py
+++ b/assist/middleware/tool_name_sanitization.py
@@ -23,7 +23,8 @@ import re
 from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware, AgentState
-from langchain_core.messages import AIMessage, ToolMessage
+from langchain_core.messages import AIMessage, RemoveMessage, ToolMessage
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.runtime import Runtime
 
 logger = logging.getLogger(__name__)
@@ -90,7 +91,11 @@ class ToolNameSanitizationMiddleware(AgentMiddleware):
                     tc for tc in ak_calls if tc.get("id") in valid_ids
                 ]
 
-        return {"messages": messages[:-1] + [new_last]}
+        # Return ONLY the modified last message — add_messages replaces by
+        # id (new_last keeps the model id).  Returning the whole list would
+        # re-append id-less Human/Tool messages as duplicates; see
+        # docs/2026-06-05-middleware-message-duplication.org.
+        return {"messages": [new_last]}
 
     # ------------------------------------------------------------------
     # before_model: scrub history of any past invalid tool calls
@@ -156,4 +161,11 @@ class ToolNameSanitizationMiddleware(AgentMiddleware):
             "Sanitized %d invalid tool call(s) from conversation history",
             len(bad_ids),
         )
-        return {"messages": cleaned}
+        # Overwrite the whole history: clear then re-add the cleaned list.
+        # add_messages can only add/replace by id — returning a shorter list
+        # alone would NOT remove the bad messages (they'd persist) and would
+        # re-append the id-less ones as duplicates.  REMOVE_ALL_MESSAGES is
+        # the idiom for a true history rewrite; per-id RemoveMessage can't
+        # target the id-less messages we need to drop.  See
+        # docs/2026-06-05-middleware-message-duplication.org.
+        return {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES)] + cleaned}

--- a/docs/2026-06-05-middleware-message-duplication.org
+++ b/docs/2026-06-05-middleware-message-duplication.org
@@ -1,0 +1,117 @@
+#+title: Middleware corrupts message history by re-appending id-less messages
+#+date: <2026-06-05>
+
+* Problem (observed in production)
+Thread =20260605060257-e3f8753c= ("Tell me about James Blake's latest
+album and what it means to be an independent record.") showed two
+symptoms in the web UI:
+1. The user's prompt rendered TWICE — once at the bottom (oldest) and
+   once at the top (newest).
+2. No answer: the last message in the thread was the user's own prompt,
+   with nothing after it.
+
+* Root cause
+The =messages= channel uses LangGraph's =add_messages= reducer, which
+de-duplicates by =.id=.  Persisted =HumanMessage= / =ToolMessage=
+objects come back from the SqliteSaver checkpointer with =id=None=
+(confirmed: =get_raw_messages= shows id=None for every human/tool
+message; only AIMessages carry the model's =lc_run--…= id).
+
+Several middlewares, when they modify the latest AI message, return the
+ENTIRE message list:
+
+#+begin_src python
+return {"messages": messages[:-1] + [new_last]}
+#+end_src
+
+Because =after_model= receives a freshly-deserialized copy of the
+state, the id-less messages it returns are DIFFERENT objects from the
+ones already in the channel.  =add_messages= assigns fresh ids to both
+copies independently, they don't match, and the id-less messages get
+**re-appended as duplicates**.  The AIMessage (which has an id) is
+correctly replaced; everything else without an id is doubled.
+
+Reproduced against the real reducer (separate deserialized objects):
+- full-list return → duplicate trailing =HumanMessage= + replayed
+  =ToolMessage=s (the prod state had a duplicate prompt at index [10]
+  plus orphan tool results [11–15]).
+- =return {"messages": [new_last]}= → clean (last AIMessage replaced by
+  id, nothing else re-sent).
+
+In the prod thread the trigger was =LoopDetectionMiddleware= Pattern F
+(subagent-redispatch): the research sub-agents hit search rate limits,
+saved no reference files, the orchestrator re-dispatched them, loop
+detection fired and returned the full list → the duplicate prompt.
+That trailing, unanswered =HumanMessage= is why the prompt renders at
+both ends and why it looks like there was no answer.
+
+* Scope — two variants of the same anti-pattern
+** Variant A — after_model modifies ONLY the last AIMessage
+The last AIMessage always carries the model's id, so returning just it
+replaces it in place.  Sites:
+- =loop_detection.py= (the reported trigger)
+- =subagent_type_inference.py=
+- =tool_name_sanitization.py= (after_model)
+- =json_validation_middleware.py= (after_model)
+
+Fix: =return {"messages": [new_last]}= (return only the modified
+message; the reducer replaces by id).
+
+** Variant B — before_model rebuilds the WHOLE history (removes / edits middle messages)
+- =tool_name_sanitization.py= (before_model) — drops bad tool results.
+- =json_validation_middleware.py= (before_model) — fixes invalid JSON
+  escapes in past tool calls.
+
+These are DOUBLY broken: returning a shorter/edited list through
+=add_messages= cannot REMOVE a message (the reducer only adds/replaces
+by id), so the bad message stays AND the id-less messages duplicate.
+Reproduced: a before_model "scrub" of a bad tool message left the bad
+message in place and duplicated the human + good tool message.
+
+Fix: clear and rewrite atomically —
+=return {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES)] + cleaned}=.
+=REMOVE_ALL_MESSAGES= ('__remove_all__') is exported from
+=langgraph.graph.message=; per-id =RemoveMessage= is NOT viable because
+the messages to remove have =id=None=.  Verified: yields exactly the
+cleaned history, bad message gone, no duplication.
+
+*Behavior delta (intended).*  This is not a pure de-duplication fix for
+the two before_model scrubs: today they SILENTLY FAIL (the bad tool
+message is never removed, only the good messages duplicate).  After the
+fix they remove the bad messages for the first time, so the model stops
+re-seeing invalid-tool-call results / bad-JSON tool calls on subsequent
+turns.  Desirable and designed-for, but a genuine runtime behavior
+change, not just object identity.
+
+* Contract (tests)
+This is a deterministic reducer-level bug — no LLM eval can reliably
+reproduce the rate-limit→loop chain, so the contract is a unit test, not
+an eval.  Each fixed middleware gets a regression test that:
+1. builds a state with id-less Human/Tool messages (as the checkpointer
+   produces) plus an id'd AIMessage,
+2. invokes the hook,
+3. applies =add_messages= to a SEPARATE copy of the input (faithfully
+   reproducing the deserialization gap), and
+4. asserts no id-less message is duplicated, and for Variant B that the
+   targeted message is actually removed.
+
+* Design-review outcome
+Two proposed hardenings were DROPPED as theoretical (no observed-real
+case), per the repo's no-theoretical-code rule:
+- an empty-=cleaned= guard in tool_name_sanitization before_model — the
+  user's HumanMessage always survives the scrub, so =cleaned= can't be
+  empty when there is anything to remove.
+- an =isinstance(AIMessage)= guard in json_validation after_model — the
+  existing =hasattr('tool_calls') and tool_calls= check already excludes
+  every non-AI message (only AIMessage carries populated tool_calls).
+
+Variant A precondition (pinned by the tests, not by a code guard): the
+last message is always the model's just-generated AIMessage, which
+carries an =lc_run--…= id, so =[new_last]= replaces by id rather than
+appending.  json_validation after_model also stops mutating the channel
+object in place (uses =model_copy=) for parity with the other three.
+
+* Status
+- Investigation + root cause confirmed and reproduced.
+- Fix scope: A + B (6 sites) per operator.
+- Verified against langgraph 1.2.0 / langchain-core 1.4.0.

--- a/tests/middleware/test_json_validation_middleware.py
+++ b/tests/middleware/test_json_validation_middleware.py
@@ -9,9 +9,21 @@ requests to vLLM, including:
 import json
 import pytest
 from unittest.mock import Mock
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage
 
 from assist.middleware.json_validation_middleware import JsonValidationMiddleware
+
+
+def _payload(result):
+    """Concrete messages from a before_model return, minus the reset marker.
+
+    before_model rewrites history as ``[RemoveMessage(REMOVE_ALL_MESSAGES)] +
+    cleaned`` (it must clear-then-readd so add_messages actually removes, and
+    doesn't re-append id-less messages as duplicates — see
+    docs/2026-06-05-middleware-message-duplication.org).  The concrete
+    messages are everything after that leading marker.
+    """
+    return [m for m in result["messages"] if not isinstance(m, RemoveMessage)]
 
 
 class TestJsonValidationMiddleware:
@@ -83,7 +95,7 @@ And escaped quote: \"quoted\""""
 
         # Should return modified state
         if result is not None:
-            sanitized_messages = result["messages"]
+            sanitized_messages = _payload(result)
             sanitized_content = sanitized_messages[0].content
 
             # Verify it's JSON-safe
@@ -114,7 +126,7 @@ And escaped quote: \"quoted\""""
 
         # Should return modified state
         if result is not None:
-            sanitized_messages = result["messages"]
+            sanitized_messages = _payload(result)
             sanitized_args = sanitized_messages[0].tool_calls[0]['args']
 
             # Verify args are JSON-safe
@@ -192,7 +204,7 @@ This report provides a comprehensive comparison of technologies A and B.
 
         # Extract the content (modified or original)
         if result is not None:
-            final_content = result["messages"][0].tool_calls[0]['args']['content']
+            final_content = _payload(result)[0].tool_calls[0]['args']['content']
         else:
             final_content = msg.tool_calls[0]['args']['content']
 
@@ -389,7 +401,7 @@ class TestInvalidEscapeInToolCallArguments:
         assert result is not None, "Middleware should have detected and fixed invalid JSON"
 
         # Extract the fixed arguments string
-        fixed_msg = result["messages"][1]
+        fixed_msg = _payload(result)[1]
         fixed_args_str = fixed_msg.additional_kwargs['tool_calls'][0]['function']['arguments']
 
         # The fixed arguments must be valid JSON
@@ -429,7 +441,7 @@ class TestInvalidEscapeInToolCallArguments:
 
         # Should not modify valid arguments
         if result is not None:
-            fixed_args = result["messages"][0].additional_kwargs['tool_calls'][0]['function']['arguments']
+            fixed_args = _payload(result)[0].additional_kwargs['tool_calls'][0]['function']['arguments']
             assert fixed_args == valid_arguments
 
     def test_fix_json_invalid_escapes(self):

--- a/tests/middleware/test_message_duplication.py
+++ b/tests/middleware/test_message_duplication.py
@@ -18,7 +18,6 @@ crux — these tests assert it (left-operand human/tool are ``id=None``).
 """
 from unittest.mock import Mock
 
-import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.graph.message import add_messages
 
@@ -224,8 +223,10 @@ class TestBeforeModelScrub:
 
         mw = JsonValidationMiddleware(strict=False)
         update = mw.before_model({"messages": incoming}, Mock())
-        if update is None:
-            pytest.skip("json_validation before_model did not flag this input")
+        # The \x07 control char deterministically trips content sanitization,
+        # so the scrub must fire — a skip here would let the suite pass if the
+        # scrub silently stopped working.
+        assert update is not None, "control char should have tripped sanitization"
 
         merged = add_messages(channel, update["messages"])
         counts = _content_counts(merged)

--- a/tests/middleware/test_message_duplication.py
+++ b/tests/middleware/test_message_duplication.py
@@ -1,0 +1,234 @@
+"""Regression tests for the middleware message-duplication bug.
+
+All six fixed hooks shared one anti-pattern: when a middleware modified a
+message it returned the WHOLE ``messages`` list.  The channel reducer
+(``add_messages``) dedupes by ``.id``, but the checkpointer deserializes
+``HumanMessage`` / ``ToolMessage`` with ``id=None``.  Because ``after_model``
+receives a *separate* deserialized copy of the state, returning the full list
+re-appends every id-less message as a duplicate — which is what put a duplicate
+trailing ``HumanMessage`` in prod thread 20260605060257-e3f8753c (prompt
+rendered twice, looked unanswered).  See
+docs/2026-06-05-middleware-message-duplication.org.
+
+Each test reproduces the deserialization gap faithfully: the hook is fed one
+set of message objects (``incoming``) and its return is reduced against a
+*separate, identical* set (``channel``).  A test that reused the same objects
+would pass even against the buggy full-list return, so the separation is the
+crux — these tests assert it (left-operand human/tool are ``id=None``).
+"""
+from unittest.mock import Mock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.graph.message import add_messages
+
+from assist.middleware.loop_detection import LoopDetectionMiddleware
+from assist.middleware.subagent_type_inference import SubagentTypeInferenceMiddleware
+from assist.middleware.tool_name_sanitization import ToolNameSanitizationMiddleware
+from assist.middleware.json_validation_middleware import JsonValidationMiddleware
+
+
+def _ai(tc_id, name, args, *, id, content=""):
+    """AIMessage with a model-style id and one tool call (mirrors prod)."""
+    msg = AIMessage(content=content, id=id)
+    msg.tool_calls = [{"id": tc_id, "name": name, "args": args}]
+    return msg
+
+
+def _tool(tc_id, content, status="success"):
+    """ToolMessage with id=None, as the checkpointer deserializes it."""
+    return ToolMessage(content=content, tool_call_id=tc_id, status=status)
+
+
+def _human(content):
+    return HumanMessage(content=content)  # id=None
+
+
+def _content_counts(messages):
+    """Count messages by (type, content) so duplicates are visible."""
+    counts = {}
+    for m in messages:
+        key = (type(m).__name__, str(m.content))
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _assert_deserialization_gap(channel):
+    """Pin the precondition the bug needs: id-less human/tool, id'd last AI."""
+    for m in channel:
+        if isinstance(m, (HumanMessage, ToolMessage)):
+            assert m.id is None, f"test setup: {type(m).__name__} should be id-less"
+    assert isinstance(channel[-1], AIMessage) and channel[-1].id, (
+        "test setup: last message must be an AIMessage carrying an id"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Variant A — after_model hooks that modify only the last AIMessage
+# ---------------------------------------------------------------------------
+
+class TestAfterModelNoDuplication:
+    def test_loop_detection(self):
+        # Pattern A: same tool + same error twice, last call extends it.
+        def build():
+            return [
+                _human("do the thing"),
+                _ai("c1", "write_file", {"file_path": "/a"}, id="ai-1"),
+                _tool("c1", "Error: cannot write /a"),
+                _ai("c2", "write_file", {"file_path": "/a"}, id="ai-2"),
+                _tool("c2", "Error: cannot write /a"),
+                _ai("c3", "write_file", {"file_path": "/a"}, id="ai-3"),
+            ]
+        channel, incoming = build(), build()
+        _assert_deserialization_gap(channel)
+
+        mw = LoopDetectionMiddleware(error_repeat_threshold=2)
+        update = mw.after_model({"messages": incoming}, Mock())
+        assert update is not None, "loop should have been detected"
+
+        merged = add_messages(channel, update["messages"])
+        counts = _content_counts(merged)
+        assert counts[("HumanMessage", "do the thing")] == 1
+        # The last AI is replaced in place: same count as the channel, the
+        # final message has no tool calls (loop terminated).
+        assert len(merged) == len(channel)
+        assert merged[-1].tool_calls == []
+
+    def test_tool_name_sanitization(self):
+        def build():
+            return [
+                _human("hello"),
+                _tool("prev", "earlier result"),
+                _ai("bad", "[]", {}, id="ai-1"),  # invalid tool name -> stripped
+            ]
+        channel, incoming = build(), build()
+        _assert_deserialization_gap(channel)
+
+        mw = ToolNameSanitizationMiddleware()
+        update = mw.after_model({"messages": incoming}, Mock())
+        assert update is not None
+
+        merged = add_messages(channel, update["messages"])
+        counts = _content_counts(merged)
+        assert counts[("HumanMessage", "hello")] == 1
+        assert counts[("ToolMessage", "earlier result")] == 1
+        assert len(merged) == len(channel)
+        assert merged[-1].tool_calls == []
+
+    def test_subagent_type_inference(self):
+        def build():
+            return [
+                _human("research X"),
+                _tool("prev", "earlier result"),
+                # A `task` call whose subagent_type is wrong/missing so the
+                # middleware patches it -> returns the modified last message.
+                _ai("t1", "task",
+                    {"description": "go", "subagent_type": "reasearch-agent"},
+                    id="ai-1"),
+            ]
+        channel, incoming = build(), build()
+        _assert_deserialization_gap(channel)
+
+        mw = SubagentTypeInferenceMiddleware(valid_subagent_types={"research-agent"})
+        update = mw.after_model({"messages": incoming}, Mock())
+        assert update is not None, "subagent type should have been inferred/patched"
+
+        merged = add_messages(channel, update["messages"])
+        counts = _content_counts(merged)
+        assert counts[("HumanMessage", "research X")] == 1
+        assert counts[("ToolMessage", "earlier result")] == 1
+        assert len(merged) == len(channel)
+
+    def test_json_validation(self):
+        # after_model only flags a tool call carrying a raw `function`
+        # payload with invalid-JSON `arguments` (see _validate_tool_call);
+        # craft exactly that so the fixed return path is exercised.
+        def build():
+            ai = AIMessage(content="", id="ai-1")
+            ai.tool_calls = [{
+                "id": "c1", "name": "write_file", "args": {"file_path": "/a"},
+                "function": {"name": "write_file",
+                             "arguments": '{"file_path": "/a", invalid}'},
+            }]
+            return [_human("hi"), _tool("prev", "earlier result"), ai]
+        channel, incoming = build(), build()
+        _assert_deserialization_gap(channel)
+
+        mw = JsonValidationMiddleware(strict=False)
+        update = mw.after_model({"messages": incoming}, Mock())
+        assert update is not None, "invalid-JSON arguments should have been flagged"
+
+        merged = add_messages(channel, update["messages"])
+        counts = _content_counts(merged)
+        assert counts[("HumanMessage", "hi")] == 1
+        assert counts[("ToolMessage", "earlier result")] == 1
+        assert len(merged) == len(channel)
+        # The fix returns a COPY (no in-place mutation of the channel object).
+        assert incoming[-1] is not merged[-1]
+
+
+# ---------------------------------------------------------------------------
+# Variant B — before_model history scrubs (must REMOVE, not just dedupe)
+# ---------------------------------------------------------------------------
+
+class TestBeforeModelScrub:
+    def test_tool_name_sanitization_removes_bad_messages(self):
+        # History carries an AIMessage with an invalid-named tool call plus
+        # its result; the scrub must remove BOTH and not duplicate anything.
+        def build():
+            ai = AIMessage(content="", id="ai-1")
+            ai.tool_calls = [
+                {"id": "bad", "name": "[]", "args": {}},
+                {"id": "ok", "name": "ls", "args": {"path": "/"}},
+            ]
+            return [
+                _human("hello"),
+                ai,
+                _tool("bad", "bad result"),
+                _tool("ok", "good result"),
+            ]
+        channel, incoming = build(), build()
+        for m in channel:
+            if isinstance(m, (HumanMessage, ToolMessage)):
+                assert m.id is None
+
+        mw = ToolNameSanitizationMiddleware()
+        update = mw.before_model({"messages": incoming}, Mock())
+        assert update is not None, "scrub should have fired"
+
+        merged = add_messages(channel, update["messages"])
+        counts = _content_counts(merged)
+        # Bad tool result is actually gone (the old code left it in place).
+        assert ("ToolMessage", "bad result") not in counts
+        # Good messages survive exactly once (no duplication).
+        assert counts[("HumanMessage", "hello")] == 1
+        assert counts[("ToolMessage", "good result")] == 1
+        # The surviving AI keeps only the valid call.
+        ai_msgs = [m for m in merged if isinstance(m, AIMessage)]
+        assert len(ai_msgs) == 1
+        assert [tc["name"] for tc in ai_msgs[0].tool_calls] == ["ls"]
+
+    def test_json_validation_scrub_no_duplication(self):
+        # A control character in past content triggers before_model
+        # sanitization, which returns the rewritten history.
+        def build():
+            return [
+                _human("hello"),
+                _tool("c1", "result with \x07 bell control char"),
+                AIMessage(content="prior answer", id="ai-1"),
+            ]
+        channel, incoming = build(), build()
+        for m in channel:
+            if isinstance(m, (HumanMessage, ToolMessage)):
+                assert m.id is None
+
+        mw = JsonValidationMiddleware(strict=False)
+        update = mw.before_model({"messages": incoming}, Mock())
+        if update is None:
+            pytest.skip("json_validation before_model did not flag this input")
+
+        merged = add_messages(channel, update["messages"])
+        counts = _content_counts(merged)
+        assert counts[("HumanMessage", "hello")] == 1
+        # Exactly the same number of messages — content sanitized, none added.
+        assert len(merged) == len(channel)


### PR DESCRIPTION
## What & why

Reported from thread `20260605060257-e3f8753c` ("Tell me about James Blake's latest album…"): the prompt rendered **twice** in the web UI (top and bottom) and the thread looked **unanswered**.

Both symptoms trace to one mechanical bug. The LangGraph `messages` channel uses the `add_messages` reducer, which de-duplicates by `.id`. The SqliteSaver checkpointer deserializes `HumanMessage`/`ToolMessage` with **`id=None`** (only AIMessages carry an `lc_run--…` id). Several middleware hooks, when they modified the latest AI message, returned the **whole** message list:

```python
return {"messages": messages[:-1] + [new_last]}
```

Because `after_model` receives a *separately deserialized* copy of the state, the id-less messages it returns are different objects from the channel's. `add_messages` assigns fresh ids to both and **re-appends the id-less ones as duplicates**. In the prod thread, `LoopDetectionMiddleware` Pattern F fired (the research sub-agents hit search rate limits and the orchestrator re-dispatched them), returned the full list, and produced a duplicate trailing `HumanMessage` — which renders at both ends and leaves the user's question as the last message (no answer after it).

Reproduced against the real reducer with separate objects: full-list return → duplicate human + replayed tool messages; `return {"messages": [new_last]}` → clean.

## The fix (6 sites, two variants)

**Variant A — `after_model` modifies only the last (id-bearing) AIMessage.** Return only the modified message; `add_messages` replaces it by id.
- `loop_detection.py`, `subagent_type_inference.py`, `tool_name_sanitization.py`, `json_validation_middleware.py`
- `json_validation` also stops mutating the channel object in place (uses `model_copy`).

**Variant B — `before_model` history scrubs that REMOVE/edit middle messages.** A plain shorter list can't remove anything via `add_messages` (the reducer only adds/replaces by id), so today these scrubs **silently fail** — the bad message persists *and* the good ones duplicate. Fixed with a clear-and-rewrite:
```python
return {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES)] + cleaned}
```
- `tool_name_sanitization.py`, `json_validation_middleware.py`

## Behavior change from review

The two Variant-B scrubs go from *silently broken* to *actually removing* the bad messages (invalid-tool-name results; bad-JSON tool calls) for the first time — so the model stops re-seeing them on later turns. Desirable and designed-for, but a genuine runtime behavior change, not just object identity.

## Tests

This is a deterministic reducer-level bug, so the contract is a unit test, not an LLM eval. New `tests/middleware/test_message_duplication.py` reproduces the deserialization gap (separate `channel` vs `incoming` objects) for all 6 hooks and asserts no id-less duplication (and, for Variant B, that the targeted message is actually removed). Verified the tests **fail on the old code** and pass on the fix. Existing `test_json_validation_middleware.py` updated for the new return shape via a `_payload()` helper. Full unit suite green.

Design + investigation: `docs/2026-06-05-middleware-message-duplication.org`.

## Out of scope (separate issue)

This fixes the message corruption and the dangling-unanswered-human. The *deeper* reason that thread had no substantive answer — the research sub-agents hitting search rate limits and the orchestrator giving up — is a separate research/rate-limit matter, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)