### PR TITLE
fix(sandbox): stamp run uid/gid on uploads so write_file output is editable

### DIFF
--- a/assist/sandbox.py
+++ b/assist/sandbox.py
@@ -1,8 +1,10 @@
 """Docker sandbox backend for isolated code execution.
 
 Implements BaseSandbox from deepagents, providing execute() via Docker
-container.exec_run(). All file operations (read, write, edit, grep, glob, ls)
-are inherited from BaseSandbox and work via execute().
+container.exec_run(). Most file operations (read, edit, grep, glob, ls) are
+inherited from BaseSandbox and work via execute(); write() goes through
+upload_files()/put_archive(), which is why upload ownership has to be stamped
+explicitly (see _run_uid_gid / upload_files).
 
 Paths are prefixed with work_dir (/workspace) so that agent paths like
 /myfile.txt map to /workspace/myfile.txt inside the container, which is
@@ -113,6 +115,7 @@ class DockerSandboxBackend(BaseSandbox):
         self.container = container
         self.work_dir = work_dir.rstrip("/")
         self._strip_prefixes = strip_prefixes
+        self._run_ids: tuple[int, int] | None = None
 
     def _strip(self, path: str | None) -> str | None:
         if not path or not self._strip_prefixes:
@@ -138,6 +141,59 @@ class DockerSandboxBackend(BaseSandbox):
         if path.startswith(self.work_dir):
             return path
         return self.work_dir + (path if path.startswith("/") else "/" + path)
+
+    def _run_uid_gid(self) -> tuple[int, int]:
+        """Resolve the container's run user — the single source of file ownership.
+
+        The container is started with ``user="<uid>:<gid>"`` (the workspace
+        owner) in ``SandboxManager.get_sandbox_backend``.  That one decision
+        governs *everything*: the main process, every ``exec_run`` (which
+        inherits the run user when no ``user=`` is passed — so ``read``,
+        ``write``'s preflight, ``edit``, ``execute`` all run as it), and the
+        ownership uploads must stamp.
+
+        ``put_archive`` is the one operation that does NOT inherit it: the
+        Docker daemon extracts archives as root regardless of the container's
+        run user, so a bare ``TarInfo`` (uid/gid default to 0) lands every
+        ``write_file`` as root:root — which the non-root sandbox then can't
+        ``edit_file`` (PermissionError on the rewrite).  ``upload_files``
+        closes that gap by stamping the run uid/gid onto the tar member,
+        reading it back from the live container here so it can never drift
+        from what the container actually runs as.
+
+        Falls back to the web-process owner if the container's configured
+        user is missing/non-numeric (e.g. a mocked container in tests).  In
+        the single-user deploy that equals the run user — and it is still
+        strictly better than leaving uploads root-owned.
+        """
+        if self._run_ids is not None:
+            return self._run_ids
+        uid = gid = None
+        configured = None
+        try:
+            configured = self.container.attrs["Config"]["User"]
+            parts = str(configured).split(":")
+            uid = int(parts[0])
+            gid = int(parts[1]) if len(parts) > 1 else uid
+        except (KeyError, TypeError, ValueError, AttributeError):
+            uid = gid = None
+        if uid is None:
+            # The deploy always starts the container with a numeric
+            # `user="uid:gid"`, so an unparseable Config.User on a real
+            # sandbox means something drifted (docker-py format change, a
+            # container started without `user=`).  Don't silently paper over
+            # it — that's how the original root-owned-upload bug hid.  The
+            # getuid fallback keeps uploads non-root (correct in the
+            # single-user deploy and for mocked containers in tests), but log
+            # loudly so the drift is visible before the next PermissionError.
+            uid, gid = os.getuid(), os.getgid()
+            logger.warning(
+                "Sandbox container %s has no parseable Config.User (%r); "
+                "stamping uploads with the web-process owner %d:%d instead.",
+                getattr(self.container, "id", "?"), configured, uid, gid,
+            )
+        self._run_ids = (uid, gid)
+        return self._run_ids
 
     @property
     def id(self) -> str:
@@ -275,6 +331,7 @@ class DockerSandboxBackend(BaseSandbox):
         import io
         import tarfile
 
+        uid, gid = self._run_uid_gid()
         responses = []
         for path, content in files:
             resolved = self._resolve(path)
@@ -283,6 +340,12 @@ class DockerSandboxBackend(BaseSandbox):
                 with tarfile.open(fileobj=tar_stream, mode="w") as tar:
                     info = tarfile.TarInfo(name=resolved.lstrip("/"))
                     info.size = len(content)
+                    # Stamp the run uid/gid so put_archive (which extracts as
+                    # root) doesn't leave the file root-owned and un-editable
+                    # by the non-root sandbox.  uname/gname stay empty so the
+                    # numeric ids are authoritative.  See _run_uid_gid.
+                    info.uid = uid
+                    info.gid = gid
                     tar.addfile(info, io.BytesIO(content))
                 tar_stream.seek(0)
                 self.container.put_archive("/", tar_stream)

--- a/assist/sandbox_manager.py
+++ b/assist/sandbox_manager.py
@@ -244,6 +244,15 @@ class SandboxManager:
                 "whole threads dir at once, $ASSIST_THREADS_DIR).  "
                 "See docs/2026-05-08-restrict-git-real-via-non-root-sandbox.org."
             )
+        # SINGLE SOURCE OF TRUTH for the sandbox run user.  This one value
+        # (the workspace owner) is applied via `containers.run(user=...)`
+        # below and governs everything downstream: every `exec_run` inherits
+        # it (no call passes `user=`), and `DockerSandboxBackend.upload_files`
+        # reads it back off the container (`_run_uid_gid`) to stamp uploaded
+        # files with the same ownership — otherwise put_archive's root default
+        # leaves write_file output un-editable.  New features must NOT pass a
+        # different `user=` to `exec_run` or hardcode a uid; derive from the
+        # container's run user so ownership and execution stay aligned.
         user_arg = f"{st.st_uid}:{st.st_gid}"
 
         # Egress proxy bring-up runs OUTSIDE the broad-except below.

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -5,7 +5,7 @@ All Docker interactions are mocked — no real Docker daemon needed.
 import os
 import tempfile
 import shutil
-from unittest import TestCase
+from unittest import TestCase, skipIf
 from unittest.mock import patch, MagicMock, PropertyMock
 
 from assist.sandbox import (
@@ -341,6 +341,60 @@ class TestDockerSandboxBackendPathPrefixing(TestCase):
 
         self.assertEqual(len(responses), 1)
         self.assertEqual(responses[0].error, "file_not_found")
+
+    @staticmethod
+    def _uploaded_tarinfo(put_archive_mock):
+        """Pull the single TarInfo out of a captured put_archive(stream) call."""
+        import io
+        import tarfile
+
+        stream = put_archive_mock.call_args[0][1]
+        stream.seek(0)
+        with tarfile.open(fileobj=io.BytesIO(stream.read()), mode="r") as tar:
+            members = tar.getmembers()
+        assert len(members) == 1, members
+        return members[0]
+
+    def test_upload_files_stamps_run_uid_gid(self):
+        # Regression: a bare TarInfo (uid/gid default to 0) makes put_archive
+        # — which extracts as root — leave write_file output root-owned, which
+        # the non-root sandbox then can't edit_file (PermissionError).  The
+        # uploaded file must carry the container's run uid/gid instead.
+        self.container.attrs = {"Config": {"User": "1007:1009"}}
+        self.container.put_archive.return_value = True
+
+        responses = self.sandbox.upload_files([("/workspace/foo.md", b"hello")])
+
+        self.assertIsNone(responses[0].error)
+        member = self._uploaded_tarinfo(self.container.put_archive)
+        self.assertEqual(member.uid, 1007)
+        self.assertEqual(member.gid, 1009)
+        # Names stay empty so the numeric ids are authoritative on extract.
+        self.assertEqual(member.uname, "")
+        self.assertEqual(member.gname, "")
+
+    def test_upload_files_uid_only_user_reuses_for_gid(self):
+        self.container.attrs = {"Config": {"User": "1007"}}
+        self.container.put_archive.return_value = True
+
+        self.sandbox.upload_files([("/workspace/foo.md", b"hi")])
+
+        member = self._uploaded_tarinfo(self.container.put_archive)
+        self.assertEqual((member.uid, member.gid), (1007, 1007))
+
+    @skipIf(os.getuid() == 0, "fallback asserts a non-root owner; meaningless as root")
+    def test_upload_files_falls_back_to_process_owner_when_user_unparseable(self):
+        # A non-numeric / missing Config.User (e.g. a mocked container) must
+        # not silently revert to root-owned uploads.
+        self.container.attrs = {"Config": {"User": ""}}
+        self.container.put_archive.return_value = True
+
+        self.sandbox.upload_files([("/workspace/foo.md", b"hi")])
+
+        member = self._uploaded_tarinfo(self.container.put_archive)
+        self.assertEqual(member.uid, os.getuid())
+        self.assertEqual(member.gid, os.getgid())
+        self.assertNotEqual(member.uid, 0)
 
 
 class TestSandboxManager(TestCase):


### PR DESCRIPTION
## Problem

`edit_file` failed in prod (thread `20260606083812`) with:

\`\`\`
File "<string>", line 46, in <module>
    with open(path, 'wb') as f:
PermissionError: [Errno 13] Permission denied: '/workspace/references/independent_record.md'
\`\`\`

The file existed and was readable (the server-side edit script got past `isfile` + string-match, all the way to the write), but the rewrite was denied.

## Root cause (reproduced against the real `assist-sandbox` image)

1. `BaseSandbox.write()` (deepagents) doesn't write via a shell command — it calls `upload_files()` → `container.put_archive()`.
2. The Docker daemon extracts archives **as root, regardless of the container's `--user`**. Our `DockerSandboxBackend.upload_files` built the tar member with a bare `tarfile.TarInfo` (uid/gid default to **0**), so every `write_file` landed **root:root, mode 0644** — on the host bind-mount too.
3. The sandbox container runs as a **non-root** user (the workspace owner, mandated by the privilege-separation layer — `docs/2026-05-08-restrict-git-real-via-non-root-sandbox.org`). `edit_file`'s server-side script runs as that uid via `exec_run` → `open(path,'wb')` on a root-owned 0644 file → **PermissionError**.

So any `write_file` → `edit_file` on the same path was broken. Verified empirically: a bare `TarInfo` yields `-rw-r--r-- 0 0` and `open('wb')` fails as the run user; stamping the run uid/gid yields `-rw-r--r-- 1000 1000` and the edit succeeds.

A secondary diagnosis hazard: deepagents truncates the edit error `detail` to `output[:200]` — the *first* 200 chars of a traceback (just the header), not the `PermissionError` at the bottom — so the real cause was invisible in the tool result and only recoverable from the service journal.

## Fix

`assist/sandbox.py` — `upload_files` now stamps the tar member's `uid`/`gid` with the container's run user, resolved by a new `_run_uid_gid()` that reads it back off the live container's `Config.User`. That's the **single source of truth**: `exec_run` already inherits the run user automatically (verified: it follows `docker run --user`, not the image `USER`), so reading the same value for uploads makes ownership and execution structurally incapable of diverging. Cached (the run user is immutable post-creation). Falls back to the web-process owner **with a loud `logger.warning`** if `Config.User` is ever unparseable, rather than silently reverting to root-owned uploads.

`assist/sandbox_manager.py` — comment marking `user_arg` as the single source of truth and warning future features not to override `exec_run(user=)` or hardcode a uid.

`download_files` deliberately unchanged: it reads bytes *out* of the container and never chowns on the host, so tar ownership is irrelevant there.

## Top-level alignment

The container's run user (set once in `SandboxManager` from the workspace owner) now governs **all three** of: the main process, every `exec_run` (inherited), and upload ownership (`_run_uid_gid`). No second constant to drift; new features that spin up a sandbox or do file ops inherit the same user automatically.

## Existing root-owned files

Pre-existing root-owned files from before this fix are swept by the recursive `chown -R $USER:$USER $ASSIST_THREADS_DIR` that already runs on every `make deploy-code` / `install-service.sh`. This fix prevents new ones and repairs the in-session write→edit path.

## Testing

- 3 new unit tests in `tests/test_sandbox.py` pin the wire-level contract (parse the captured `put_archive` stream, assert `TarInfo.uid/gid/uname/gname`): happy path (`"1007:1009"`), uid-only user, and the non-root fallback (skipped when run as root).
- Full `tests/test_sandbox*.py` suites pass.
- End-to-end against the real image: `write_file` → file owned `1000:1000` → `edit_file` succeeds (the exact prod failure path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)