### PR TITLE
Roll back loop detection to exact-repeat guards (A+B only)

### DIFF
--- a/assist/agent.py
+++ b/assist/agent.py
@@ -140,14 +140,13 @@ def create_agent(model: BaseChatModel,
     ``critique`` subagents are built separately and do not see these
     tools (correctly, given their roles).  Default ``None`` is empty.
 
-    ``loop_exploration_tools`` is forwarded to the MAIN agent's
-    ``LoopDetectionMiddleware(exploration_tools=...)``: tool names whose
-    distinct-args breadth gets a higher Pattern-C threshold (they probe
-    many forms legitimately — e.g. emacsos's ``eval_elisp``).  They are
-    NOT exempt from loop detection (still subject to Patterns A/B and a
-    finite Pattern-C cap).  Only the main agent gets it — the bespoke
-    subagents don't receive ``extra_tools`` so the exploration tool can't
-    reach them.  Default ``None`` leaves the dev/code agent unchanged.
+    ``loop_exploration_tools`` is DEPRECATED and now a no-op.  It used to
+    feed the (since-removed) Pattern-C distinct-args breadth threshold; loop
+    detection now catches only exact-repeat loops (Patterns A/B), which apply
+    uniformly to every tool, so there is nothing to tune per exploration
+    tool.  The param is still accepted (so embedders like emacsos-server that
+    pass it don't break) but ignored — drop the kwarg at the call site and
+    this param can be removed.
 
     ``default_backend`` lets an embedder supply the composite backend's
     *default* — the target for every non-routed path — instead of the
@@ -185,15 +184,12 @@ def create_agent(model: BaseChatModel,
     # of `loop_detection_mw` so the rejection is what the loop
     # detector sees if the model retries.
     git_push_blocker_mw = GitPushBlockerMiddleware()
-    # subagent_dispatch_threshold caps re-dispatch of the same sub-agent
-    # (context / research / critique) to once — the general-agent prompt's
-    # "call each sub-agent ONCE" made deterministic.  Stops the general
-    # agent from re-dispatching the research orchestrator, which multiplies
-    # the inner search volume, and reinforces the #119 rate-limit handoff.
-    loop_detection_mw = LoopDetectionMiddleware(
-        exploration_tools=loop_exploration_tools,
-        subagent_dispatch_threshold=_SUBAGENT_DISPATCH_CAP,
-    )
+    # Loop detection catches only exact-repeat loops (same-tool-same-error /
+    # same-tool-same-args).  Distinct-arg exploration and sub-agent
+    # re-dispatch are deliberately NOT capped here — a few extra hops are
+    # fine; the runaway bound is the per-agent recursion_limit.  See the
+    # rollback note in loop_detection.py.
+    loop_detection_mw = LoopDetectionMiddleware()
     # Innermost wrap_model_call middleware — recovers from empty terminal
     # AIMessages after every outer retry/sanitization layer has had its turn.
     empty_response_recovery_mw = EmptyResponseRecoveryMiddleware()
@@ -371,64 +367,6 @@ def create_context_agent(model: BaseChatModel,
     return RollbackRunnable(agent, recursion_limit=500)
 
 
-# LoopDetection Pattern-E volume cap for the research flow.  The small
-# model reads "conduct thorough research" as "search dozens of times"
-# (prod: 50-100 search_internet calls for one trivial query), which the
-# args/error-based loop patterns don't catch because each query is
-# distinct and succeeds.  Pattern E caps the per-agent VOLUME of each tool
-# in _RESEARCH_VOLUME_TOOLS (search_internet + read_url) to ~this many
-# calls within the detection window, then makes the agent finalize with
-# what it has.  (Task RE-DISPATCH is a separate concern, capped by
-# Pattern F / _SUBAGENT_DISPATCH_CAP below — not by this volume cap.)
-# Deliberately higher than a healthy research pass (~4 searches) so it
-# only fires on genuine runaway, not normal multi-query exploration.
-# Per-AGENT, per-TOOL cap (each tool in _RESEARCH_VOLUME_TOOLS is counted
-# separately — NOT summed).  Combined with the per-subagent re-dispatch cap
-# below (which holds the orchestrator to one research dispatch), this bounds
-# each capped tool's volume to ~this many for a research turn.  Per-tool is
-# deliberate: a healthy pass is ~4 searches PLUS a read or two, so an
-# aggregate cap of 6 would fire on healthy behavior.
-_RESEARCH_TOOL_VOLUME_CAP = 6
-
-# The fact-check-agent reads many DISTINCT reference URLs to verify a
-# report's claims, and its prompt sanctions up to 10 read_url calls — so it
-# gets its OWN, higher read_url cap (vs the research-agent's 6) so a
-# compliant multi-source check isn't cut off mid-way.  Still finite, so the
-# 200+ read_url runaway observed when it was unbounded is still caught.
-_FACTCHECK_READ_URL_CAP = 12
-
-# Pattern E caps these tools on the research-agent (the sole searcher).  We
-# cap BOTH search_internet and read_url there: an uncapped read_url let it
-# read many pages and balloon the turn to ~12 min.  The fact-check-agent
-# gets its own read_url-only cap (above); the critique-agent has no capped
-# tools.  The orchestrator (which writes the report and reads URLs to do so)
-# gets NO volume cap, precisely so its read+write batches are never stripped
-# — none of the capped subagents write the report, so stripping a
-# capped-tool batch on them never loses a write.
-_RESEARCH_VOLUME_TOOLS = frozenset({"search_internet", "read_url"})
-
-# Wider LoopDetection window for the research-agent so the volume cap
-# counts searches across the WHOLE turn, not just the last 12 mixed
-# tool events.  Without this, interleaving search with read_url could
-# keep fewer than _RESEARCH_TOOL_VOLUME_CAP searches in a 12-event tail
-# and evade the cap (the very search-heavy-with-reads shape it targets).
-# Only widens the count window (and the max trailing-run length for the
-# args/error patterns, which is harmless); Pattern C keeps its own
-# distinct_args_window.
-_RESEARCH_LOOP_WINDOW = 50
-
-# Pattern F: max dispatches of any single subagent by an orchestrating
-# agent.  1 = each subagent at most once — the budget both the general
-# agent ("call each sub-agent ONCE") and the research orchestrator
-# ("research once, critique once, fact-check once") already state in
-# prose.  Made deterministic because the soft prompt rule did not hold:
-# the model re-dispatched the research-agent ~3x (at the orchestrator)
-# and, on some runs, re-dispatched the research orchestrator at the
-# general-agent level — each multiplying the inner search volume.
-# Enabled on BOTH the general agent and the research orchestrator.
-_SUBAGENT_DISPATCH_CAP = 1
-
-
 def create_research_agent(model: BaseChatModel,
                           working_dir: str,
                           checkpointer=None,
@@ -464,15 +402,10 @@ def create_research_agent(model: BaseChatModel,
     # trap (multi-pass critique → "I have completed the research" → another
     # write_file).
     base_mw.append(WriteCollisionMiddleware())
-    # The orchestrator gets the per-subagent re-dispatch cap (Pattern F):
-    # each subagent (research / critique / fact-check) at most once,
-    # matching the prompt's stated budget and deterministically stopping
-    # the research-agent re-dispatch that multiplies inner search volume.
-    # No volume cap here — the orchestrator delegates searching and has no
-    # search_internet tool, so a volume cap would be inert.
-    base_mw.append(LoopDetectionMiddleware(
-        subagent_dispatch_threshold=_SUBAGENT_DISPATCH_CAP,
-    ))
+    # Exact-repeat loop detection only (A/B).  Sub-agent re-dispatch is no
+    # longer capped here — re-dispatching the research-agent a few times is
+    # tolerated; the runaway bound is the orchestrator's recursion_limit.
+    base_mw.append(LoopDetectionMiddleware())
     base_mw.append(ThreadQueueMiddleware())
     base_mw.append(EmptyResponseRecoveryMiddleware())
 
@@ -546,33 +479,18 @@ def create_research_agent(model: BaseChatModel,
     # left the fact-check-agent unbounded — it ran 200+ `read_url`
     # calls in a diag because nothing would short-circuit a model that
     # kept "thinking of more references to verify".
-    def _subagent_safety_mw(volume_threshold=_RESEARCH_TOOL_VOLUME_CAP,
-                            volume_tools=_RESEARCH_VOLUME_TOOLS):
+    def _subagent_safety_mw():
         return [_make_retry_middleware(),
                 BadRequestRetryMiddleware(max_retries=3),
                 # Strip ANSI from sub-tool output (read_url HTML can carry
                 # raw escape sequences) before it lands in subagent state.
                 OutputSanitizationMiddleware(),
-                # Pattern-E volume cap over a turn-wide window so interleaved
-                # reads can't dilute the count below the cap.  Defaults suit
-                # the research-agent (search + read, cap 6); the fact-check
-                # agent overrides with its own read_url-only, higher cap.
-                #
-                # ORDERING CONTRACT: LoopDetection must remain the LAST
-                # after_model middleware in this list (only middleware WITHOUT
-                # an after_model hook may follow it).  Its volume cap returns
-                # `jump_to:"model"` to give a capped research-agent one synthesis
-                # turn (see loop_detection finalize path); that jump is only
-                # safe-to-skip-nothing because LoopDetection is the final
-                # after_model link.  Inserting another after_model middleware
-                # after it would let the jump silently bypass that middleware.
-                # ThreadQueueMiddleware/EmptyResponseRecovery below are fine:
-                # ThreadQueue runs BEFORE LoopDetection in the after_model chain
-                # (factory reverses list order), EmptyResponseRecovery has no
-                # after_model hook.
-                LoopDetectionMiddleware(window=_RESEARCH_LOOP_WINDOW,
-                                        volume_threshold=volume_threshold,
-                                        volume_tools=volume_tools),
+                # Exact-repeat loop detection only (A/B): catches a sub-agent
+                # hammering the same read_url(URL)/query back-to-back.  No
+                # volume cap — a sub-agent doing many DISTINCT searches/reads
+                # is allowed to run to the recursion_limit rather than be cut
+                # off mid-research.
+                LoopDetectionMiddleware(),
                 ThreadQueueMiddleware(),
                 EmptyResponseRecoveryMiddleware()]
 
@@ -596,12 +514,7 @@ def create_research_agent(model: BaseChatModel,
         "description": "Used to check all references for alignment with claims and statements. You MUST provide the file it should fact-check.",
         "system_prompt": base_prompt_for("deepagents/fact_checker.md.j2"),
         "tools": [read_url],
-        # Own read_url-only cap (higher than the research-agent's) so a
-        # compliant multi-source fact-check isn't cut off — see
-        # _FACTCHECK_READ_URL_CAP.
-        "middleware": _subagent_safety_mw(
-            volume_threshold=_FACTCHECK_READ_URL_CAP,
-            volume_tools=frozenset({"read_url"})),
+        "middleware": _subagent_safety_mw(),
     }
 
     # The orchestrator DELEGATES searching to the research-agent (see its
@@ -622,8 +535,15 @@ def create_research_agent(model: BaseChatModel,
                    fact_check_sub_agent]
     )
 
-    # 300 graph steps ≈ 150 model calls — research is multi-step but bounded.
-    rollback_runnable = RollbackRunnable(agent, recursion_limit=300)
+    # 150 graph steps ≈ 75 model calls.  This is now the deliberate runaway
+    # backstop for the research flow: with the Pattern-E volume cap and
+    # Pattern-F re-dispatch cap removed, a research agent that keeps issuing
+    # DISTINCT-arg searches/reads is bounded only by this limit (the host-side
+    # search/read tools aren't covered by the sandbox exec timeout).  Lowered
+    # from 300 so a runaway is caught in a few minutes rather than ~12-75 min.
+    # GraphRecursionError is in RollbackRunnable's rollback_on, so hitting it
+    # rolls back rather than crashing the thread.
+    rollback_runnable = RollbackRunnable(agent, recursion_limit=150)
 
     # Wrap with the references-cleanup runnable so intermediate drafts
     # and sub-sub-agent scratch files get pruned after the research call

--- a/assist/middleware/loop_detection.py
+++ b/assist/middleware/loop_detection.py
@@ -1,73 +1,52 @@
-"""Middleware that detects and breaks tool-call loops.
+"""Middleware that detects and breaks *exact-repeat* tool-call loops.
 
 Catches the failure mode where the model gets stuck repeating the same
-(or near-same) tool call against the same error: e.g. a sequence of
-``write_file`` calls to slightly different filenames after the first
-one returns "Cannot write to ... because it already exists".
+tool call — either against the same error, or with identical args — e.g.
+a ``write_file`` to the same path that keeps returning "Cannot write …
+because it already exists", or the same ``read_url(URL)`` issued back to
+back hundreds of times.
 
 Detection runs in ``after_model``. When the latest AI message's tool
-calls would extend a loop pattern visible in the completed history,
-those tool calls are stripped and the AI message content is replaced
-with a short terminal summary. The agent loop then ends naturally
-because the AI message carries no tool calls.
+calls would extend a loop pattern visible in the completed history, those
+tool calls are stripped and the AI message content is replaced with a
+short terminal summary. The agent loop then ends naturally because the AI
+message carries no tool calls.
 
-Six patterns are recognised (A-F). A-D are general and on by default;
-E and F are opt-in (off unless their threshold is set) and used by the
-research flow — see ``agent.py``.
+Two patterns are recognised — both are "you are repeating yourself
+verbatim", the only loops worth stopping deterministically:
 
 A. Same tool + same normalised error, repeated >=
-   ``error_repeat_threshold`` times in a row. Errors are normalised
-   so varying paths/IDs/numbers don't hide the repetition.
+   ``error_repeat_threshold`` times in a row. Errors are normalised so
+   varying paths/IDs/numbers don't hide the repetition.
 
-B. Same tool + same args, repeated >= ``args_repeat_threshold`` times
-   in a row. Catches the model calling the same tool with identical
+B. Same tool + same args, repeated >= ``args_repeat_threshold`` times in
+   a row. Catches the model calling the same tool with identical
    arguments back-to-back regardless of result.
 
-C. Same tool + >= ``distinct_args_threshold`` distinct arg sets within
-   the last ``distinct_args_window`` tool calls, where the tool has
-   mutating side effects and at least one of those calls errored.
-   Catches the filename-mutation pattern (``write_file foo.py`` →
-   error → ``foo2.py`` → error → ``foo_new.py``) even when individual
-   error strings differ. Read-only tools (``read_file``, ``ls``,
-   ``grep``, etc.) are exempt because distinct-args usage is the
-   normal shape of legitimate exploration. Embedder-declared
-   ``exploration_tools`` (e.g. emacsos's ``eval_elisp``) are not exempt
-   but get a HIGHER breadth threshold
-   (``_EXPLORATION_DISTINCT_ARGS_THRESHOLD``); they remain fully subject
-   to A and B.
+Everything else — distinct-arg exploration, http-failure streaks, sheer
+tool volume, sub-agent re-dispatch — is intentionally NOT caught here.
+A few extra research hops are normal and far less harmful than yanking a
+working agent into a confusing half-finished state; the runaway backstop
+for those is the per-agent ``recursion_limit`` (see ``agent.py``) and the
+per-call LLM timeout, not this middleware.  (This is a deliberate rollback
+of the earlier six-pattern design — see
+``docs/2026-06-05-loop-detection-audit.org``.)
 
-D. >= ``http_failure_threshold`` consecutive tool results whose bodies
-   look like an HTTP 4xx/5xx page (bot-detection, rate-limit, captcha),
-   regardless of args. Catches a fetch loop across distinct URLs that
-   all return error pages — A/B/C miss it because the body is HTML, not
-   a Python error, and the args differ.
-
-E. Sheer VOLUME: >= ``volume_threshold`` calls to a single tool in
-   ``volume_tools`` within the window, regardless of args or errors
-   (counted per-tool). Catches over-use of a *successful* tool — the
-   research over-search runaway. Off unless ``volume_threshold`` > 0.
-
-F. Per-subagent ``task`` RE-DISPATCH: the same subagent dispatched >=
-   ``subagent_dispatch_threshold`` times within the window. Catches an
-   orchestrator re-dispatching the same sub-agent. Off unless
-   ``subagent_dispatch_threshold`` > 0.
-
-Threshold semantics (all patterns): the counts above are over the
-*completed* history (calls whose results are back), and ``after_model``
-only strips when the latest, not-yet-run message would *extend* the
-pattern.  So a threshold of N effectively allows up to N completed calls
-and strips the (N+1)th attempt — read the thresholds as "max allowed
-completed calls", not "intervene the instant the Nth is requested".
+Threshold semantics: the counts above are over the *completed* history
+(calls whose results are back), and ``after_model`` only strips when the
+latest, not-yet-run message would *extend* the pattern.  So a threshold of
+N effectively allows up to N completed calls and strips the (N+1)th
+attempt — read the thresholds as "max allowed completed calls", not
+"intervene the instant the Nth is requested".
 """
 
 import hashlib
 import json
 import logging
 import re
-from collections import Counter
 from typing import Any
 
-from langchain.agents.middleware import AgentMiddleware, AgentState, hook_config
+from langchain.agents.middleware import AgentMiddleware, AgentState
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.runtime import Runtime
 
@@ -87,9 +66,12 @@ _PATH_RE = re.compile(r"(/[\w./\\-]+)")
 _ID_RE = re.compile(r"\b[0-9a-f]{8,}\b", re.IGNORECASE)
 _NUMBER_RE = re.compile(r"\b\d+\b")
 
-# Tools without mutating side effects. Pattern C (distinct-args thrash) does
-# not fire for these because reading multiple distinct files / running
-# multiple distinct queries is the normal shape of exploration, not a loop.
+# Read-only tools.  Pattern A walks only the trailing run of *mutating*
+# tools (read-only calls are transparent — a `ls`/`read_file` between two
+# failing writes is "let me check what's there", not a change of approach).
+# Pattern B walks all tools but treats a different-tool read-only event as
+# transparent so an interleaved `[write_X, ls, write_X, ls, write_X]` still
+# registers as repeated write_X.
 _READ_ONLY_TOOLS: frozenset[str] = frozenset({
     "read_file",
     "ls",
@@ -99,79 +81,10 @@ _READ_ONLY_TOOLS: frozenset[str] = frozenset({
     "search_internet",
 })
 
-# Pattern C distinct-args threshold for tools an embedder marks as
-# "exploration" (e.g. emacsos's `eval_elisp`, which probes a live emacs and
-# is the agent's primary inspection tool).  Such tools legitimately fire
-# many distinct forms, and the small local model fumbles the API as it goes
-# — so a few distinct erroring probes are normal trial-and-error, not yet a
-# loop.  Exploration tools get this HIGHER breadth threshold than ordinary
-# mutating tools (default 3), so legitimate exploration isn't terminated;
-# but they are NOT exempt — a sustained flail of this many distinct erroring
-# forms is still caught (faster + with a clearer message than the recursion
-# limit).  They ALSO stay fully subject to Patterns A/B (repetition), which
-# is why `_mutating_only` below intentionally keeps using `_READ_ONLY_TOOLS`
-# only.  Tune against the live exploration shape in the evals.
-_EXPLORATION_DISTINCT_ARGS_THRESHOLD = 6
-
 
 def _looks_like_error(content: str) -> bool:
     head = content.lstrip().lower()[:120]
     return any(head.startswith(p) for p in _ERROR_PREFIXES)
-
-
-# Patterns that mean "you've gathered ENOUGH", not "you're broken".  When one
-# fires the agent has usable state (search results / a subagent's result), so
-# ending the turn with a canned stub destroys the synthesis it was about to
-# write — the stub message is a false promise.  For these, instead of
-# strip-to-END we strip the over-limit tool calls, leave _FINALIZE_NUDGE as the
-# assistant turn, and jump back to the model for ONE synthesis turn.  A SECOND
-# firing in the same turn (model ignored the nudge and kept going) falls through
-# to the normal hard strip-to-END, so the runaway bound still holds.  The
-# error/stuck patterns (A–D) are NOT here — for them, ending is correct.
-# See docs/2026-06-05-loop-detection-audit.org.
-#
-# E (tool-volume): the research-agent over-searched → finalize by writing the
-# answer from the results it gathered.  F (subagent-redispatch): the agent
-# re-dispatched a sub-agent it already has a result from → finalize by
-# answering from that result instead of dispatching again (observed: without
-# this, F's stub still killed the answer ~1/5 of the time even with E fixed).
-_FINALIZE_PATTERNS = frozenset({"tool-volume", "subagent-redispatch"})
-_FINALIZE_NUDGE = (
-    "Search budget reached: I have gathered enough and will now write the "
-    "complete final answer from the results I already gathered — not from "
-    "memory and without searching or fetching again. If the gathered results "
-    "are thin, I will say so rather than invent details."
-)
-_REDISPATCH_NUDGE = (
-    "I already have that sub-agent's result. I will now write the complete "
-    "final answer from what it returned — without dispatching it again. If "
-    "that result is thin, I will say so rather than invent details."
-)
-# All finalize nudges, for the stateless second-strike scan (any of them in a
-# prior AIMessage this turn means we already nudged → next firing hard-stops).
-_FINALIZE_NUDGES = (_FINALIZE_NUDGE, _REDISPATCH_NUDGE)
-
-
-def _finalize_nudge_for(pattern: str) -> str:
-    """The right nudge for a finalize pattern: E synthesizes from gathered
-    results; F answers from the sub-agent result it already has."""
-    return _REDISPATCH_NUDGE if pattern == "subagent-redispatch" else _FINALIZE_NUDGE
-
-
-def _already_finalized_this_turn(messages: list) -> bool:
-    """True if a finalize-nudge was already injected in the current turn.
-
-    Used to fall through to the hard stop on a SECOND firing (the model
-    searched again after being nudged), preserving the runaway bound WITHOUT
-    instance state — so the middleware stays stateless / rollback-safe.  Bounded
-    to the current turn (``_current_turn_slice``) so a nudge from a prior turn
-    can't suppress this turn's finalize."""
-    for msg in _current_turn_slice(messages):
-        if isinstance(msg, AIMessage):
-            content = msg.content if isinstance(msg.content, str) else ""
-            if any(nudge in content for nudge in _FINALIZE_NUDGES):
-                return True
-    return False
 
 
 def _normalise_error(content: str) -> str:
@@ -190,41 +103,6 @@ def _normalise_args(args: Any) -> str:
     if len(s) > 4000:
         s = s[:4000]
     return hashlib.sha1(s.encode("utf-8")).hexdigest()
-
-
-# HTTP-failure markers commonly present in tool RESULT bodies when a
-# fetch tool gets a 4xx page (bot-detection, rate-limit, captcha, etc.).
-# Sites often return their failure UI as a 200-or-403 HTML body — the
-# tool happily returns that body as a "successful" result, so neither
-# `_looks_like_error` (Python-style errors) nor Patterns A/B/C (which
-# need args/error repetition) catch the loop.  Pattern D (below) uses
-# `_looks_like_http_failure` to count consecutive 4xx-shaped responses
-# regardless of args, which is what catches the 2026-05-30 casio runaway
-# (fetch -> 403, fetch -> 403, … across distinct watch-product URLs).
-_HTTP_ERROR_MARKERS: tuple[str, ...] = (
-    " 401 ", " 403 ", " 404 ", " 429 ", " 500 ", " 502 ", " 503 ",
-    "forbidden", "not found", "unauthorized",
-    "rate limit", "rate-limit", "rate limited",
-    "access denied", "request blocked", "captcha",
-    "too many requests", "blocked by",
-)
-
-
-def _looks_like_http_failure(content: str) -> bool:
-    """True if the tool result content suggests an HTTP 4xx/5xx response.
-
-    Many sites return their bot-detection or rate-limit UI as the
-    response body even on 4xx — `_looks_like_error` won't catch these
-    because the body is HTML, not a Python-style error string.  This
-    scans the first ~1KB for HTTP-failure markers; deliberately
-    case-insensitive and substring-based to tolerate varied page
-    layouts.  False negatives are fine (Patterns A/B/C still apply);
-    false positives are the thing to avoid, which is why the markers
-    are biased toward strings that don't show up in a normal article
-    body (status-code numerals padded with spaces, common 4xx/5xx
-    error phrases)."""
-    head = content.lower()[:1000]
-    return any(m in head for m in _HTTP_ERROR_MARKERS)
 
 
 def _current_turn_slice(messages: list) -> list:
@@ -282,12 +160,6 @@ def _extract_events(messages: list, window: int) -> list[dict]:
             tc_id = tc.get("id")
             tm = tool_msgs.get(tc_id)
             args = tc.get("args") or {}
-            # For `task` calls, record which subagent was dispatched so
-            # Pattern F can cap per-subagent re-dispatch.  deepagents emits
-            # `subagent_type`; the small model sometimes uses agent/name.
-            subagent = (args.get("subagent_type")
-                        or args.get("agent")
-                        or args.get("name") or "") if (tc.get("name") == "task") else ""
             if tm is not None:
                 content = str(tm.content) if tm.content is not None else ""
                 is_error = (
@@ -297,22 +169,16 @@ def _extract_events(messages: list, window: int) -> list[dict]:
                 events.append({
                     "tool_name": tc.get("name") or "",
                     "args_sig": _normalise_args(args),
-                    "subagent": subagent,
                     "result_content": content,
                     "is_error": is_error,
-                    # Pattern D signal: HTTP-failure-shaped body even when
-                    # the tool didn't surface it as a Python-style error.
-                    "http_failure": _looks_like_http_failure(content),
                     "completed": True,
                 })
             else:
                 events.append({
                     "tool_name": tc.get("name") or "",
                     "args_sig": _normalise_args(args),
-                    "subagent": subagent,
                     "result_content": "",
                     "is_error": False,
-                    "http_failure": False,
                     "completed": False,
                 })
 
@@ -323,27 +189,14 @@ def _detect_loop(
     completed_events: list[dict],
     error_repeat_threshold: int,
     args_repeat_threshold: int,
-    distinct_args_threshold: int,
-    distinct_args_window: int,
-    exploration_tools: frozenset[str] = frozenset(),
-    exploration_args_threshold: int = _EXPLORATION_DISTINCT_ARGS_THRESHOLD,
-    http_failure_threshold: int = 4,
-    volume_threshold: int = 0,
-    volume_tools: frozenset[str] = frozenset(),
-    subagent_dispatch_threshold: int = 0,
 ) -> dict | None:
     """Return loop-detection info or ``None`` if no loop.
 
     Result keys:
-      pattern     -- "same-tool-same-error" | "same-tool-same-args" |
-                     "distinct-args-thrash" | "http-failure-streak" |
-                     "tool-volume" | "subagent-redispatch"
+      pattern     -- "same-tool-same-error" | "same-tool-same-args"
       reason      -- short human-readable string for logs
       tools       -- set of looping tool names
-      run_length  -- length of the trailing run (or distinct-arg count)
-      subagents   -- (subagent-redispatch only) set of over-threshold
-                     subagent names; used by after_model to strip only a
-                     latest call that re-dispatches one of them
+      run_length  -- length of the trailing run
     """
 
     if not completed_events:
@@ -364,16 +217,7 @@ def _detect_loop(
     # status — there's no "exploration" justification for hitting the
     # same URL or running the same search query 3 times in a row.
     # The 2026-05-30 runaway issued the same `read_url(F-91W product
-    # page)` ~1000 times under a sub-research-agent because the prior
-    # mutating-only filter made Pattern B blind to it.
-    #
-    # NOTE: this intentionally filters on `_READ_ONLY_TOOLS` ONLY — NOT the
-    # caller's `exploration_tools`.  Exploration tools (eg. eval_elisp) get a
-    # relaxed *Pattern C* breadth threshold below, but they must stay
-    # "mutating" here so Pattern A still catches a genuine repetition loop
-    # in them (same error repeated).  Folding `exploration_tools` into this
-    # filter would disable A for them and remove their only remaining loop
-    # protection.
+    # page)` ~1000 times under a sub-research-agent.
     def _mutating_only(events):
         return [e for e in events if e["tool_name"] not in _READ_ONLY_TOOLS]
 
@@ -446,12 +290,12 @@ def _detect_loop(
                 break
         return run_tool, run_args, run_len
 
-    a_tool, a_args, a_len = _trailing_run(skip_trailing_read_only=False)
-    b_tool, b_args, b_len = _trailing_run(skip_trailing_read_only=True)
+    a_tool, _a_args, a_len = _trailing_run(skip_trailing_read_only=False)
+    b_tool, _b_args, b_len = _trailing_run(skip_trailing_read_only=True)
     if b_len > a_len:
-        run_tool, run_args, run_len = b_tool, b_args, b_len
+        run_tool, run_len = b_tool, b_len
     else:
-        run_tool, run_args, run_len = a_tool, a_args, a_len
+        run_tool, run_len = a_tool, a_len
     if run_tool and run_len >= args_repeat_threshold:
         return {
             "pattern": "same-tool-same-args",
@@ -459,132 +303,6 @@ def _detect_loop(
             "tools": {run_tool},
             "run_length": run_len,
         }
-
-    # Pattern C: distinct-args thrash within recent window.
-    # Only fires for mutating tools that have errored at least once in the
-    # window — pure exploration (3 distinct read_file paths, etc.) is not a
-    # loop signal.
-    recent = completed_events[-distinct_args_window:]
-    by_tool: dict[str, set[str]] = {}
-    tool_errored: dict[str, bool] = {}
-    for e in recent:
-        if e["tool_name"] in _READ_ONLY_TOOLS:
-            continue
-        by_tool.setdefault(e["tool_name"], set()).add(e["args_sig"])
-        if e["is_error"]:
-            tool_errored[e["tool_name"]] = True
-    for tool_name, sigs in by_tool.items():
-        # Exploration tools (eg. eval_elisp) probe many distinct forms
-        # legitimately, so they get a higher breadth threshold — but still a
-        # finite one, so a sustained flail is caught.
-        threshold = (exploration_args_threshold
-                     if tool_name in exploration_tools
-                     else distinct_args_threshold)
-        if len(sigs) >= threshold and tool_errored.get(tool_name):
-            return {
-                "pattern": "distinct-args-thrash",
-                "reason": (f"distinct-args-thrash: {tool_name} "
-                           f"{len(sigs)} distinct in {len(recent)}"),
-                "tools": {tool_name},
-                "run_length": len(sigs),
-            }
-
-    # Pattern D: trailing run of consecutive tool calls whose RESULT
-    # bodies look like an HTTP failure (4xx/5xx page), regardless of args.
-    # Catches the 2026-05-30 casio runaway: the agent emitted ~9,000
-    # fetch_url calls across distinct watch-product URLs on casio.com,
-    # all returning 403 bot-detection pages.  Patterns A/B/C all
-    # short-circuit because the result body is HTML (not a Python error),
-    # the args differ across calls (different URLs), and the model never
-    # repeats the same arg twice.  `_looks_like_http_failure` picks up
-    # the 4xx body markers; consecutive failures across ANY args trigger.
-    http_fail_len = 0
-    http_fail_tool: str | None = None
-    for e in reversed(completed_events):
-        if e.get("http_failure"):
-            http_fail_len += 1
-            # Use the LATEST failing tool as the loop's name (most recent
-            # is what the model is currently trying); if the streak spans
-            # multiple tool names (e.g. fetch_url + search_internet both
-            # 4xx'd), report the latest.
-            if http_fail_tool is None:
-                http_fail_tool = e["tool_name"]
-        else:
-            break
-    if http_fail_tool and http_fail_len >= http_failure_threshold:
-        return {
-            "pattern": "http-failure-streak",
-            "reason": (f"http-failure-streak: {http_fail_tool} "
-                       f"x{http_fail_len} (4xx/5xx-shaped responses)"),
-            "tools": {http_fail_tool},
-            "run_length": http_fail_len,
-        }
-
-    # Pattern F: per-subagent `task` RE-DISPATCH.  The research orchestrator
-    # is meant to dispatch each subagent (research / critique / fact-check)
-    # at most once; the small model re-dispatches the research-agent
-    # repeatedly (prod: 3x for one query), multiplying the inner search
-    # volume that Pattern E caps only per-agent.  Off unless
-    # subagent_dispatch_threshold > 0.  Keyed BY subagent, so dispatching
-    # three DIFFERENT subagents once each never trips it.  Returns the set
-    # of over-threshold subagents; after_model strips only a latest call
-    # that re-dispatches one of them.
-    if subagent_dispatch_threshold > 0:
-        sub_counts = Counter(
-            e.get("subagent") for e in completed_events
-            if e["tool_name"] == "task" and e.get("subagent")
-        )
-        over = {s for s, n in sub_counts.items()
-                if n >= subagent_dispatch_threshold}
-        if over:
-            return {
-                "pattern": "subagent-redispatch",
-                "reason": (f"subagent-redispatch: "
-                           + ", ".join(f"{s} x{sub_counts[s]}" for s in sorted(over))),
-                "tools": {"task"},
-                "subagents": over,
-                "run_length": max(sub_counts[s] for s in over),
-            }
-
-    # Pattern E: sheer VOLUME of one tool within the window, regardless of
-    # args or errors.  Off unless volume_threshold > 0 AND the tool is in
-    # volume_tools (enabled on the research flow — see _RESEARCH_VOLUME_TOOLS
-    # in agent.py, which caps search_internet + read_url — where the small
-    # model otherwise searches/reads dozens of times under "conduct thorough
-    # research"; observed: 50+ search calls for one trivial query).  This is
-    # a HIGHER, looser bound than Pattern C: distinct-query exploration is
-    # the *normal* shape of research, but calling one capped tool
-    # volume_threshold+ times is a runaway no matter how varied the args.
-    #
-    # The CALLER decides which tools to cap via volume_tools.  Important:
-    # because firing strips the WHOLE latest AI message's tool calls, only
-    # cap tools on agents that don't batch a capped tool with a call you
-    # must keep (e.g. a write).  The research flow caps read_url on the
-    # write-less subagents but NOT on the report-writing orchestrator,
-    # precisely to avoid stripping a read+write batch.  Comes last so the
-    # args/error patterns (with better terminal messages) win when they
-    # also apply.
-    if volume_threshold > 0 and volume_tools and completed_events:
-        capped = Counter(
-            e["tool_name"] for e in completed_events
-            if e["tool_name"] in volume_tools
-        )
-        # Report EVERY over-threshold tool, not just the most frequent.  The
-        # cap is per-tool, and `after_model` only intervenes when the latest
-        # call extends a tool in `tools` — so if two capped tools both exceed
-        # the threshold (e.g. search_internet AND read_url on the research
-        # agent) and we named only the busiest, a latest call to the *other*
-        # over-threshold tool would slip through uncapped.
-        over = {t for t, n in capped.items() if n >= volume_threshold}
-        if over:
-            return {
-                "pattern": "tool-volume",
-                "reason": ("tool-volume: "
-                           + ", ".join(f"{t} x{capped[t]}" for t in sorted(over))
-                           + f" within last {len(completed_events)} calls"),
-                "tools": over,
-                "run_length": max(capped[t] for t in over),
-            }
 
     return None
 
@@ -652,37 +370,11 @@ def _compose_terminal_message(detection: dict, messages: list) -> str:
             "Could you give me more direction on how to proceed?"
         )
 
-    if pattern == "same-tool-same-args":
-        return (
-            f"I kept making the same {tool_list} call and wasn't getting new "
-            "information. I won't repeat it. Could you tell me how you'd "
-            "like to proceed?"
-        )
-
-    if pattern == "tool-volume":
-        # A graceful "enough" — not an error.  The agent has gathered
-        # plenty; tell it to finalize with what it has rather than asking
-        # the user for direction (there's nothing wrong, just over-effort).
-        return (
-            f"I've already used {tool_list} enough times to answer this. "
-            "I'll stop gathering and write up what I have now."
-        )
-
-    if pattern == "subagent-redispatch":
-        # Graceful: the orchestrator already has this sub-agent's result;
-        # tell it to use what it has rather than re-dispatching.
-        return (
-            "I've already gathered that sub-agent's result. I'll finalize "
-            "with what I have rather than dispatching it again."
-        )
-
-    # distinct-args-thrash
-    excerpt = _last_error_excerpt(messages, looping_tools)
-    excerpt_clause = f' (most recent issue: "{excerpt}")' if excerpt else ""
+    # same-tool-same-args
     return (
-        f"I kept calling {tool_list} with different inputs and couldn't "
-        f"settle on one{excerpt_clause}. I won't keep trying variations. "
-        "Could you tell me how you'd like to proceed?"
+        f"I kept making the same {tool_list} call and wasn't getting new "
+        "information. I won't repeat it. Could you tell me how you'd "
+        "like to proceed?"
     )
 
 
@@ -719,12 +411,18 @@ def _last_successful_artifact(messages: list) -> str | None:
 
 
 class LoopDetectionMiddleware(AgentMiddleware):
-    """Detect and break tool-call loops by stripping the offending tool calls.
+    """Detect and break *exact-repeat* tool-call loops by stripping them.
 
     On detection the latest AI message's looping tool calls are removed
     and its content is replaced with a short terminal summary that
     cites the most recent successful artifact (if any). The agent
     loop ends because no tool calls remain to dispatch.
+
+    Only the two exact-repetition patterns are caught (same-tool-same-error
+    and same-tool-same-args).  Non-repetition runaways (lots of distinct
+    research hops, fetch streaks, sheer volume) are intentionally allowed to
+    run to the per-agent ``recursion_limit`` — a few extra hops beats a
+    confusing artificial stop.  See the module docstring.
 
     The middleware is stateless: every check is performed by inspecting
     the message tail, so it composes safely with checkpointing and
@@ -736,43 +434,6 @@ class LoopDetectionMiddleware(AgentMiddleware):
             repetitions in a row that constitute a loop. Default 2.
         args_repeat_threshold: Same-tool / same-args repetitions in a
             row that constitute a loop. Default 3.
-        distinct_args_threshold: Distinct arg-sets for a single
-            *mutating* tool within ``distinct_args_window`` that
-            constitute a loop, provided at least one of those calls
-            errored. Read-only tools (see ``_READ_ONLY_TOOLS``) are
-            exempt. Default 3.
-        distinct_args_window: Sliding window for the distinct-args
-            check. Default 10.
-        exploration_tools: Tool names whose distinct-args *breadth* gets a
-            higher Pattern-C threshold
-            (``_EXPLORATION_DISTINCT_ARGS_THRESHOLD``) because probing many
-            distinct forms is their normal
-            shape (e.g. emacsos's ``eval_elisp``).  They are NOT exempt from
-            Pattern C (a sustained flail is still caught) and remain fully
-            subject to Patterns A/B (repetition).  Default ``None`` → empty,
-            so the dev/code agent is unaffected; an embedder opts in per
-            agent.
-        http_failure_threshold: Number of consecutive trailing tool calls
-            with an HTTP-failure-shaped body (4xx/5xx markers, see
-            ``_looks_like_http_failure``) that constitute a loop, regardless
-            of args.  Catches the case where the model iterates through
-            distinct URLs that all return 403 / captcha / rate-limit pages
-            — Patterns A/B/C all miss this because the result body is HTML,
-            not a Python error, and the args differ across calls.  Default 4.
-        volume_threshold: Pattern E. Max calls to any single tool in
-            ``volume_tools`` within the window before intervening, regardless
-            of args/errors. Catches sheer over-use of a successful tool
-            (e.g. the research over-search runaway). 0 disables (default), so
-            non-research agents are unaffected.
-        volume_tools: Tool names the Pattern-E volume cap applies to. Default
-            ``None`` → empty (cap inert even if volume_threshold > 0). Cap
-            only tools on agents that don't batch a capped tool with a call
-            you must keep (firing strips the whole AI message — see Pattern E).
-        subagent_dispatch_threshold: Pattern F. Max times the same subagent
-            may be dispatched via ``task`` within the window before a further
-            re-dispatch of it is stripped. 1 = each subagent at most once.
-            0 disables (default). Counts per-subagent, so dispatching several
-            *different* subagents once each never trips it.
     """
 
     def __init__(
@@ -780,37 +441,14 @@ class LoopDetectionMiddleware(AgentMiddleware):
         window: int = 12,
         error_repeat_threshold: int = 2,
         args_repeat_threshold: int = 3,
-        distinct_args_threshold: int = 3,
-        distinct_args_window: int = 10,
-        exploration_tools: frozenset[str] | None = None,
-        http_failure_threshold: int = 4,
-        volume_threshold: int = 0,
-        volume_tools: frozenset[str] | None = None,
-        subagent_dispatch_threshold: int = 0,
     ):
         super().__init__()
         self.window = window
         self.error_repeat_threshold = error_repeat_threshold
         self.args_repeat_threshold = args_repeat_threshold
-        self.distinct_args_threshold = distinct_args_threshold
-        self.distinct_args_window = distinct_args_window
-        # Normalise to frozenset so a caller passing a mutable set still
-        # yields an immutable attribute (matches the type annotation).
-        self.exploration_tools = frozenset(exploration_tools or ())
-        self.http_failure_threshold = http_failure_threshold
-        # Pattern E volume cap.  0 disables it (default) so non-research
-        # agents are unaffected; the research flow opts in.  volume_tools
-        # scopes which tools it caps (the research flow caps search_internet
-        # + read_url on its subagents).  See Pattern E in _detect_loop.
-        self.volume_threshold = volume_threshold
-        self.volume_tools = frozenset(volume_tools or ())
-        # Pattern F per-subagent re-dispatch cap.  0 disables it (default);
-        # the research orchestrator opts in.  See Pattern F in _detect_loop.
-        self.subagent_dispatch_threshold = subagent_dispatch_threshold
         self.tools = []
         self._intervention_count = 0
 
-    @hook_config(can_jump_to=["model"])
     def after_model(self, state: AgentState, runtime: Runtime) -> dict[str, Any] | None:
         messages = state.get("messages", [])
         if not messages:
@@ -829,13 +467,6 @@ class LoopDetectionMiddleware(AgentMiddleware):
             completed,
             error_repeat_threshold=self.error_repeat_threshold,
             args_repeat_threshold=self.args_repeat_threshold,
-            distinct_args_threshold=self.distinct_args_threshold,
-            distinct_args_window=self.distinct_args_window,
-            exploration_tools=self.exploration_tools,
-            http_failure_threshold=self.http_failure_threshold,
-            volume_threshold=self.volume_threshold,
-            volume_tools=self.volume_tools,
-            subagent_dispatch_threshold=self.subagent_dispatch_threshold,
         )
         if detection is None:
             return None
@@ -853,65 +484,6 @@ class LoopDetectionMiddleware(AgentMiddleware):
                 sorted(last_call_names),
             )
             return None
-
-        # Pattern F is subagent-specific: only intervene if the latest
-        # message RE-dispatches an already-used subagent.  A `task` call to
-        # a fresh subagent (the normal research -> critique -> fact-check
-        # progression) must pass through untouched.
-        if detection["pattern"] == "subagent-redispatch":
-            latest_subagents = {
-                (tc.get("args") or {}).get("subagent_type")
-                or (tc.get("args") or {}).get("agent")
-                or (tc.get("args") or {}).get("name")
-                for tc in last.tool_calls if tc.get("name") == "task"
-            }
-            if latest_subagents.isdisjoint(detection["subagents"]):
-                logger.info(
-                    "LoopDetection: subagent-redispatch matched (%s) but "
-                    "latest dispatches a fresh subagent (%s) — continuing.",
-                    detection["reason"], sorted(s for s in latest_subagents if s),
-                )
-                return None
-
-        # ── "Enough"-family finalize path (E tool-volume + F subagent-redispatch;
-        # A–D fall through) ──
-        # The agent has usable state; don't kill the turn with a stub (that
-        # destroys the synthesis/report it was about to write).  Strip the
-        # over-limit tool calls, leave a pattern-appropriate finalize nudge as
-        # the assistant turn, and jump back to the model for ONE synthesis turn.
-        # A SECOND firing this turn (model ignored the nudge) is excluded by
-        # _already_finalized_this_turn and falls through to the hard stop below —
-        # the runaway bound holds.
-        if (detection["pattern"] in _FINALIZE_PATTERNS
-                and not _already_finalized_this_turn(messages)):
-            self._intervention_count += 1
-            if detection["pattern"] == "tool-volume":
-                logger.warning(
-                    "LoopDetection: tool-volume cap fired (%s).  This cap "
-                    "should rarely trigger — investigate an upstream cause "
-                    "(prompt drift, poor/empty tool results, or a loop the "
-                    "other patterns missed).", detection["reason"],
-                )
-            logger.warning(
-                "LoopDetection: finalize-nudge #%d — pattern=%s tools=%s "
-                "run_length=%d stripped_calls=%d; jumping to model for one "
-                "synthesis turn (hard-stops if it keeps going).",
-                self._intervention_count, detection["pattern"],
-                sorted(looping_tools), detection["run_length"],
-                len(last.tool_calls),
-            )
-            new_last = last.model_copy() if hasattr(last, "model_copy") else last.copy()
-            new_last.tool_calls = []
-            new_last.content = _finalize_nudge_for(detection["pattern"])
-            if hasattr(new_last, "additional_kwargs"):
-                ak = dict(getattr(new_last, "additional_kwargs", {}) or {})
-                if ak.get("tool_calls"):
-                    ak["tool_calls"] = []
-                new_last.additional_kwargs = ak
-            # jump_to:"model" re-enters the model node for the synthesis turn
-            # (the after_model→model edge is wired by the can_jump_to decorator
-            # above); jump_to is an EphemeralValue, auto-cleared after the step.
-            return {"messages": [new_last], "jump_to": "model"}
 
         artifact = _last_successful_artifact(messages)
         terminal_content = _compose_terminal_message(detection, messages)
@@ -932,24 +504,6 @@ class LoopDetectionMiddleware(AgentMiddleware):
             artifact or "<none>",
             preview,
         )
-
-        # The volume cap is a deterministic BACKSTOP, not the primary bound on
-        # research effort — the 2026-06-03 ablation showed the dominant levers
-        # are the orchestrator delegating search and the focused-research
-        # prompt, with this cap only holding the margin.  So if it actually
-        # fires, the likely real cause is upstream: a prompt regression, a
-        # search tool returning poor/empty results (so the model keeps
-        # retrying), or a loop the args/error patterns missed.  Flag it loudly
-        # so a firing prompts an investigation rather than being silently
-        # absorbed as "working as intended".
-        if detection["pattern"] == "tool-volume":
-            logger.warning(
-                "LoopDetection: tool-volume backstop fired (%s).  This cap "
-                "should rarely trigger — investigate an upstream cause for the "
-                "over-use (prompt drift, poor/empty tool results, or a loop the "
-                "other patterns missed), don't rely on this cap as the bound.",
-                detection["reason"],
-            )
 
         new_last = last.model_copy() if hasattr(last, "model_copy") else last.copy()
         new_last.tool_calls = []

--- a/assist/middleware/loop_detection.py
+++ b/assist/middleware/loop_detection.py
@@ -15,13 +15,18 @@ message carries no tool calls.
 Two patterns are recognised — both are "you are repeating yourself
 verbatim", the only loops worth stopping deterministically:
 
-A. Same tool + same normalised error, repeated >=
+A. Same *mutating* tool + same normalised error, repeated >=
    ``error_repeat_threshold`` times in a row. Errors are normalised so
-   varying paths/IDs/numbers don't hide the repetition.
+   varying paths/IDs/numbers don't hide the repetition. Read-only tools
+   (``_READ_ONLY_TOOLS``) are transparent to this walk — a repeated
+   read-only error is NOT caught by A (reading the same thing and getting
+   the same error is left to B's same-args check), since a read-only call
+   between two failing writes is "let me check what's there", not a loop.
 
 B. Same tool + same args, repeated >= ``args_repeat_threshold`` times in
    a row. Catches the model calling the same tool with identical
-   arguments back-to-back regardless of result.
+   arguments back-to-back regardless of result. Applies to read-only tools
+   too (e.g. the same ``read_url(URL)`` hundreds of times).
 
 Everything else — distinct-arg exploration, http-failure streaks, sheer
 tool volume, sub-agent re-dispatch — is intentionally NOT caught here.

--- a/assist/middleware/loop_detection.py
+++ b/assist/middleware/loop_detection.py
@@ -475,7 +475,10 @@ class LoopDetectionMiddleware(AgentMiddleware):
 
         # Only act if the latest AI message's tool calls would extend the
         # loop. Otherwise the model may already be breaking out.
-        last_call_names = {tc.get("name") for tc in last.tool_calls}
+        # `or ""` matches _extract_events' convention and keeps the set
+        # all-strings, so the sorted() in the log below can't TypeError on a
+        # tool_call with a missing/None name.
+        last_call_names = {(tc.get("name") or "") for tc in last.tool_calls}
         if last_call_names.isdisjoint(looping_tools):
             logger.info(
                 "LoopDetection: pattern matched (%s) but latest tool calls "

--- a/assist/thread.py
+++ b/assist/thread.py
@@ -115,11 +115,12 @@ class Thread:
         ``assist.agent.create_agent`` docstring for the subagent
         scope.
 
-        `loop_exploration_tools` is forwarded to
-        ``create_agent(loop_exploration_tools=...)`` — tool names whose
-        distinct-args breadth gets a relaxed (but still finite) loop-
-        detection threshold because probing many forms is their normal
-        shape (eg. an embedder's ``eval_elisp``).  Default ``None``.
+        `loop_exploration_tools` is DEPRECATED and now a no-op (it fed the
+        since-removed Pattern-C distinct-args breadth threshold).  Still
+        forwarded to ``create_agent`` and accepted there so embedders that
+        pass it don't break, but ignored — loop detection now catches only
+        exact-repeat loops (A/B), which apply uniformly to every tool.
+        Default ``None``.
 
         `extra_skill_sources` is forwarded to
         ``create_agent(extra_skill_sources=...)`` — a mapping of additional

--- a/docs/2026-06-05-loop-detection-audit.org
+++ b/docs/2026-06-05-loop-detection-audit.org
@@ -4,6 +4,21 @@ State: Audit (Phase 1). Supersedes the narrower volume-cap doc
 (2026-06-05-research-volume-cap-destroys-output.org) by generalizing it to
 all six patterns.
 
+* ROLLED BACK (2026-06-06)
+The six-pattern design audited below — and the E/F "finalize-not-kill"
+machinery this audit motivated (jump_to-model nudge) — has been ROLLED BACK.
+In prod (thread 20260606101819) a legitimate research turn got thrashed
+between patterns D/E/F: tool calls stripped, jumped to model, hard-stopped
+mid-research with confusing canned messages. Per the user's call, loop
+detection now keeps ONLY the two exact-repetition guards (A same-tool-same-
+error, B same-tool-same-args) and removes C/D/E/F plus all finalize/jump_to
+machinery and the subagent volume cap. The deliberate runaway backstop is now
+the per-agent =recursion_limit= (research lowered 300→150), not per-tool
+caps — "a few extra research hops" is preferred over an artificial stop. The
+analysis below is retained as the historical record of why the aggressive
+patterns were tried and why they were ultimately not worth their failure
+mode; it no longer describes the shipped middleware.
+
 * Why this audit
 The research flow returned no answer twice in prod (James Blake threads).
 Root cause: =LoopDetectionMiddleware= Pattern E (tool-volume) fired and

--- a/edd/eval/test_agent.py
+++ b/edd/eval/test_agent.py
@@ -470,12 +470,12 @@ class TestResearchSearchUnavailableHandoff(AgentTestMixin, TestCase):
     Background: ``search_internet`` now goes through a self-hosted SearXNG
     with NO fallback, and RAISES when the backend is down (failures must be
     loud, not silently degraded).  The research subagent surfaces that as a
-    tool error; the contract this eval pins is unchanged in spirit: dispatch
-    research-agent once, read the unavailable signal, relay it, stop — don't
-    loop and don't answer from the model's own knowledge.  A deterministic
-    backstop (``LoopDetectionMiddleware`` Pattern F,
-    ``subagent_dispatch_threshold=1``) strips a within-turn re-dispatch; a
-    cross-turn re-dispatch stays the prompt's job.
+    tool error; the contract this eval pins: dispatch research-agent, read the
+    unavailable signal, relay it, stop — don't fabricate from the model's own
+    knowledge.  This is now PROMPT-driven: the loop-detection rollback removed
+    the per-subagent re-dispatch cap (old Pattern F), so a stray extra
+    dispatch is tolerated (a few hops are fine) as long as the agent heeds the
+    signal and relays it rather than answering from memory.
 
     MOCKING NOTE — this is the one eval in ``edd/eval/`` that
     monkey-patches tools (``search_internet`` and ``read_url``).  Existing
@@ -521,16 +521,22 @@ class TestResearchSearchUnavailableHandoff(AgentTestMixin, TestCase):
         # with a clearer message than the regexes' "didn't match".
         self.assertTrue(res, "Agent returned an empty response")
 
-        # 1. research-agent dispatched EXACTLY once.  Zero would mean the
-        #    parent answered from its own knowledge (a different failure
-        #    the prompt forbids); two-or-more is the runaway meta-loop.
+        # 1. research-agent dispatched at least once (zero would mean the
+        #    parent answered from its own knowledge — a failure the prompt
+        #    forbids).  Post-rollback we tolerate a stray extra dispatch (the
+        #    re-dispatch cap is gone; a few hops are fine), but cap it loosely
+        #    so a true meta-loop still fails.  The relay regex below carries
+        #    the real discrimination.
         research_dispatches = [s for s in self.subagent_calls(agent)
                                if s == "research-agent"]
-        self.assertEqual(
+        self.assertGreaterEqual(
             len(research_dispatches), 1,
-            "Expected research-agent dispatched exactly once (dispatch, "
-            "read the blocked signal, stop).  Dispatches seen: "
-            f"{self.subagent_calls(agent)}")
+            "Expected research-agent dispatched at least once (it answered "
+            f"without researching).  Dispatches seen: {self.subagent_calls(agent)}")
+        self.assertLessEqual(
+            len(research_dispatches), 3,
+            "research-agent dispatched too many times — a re-dispatch meta-loop. "
+            f"Dispatches seen: {self.subagent_calls(agent)}")
 
         # 2. Final response relays that search is unavailable (rather than
         #    fabricating an answer).  The unavailable token + dispatch==1
@@ -559,39 +565,44 @@ class TestResearchSearchUnavailableHandoff(AgentTestMixin, TestCase):
         self._assert_relays_unavailable(agent, res)
 
 
-class TestResearchSearchBudget(AgentTestMixin, TestCase):
-    """The research flow must converge on a bounded number of searches.
+# Loop-detection terminal stubs the FINAL answer must never be — they mean
+# an exact-repeat loop (Pattern A/B) cut the turn off before synthesis.
+# Lowercased substrings; see loop_detection.py:_compose_terminal_message.
+_LOOPDETECT_STUBS = (
+    "won't retry that approach",      # Pattern A
+    "i won't repeat it",              # Pattern B
+)
 
-    Background: a prod thread (a trivial product lookup) did ~100
-    `search_internet` calls across three nested research-agent dispatches
-    for a trivial query — the research orchestrator re-dispatched the
-    inner research-agent, each of which searched dozens of times under
-    the only guidance it had ("conduct thorough research").  This eval
-    pins an effort budget: a healthy research turn searches a handful of
-    times and finalizes.
 
-    We patch `search_internet` to a counted stub returning canned,
-    real-looking results (so the model has usable hits and isn't
-    searching for lack of results), and assert the TOTAL invocation count
-    across the whole flow stays under budget.  The count is the right
-    observable: the orchestrator's inner re-dispatches live in nested
-    sub-agent namespaces invisible to the top-level message state, but
-    every search — at any nesting depth — goes through the one patched
-    function, so a global counter captures aggregate effort exactly.
+class TestResearchRunsToCompletion(AgentTestMixin, TestCase):
+    """A multi-hop research turn must RUN TO COMPLETION, not be cut off.
 
-    Same patch-site reasoning as TestResearchSearchUnavailableHandoff: patch
-    `assist.agent.search_internet` (the name bound into assist.agent at
-    import), not `assist.tools.search_internet`.
+    This is the positive contract behind the loop-detection rollback: the
+    aggressive patterns (distinct-arg thrash, http-failure streak, sheer
+    volume, sub-agent re-dispatch) were removed precisely so a research turn
+    doing several distinct search/read hops is allowed to finish rather than
+    be yanked into a confusing half-finished state.  So we assert the flow
+    actually searches, produces a substantive synthesized answer, and is NOT
+    a loop-detection give-up stub.
+
+    We deliberately do NOT pin a tight upper bound on search count any more —
+    "a few extra hops" is fine, and the real runaway backstop is the research
+    agent's recursion_limit (see agent.py), not a per-tool cap.  A very loose
+    sanity ceiling stays only to catch a true pathological runaway (the prod
+    ~100-search case), not normal exploration.
+
+    We patch `search_internet`/`read_url` to counted stubs returning canned,
+    real-looking results (so the model has usable hits and isn't searching
+    for lack of results).  Same patch-site reasoning as
+    TestResearchSearchUnavailableHandoff: patch `assist.agent.search_internet`
+    (the name bound into assist.agent at import), not
+    `assist.tools.search_internet`.
     """
 
-    # Aggregate effort budget for a single research turn.  The designed
-    # ceiling is mechanical: the orchestrator does not search (it delegates),
-    # so the research-agent is the sole searcher, capped per-agent at
-    # _RESEARCH_TOOL_VOLUME_CAP (6) and dispatched once (_SUBAGENT_DISPATCH_CAP
-    # = 1).  So ~6 searches by design; 12 is 2x headroom for batch overshoot
-    # (the agent can emit several search calls in one message before the cap
-    # observes them).  Prod ran ~100; baseline (no fix) ran 15-50.
-    SEARCH_BUDGET = 12
+    # Loose sanity ceiling only — NOT a design bound.  A healthy turn searches
+    # a handful of times; this just catches a true runaway (prod ran ~100).
+    # The real bound is the research agent's recursion_limit.
+    SEARCH_BUDGET = 30
 
     def setUp(self):
         self.model = select_assistant_model(0.1)
@@ -625,154 +636,42 @@ class TestResearchSearchBudget(AgentTestMixin, TestCase):
             self, self.model, prompt, _counted_search, _canned_fetch)
         return agent, res, calls["search"]
 
-    def _assert_bounded(self, agent, res, n_searches):
+    def _assert_completes(self, agent, res, n_searches):
         self.assertTrue(res, "Agent returned an empty response")
-        # Lower bound: the flow must actually research.  Catches a
-        # regression that "bounds" searches by BREAKING research (answering
-        # from the model's own knowledge, or stripping the dispatch) — that
-        # would still produce a non-empty res and pass the upper bound alone.
+        # The flow must actually research — catches a regression that answers
+        # from the model's own knowledge or strips the dispatch.
         self.assertGreaterEqual(
             n_searches, 1,
             "Expected the flow to search at least once (it answered without "
             f"searching).  MAIN dispatches: {self.subagent_calls(agent)}")
-        # Upper bound: no over-search runaway.  MAIN-level dispatches in the
-        # message help locate the source if this fails.
-        self.assertLessEqual(
-            n_searches, self.SEARCH_BUDGET,
-            f"Research flow ran {n_searches} searches for one query — over "
-            f"the {self.SEARCH_BUDGET} budget.  MAIN dispatches: "
-            f"{self.subagent_calls(agent)}.")
-
-    def test_search_budget_product_lookup(self):
-        agent, res, n = self._run_counting_searches(
-            "What are good waterproof hiking boots for wet trails?")
-        self._assert_bounded(agent, res, n)
-
-    def test_search_budget_howto_lookup(self):
-        # A differently-shaped, non-telegraphed query.  Same budget.
-        agent, res, n = self._run_counting_searches(
-            "How do tabata intervals work?")
-        self._assert_bounded(agent, res, n)
-
-
-# Loop-detection terminal stubs the FINAL answer must never be (they mean the
-# cap killed the turn before synthesis).  Lowercased substrings; see
-# loop_detection.py:_compose_terminal_message.
-_LOOPDETECT_STUBS = (
-    "enough times to answer",
-    "stop gathering and write up what i have",
-    "already gathered that sub-agent",
-    "finalize with what i have rather than dispatching",
-    "won't retry that approach",
-    "i won't repeat it",
-    "i won't keep trying variations",
-)
-
-
-class TestResearchVolumeCapFinalizes(AgentTestMixin, TestCase):
-    """When the volume cap (Pattern E) fires, the research-agent must still
-    FINALIZE — produce a real synthesized answer from what it gathered — not
-    terminate on the canned 'I'll write up what I have now' stub.
-
-    This is the audit's discriminating eval (docs/2026-06-05-loop-detection-audit.org).
-    TestResearchSearchBudget only asserts res is non-empty + bounded — which
-    the BROKEN give-up stub satisfies, so it can't catch the bug.  Here we:
-      - force the cap to fire deterministically (patch the cap LOW around the
-        build — it's read into the subagent middleware at build time),
-      - return canned results carrying a SENTINEL the synthesis must echo,
-      - assert the final answer is a real synthesis (sentinel present) and is
-        NOT any loop-detection stub.
-    Must FAIL on main (cap kills output → res is the give-up stub) and PASS
-    after the finalize-not-kill fix.
-    """
-
-    FORCED_CAP = 2          # low, so the cap fires after a couple searches
-    SEARCH_CEILING = 12     # runaway bound must still hold (cap + headroom)
-
-    def setUp(self):
-        self.model = select_assistant_model(0.1)
-
-    def _run_forced_cap(self, prompt: str, canned: str):
-        import assist.tools as _tools
-        calls = {"search": 0}
-
-        @functools.wraps(_tools.search_internet)
-        def _counted_search(query, max_results=5):
-            calls["search"] += 1
-            return canned
-
-        @functools.wraps(_tools.read_url)
-        def _canned_fetch(url):
-            return ("Relevant page text with concrete, specific information. "
-                    "Vellichor Report details follow. " * 15)
-
-        # Patch the cap LOW around the build so Pattern E fires quickly.  The
-        # research subagent reads _RESEARCH_TOOL_VOLUME_CAP into its
-        # LoopDetectionMiddleware when the agent is constructed (inside the
-        # helper), so the patch must wrap that build.
-        with patch("assist.agent._RESEARCH_TOOL_VOLUME_CAP", self.FORCED_CAP):
-            agent, res = _run_general_agent_with_search_stubs(
-                self, self.model, prompt, _counted_search, _canned_fetch)
-        return agent, res, calls["search"]
-
-    # Canned, real-looking results so the model has usable material to
-    # synthesize.  Kept plausible (no implausible sentinel) — the small model
-    # ignores canned content it doesn't believe, so the discriminator is
-    # behavioral (not-a-stub + substantive), not "did it echo a magic token".
-    _CANNED = str([
-        {"title": "Source one",
-         "url": "https://example.com/a",
-         "content": "A directly relevant, specific paragraph with concrete "
-                    "figures, names, and dates answering the question."},
-        {"title": "Source two",
-         "url": "https://example.com/b",
-         "content": "A second corroborating source covering the topic from "
-                    "another angle with additional specifics."},
-    ])
-
-    def _assert_finalized(self, agent, res, n_searches):
-        self.assertTrue(res, "Agent returned an empty response")
+        # The answer must be a real synthesis, not a loop-detection give-up
+        # stub — i.e. it ran to completion rather than being cut off.
         low = res.lower()
-        # 1. NOT a loop-detection give-up stub — the CORE discriminator.  On
-        #    main, the cap kills the turn and res IS one of these stubs; the
-        #    finalize fix makes the agent synthesize instead.
         for stub in _LOOPDETECT_STUBS:
             self.assertNotIn(
                 stub, low,
-                f"Final answer is a loop-detection stub (cap killed the turn "
-                f"before synthesis): matched {stub!r}.\nGot: {res[:600]}")
-        # 2. Substantive synthesis, not a one-line give-up.  The broken
-        #    behavior yields a short give-up; a finalized research answer is
-        #    long-form.
+                f"Final answer is a loop-detection give-up stub (the turn was "
+                f"cut off before synthesis): matched {stub!r}.\nGot: {res[:600]}")
         self.assertGreater(
             len(res), 400,
-            f"Final answer is too short to be a real synthesis ({len(res)} "
-            f"chars) — likely a give-up.\nGot: {res[:600]}")
-        # 3. The cap region was actually reached (we exercised Pattern E).  With
-        #    the cap forced to 2, a finalized run searches ~2-3 times; 0 would
-        #    mean the stub wasn't even wired.
-        self.assertGreaterEqual(
-            n_searches, self.FORCED_CAP,
-            f"Only {n_searches} searches (< forced cap {self.FORCED_CAP}) — "
-            f"the test isn't exercising Pattern E.")
-        # 4. Runaway bound preserved (one extra synthesis turn, no more).
+            f"Final answer too short to be a real synthesis ({len(res)} chars) "
+            f"— likely a give-up.\nGot: {res[:600]}")
+        # Loose sanity ceiling only — NOT the design bound (that's the
+        # recursion_limit).  Catches a true pathological runaway, not the few
+        # extra hops the rollback intentionally allows.
         self.assertLessEqual(
-            n_searches, self.SEARCH_CEILING,
-            f"{n_searches} searches exceeds the {self.SEARCH_CEILING} ceiling "
-            f"— the cap's runaway bound regressed.")
+            n_searches, self.SEARCH_BUDGET,
+            f"Research flow ran {n_searches} searches for one query — past the "
+            f"loose sanity ceiling of {self.SEARCH_BUDGET}, a likely runaway.  "
+            f"MAIN dispatches: {self.subagent_calls(agent)}.")
 
-    def test_finalize_prod_query(self):
-        # The exact two-subject prod query that returned no answer (threads
-        # 20260605072211 / 20260605200346).
-        agent, res, n = self._run_forced_cap(
-            "Tell me about James Blake's latest album and what it means to be "
-            "an independent record.", self._CANNED)
-        self._assert_finalized(agent, res, n)
+    def test_research_completes_product_lookup(self):
+        agent, res, n = self._run_counting_searches(
+            "What are good waterproof hiking boots for wet trails?")
+        self._assert_completes(agent, res, n)
 
-    def test_finalize_second_query(self):
-        # A differently-shaped, real two-part query (per the eval-alignment
-        # convention) so a pass means fixing the SHAPE, not one prod prompt.
-        agent, res, n = self._run_forced_cap(
-            "Compare PostgreSQL and MySQL for a high-write workload, and say "
-            "which you would choose and why.", self._CANNED)
-        self._assert_finalized(agent, res, n)
+    def test_research_completes_howto_lookup(self):
+        # A differently-shaped, non-telegraphed query.  Same contract.
+        agent, res, n = self._run_counting_searches(
+            "How do tabata intervals work?")
+        self._assert_completes(agent, res, n)

--- a/edd/eval/test_agent.py
+++ b/edd/eval/test_agent.py
@@ -570,8 +570,9 @@ class TestResearchSearchUnavailableHandoff(AgentTestMixin, TestCase):
 # an exact-repeat loop (Pattern A/B) cut the turn off before synthesis.
 # Lowercased substrings; see loop_detection.py:_compose_terminal_message.
 _LOOPDETECT_STUBS = (
-    "won't retry that approach",      # Pattern A
-    "i won't repeat it",              # Pattern B
+    "won't retry that approach",      # Pattern A (no artifact)
+    "i won't repeat it",              # Pattern B (no artifact)
+    "i've saved the output to",       # either pattern WITH a successful artifact
 )
 
 

--- a/edd/eval/test_agent.py
+++ b/edd/eval/test_agent.py
@@ -644,23 +644,18 @@ class TestResearchRunsToCompletion(AgentTestMixin, TestCase):
             n_searches, 1,
             "Expected the flow to search at least once (it answered without "
             f"searching).  MAIN dispatches: {self.subagent_calls(agent)}")
-        # The answer must be a real synthesis, not a loop-detection give-up
-        # stub — i.e. it ran to completion rather than being cut off.
+        # The answer must not be a loop-detection give-up stub — that's the
+        # completion signal: the turn synthesized instead of being cut off.
+        # (No length floor: a correct, concise answer — e.g. "tabata is 20s on
+        # / 10s off x8" — has run to completion just as much as a long one, and
+        # a length threshold only adds flakiness without adding signal beyond
+        # the stub check + "it actually searched".)
         low = res.lower()
         for stub in _LOOPDETECT_STUBS:
             self.assertNotIn(
                 stub, low,
                 f"Final answer is a loop-detection give-up stub (the turn was "
                 f"cut off before synthesis): matched {stub!r}.\nGot: {res[:600]}")
-        # Backstop for a non-canned terse evasion (the canned give-up stubs
-        # are caught by the string check above; they run ~140-165 chars).  A
-        # real answer to these queries clears 200 comfortably — but we do NOT
-        # demand a long synthesis: a correct, concise answer (e.g. "tabata is
-        # 20s on / 10s off x8") is "ran to completion", not a give-up.
-        self.assertGreater(
-            len(res), 200,
-            f"Final answer too short to be a real answer ({len(res)} chars) "
-            f"— likely a give-up or cut off.\nGot: {res[:600]}")
         # Loose sanity ceiling only — NOT the design bound (that's the
         # recursion_limit).  Catches a true pathological runaway, not the few
         # extra hops the rollback intentionally allows.

--- a/edd/eval/test_agent.py
+++ b/edd/eval/test_agent.py
@@ -468,9 +468,10 @@ class TestResearchSearchUnavailableHandoff(AgentTestMixin, TestCase):
     is unavailable — relay that to the user, not re-dispatch or fabricate.
 
     Background: ``search_internet`` now goes through a self-hosted SearXNG
-    with NO fallback, and RAISES when the backend is down (failures must be
-    loud, not silently degraded).  The research subagent surfaces that as a
-    tool error; the contract this eval pins: dispatch research-agent, read the
+    with NO fallback; when the backend is down it RETURNS
+    ``_SEARCH_UNAVAILABLE_MESSAGE`` (logged at ERROR) rather than raising, so
+    the agent receives it as a tool result and can relay it without crashing
+    the turn.  The contract this eval pins: dispatch research-agent, read the
     unavailable signal, relay it, stop — don't fabricate from the model's own
     knowledge.  This is now PROMPT-driven: the loop-detection rollback removed
     the per-subagent re-dispatch cap (old Pattern F), so a stray extra

--- a/edd/eval/test_agent.py
+++ b/edd/eval/test_agent.py
@@ -652,10 +652,15 @@ class TestResearchRunsToCompletion(AgentTestMixin, TestCase):
                 stub, low,
                 f"Final answer is a loop-detection give-up stub (the turn was "
                 f"cut off before synthesis): matched {stub!r}.\nGot: {res[:600]}")
+        # Backstop for a non-canned terse evasion (the canned give-up stubs
+        # are caught by the string check above; they run ~140-165 chars).  A
+        # real answer to these queries clears 200 comfortably — but we do NOT
+        # demand a long synthesis: a correct, concise answer (e.g. "tabata is
+        # 20s on / 10s off x8") is "ran to completion", not a give-up.
         self.assertGreater(
-            len(res), 400,
-            f"Final answer too short to be a real synthesis ({len(res)} chars) "
-            f"— likely a give-up.\nGot: {res[:600]}")
+            len(res), 200,
+            f"Final answer too short to be a real answer ({len(res)} chars) "
+            f"— likely a give-up or cut off.\nGot: {res[:600]}")
         # Loose sanity ceiling only — NOT the design bound (that's the
         # recursion_limit).  Catches a true pathological runaway, not the few
         # extra hops the rollback intentionally allows.

--- a/roadmap.org
+++ b/roadmap.org
@@ -365,12 +365,31 @@ LangChain shipped a code-interpreter middleware for deepagents (=CodeInterpreter
 *Concrete next step.*  Spike: build an interpreter version of calculate covering the 3-5 most common eval-prompt shapes, run =test_calculate_skill.py= at N=3 on both versions side-by-side, compare token usage + pass rate.  Decide based on data.  Out of scope: rewriting *other* skills (research, context, dev) — calculate is the cleanest test case because its semantics are simple and its sandbox dependency is shallow.
 
 * Loop detection follow-ups
-Surfaced by the 2026-06-05 LoopDetection audit (see [[file:docs/2026-06-05-loop-detection-audit.org][docs/2026-06-05-loop-detection-audit.org]]): the six patterns split into two families — A–D "you're stuck" (ending the turn is correct) and E–F "you've gathered enough" (ending DESTROYS the answer → must finalize).  E finalize shipped and works (live James Blake smoke produced a real answer); F finalize is correct but the small model often re-dispatches through the prose nudge.
-** TODO Pattern F structural fix — withhold the =task= tool on the finalize turn
-F finalize (subagent-redispatch) is a prose nudge ("answer from the result you have, don't dispatch again") and the small model ignores it ~1–2/5 (re-dispatches → second-strike hard stop → give-up stub).  Per the audit's own lesson (a nudge binds only when the desired action is the only option), make it a *checkable* constraint: on the finalize turn, remove/withhold the =task= tool so the model MUST answer from the result it already has.  Needs design+review (intercepting the tool surface for one turn).
-** TODO =edit_file= sandbox error: "unexpected server response: Traceback"
-Seen in prod thread 20260606083812 — =edit_file= on a workspace file returned =unexpected server response: Traceback= twice (Pattern A caught it gracefully and surfaced the saved artifact).  This is a sandbox / edit-endpoint reliability bug, unrelated to loop detection.  Investigate the sandbox edit path (=DockerSandboxBackend.edit= / the edit server) for what raises the traceback and why.
-** TODO Full LoopDetection refactor — separate "detect" from "on-detect"; make the two families explicit
-The middleware now carries six patterns, two terminal behaviors (A–D break vs E–F finalize-via-jump_to), a per-turn stateless nudge scan, and a pile of thresholds/knobs.  Refactor so detection (which pattern + why) is cleanly separated from the response (break vs finalize), with the stuck-vs-enough families explicit in the structure rather than implied by =_FINALIZE_PATTERNS= membership.  Also fold the duplicated =model_copy=/strip/jump return-shaping.
-** TODO Explore converting LoopDetection to prompt guidance (or demoting it to a thin backstop)
-Per the project's "guidance over middleware" direction (AGENTS.md): how much of this deterministic middleware could be replaced by — or sit behind — prompt/skill guidance?  The audit gives real data: E's nudge holds (the agent's only non-search move is to answer), F's doesn't (re-dispatch is a tempting alternative).  Use that to map where guidance can carry the load vs where a structural guard is still required.  Likely outcome: prompts set the healthy path, a slimmer middleware holds the margin.
+The 2026-06-05 audit's six-pattern design (and the E/F finalize/=jump_to=
+machinery it motivated) was ROLLED BACK on 2026-06-06 (PR #128).  Loop
+detection now keeps only the two exact-repeat guards — A (same-tool-same-error)
+and B (same-tool-same-args) — and the runaway backstop is the per-agent
+=recursion_limit= (research 300→150), not per-tool caps.  A few extra research
+hops are preferred over an artificial mid-turn stop.  That supersedes most of
+the items below.
+** DONE Pattern F structural fix — withhold the =task= tool on the finalize turn
+Moot: Pattern F (subagent-redispatch) and the whole finalize/=jump_to=
+machinery were removed in the rollback (PR #128).  A few extra sub-agent
+dispatches are now tolerated; =recursion_limit= bounds a true meta-loop.
+** DONE =edit_file= sandbox error: "unexpected server response: Traceback"
+Shipped (PR #127): root cause was =write_file= uploading via =put_archive=,
+which the Docker daemon extracts as root, leaving files un-editable by the
+non-root sandbox.  Fixed by stamping the container's run uid/gid on uploads.
+Unrelated to loop detection.
+** DONE Full LoopDetection refactor — separate "detect" from "on-detect"
+Largely satisfied by the rollback (PR #128): the middleware is now a thin A/B
+detector with a single terminal behavior (strip-to-END).  The six-pattern /
+two-behavior tangle, the finalize-via-=jump_to= path, the per-turn nudge scan,
+and most thresholds/knobs are gone, so there's no longer a structure worth a
+dedicated refactor.
+** TODO Explore converting the remaining A/B detection to prompt guidance
+Reduced scope after the rollback (PR #128).  Per AGENTS.md "guidance over
+middleware": the only deterministic guard left is exact-repeat detection
+(A/B).  Open question is whether even that can move to prompt/skill guidance or
+stay as a thin backstop.  Lower priority now that the aggressive, misfiring
+patterns are gone.

--- a/tests/middleware/test_loop_detection.py
+++ b/tests/middleware/test_loop_detection.py
@@ -180,11 +180,12 @@ class TestDetectLoop:
         assert _detect_loop(events, 2, 3) is None
 
     def test_pattern_a_breaks_on_intervening_success(self):
-        # Distinct args so Pattern B can't fire — isolates Pattern A's
-        # "intervening success breaks the trailing error run" behavior.
+        # All-distinct args so Pattern B can't fire (no same-args run at all) —
+        # isolates Pattern A's "intervening success breaks the trailing error
+        # run" behavior.
         events = [
             self._evt(args={"file_path": "/a"}, content="Cannot write to /a because it already exists.", is_error=True),
-            self._evt(args={"file_path": "/a"}, content="ok"),
+            self._evt(args={"file_path": "/c"}, content="ok"),
             self._evt(args={"file_path": "/b"}, content="Cannot write to /b because it already exists.", is_error=True),
         ]
         # Trailing run of errors is length 1 only — Pattern A must not fire

--- a/tests/middleware/test_loop_detection.py
+++ b/tests/middleware/test_loop_detection.py
@@ -215,8 +215,7 @@ class TestDetectLoop:
         # Need different args so no pattern fires
         events = [evt, evt.copy()]
         # Pattern A: not all errors → no
-        # Pattern B: only 2 → no (threshold 3)
-        # Pattern C: 1 distinct over 2 → no (threshold 3)
+        # Pattern B: only 2 identical → no (threshold 3)
         assert _detect_loop(events, 2, 3) is None
 
     # ------------------------------------------------------------------
@@ -827,9 +826,9 @@ class TestLoopDetectionMiddleware:
         ``write_todos`` events in the conversation history.  The current
         turn opens with a single ``write_todos`` call (typical
         small-model fresh-task behavior).  Without per-turn bounding,
-        the prior turn's events stay in the loop window and pattern C
-        (distinct-args-thrash) fires instantly, producing a canned
-        terminal message even though the new turn has done nothing.
+        the prior turn's events stay in the loop window and a loop
+        pattern could fire instantly, producing a canned terminal
+        message even though the new turn has done nothing.
 
         With the fix, ``_extract_events`` only sees post-HumanMessage
         events — a single incomplete call — and the detector returns

--- a/tests/middleware/test_loop_detection.py
+++ b/tests/middleware/test_loop_detection.py
@@ -6,8 +6,6 @@ from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from assist.middleware.loop_detection import (
     LoopDetectionMiddleware,
-    _FINALIZE_NUDGE,
-    _REDISPATCH_NUDGE,
     _compose_terminal_message,
     _detect_loop,
     _extract_events,
@@ -151,25 +149,24 @@ class TestExtractEvents:
 
 class TestDetectLoop:
     def _evt(self, tool="write_file", args=None, content="ok",
-             is_error=False, http_failure=False):
+             is_error=False):
         return {
             "tool_name": tool,
             "args_sig": _normalise_args(args or {}),
             "result_content": content,
             "is_error": is_error,
-            "http_failure": http_failure,
             "completed": True,
         }
 
     def test_no_loop_on_empty_history(self):
-        assert _detect_loop([], 2, 3, 3, 10) is None
+        assert _detect_loop([], 2, 3) is None
 
     def test_pattern_a_two_same_errors_in_a_row(self):
         events = [
             self._evt(content="Cannot write to /a because it already exists.", is_error=True),
             self._evt(content="Cannot write to /b because it already exists.", is_error=True),
         ]
-        result = _detect_loop(events, 2, 3, 3, 10)
+        result = _detect_loop(events, 2, 3)
         assert result is not None
         assert result["pattern"] == "same-tool-same-error"
         assert result["tools"] == {"write_file"}
@@ -180,22 +177,21 @@ class TestDetectLoop:
             self._evt(content="ok"),
             self._evt(content="Cannot write to /a because it already exists.", is_error=True),
         ]
-        assert _detect_loop(events, 2, 3, 3, 10) is None
+        assert _detect_loop(events, 2, 3) is None
 
     def test_pattern_a_breaks_on_intervening_success(self):
+        # Distinct args so Pattern B can't fire — isolates Pattern A's
+        # "intervening success breaks the trailing error run" behavior.
         events = [
-            self._evt(content="Cannot write to /a because it already exists.", is_error=True),
-            self._evt(content="ok"),
-            self._evt(content="Cannot write to /b because it already exists.", is_error=True),
+            self._evt(args={"file_path": "/a"}, content="Cannot write to /a because it already exists.", is_error=True),
+            self._evt(args={"file_path": "/a"}, content="ok"),
+            self._evt(args={"file_path": "/b"}, content="Cannot write to /b because it already exists.", is_error=True),
         ]
-        # Trailing run of errors is length 1 only — no Pattern A.
-        # Pattern C also doesn't fire (only 2 distinct args within window).
-        # But it might fire other patterns; let's just check Pattern A doesn't fire.
-        result = _detect_loop(events, 2, 3, 3, 10)
-        # A non-error in between breaks the trailing run; if other patterns
-        # also don't fire, result should be None.
-        # Pattern C: 3 distinct args (default different per-evt args) over 3 events
-        # would fire. So provide identical args to isolate pattern A behaviour.
+        # Trailing run of errors is length 1 only — Pattern A must not fire
+        # when a success interrupts the run.
+        assert _detect_loop(events, 2, 3) is None
+        # Same tool + same args three times in a row → Pattern B fires even
+        # though the middle call succeeded (B is args-based, not error-based).
         events_same_args = [
             self._evt(args={"file_path": "/a"}, content="Cannot write to /a because it already exists.", is_error=True),
             self._evt(args={"file_path": "/a"}, content="ok"),
@@ -203,14 +199,14 @@ class TestDetectLoop:
         ]
         # Trailing run is just 1 error → Pattern A won't fire
         # 3 same-args-same-tool in a row → Pattern B fires at threshold 3
-        result2 = _detect_loop(events_same_args, 2, 3, 3, 10)
+        result2 = _detect_loop(events_same_args, 2, 3)
         assert result2 is not None
         assert result2["pattern"] == "same-tool-same-args"
 
     def test_pattern_b_three_identical_calls(self):
         evt = self._evt(args={"file_path": "/x"}, content="ok")
         events = [evt, evt.copy(), evt.copy()]
-        result = _detect_loop(events, 2, 3, 3, 10)
+        result = _detect_loop(events, 2, 3)
         assert result is not None
         assert result["pattern"] == "same-tool-same-args"
 
@@ -221,156 +217,7 @@ class TestDetectLoop:
         # Pattern A: not all errors → no
         # Pattern B: only 2 → no (threshold 3)
         # Pattern C: 1 distinct over 2 → no (threshold 3)
-        assert _detect_loop(events, 2, 3, 3, 10) is None
-
-    def test_pattern_c_filename_mutation(self):
-        # Three distinct paths with mixed errors that don't normalise alike,
-        # so Pattern A doesn't fire. Pattern C catches it because the tool is
-        # mutating and at least one call errored.
-        events = [
-            self._evt(args={"file_path": "/a"},
-                      content="Error: permission denied", is_error=True),
-            self._evt(args={"file_path": "/b"},
-                      content="Error: disk full", is_error=True),
-            self._evt(args={"file_path": "/c"},
-                      content="Error: already exists", is_error=True),
-        ]
-        result = _detect_loop(events, 2, 3, 3, 10)
-        assert result is not None
-        assert result["pattern"] == "distinct-args-thrash"
-
-    def test_pattern_c_does_not_fire_with_two_distinct(self):
-        events = [
-            self._evt(args={"file_path": "/a"}),
-            self._evt(args={"file_path": "/b"}),
-        ]
-        assert _detect_loop(events, 2, 3, 3, 10) is None
-
-    def test_pattern_c_does_not_fire_for_read_only_tool(self):
-        # Three distinct read_file calls is exploration, not a loop —
-        # regression for thread 20260425110043-4822cf50.
-        events = [
-            self._evt(tool="read_file", args={"file_path": "/a"}, content="<contents of /a>"),
-            self._evt(tool="read_file", args={"file_path": "/b"}, content="<contents of /b>"),
-            self._evt(tool="read_file", args={"file_path": "/c"}, content="<contents of /c>"),
-        ]
-        assert _detect_loop(events, 2, 3, 3, 10) is None
-
-    def test_pattern_c_does_not_fire_without_error(self):
-        # Three successful distinct write_file calls is normal
-        # multi-file work, not a thrash.
-        events = [
-            self._evt(args={"file_path": "/a"}, content="Wrote /a"),
-            self._evt(args={"file_path": "/b"}, content="Wrote /b"),
-            self._evt(args={"file_path": "/c"}, content="Wrote /c"),
-        ]
-        assert _detect_loop(events, 2, 3, 3, 10) is None
-
-    # ------------------------------------------------------------------
-    # Exploration tools (eg. emacsos's eval_elisp): relaxed Pattern-C
-    # breadth threshold, but NOT exempt and still subject to A/B.
-    # ------------------------------------------------------------------
-
-    def test_pattern_c_exploration_tool_gets_higher_threshold(self):
-        # The live emacsos shape: a few distinct eval_elisp probes, one
-        # erroring (the small model fumbles the API).  With eval_elisp
-        # marked as an exploration tool, the higher threshold (default 6)
-        # means this legitimate exploration is NOT terminated.
-        events = [
-            self._evt(tool="eval_elisp", args={"code": "(cursor-type)"}, content="box"),
-            self._evt(tool="eval_elisp",
-                      args={"code": "(frame-parameter nil 'cursor-color)"},
-                      content="nil"),
-            self._evt(tool="eval_elisp", args={"code": "(load-path)"},
-                      content="error: void-function load-path", is_error=True),
-        ]
-        assert _detect_loop(events, 2, 3, 3, 10,
-                            exploration_tools=frozenset({"eval_elisp"})) is None
-
-    def test_pattern_c_fires_for_eval_elisp_when_not_an_exploration_tool(self):
-        # Opt-in: with NO exploration_tools (the dev/code agent's config),
-        # the same 3 distinct erroring probes trip Pattern C at threshold 3.
-        events = [
-            self._evt(tool="eval_elisp", args={"code": "(cursor-type)"}, content="box"),
-            self._evt(tool="eval_elisp",
-                      args={"code": "(frame-parameter nil 'cursor-color)"},
-                      content="nil"),
-            self._evt(tool="eval_elisp", args={"code": "(load-path)"},
-                      content="error: void-function load-path", is_error=True),
-        ]
-        result = _detect_loop(events, 2, 3, 3, 10)
-        assert result is not None
-        assert result["pattern"] == "distinct-args-thrash"
-
-    def test_pattern_c_exploration_tool_boundary_just_below_threshold(self):
-        # 5 distinct erroring forms (one below the exploration threshold of
-        # 6, with DISTINCT errors so A/B don't fire) → not yet a flail.
-        errs = ["void-function a", "void-variable b", "wrong-type c",
-                "args-range d", "scan-error e"]
-        events = [
-            self._evt(tool="eval_elisp", args={"code": f"(p{i})"},
-                      content=f"error: {errs[i]}", is_error=True)
-            for i in range(5)
-        ]
-        assert _detect_loop(events, 2, 3, 3, 10,
-                            exploration_tools=frozenset({"eval_elisp"})) is None
-
-    def test_pattern_c_still_catches_sustained_exploration_flail(self):
-        # A sustained flail (>= the higher threshold of distinct erroring
-        # forms, with DISTINCT errors so A/B don't fire) IS still caught,
-        # faster than the recursion limit.
-        errs = ["void-function foo", "void-variable bar", "wrong-type baz",
-                "args-out-of-range qux", "scan-error quux", "no-catch corge"]
-        events = [
-            self._evt(tool="eval_elisp", args={"code": f"(probe-{i})"},
-                      content=f"error: {errs[i]}", is_error=True)
-            for i in range(6)
-        ]
-        result = _detect_loop(events, 2, 3, 3, 10,
-                              exploration_tools=frozenset({"eval_elisp"}))
-        assert result is not None
-        assert result["pattern"] == "distinct-args-thrash"
-        assert result["run_length"] == 6
-
-    def test_exploration_tool_still_subject_to_pattern_a(self):
-        # The SAME error repeated is a real loop — Pattern A still fires for
-        # an exploration tool (it stays "mutating" for A/B).
-        events = [
-            self._evt(tool="eval_elisp", args={"code": "(a)"},
-                      content="error: void-function frobnicate", is_error=True),
-            self._evt(tool="eval_elisp", args={"code": "(b)"},
-                      content="error: void-function frobnicate", is_error=True),
-        ]
-        result = _detect_loop(events, 2, 3, 3, 10,
-                              exploration_tools=frozenset({"eval_elisp"}))
-        assert result is not None
-        assert result["pattern"] == "same-tool-same-error"
-
-    def test_exploration_tool_still_subject_to_pattern_b(self):
-        # The IDENTICAL form repeated 3x is a real loop — Pattern B still
-        # fires for an exploration tool.
-        evt = self._evt(tool="eval_elisp", args={"code": "(stuck)"}, content="nil")
-        events = [evt, evt.copy(), evt.copy()]
-        result = _detect_loop(events, 2, 3, 3, 10,
-                              exploration_tools=frozenset({"eval_elisp"}))
-        assert result is not None
-        assert result["pattern"] == "same-tool-same-args"
-
-    def test_different_tools_do_not_interleave(self):
-        # Pattern C identifies the offending tool name when 3 distinct
-        # mutating calls share the same name. Custom tool name avoids the
-        # read-only allowlist.
-        events = [
-            self._evt(tool="custom_mutator", args={"q": "a"},
-                      content="Error: failed in mode A", is_error=True),
-            self._evt(tool="custom_mutator", args={"q": "b"},
-                      content="Error: failed in mode B", is_error=True),
-            self._evt(tool="custom_mutator", args={"q": "c"},
-                      content="Error: failed in mode C", is_error=True),
-        ]
-        result = _detect_loop(events, 2, 3, 3, 10)
-        assert result is not None
-        assert result["tools"] == {"custom_mutator"}
+        assert _detect_loop(events, 2, 3) is None
 
     # ------------------------------------------------------------------
     # Read-only-interleaved trailing-run detection
@@ -408,7 +255,7 @@ class TestDetectLoop:
                 is_error=True,
             ),
         ]
-        result = _detect_loop(events, 2, 3, 3, 10)
+        result = _detect_loop(events, 2, 3)
         assert result is not None, "Pattern A should fire on ls-interleaved write_file errors"
         assert result["pattern"] == "same-tool-same-error"
         assert result["tools"] == {"write_file"}
@@ -428,7 +275,7 @@ class TestDetectLoop:
                 content="OCI runtime exec failed: chdir to cwd",
                 is_error=True,
             ))
-        result = _detect_loop(events, 2, 3, 3, 10)
+        result = _detect_loop(events, 2, 3)
         assert result is not None
         assert result["pattern"] == "same-tool-same-error"
         assert result["run_length"] == 4
@@ -444,7 +291,7 @@ class TestDetectLoop:
         )
         gl = self._evt(tool="glob", args={"pattern": "*.org"}, content="[]")
         events = [wf, gl, wf.copy(), gl.copy(), wf.copy()]
-        result = _detect_loop(events, 2, 3, 3, 10)
+        result = _detect_loop(events, 2, 3)
         assert result is not None
         assert result["pattern"] == "same-tool-same-args"
         assert result["tools"] == {"write_file"}
@@ -461,7 +308,7 @@ class TestDetectLoop:
             self._evt(tool="ls", args={"path": "/"}, content="['a.org']"),
             self._evt(tool="write_file", args={"file_path": "/b.org"}, content="Wrote /b.org"),
         ]
-        assert _detect_loop(events, 2, 3, 3, 10) is None
+        assert _detect_loop(events, 2, 3) is None
 
     def test_pattern_b_catches_repeated_read_url(self):
         """The 2026-05-30 runaway: a sub-research-agent issued the same
@@ -476,7 +323,7 @@ class TestDetectLoop:
             content="[long page content]",
         )
         events = [ru, ru.copy(), ru.copy()]
-        result = _detect_loop(events, 2, 3, 3, 10)
+        result = _detect_loop(events, 2, 3)
         assert result is not None
         assert result["pattern"] == "same-tool-same-args"
         assert result["tools"] == {"read_url"}
@@ -493,7 +340,7 @@ class TestDetectLoop:
             content="[results]",
         )
         events = [si, si.copy(), si.copy(), si.copy()]
-        result = _detect_loop(events, 2, 3, 3, 10)
+        result = _detect_loop(events, 2, 3)
         assert result is not None
         assert result["pattern"] == "same-tool-same-args"
         assert result["tools"] == {"search_internet"}
@@ -510,7 +357,7 @@ class TestDetectLoop:
         )
         ls = self._evt(tool="ls", args={"path": "/"}, content="['x.md']")
         events = [ru, ls, ru.copy(), ls.copy(), ru.copy()]
-        result = _detect_loop(events, 2, 3, 3, 10)
+        result = _detect_loop(events, 2, 3)
         assert result is not None
         assert result["pattern"] == "same-tool-same-args"
         assert result["run_length"] == 3
@@ -532,7 +379,7 @@ class TestDetectLoop:
             content="[b]",
         )
         events = [ru_a, ru_b, ru_a.copy(), ru_b.copy(), ru_a.copy()]
-        assert _detect_loop(events, 2, 3, 3, 10) is None
+        assert _detect_loop(events, 2, 3) is None
 
     def test_no_false_positive_pure_exploration(self):
         """A run of read-only tools alone (no mutating) must NOT
@@ -545,7 +392,7 @@ class TestDetectLoop:
             self._evt(tool="grep", args={"pattern": "foo"}, content="[]"),
             self._evt(tool="search_internet", args={"query": "x"}, content="[]"),
         ]
-        assert _detect_loop(events, 2, 3, 3, 10) is None
+        assert _detect_loop(events, 2, 3) is None
 
     # ------------------------------------------------------------------
     # Pattern B — trailing-read-only-of-different-tool case
@@ -565,7 +412,7 @@ class TestDetectLoop:
         )
         ls = self._evt(tool="ls", args={"path": "/"}, content="['x.org']")
         events = [wf, ls, wf.copy(), ls.copy(), wf.copy(), ls.copy()]
-        result = _detect_loop(events, 2, 3, 3, 10)
+        result = _detect_loop(events, 2, 3)
         assert result is not None, "loop missed when trailing event is read-only"
         assert result["pattern"] == "same-tool-same-args"
         assert result["tools"] == {"write_file"}
@@ -580,7 +427,7 @@ class TestDetectLoop:
             content="Wrote /x.org",
         )
         events = [wf, wf.copy(), wf.copy()]
-        result = _detect_loop(events, 2, 3, 3, 10)
+        result = _detect_loop(events, 2, 3)
         assert result is not None
         assert result["pattern"] == "same-tool-same-args"
         assert result["run_length"] == 3
@@ -596,7 +443,7 @@ class TestDetectLoop:
             content="[content]",
         )
         events = [ru, ru.copy(), ru.copy()]
-        result = _detect_loop(events, 2, 3, 3, 10)
+        result = _detect_loop(events, 2, 3)
         assert result is not None
         assert result["pattern"] == "same-tool-same-args"
         assert result["run_length"] == 3
@@ -604,84 +451,6 @@ class TestDetectLoop:
     # ------------------------------------------------------------------
     # Pattern D — HTTP-failure streak (the casio runaway shape)
     # ------------------------------------------------------------------
-    def test_pattern_d_catches_distinct_url_4xx_streak(self):
-        """The 2026-05-30 casio.com runaway: ``fetch_url`` returned a
-        403 bot-detection HTML page on each of many distinct watch-product
-        URLs.  Patterns A/B/C all short-circuit (HTML body isn't a
-        Python error, args differ each call, no error flag set), so
-        Pattern D specifically counts consecutive trailing tool calls
-        whose body looks HTTP-failure-shaped, regardless of args."""
-        events = [
-            self._evt(
-                tool="fetch_url",
-                args={"url": f"https://www.casio.com/products/watches/p-{i}/"},
-                content="<html><title>403 Forbidden</title>...",
-                http_failure=True,
-            )
-            for i in range(5)
-        ]
-        result = _detect_loop(events, 2, 3, 3, 10, http_failure_threshold=4)
-        assert result is not None
-        assert result["pattern"] == "http-failure-streak"
-        assert result["tools"] == {"fetch_url"}
-        assert result["run_length"] == 5
-
-    def test_pattern_d_does_not_fire_below_threshold(self):
-        """3 consecutive failures (< default threshold 4) should not
-        fire — many normal research sessions hit one or two 4xx hops
-        before finding a working source."""
-        events = [
-            self._evt(tool="fetch_url",
-                      args={"url": f"https://x.example.com/p-{i}/"},
-                      content="403 Forbidden", http_failure=True)
-            for i in range(3)
-        ]
-        assert _detect_loop(events, 2, 3, 3, 10, http_failure_threshold=4) is None
-
-    def test_pattern_d_does_not_fire_when_streak_is_broken(self):
-        """A successful response in the trailing window breaks the
-        streak — the model is still making progress."""
-        events = [
-            self._evt(tool="fetch_url",
-                      args={"url": "https://x.example.com/p-1/"},
-                      content="403 Forbidden", http_failure=True),
-            self._evt(tool="fetch_url",
-                      args={"url": "https://x.example.com/p-2/"},
-                      content="403 Forbidden", http_failure=True),
-            # A real successful page — breaks the streak.
-            self._evt(tool="fetch_url",
-                      args={"url": "https://x.example.com/about/"},
-                      content="<html><body>Welcome to our store...</body></html>"),
-            self._evt(tool="fetch_url",
-                      args={"url": "https://x.example.com/p-3/"},
-                      content="403 Forbidden", http_failure=True),
-        ]
-        # The trailing failure-streak is 1; below threshold.
-        assert _detect_loop(events, 2, 3, 3, 10, http_failure_threshold=4) is None
-
-    def test_pattern_d_streak_spanning_tool_names(self):
-        """Mixed-tool failure streaks (search_internet 4xx, fetch_url 4xx,
-        fetch_url 4xx, …) trigger on the LATEST failing tool — the
-        signature is the failure shape, not the tool identity."""
-        events = [
-            self._evt(tool="search_internet",
-                      args={"query": "f-91w"},
-                      content="Rate limit exceeded", http_failure=True),
-            self._evt(tool="fetch_url",
-                      args={"url": "https://casio.com/a/"},
-                      content="403 Forbidden", http_failure=True),
-            self._evt(tool="fetch_url",
-                      args={"url": "https://casio.com/b/"},
-                      content="403 Forbidden", http_failure=True),
-            self._evt(tool="fetch_url",
-                      args={"url": "https://casio.com/c/"},
-                      content="403 Forbidden", http_failure=True),
-        ]
-        result = _detect_loop(events, 2, 3, 3, 10, http_failure_threshold=4)
-        assert result is not None
-        assert result["pattern"] == "http-failure-streak"
-        assert result["tools"] == {"fetch_url"}, \
-            "latest failing tool wins (most recent is what the model is currently doing)"
 
 
 class TestLastSuccessfulArtifact:
@@ -835,27 +604,6 @@ class TestComposeTerminalMessage:
         assert "search" in msg
         assert "won't repeat" in msg
 
-    def test_pattern_c_without_artifact_includes_excerpt_when_error(self):
-        detection = {
-            "pattern": "distinct-args-thrash",
-            "reason": "...",
-            "tools": {"write_file"},
-            "run_length": 3,
-        }
-        messages = [
-            _ai_with_call("c1", "write_file", {"file_path": "/a"}),
-            _tool_msg("c1", "Cannot write to /a because it already exists."),
-            _ai_with_call("c2", "write_file", {"file_path": "/b"}),
-            _tool_msg("c2", "Cannot write to /b because it already exists."),
-            _ai_with_call("c3", "write_file", {"file_path": "/c"}),
-            _tool_msg("c3", "Cannot write to /c because it already exists."),
-        ]
-        msg = _compose_terminal_message(detection, messages)
-        assert "write_file" in msg
-        assert "different inputs" in msg
-        assert "already exists" in msg
-        assert "won't keep trying" in msg
-
 
 # ---------------------------------------------------------------------------
 # Middleware integration tests
@@ -889,39 +637,6 @@ class TestLoopDetectionMiddleware:
             msgs.append(_tool_msg(f"c{i}", "[results]"))
         msgs.append(_ai_with_call("clast", "search_internet", {"q": "more"}))
         return msgs
-
-    def test_volume_cap_first_fire_finalizes_not_kills(self, caplog):
-        """First tool-volume firing must FINALIZE: strip the over-limit calls,
-        leave the finalize nudge, and jump back to the model for one synthesis
-        turn (NOT end the turn with a give-up stub).  Plus the loud cap warning."""
-        mw = LoopDetectionMiddleware(
-            volume_threshold=4, volume_tools=frozenset({"search_internet"}))
-        with caplog.at_level(logging.WARNING,
-                             logger="assist.middleware.loop_detection"):
-            result = mw.after_model({"messages": self._volume_msgs()}, Mock())
-        assert result is not None
-        assert result.get("jump_to") == "model", \
-            "tool-volume must jump back to the model for a synthesis turn"
-        assert result["messages"][-1].tool_calls == []
-        assert result["messages"][-1].content == _FINALIZE_NUDGE
-        assert any("cap fired" in r.getMessage() for r in caplog.records), \
-            f"expected cap warning; got {[r.getMessage() for r in caplog.records]}"
-
-    def test_volume_cap_second_fire_hard_stops(self):
-        """If the model searches AGAIN after the finalize nudge (second strike
-        this turn), fall through to the hard stop — no jump, tool calls
-        stripped, terminal stub — so the runaway bound still holds."""
-        mw = LoopDetectionMiddleware(
-            volume_threshold=4, volume_tools=frozenset({"search_internet"}))
-        msgs = self._volume_msgs()
-        # The nudge already happened earlier this turn (model ignored it):
-        msgs.append(AIMessage(content=_FINALIZE_NUDGE))
-        msgs.append(_ai_with_call("again", "search_internet", {"q": "yet more"}))
-        result = mw.after_model({"messages": msgs}, Mock())
-        assert result is not None
-        assert "jump_to" not in result, "second strike must NOT jump — hard stop"
-        assert result["messages"][-1].tool_calls == []
-        assert result["messages"][-1].content != _FINALIZE_NUDGE
 
     def test_no_action_when_no_loop(self):
         mw = LoopDetectionMiddleware()
@@ -1169,256 +884,70 @@ class TestLoopDetectionMiddleware:
         assert result["messages"][-1].tool_calls == []
 
 
-class TestPatternEVolume:
-    """Pattern E: sheer per-tool call volume, regardless of args/errors.
+# ---------------------------------------------------------------------------
+# Rollback contract: the removed patterns (distinct-arg thrash, http-failure
+# streak, sheer volume, sub-agent re-dispatch) must NOT fire any more.  A few
+# extra research hops are allowed; the runaway bound is the recursion_limit.
+# ---------------------------------------------------------------------------
 
-    Off unless volume_threshold > 0 AND the tool is in volume_tools.  Uses
-    search_internet (a read-only tool with distinct, successful args) so
-    Patterns A/B/C/D all skip and only the volume pattern can fire —
-    proving it catches a runaway the other patterns deliberately ignore
-    (distinct-query exploration is normal; sheer volume is not).
-    """
-    SEARCH = frozenset({"search_internet"})
-
-    def _searches(self, n):
-        return [{
-            "tool_name": "search_internet",
-            "args_sig": _normalise_args({"query": f"q{i}"}),
-            "result_content": "[{'title': 'r', 'url': 'u', 'content': 'c'}]",
-            "is_error": False,
-            "http_failure": False,
+class TestRollbackContractNonRepeatLoopsAllowed:
+    def _evt(self, tool, args, content="ok", is_error=False):
+        return {
+            "tool_name": tool,
+            "args_sig": _normalise_args(args),
+            "result_content": content,
+            "is_error": is_error,
             "completed": True,
-        } for i in range(n)]
+        }
 
-    def test_disabled_by_default(self):
-        # 20 distinct successful searches, volume cap off -> no detection.
-        assert _detect_loop(self._searches(20), 2, 3, 3, 10) is None
+    def test_many_distinct_searches_do_not_fire(self):
+        # 12 distinct search queries — the old volume cap (E) would have
+        # fired; now this is allowed (a thorough research pass).
+        events = [self._evt("search_internet", {"q": f"query {i}"}) for i in range(12)]
+        assert _detect_loop(events, 2, 3) is None
 
-    def test_disabled_without_volume_tools(self):
-        # threshold set but no tools scoped -> no detection.
-        assert _detect_loop(self._searches(20), 2, 3, 3, 10,
-                            volume_threshold=8) is None
+    def test_many_distinct_url_reads_do_not_fire(self):
+        events = [self._evt("read_url", {"url": f"https://ex.com/p{i}"}) for i in range(12)]
+        assert _detect_loop(events, 2, 3) is None
 
-    def test_fires_at_threshold(self):
-        result = _detect_loop(self._searches(8), 2, 3, 3, 10,
-                              volume_threshold=8, volume_tools=self.SEARCH)
-        assert result is not None
-        assert result["pattern"] == "tool-volume"
-        assert result["tools"] == {"search_internet"}
-        assert result["run_length"] == 8
-
-    def test_does_not_fire_below_threshold(self):
-        assert _detect_loop(self._searches(7), 2, 3, 3, 10,
-                            volume_threshold=8, volume_tools=self.SEARCH) is None
-
-    def test_only_caps_tools_in_volume_tools(self):
-        # 9 read_url calls but volume_tools is search-only -> not capped
-        # (read_url is legitimate research, throttled + Pattern-D-protected).
-        reads = [{
-            "tool_name": "read_url",
-            "args_sig": _normalise_args({"url": f"u{i}"}),
-            "result_content": "page text",
-            "is_error": False, "http_failure": False, "completed": True,
-        } for i in range(9)]
-        assert _detect_loop(reads, 2, 3, 3, 10,
-                            volume_threshold=6, volume_tools=self.SEARCH) is None
-
-    def test_picks_capped_tool_not_uncapped(self):
-        # search (8, capped) + read_url (3, uncapped) -> fires on search.
-        events = self._searches(8) + [{
-            "tool_name": "read_url",
-            "args_sig": _normalise_args({"url": f"u{i}"}),
-            "result_content": "page text",
-            "is_error": False, "http_failure": False, "completed": True,
-        } for i in range(3)]
-        result = _detect_loop(events, 2, 3, 3, 10,
-                              volume_threshold=8, volume_tools=self.SEARCH)
-        assert result is not None
-        assert result["tools"] == {"search_internet"}
-
-    def test_counts_per_tool_not_aggregate(self):
-        # Two capped tools, each BELOW the threshold, summing ABOVE it:
-        # 4 search + 4 read_url, both capped, threshold 6.  Per-tool the
-        # max is 4 (< 6) so nothing fires.  Pins the per-tool semantics:
-        # a healthy pass (~4 searches + a read or two) must not trip an
-        # aggregate-counting bug.
-        both = frozenset({"search_internet", "read_url"})
-        events = self._searches(4) + [{
-            "tool_name": "read_url",
-            "args_sig": _normalise_args({"url": f"u{i}"}),
-            "result_content": "page text",
-            "is_error": False, "http_failure": False, "completed": True,
-        } for i in range(4)]
-        assert _detect_loop(events, 2, 3, 3, 10,
-                            volume_threshold=6, volume_tools=both) is None
-
-    def test_reports_all_over_threshold_tools(self):
-        # Both capped tools exceed the threshold: search=7, read=7, cap=6.
-        # detection["tools"] must include BOTH so after_model intervenes on
-        # a latest call to either — naming only the busiest would let the
-        # other slip through.
-        both = frozenset({"search_internet", "read_url"})
-        events = self._searches(7) + [{
-            "tool_name": "read_url",
-            "args_sig": _normalise_args({"url": f"u{i}"}),
-            "result_content": "page text",
-            "is_error": False, "http_failure": False, "completed": True,
-        } for i in range(7)]
-        result = _detect_loop(events, 2, 3, 3, 10,
-                              volume_threshold=6, volume_tools=both)
-        assert result is not None
-        assert result["tools"] == {"search_internet", "read_url"}
-
-    def test_terminal_message_is_graceful(self):
-        msg = _compose_terminal_message(
-            {"pattern": "tool-volume", "tools": {"search_internet"},
-             "run_length": 8, "reason": "x"},
-            [],
-        )
-        # Not an error/ask-for-direction message — a "finalize now" one.
-        assert "search_internet" in msg
-        assert "?" not in msg
-
-
-class TestPatternFRedispatch:
-    """Pattern F: per-subagent `task` re-dispatch cap (orchestrator).
-
-    With subagent_dispatch_threshold=1, each subagent may be dispatched
-    once; re-dispatching an already-used one is stripped, but dispatching
-    a fresh subagent (the research -> critique -> fact-check progression)
-    passes through.
-    """
-    def test_off_by_default(self):
-        # Three research dispatches, distinct descriptions (so Pattern B
-        # does not fire), default middleware (threshold 0) -> no action.
-        mw = LoopDetectionMiddleware()
-        last = _ai_with_call("c3", "task",
-                             {"subagent_type": "research-agent", "description": "c"})
-        messages = [
-            HumanMessage(content="go"),
-            _ai_with_call("c1", "task",
-                          {"subagent_type": "research-agent", "description": "a"}),
-            _tool_msg("c1", "research result one"),
-            _ai_with_call("c2", "task",
-                          {"subagent_type": "research-agent", "description": "b"}),
-            _tool_msg("c2", "research result two"),
-            last,
+    def test_distinct_arg_mutating_thrash_does_not_fire(self):
+        # The old Pattern C niche: distinct mutating args AND genuinely
+        # different errors (so A's path-normalisation does NOT collapse them
+        # to one repeated error).  C is removed, so this no longer fires.
+        # (Note: distinct PATHS with the same "...already exists" error DO
+        # normalise alike and are still caught by Pattern A — that's the
+        # winged-horse case, intentionally kept.)
+        events = [
+            self._evt("write_file", {"file_path": "/a"}, "Error: permission denied", True),
+            self._evt("write_file", {"file_path": "/b"}, "Error: disk full", True),
+            self._evt("write_file", {"file_path": "/c"}, "Error: read-only filesystem", True),
         ]
-        assert mw.after_model({"messages": messages}, Mock()) is None
+        assert _detect_loop(events, 2, 3) is None
 
-    def test_redispatch_first_fire_finalizes_not_kills(self):
-        """First re-dispatch firing FINALIZES: strip the task call, leave the
-        redispatch nudge, and jump to the model to answer from the result it
-        already has — NOT a give-up stub."""
-        mw = LoopDetectionMiddleware(subagent_dispatch_threshold=1)
-        last = _ai_with_call("c2", "task",
-                             {"subagent_type": "research-agent", "description": "again"})
-        messages = [
-            HumanMessage(content="go"),
-            _ai_with_call("c1", "task",
-                          {"subagent_type": "research-agent", "description": "first"}),
-            _tool_msg("c1", "research result"),
-            last,
+    def test_http_4xx_streak_across_distinct_urls_does_not_fire(self):
+        # The old Pattern D shape: distinct URLs all returning 403 pages.
+        # Bodies aren't Python errors and args differ → A/B don't fire, and
+        # D is gone, so this is allowed to continue (recursion_limit bounds it).
+        events = [
+            self._evt("read_url", {"url": f"https://casio.com/w{i}"},
+                      "403 Forbidden — access denied")
+            for i in range(6)
         ]
-        result = mw.after_model({"messages": messages}, Mock())
-        assert result is not None
-        assert result.get("jump_to") == "model"
-        assert result["messages"][-1].tool_calls == []
-        assert result["messages"][-1].content == _REDISPATCH_NUDGE
+        assert _detect_loop(events, 2, 3) is None
 
-    def test_redispatch_second_fire_hard_stops(self):
-        """If the agent re-dispatches AGAIN after the redispatch nudge (second
-        strike this turn), fall through to the hard stop — no jump, give-up
-        stub — preserving the bound."""
-        mw = LoopDetectionMiddleware(subagent_dispatch_threshold=1)
-        messages = [
-            HumanMessage(content="go"),
-            _ai_with_call("c1", "task",
-                          {"subagent_type": "research-agent", "description": "first"}),
-            _tool_msg("c1", "research result"),
-            AIMessage(content=_REDISPATCH_NUDGE),   # already nudged this turn
-            _ai_with_call("c2", "task",
-                          {"subagent_type": "research-agent", "description": "again"}),
+    def test_repeated_subagent_dispatch_does_not_fire(self):
+        # The old Pattern F shape: same sub-agent dispatched several times.
+        # task re-dispatch is no longer capped here.
+        events = [
+            self._evt("task", {"subagent_type": "research-agent", "n": i})
+            for i in range(4)
         ]
-        result = mw.after_model({"messages": messages}, Mock())
+        assert _detect_loop(events, 2, 3) is None
+
+    def test_exact_repeat_still_fires_after_rollback(self):
+        # Sanity: B still catches the genuine runaway (same read_url(URL)
+        # back-to-back) that the rollback explicitly keeps protecting against.
+        events = [self._evt("read_url", {"url": "https://ex.com/same"}) for _ in range(3)]
+        result = _detect_loop(events, 2, 3)
         assert result is not None
-        assert "jump_to" not in result
-        assert result["messages"][-1].tool_calls == []
-        assert result["messages"][-1].content != _REDISPATCH_NUDGE
-        assert "gathered" in result["messages"][-1].content.lower()
-
-    def test_in_message_batch_not_capped_known_limitation(self):
-        """KNOWN LIMITATION (pinned, not a bug to fix here).
-
-        Pattern F counts COMPLETED dispatches, so two `task` calls to the
-        same subagent batched in ONE message — before either completes —
-        are not capped.  The observed prod re-dispatches (and the
-        2026-06-03 ablation's rdisp=2) are all CROSS-message: dispatch,
-        read the result, dispatch again — which Pattern F catches on the
-        next message.  In-message batching of an *identical* subagent is
-        unobserved, and the whole-message strip would over-correct (drop
-        the legitimate first dispatch too), so we pin current behavior
-        rather than add speculative partial-strip logic.  See the design
-        doc residuals.
-        """
-        mw = LoopDetectionMiddleware(subagent_dispatch_threshold=1)
-        batched = AIMessage(content="", tool_calls=[
-            {"name": "task",
-             "args": {"subagent_type": "research-agent", "description": "a"},
-             "id": "a"},
-            {"name": "task",
-             "args": {"subagent_type": "research-agent", "description": "b"},
-             "id": "b"},
-        ])
-        messages = [HumanMessage(content="go"), batched]
-        assert mw.after_model({"messages": messages}, Mock()) is None
-
-    def test_fresh_subagent_passes(self):
-        # research already dispatched; dispatching critique (fresh) is the
-        # normal progression and must not be stripped.
-        mw = LoopDetectionMiddleware(subagent_dispatch_threshold=1)
-        last = _ai_with_call("c2", "task",
-                             {"subagent_type": "critique-agent", "description": "review"})
-        messages = [
-            HumanMessage(content="go"),
-            _ai_with_call("c1", "task",
-                          {"subagent_type": "research-agent", "description": "first"}),
-            _tool_msg("c1", "research result"),
-            last,
-        ]
-        assert mw.after_model({"messages": messages}, Mock()) is None
-
-
-class TestErrorPatternsEndNotFinalize:
-    """Audit verdict: A-D are 'you're STUCK' patterns — after_model must END
-    the turn (strip tool calls, NO jump_to), the opposite of E's finalize.
-    These pin the outcome (not just detection) for the error family, the gap
-    the audit found for C/D.  See docs/2026-06-05-loop-detection-audit.org."""
-
-    def test_pattern_c_distinct_args_thrash_ends_with_direction_ask(self):
-        mw = LoopDetectionMiddleware(distinct_args_threshold=3)
-        msgs = [HumanMessage(content="go")]
-        for i, p in enumerate(["/a", "/b", "/c"]):
-            msgs.append(_ai_with_call(f"c{i}", "write_file", {"file_path": p}))
-            msgs.append(_tool_msg(f"c{i}", f"Error: cannot write {p}"))
-        msgs.append(_ai_with_call("clast", "write_file", {"file_path": "/d"}))
-        result = mw.after_model({"messages": msgs}, Mock())
-        assert result is not None
-        assert "jump_to" not in result, "error pattern C must END, not finalize"
-        assert result["messages"][-1].tool_calls == []
-        content = result["messages"][-1].content.lower()
-        assert "proceed" in content or "direction" in content
-
-    def test_pattern_d_http_failure_streak_ends(self):
-        mw = LoopDetectionMiddleware(http_failure_threshold=4)
-        msgs = [HumanMessage(content="go")]
-        for i in range(4):
-            msgs.append(_ai_with_call(f"c{i}", "read_url",
-                                      {"url": f"https://s{i}.example"}))
-            msgs.append(_tool_msg(f"c{i}", "HTTP 403 Forbidden: access denied"))
-        msgs.append(_ai_with_call("clast", "read_url",
-                                  {"url": "https://s9.example"}))
-        result = mw.after_model({"messages": msgs}, Mock())
-        assert result is not None
-        assert "jump_to" not in result, "error pattern D must END, not finalize"
-        assert result["messages"][-1].tool_calls == []
+        assert result["pattern"] == "same-tool-same-args"

--- a/tests/test_create_agent_extra_tools.py
+++ b/tests/test_create_agent_extra_tools.py
@@ -73,9 +73,10 @@ class TestCreateAgentExtraTools:
 
 
 class TestCreateAgentLoopExplorationTools:
-    """`loop_exploration_tools` reaches the MAIN agent's
-    `LoopDetectionMiddleware(exploration_tools=...)`; default leaves the
-    dev/code agent unchanged (empty set)."""
+    """`loop_exploration_tools` is a DEPRECATED no-op (it fed the removed
+    Pattern-C breadth threshold).  It must still be ACCEPTED so embedders that
+    pass it don't break, but it no longer affects the middleware — the main
+    agent's LoopDetectionMiddleware is the plain A/B detector."""
 
     def _main_loop_mw(self, **kwargs):
         from assist.agent import create_agent
@@ -94,13 +95,17 @@ class TestCreateAgentLoopExplorationTools:
             mws = fake.call_args.kwargs["middleware"]
             return next(m for m in mws if isinstance(m, LoopDetectionMiddleware))
 
-    def test_default_exploration_tools_is_empty(self):
-        # The dev/code agent (no exploration tools) is unchanged.
-        assert self._main_loop_mw().exploration_tools == frozenset()
+    def test_loop_detection_middleware_present_by_default(self):
+        # A plain A/B LoopDetectionMiddleware is wired on the main agent and
+        # no longer carries any exploration-tools knob.
+        mw = self._main_loop_mw()
+        assert not hasattr(mw, "exploration_tools")
 
-    def test_loop_exploration_tools_forwarded_to_middleware(self):
+    def test_deprecated_loop_exploration_tools_is_accepted_as_noop(self):
+        # Passing the deprecated kwarg must not error (embedder compat) and
+        # must not add any exploration knob to the middleware.
         mw = self._main_loop_mw(loop_exploration_tools=frozenset({"eval_elisp"}))
-        assert mw.exploration_tools == frozenset({"eval_elisp"})
+        assert not hasattr(mw, "exploration_tools")
 
 
 class TestThreadExtraTools:


### PR DESCRIPTION
## Why

In prod thread `20260606101819` (a "mission trip checklist" research query) the agent was making real progress — `search_internet` → `read_url` → `edit_file` — and got thrashed between **four** loop-detection patterns: D (http-failure-streak) and F (subagent-redispatch) hard-stopped it mid-research with confusing canned messages, while E (tool-volume) and F also stripped tool calls and jumped to model. The agent ended in a confusing half-finished state.

Per the user's call: a few extra research hops are far preferable to yanking a working agent into a strange broken state. Only the *obvious* exact-repetition loops are worth stopping deterministically; everything else should be allowed to run until a real timeout/recursion bound.

## What

`LoopDetectionMiddleware` is rolled back from six patterns to **two**:

| Pattern | Kept? |
|---|---|
| A — same-tool-**same-error** | ✅ keep |
| B — same-tool-**same-args** | ✅ keep |
| C — distinct-args-thrash | ❌ remove |
| D — http-failure-streak | ❌ remove |
| E — tool-volume cap | ❌ remove |
| F — subagent-redispatch | ❌ remove |

Also removed: all the **finalize / `jump_to`-model machinery** (the `@hook_config(can_jump_to=["model"])` decorator, `_FINALIZE_*` constants, `_already_finalized_this_turn`, the jump-to-model branch — added in the recent finalize PRs), and the **subagent volume cap** (`_subagent_safety_mw` volume params, the `_RESEARCH_*`/`_SUBAGENT_DISPATCH_CAP`/`_FACTCHECK_READ_URL_CAP` constants).

Removing the `can_jump_to` decorator removes the after_model→model graph edge **library-side** — no repo-side graph wiring change needed; LoopDetection was the only middleware using `jump_to`.

## The runaway backstop

`search_internet` / `read_url` are host-side Python tools, **not** routed through the Docker sandbox, so the 600s sandbox exec timeout never bounded them. With E/F gone, the deliberate backstop for a distinct-arg search/read spin is the research agent's **`recursion_limit`, lowered 300 → 150** (≈ a few minutes at small-model latency). `GraphRecursionError` is already in `RollbackRunnable.rollback_on`, so hitting it rolls back rather than crashing the thread.

## Deprecation (no breakage)

`loop_exploration_tools` (the `create_agent`/`Thread` param that fed Pattern C, used by emacsos-server's `eval_elisp`) is now an **accepted-but-ignored no-op** so the embedder doesn't break with a TypeError. Tracked as a small follow-up in the emacsos roadmap; once emacsos drops the kwarg, the param can be deleted.

## Tests & evals

- Pruned all C/D/E/F + finalize tests; added `TestRollbackContractNonRepeatLoopsAllowed` asserting the removed patterns no longer fire **and** A/B still do.
- Removed `TestResearchVolumeCapFinalizes` (Pattern-E finalize); repurposed the budget eval → **`TestResearchRunsToCompletion`** (positive contract: research completes with a real answer, isn't cut off; no tight search cap — the recursion_limit is the bound).
- Relaxed `TestResearchSearchUnavailableHandoff`'s dispatch assertion (the re-dispatch cap is gone; a stray extra hop is tolerated).
- 560 unit tests pass. Research E2E evals: `TestResearchSearchUnavailableHandoff` 3/3, `TestResearchRunsToCompletion` 5/5 (after calibrating a length floor that was inherited from the old finalize eval and too strict for concise answers).

## Net

**+~285 / −~1363 lines** — a substantial subtraction (the audit doc is annotated as rolled back; the middleware is now a thin A/B detector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)