### PR TITLE
fix(search): use ddgs backend="auto" for engine fallback

### DIFF
--- a/assist/tools.py
+++ b/assist/tools.py
@@ -1,5 +1,5 @@
-"""Web tools the agent exposes: a throttled DuckDuckGo search and a
-per-host throttled URL fetch.
+"""Web tools the agent exposes: a throttled multi-engine web search
+(via ``ddgs`` with ``backend="auto"``) and a per-host throttled URL fetch.
 
 Throttle/rate-limit shape (added 2026-05-31 after two adjacent failure
 modes burned the dev box's IP: a research-agent emitted ~9,000
@@ -65,7 +65,7 @@ _search_circuit_open_until = 0.0
 _SEARCH_CIRCUIT_DURATION_S = 600  # 10 minutes
 
 _CIRCUIT_OPEN_MESSAGE = (
-    "Search is rate-limited (DuckDuckGo). Cannot retry for ~10 minutes. "
+    "Search is rate-limited (web search). Cannot retry for ~10 minutes. "
     "Finalize your response using what's already gathered; tell the user "
     "search is temporarily rate-limited and to try again in a few minutes."
 )
@@ -246,9 +246,17 @@ def search_internet(
     _search_throttle()
     t0 = time.time()
     try:
+        # backend="auto" rotates across ddgs's engines (DuckDuckGo, Bing,
+        # Brave, Mojeek, …) and falls back when one fails.  Pinning a single
+        # backend="duckduckgo" made us hostage to DDG's scrape endpoint, which
+        # flakily raises DDGSException("No results found.") even when the IP is
+        # fine (the browser works) — and our timing heuristic then misreads
+        # that fast empty as a rate-limit and opens the circuit for 10 min.
+        # "auto" only surfaces "No results found." when EVERY engine fails,
+        # which is the genuine-unavailable signal the circuit breaker wants.
         results = DDGS().text(query,
                               max_results=max_results,
-                              backend="duckduckgo")
+                              backend="auto")
         _record_search_success()
     except Exception as e:
         elapsed = time.time() - t0

--- a/docs/2026-06-05-search-backend-auto-fallback.org
+++ b/docs/2026-06-05-search-backend-auto-fallback.org
@@ -1,0 +1,68 @@
+#+title: Search returns nothing — pinned to the one flaky ddgs backend
+#+date: <2026-06-05>
+
+* Problem (observed in production)
+Thread =20260605072211-aa01ee43= ("James Blake independent music") — the
+FIRST research request of the morning — produced no answer.  The
+research-agent searched, got nothing, over-searched into the volume cap,
+emitted "I'll write up what I have now" (writing nothing), and the
+orchestrator gave up.  The user noted DuckDuckGo works fine from their
+browser on the SAME IP, and being "rate-limited" on the first request of
+the day makes no sense.
+
+* Root cause
+=search_internet= (=assist/tools.py=) hardcoded
+=DDGS().text(query, backend="duckduckgo")= — a SINGLE scrape backend with
+no fallback (added in =3eca708= "Moving to duckduckgo over tavily").  That
+backend is FLAKY: measured live on the prod box, it intermittently raises
+=DDGSException("No results found.")= in ~0.3s while the IP is perfectly
+fine — the browser works, and =ddgs= backends =auto= / =bing= / =brave= /
+=mojeek= all return 5 real results for the same queries.
+
+Two compounding failures from the single pin:
+1. *No engine fallback.*  When DDG's scrape endpoint flakes, the whole
+   request fails — there's no second engine to try.  A given thread gets
+   nothing; the next one may succeed (it's intermittent), which is why
+   "search works sometimes."
+2. *The flaky empty is misread as a rate-limit.*  The rate-limit timing
+   heuristic treats a fast (<3s) "No results found." as a block and opens
+   the circuit for 10 minutes — so one scrape flake can wedge search for
+   the next 10 minutes, manufacturing the "rate-limited on the first
+   request" symptom the user saw.
+
+This is NOT an IP block and NOT a real rate-limit.  It is the single
+pinned backend being unreliable.
+
+* Fix
+=backend="duckduckgo"= → =backend="auto"=.  =ddgs= "auto" rotates across
+its engines (DuckDuckGo, Bing, Brave, Mojeek, …) and falls back when one
+fails, so a single flaky engine no longer kills the request.  As a bonus
+it makes the rate-limit heuristic ACCURATE: "auto" only surfaces "No
+results found." when EVERY engine fails, which is the genuine
+search-unavailable signal the circuit breaker actually wants.
+
+Verified live on the prod box after the change: =search_internet= returns
+5 real results for every query tried (James Blake album, independent
+record labels, tabata intervals, asyncio) — where the old pin returned
+=[]= / flaky "No results found.".
+
+* Tests
+- =tests/test_tools.py::TestSearchInternet::test_uses_auto_backend_for_engine_fallback=
+  pins =backend="auto"= (fails on the old =duckduckgo= pin).  Existing
+  throttle / circuit-breaker / rate-limit-detection tests unchanged and
+  green (mocked DDGS, backend-agnostic).
+- The circuit-breaker machinery, prompts, and the rate-limit relay
+  (#118/#119) are untouched — this fixes the transport beneath them.
+
+* Out of scope / follow-ups
+- The volume-cap terminal message ("I'll write up what I have now") is a
+  false promise when it fires — the strip ends the turn and nothing is
+  written.  With working search the research-agent converges before the
+  cap, so this no longer bites the common path; the misleading message is
+  a separate UX issue.
+- A real/managed search API (roadmap item) would remove scrape flakiness
+  entirely; "auto" is the cheap, immediate resilience win.
+
+* Status
+- Root cause measured + fixed; transport now returns real results on the
+  prod box.  Backend pinned to "auto" with a regression test.

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -218,6 +218,25 @@ class TestSearchInternet:
             # 1 failure → success (reset) → 1 failure = below threshold.
             assert not tools._circuit_is_open()
 
+    def test_uses_auto_backend_for_engine_fallback(self):
+        """Must call ddgs with backend="auto", not a single pinned engine.
+
+        Pinning backend="duckduckgo" made search hostage to DDG's scrape
+        endpoint, which flakily raised "No results found." even when the IP
+        was fine — starving research and tripping the rate-limit heuristic.
+        "auto" rotates across engines and falls back, so one flaky engine no
+        longer kills the request.  Pin the contract so we don't regress to a
+        single backend."""
+        with patch.object(tools, "time") as t, \
+             patch.object(tools, "DDGS") as ddgs:
+            t.time.return_value = 5000.0
+            ddgs.return_value.text.return_value = [
+                {"title": "x", "href": "https://e.com", "body": "y"}
+            ]
+            tools.search_internet("query")
+            _, kwargs = ddgs.return_value.text.call_args
+            assert kwargs.get("backend") == "auto"
+
 
 # -------------------- rate-limit detection on exception -----------------
 


### PR DESCRIPTION
## What & why

From thread `20260605072211-aa01ee43` ("James Blake independent music") — the **first** research request of the morning produced no answer. The user noted DuckDuckGo works fine in their browser on the same IP, and being "rate-limited" on the first request makes no sense.

It wasn't a rate-limit or an IP block. `search_internet` (`assist/tools.py`) hardcoded `DDGS().text(query, backend="duckduckgo")` — a **single flaky scrape backend with no fallback** (added in `3eca708`). Measured live on the box: that backend intermittently raises `DDGSException("No results found.")` in ~0.3s while the IP is fine — `ddgs` backends `auto`/`bing`/`brave`/`mojeek` all return 5 real results for the same queries.

Two failures from the single pin:
1. **No engine fallback** — when DDG's scrape endpoint flakes, the whole request fails; a research thread gets nothing (intermittently, which is why search "works sometimes").
2. **The fast empty is misread as a rate-limit** — the timing heuristic treats a fast "No results found." as a block and opens the circuit for 10 min, manufacturing the spurious "rate-limited on the first request" symptom.

Downstream, the research-agent got nothing → over-searched into the volume cap → emitted "I'll write up what I have now" (writing nothing) → orchestrator gave up.

## Fix

`backend="duckduckgo"` → `backend="auto"`. `ddgs` "auto" rotates across engines and falls back, so one flaky engine no longer kills the request. Bonus: it makes the rate-limit heuristic accurate — "auto" only surfaces "No results found." when **every** engine fails, the genuine unavailable signal.

Verified live after the change: `search_internet` returns 5 real results for every query tried (James Blake album, independent record labels, tabata intervals, asyncio).

## Tests

`test_uses_auto_backend_for_engine_fallback` pins `backend="auto"` (fails on the old pin). Existing throttle / circuit-breaker / rate-limit-detection tests unchanged and green (mocked, backend-agnostic).

Design: `docs/2026-06-05-search-backend-auto-fallback.org`.

## Out of scope

- The volume-cap terminal message ("I'll write up what I have now") is a false promise when it fires — separate UX issue; with working search the agent converges before the cap.
- A real/managed search API (roadmap) would remove scrape flakiness entirely; "auto" is the cheap immediate win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)