### PR TITLE
Add built-in elisp skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,38 +424,38 @@ layer 2 to make a skill match, the description (layer 3) is wrong.
 
 The description is the only thing the model has to decide whether to
 load. It is matched against the user's latest message by the
-pre-action check (and by the model's general attention). Keep these
-constraints in mind:
+pre-action check (and by the model's general attention). Every built-in
+skill uses the same shape — **a one-line capability sentence, a few
+concrete `EXAMPLES`, and a `MUST load before` clause**:
 
-- **Front-load trigger keywords.** Empirically, the small model only
-  reliably matches a description when high-signal tokens appear early.
-  Putting natural prose first and a `TRIGGER WORDS — ...` list later
-  drops pass rate from ~95% to under 30%.
-- **Use a `TRIGGER WORDS — <comma-separated tokens>` segment** for
-  domain anchors: file extensions (`.org`), example filenames
-  (`projects.org`), and concrete topic words the user might say
-  (`asterisk heading`, `orphan`). These are the tokens that make
-  matching robust.
-- **Include a `MUST load before <conditions>` clause.** Without an
-  imperative-shaped condition, the model treats the description as
-  informational and skips loading. This is one of the few places
-  imperative wording earns its keep.
+- **Open with a one-line capability sentence** naming the domain in the
+  words a user would actually say (e.g. `Editing or creating org-mode
+  (\`.org\`) files without breaking heading structure.`). Leading with
+  those words keeps the high-signal tokens early.
+- **Give 2–3 `EXAMPLES — "..."; "..."` of real requests** as natural
+  phrasings, NOT a keyword list. Examples convey the *shape* of a
+  matching request, so the skill generalizes to new wording without you
+  having to keep extending a token list for every new use-case. Prefer
+  varied, realistic user phrasings over domain jargon — and don't let
+  them mirror your eval prompts, or the eval just measures lexical
+  proximity (see the project conventions in `CLAUDE.md`).
+- **End with a `MUST load before <conditions>` clause.** Without an
+  imperative-shaped condition the model treats the description as
+  informational and skips loading — the one place imperative wording
+  earns its keep.
 - **Do not describe the rules.** Anything the body explains belongs in
   the body, not the description. The agent only reads the description
   to decide *whether* to load — once it loads, the body is what it
   applies.
 - **Do not mention `read_file` or any tool name.** The middleware
   exposes `load_skill`; the description is content, not mechanism.
-- A short friendly opening (≤ 8 words, e.g. `Guidance for org-mode
-  (\`.org\`) files.`) before the trigger list reads naturally and does
-  not measurably hurt match rate.
 
 Example (the `org-format` skill):
 
 ```yaml
 ---
 name: org-format
-description: Guidance for org-mode (`.org`) files. TRIGGER WORDS — `.org`, org-mode, org file, headings, heading body, asterisk heading, orphan, projects.org. MUST load before any tool call that reads, edits, writes, or mentions a `.org` file.
+description: Editing or creating org-mode (`.org`) files without breaking heading structure. EXAMPLES — "add a new section to notes.org under the Q3 plans heading"; "tweak the second bullet under Inbox in todo.org". MUST load before any tool call that reads, edits, writes, or mentions a `.org` file.
 ---
 ```
 

--- a/assist/skills/elisp/SKILL.md
+++ b/assist/skills/elisp/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: elisp
+description: Guidance for writing Emacs Lisp. TRIGGER WORDS — elisp, emacs lisp, `.el`, defun, defvar, defcustom, defmacro, byte-compile, checkdoc, ert, `emacs --batch`. MUST load before any tool call that writes, edits, lints, tests, or runs Emacs Lisp (`.el`) code.
+---
+
+# Emacs Lisp guide
+
+Rules for writing, linting, and testing Emacs Lisp that runs reliably —
+especially headless (`emacs --batch`), which is how an agent invokes it.
+
+## Structure
+
+- Lay the file out with the conventional section markers `checkdoc` expects:
+  - header: `;;; name.el --- one-line summary  -*- lexical-binding: t; -*-`
+  - `;;; Commentary:` (what and why) then `;;; Code:` (before the code)
+  - footer: `(provide 'name)` then `;;; name.el ends here`
+- Prefer pure functions that take arguments and return values over commands
+  that act on the current buffer — pure logic is testable without a UI.
+- Namespace everything: public names `prefix-thing`, internal helpers
+  `prefix--thing`. A `defcustom` for user-facing settings, `defvar`/`defconst`
+  otherwise.
+- Resolve paths with `expand-file-name` against a root you computed (e.g. from
+  the file's own `load-file-name`) — never assume the process's working
+  directory. Note: relative `org-agenda-files` expand against `org-directory`
+  (`~/org`), NOT the cwd, which is a common silent breakage.
+
+## Run it headless — and never let it hang
+
+- Invoke as `emacs --batch -Q -l file.el --eval '(...)'`. `-Q` skips all
+  personal init, so the result is reproducible anywhere; declare everything
+  the script needs inside the file.
+- `--batch` must never block on input. A function that would prompt
+  (`y-or-n-p`, `completing-read`, a missing-file `[R]emove/[A]bort`) will hang
+  the process forever. Set the variable that suppresses the prompt instead
+  (e.g. `org-agenda-skip-unavailable-files t`).
+- Output: `princ` writes to stdout, `message` to stderr. Use `princ` for
+  anything the caller needs to read back.
+
+## Lint (treat warnings as errors)
+
+- Byte-compile and read the warnings:
+  `emacs --batch -Q -f batch-byte-compile file.el`
+- Check docstrings and conventions:
+  `emacs --batch -Q --eval '(checkdoc-file "file.el")'`
+
+## Test
+
+- Write tests with ERT — `(ert-deftest prefix-test-foo () (should (equal ...)))`
+  — in a sibling `name-tests.el`.
+- Run them headless, exiting non-zero on failure:
+  `emacs --batch -Q -l file.el -l name-tests.el -f ert-run-tests-batch-and-exit`
+
+## Look things up without leaving the shell
+
+- A function's contract is its docstring:
+  `emacs --batch -Q --eval '(princ (documentation (quote mapcar)))'`
+- Find names with `apropos`; the authoritative reference is the GNU Emacs Lisp
+  Reference Manual (the `(elisp)` Info manual, or gnu.org online).
+
+## Always verify
+
+Emacs Lisp is easy to get subtly wrong. After writing or editing a `.el` file,
+byte-compile it (warnings clean) and run its ERT tests before reporting done —
+do not rely on reading the code alone.

--- a/assist/skills/elisp/SKILL.md
+++ b/assist/skills/elisp/SKILL.md
@@ -38,8 +38,8 @@ especially headless (`emacs --batch`), which is how an agent invokes it.
 
 ## Lint (treat warnings as errors)
 
-- Byte-compile and read the warnings:
-  `emacs --batch -Q -f batch-byte-compile file.el`
+- Byte-compile, treating warnings as errors (non-zero exit on any warning):
+  `emacs --batch -Q --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile file.el`
 - Check docstrings and conventions:
   `emacs --batch -Q --eval '(checkdoc-file "file.el")'`
 

--- a/assist/skills/elisp/SKILL.md
+++ b/assist/skills/elisp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: elisp
-description: Guidance for writing Emacs Lisp. TRIGGER WORDS — elisp, emacs lisp, `.el`, defun, defvar, defcustom, defmacro, byte-compile, checkdoc, ert, `emacs --batch`. MUST load before any tool call that writes, edits, lints, tests, or runs Emacs Lisp (`.el`) code.
+description: Writing and maintaining Emacs Lisp — structuring, byte-compiling, and testing `.el` code. EXAMPLES — "why does my use-package block throw a void-function error"; "add a defcustom for a directory path and byte-compile my init cleanly"; "make this command a testable pure function with an ERT test". MUST load before any tool call that writes, edits, lints, tests, or runs Emacs Lisp (`.el`) code.
 ---
 
 # Emacs Lisp guide

--- a/edd/eval/test_elisp_skill.py
+++ b/edd/eval/test_elisp_skill.py
@@ -1,0 +1,144 @@
+"""Skill-loading + behavior evals for the built-in ``elisp`` skill.
+
+The elisp skill is generic Emacs-Lisp craft: file structure, the headless
+``emacs --batch`` invocation, and — its headline contract — the
+verify-it-yourself loop (byte-compile / ERT) so the small model doesn't rely on
+shaky elisp recall. The main eval runs in a Docker sandbox because that contract
+is *behavioral*: the agent must actually run emacs to verify, which needs a real
+``execute`` and the emacs bundled in the sandbox image.
+
+- ``test_loads_and_verifies`` — a plain "write this elisp and make sure it
+  works" request (no skill vocabulary, no "compile"/"test"/"lint"); asserts the
+  skill loaded AND the agent actually exercised the code in ``emacs --batch``
+  rather than emitting it unchecked.
+- ``test_does_not_load_on_python_task`` (no sandbox) — anti-test pinning the
+  trigger: a Python task must not load the elisp skill.
+"""
+import re
+import shutil
+import subprocess
+import tempfile
+from unittest import TestCase
+
+from langchain_core.messages import AIMessage
+
+from assist.agent import create_agent, AgentHarness
+from assist.model_manager import select_assistant_model
+from assist.sandbox_manager import SandboxManager
+
+
+def _skill_was_loaded(agent, skill_name: str) -> bool:
+    """True iff a tool call loaded the named skill (load_skill or the
+    upstream /skills/<name>/ read path). Local to this suite, mirroring the
+    other skill evals so they can drift independently."""
+    path_needle = f"/skills/{skill_name}/"
+    for m in agent.all_messages():
+        if not isinstance(m, AIMessage) or not m.tool_calls:
+            continue
+        for tc in m.tool_calls:
+            args = tc.get("args") or {}
+            if tc.get("name") == "load_skill" and args.get("name") == skill_name:
+                return True
+            for v in args.values():
+                if isinstance(v, str) and path_needle in v:
+                    return True
+    return False
+
+
+def _executed_commands(agent) -> list[str]:
+    """Command strings from every ``execute`` tool call."""
+    cmds = []
+    for m in agent.all_messages():
+        if not isinstance(m, AIMessage) or not m.tool_calls:
+            continue
+        for tc in m.tool_calls:
+            if tc.get("name") == "execute":
+                cmd = (tc.get("args") or {}).get("command", "")
+                if cmd:
+                    cmds.append(cmd)
+    return cmds
+
+
+def _cleanup_workspace(path: str) -> None:
+    """Remove a sandbox workspace, using Docker to delete root-owned files.
+    Mirrors the helper in test_calculate_skill.py / test_dev_agent.py."""
+    try:
+        subprocess.run(
+            ['docker', 'run', '--rm', '-v', f'{path}:/cleanup', 'alpine',
+             'sh', '-c', 'chmod -R 777 /cleanup 2>/dev/null; rm -rf /cleanup/*'],
+            check=False, timeout=60,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception:
+        pass
+    shutil.rmtree(path, ignore_errors=True)
+
+
+class TestElispSkillSandbox(TestCase):
+    """The skill's contract is behavioral (run emacs to verify), so this needs
+    a real sandbox with the bundled emacs."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = select_assistant_model(0.1)
+
+    def setUp(self):
+        self.workspace = tempfile.mkdtemp(prefix="elisp_skill_eval_")
+        self.sandbox = SandboxManager.get_sandbox_backend(self.workspace)
+        if self.sandbox is None:
+            self.skipTest(
+                "Docker sandbox unavailable — is Docker running and "
+                "assist-sandbox built?"
+            )
+
+    def tearDown(self):
+        SandboxManager.cleanup(self.workspace)
+        _cleanup_workspace(self.workspace)
+
+    def _ran_emacs_batch(self, agent) -> bool:
+        """True iff the agent exercised code in ``emacs --batch`` — byte-compile,
+        ERT, checkdoc, or load-and-eval all count. The contract is that the agent
+        *verified in emacs* rather than eyeballing; the exact form is the model's
+        choice."""
+        for cmd in _executed_commands(agent):
+            if re.search(r"\bemacs\b", cmd) and ("--batch" in cmd or "-batch" in cmd):
+                return True
+        return False
+
+    def test_loads_and_verifies(self):
+        agent = AgentHarness(create_agent(
+            self.model, self.workspace, sandbox_backend=self.sandbox))
+        agent.message(
+            "Write an Emacs Lisp function `demo/sum-list` that returns the sum "
+            "of a list of numbers, in a file `sum.el`. Make sure it actually "
+            "works."
+        )
+        self.assertTrue(
+            _skill_was_loaded(agent, "elisp"),
+            "agent did not load the elisp skill for an Emacs-Lisp authoring task",
+        )
+        self.assertTrue(
+            self._ran_emacs_batch(agent),
+            "elisp skill loaded but the agent never ran emacs to verify — it "
+            "should byte-compile / run ERT, not just emit elisp and trust it",
+        )
+
+
+class TestElispSkillAntiTrigger(TestCase):
+    """No sandbox: only the load decision is under test."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = select_assistant_model(0.1)
+
+    def test_does_not_load_on_python_task(self):
+        workspace = tempfile.mkdtemp(prefix="elisp_skill_anti_")
+        self.addCleanup(shutil.rmtree, workspace, ignore_errors=True)
+        agent = AgentHarness(create_agent(self.model, workspace))
+        agent.message(
+            "Write a Python function that returns the sum of a list of "
+            "numbers, and add a quick test for it."
+        )
+        self.assertFalse(
+            _skill_was_loaded(agent, "elisp"),
+            "elisp skill loaded on a pure Python task — its trigger is too broad",
+        )

--- a/edd/eval/test_elisp_skill.py
+++ b/edd/eval/test_elisp_skill.py
@@ -25,7 +25,7 @@ from langchain_core.messages import AIMessage
 
 from assist.agent import create_agent, AgentHarness
 from assist.model_manager import select_assistant_model
-from assist.sandbox_manager import SandboxManager
+from assist.sandbox_manager import SandboxManager, SANDBOX_IMAGE
 
 
 def _skill_was_loaded(agent, skill_name: str) -> bool:
@@ -95,16 +95,24 @@ class TestElispSkillSandbox(TestCase):
         SandboxManager.cleanup(self.workspace)
         _cleanup_workspace(self.workspace)
 
+    # Markers of an action that actually loads/compiles/checks a file, so
+    # `target` appearing merely as a positional file argument (which Emacs does
+    # not evaluate) doesn't count as verification.
+    _VERIFY_ACTIONS = ("batch-byte-compile", "byte-compile-file", "checkdoc",
+                       "ert-run-tests", "load-file", "-l ", "--load")
+
     def _verified_file_in_emacs(self, agent, target: str) -> bool:
-        """True iff the agent ran an ``emacs --batch`` command that references
-        ``target`` — the file it was asked to write — so it verified THAT code
-        (byte-compile / load / ERT loading it), not some unrelated file or a
-        no-op like ``emacs --batch --version``. The exact form (compile vs test
-        vs load-and-eval) is the model's choice."""
+        """True iff the agent ran an ``emacs --batch`` command that VERIFIES
+        ``target`` — the file it was asked to write — via a real load/compile/
+        check action (byte-compile / load / ERT / checkdoc), not some unrelated
+        file, a bare positional visit, or a no-op like ``--version``. The exact
+        form is the model's choice."""
         for cmd in _executed_commands(agent):
-            if (re.search(r"\bemacs\b", cmd)
+            if not (re.search(r"\bemacs\b", cmd)
                     and ("--batch" in cmd or "-batch" in cmd)
                     and target in cmd):
+                continue
+            if any(action in cmd for action in self._VERIFY_ACTIONS):
                 return True
         return False
 
@@ -133,7 +141,7 @@ class TestElispSkillSandbox(TestCase):
         the agent produced (not to drive the agent)."""
         return subprocess.run(
             ['docker', 'run', '--rm', '-v', f'{self.workspace}:/workspace',
-             '-w', '/workspace', 'assist-sandbox', 'bash', '-c', script],
+             '-w', '/workspace', SANDBOX_IMAGE, 'bash', '-c', script],
             capture_output=True, text=True, timeout=120)
 
     def test_writes_wellformed_elisp(self):

--- a/edd/eval/test_elisp_skill.py
+++ b/edd/eval/test_elisp_skill.py
@@ -152,12 +152,15 @@ class TestElispSkillSandbox(TestCase):
         path = os.path.join(self.workspace, "mathy.el")
         self.assertTrue(os.path.exists(path), "agent did not write mathy.el")
 
-        # Well-formed: lexical-binding cookie present.
+        # Well-formed: a real first-line `-*- lexical-binding: t; -*-` cookie
+        # (not merely the string appearing somewhere like a Commentary line).
         with open(path, encoding="utf-8") as f:
             src = f.read()
+        first_line = src.splitlines()[0] if src.splitlines() else ""
         self.assertRegex(
-            src, r"lexical-binding:\s*t",
-            "mathy.el is missing the `lexical-binding: t` file-local cookie",
+            first_line, r"-\*-.*lexical-binding:\s*t.*-\*-",
+            f"mathy.el's first line lacks a valid `-*- lexical-binding: t; -*-` "
+            f"file-local cookie; got: {first_line!r}",
         )
 
         # Well-formed + working: byte-compiles with no error...
@@ -171,6 +174,10 @@ class TestElispSkillSandbox(TestCase):
         # ...and computes the right answer.
         run = self._sandbox_sh(
             "emacs --batch -Q -l mathy.el --eval '(princ (mathy-factorial 5))'")
+        self.assertEqual(
+            run.returncode, 0,
+            f"loading/running mathy.el failed:\n{run.stdout}\n{run.stderr}",
+        )
         self.assertIn(
             "120", run.stdout,
             f"(mathy-factorial 5) did not return 120:\n{run.stdout}\n{run.stderr}",

--- a/edd/eval/test_elisp_skill.py
+++ b/edd/eval/test_elisp_skill.py
@@ -153,7 +153,8 @@ class TestElispSkillSandbox(TestCase):
         self.assertTrue(os.path.exists(path), "agent did not write mathy.el")
 
         # Well-formed: lexical-binding cookie present.
-        src = open(path).read()
+        with open(path, encoding="utf-8") as f:
+            src = f.read()
         self.assertRegex(
             src, r"lexical-binding:\s*t",
             "mathy.el is missing the `lexical-binding: t` file-local cookie",

--- a/edd/eval/test_elisp_skill.py
+++ b/edd/eval/test_elisp_skill.py
@@ -96,12 +96,16 @@ class TestElispSkillSandbox(TestCase):
         _cleanup_workspace(self.workspace)
 
     def _ran_emacs_batch(self, agent) -> bool:
-        """True iff the agent exercised code in ``emacs --batch`` — byte-compile,
-        ERT, checkdoc, or load-and-eval all count. The contract is that the agent
-        *verified in emacs* rather than eyeballing; the exact form is the model's
-        choice."""
+        """True iff the agent VERIFIED the code in ``emacs --batch`` — the call
+        must actually touch elisp (a ``.el`` file, or a byte-compile / ERT /
+        checkdoc action), so a no-op like ``emacs --batch --version`` does not
+        count. The exact form is the model's choice."""
         for cmd in _executed_commands(agent):
-            if re.search(r"\bemacs\b", cmd) and ("--batch" in cmd or "-batch" in cmd):
+            if not (re.search(r"\bemacs\b", cmd)
+                    and ("--batch" in cmd or "-batch" in cmd)):
+                continue
+            if (".el" in cmd or "byte-compile" in cmd
+                    or "ert-run-tests" in cmd or "checkdoc" in cmd):
                 return True
         return False
 
@@ -165,11 +169,12 @@ class TestElispSkillSandbox(TestCase):
 
         # Well-formed + working: byte-compiles with no error...
         bc = self._sandbox_sh(
-            "emacs --batch -Q -f batch-byte-compile mathy.el 2>&1; echo EXIT:$?")
-        self.assertIn("EXIT:0", bc.stdout,
-                      f"mathy.el did not byte-compile cleanly:\n{bc.stdout}")
-        self.assertNotIn("Error", bc.stdout,
-                         f"byte-compile reported an error:\n{bc.stdout}")
+            "emacs --batch -Q --eval '(setq byte-compile-error-on-warn t)' "
+            "-f batch-byte-compile mathy.el 2>&1; echo EXIT:$?")
+        self.assertIn(
+            "EXIT:0", bc.stdout,
+            f"mathy.el did not byte-compile cleanly (warnings count as "
+            f"errors):\n{bc.stdout}")
 
         # ...and computes the right answer.
         run = self._sandbox_sh(

--- a/edd/eval/test_elisp_skill.py
+++ b/edd/eval/test_elisp_skill.py
@@ -21,57 +21,11 @@ import subprocess
 import tempfile
 from unittest import TestCase
 
-from langchain_core.messages import AIMessage
-
 from assist.agent import create_agent, AgentHarness
 from assist.model_manager import select_assistant_model
 from assist.sandbox_manager import SandboxManager, SANDBOX_IMAGE
 
-
-def _skill_was_loaded(agent, skill_name: str) -> bool:
-    """True iff a tool call loaded the named skill (load_skill or the
-    upstream /skills/<name>/ read path). Local to this suite, mirroring the
-    other skill evals so they can drift independently."""
-    path_needle = f"/skills/{skill_name}/"
-    for m in agent.all_messages():
-        if not isinstance(m, AIMessage) or not m.tool_calls:
-            continue
-        for tc in m.tool_calls:
-            args = tc.get("args") or {}
-            if tc.get("name") == "load_skill" and args.get("name") == skill_name:
-                return True
-            for v in args.values():
-                if isinstance(v, str) and path_needle in v:
-                    return True
-    return False
-
-
-def _executed_commands(agent) -> list[str]:
-    """Command strings from every ``execute`` tool call."""
-    cmds = []
-    for m in agent.all_messages():
-        if not isinstance(m, AIMessage) or not m.tool_calls:
-            continue
-        for tc in m.tool_calls:
-            if tc.get("name") == "execute":
-                cmd = (tc.get("args") or {}).get("command", "")
-                if cmd:
-                    cmds.append(cmd)
-    return cmds
-
-
-def _cleanup_workspace(path: str) -> None:
-    """Remove a sandbox workspace, using Docker to delete root-owned files.
-    Mirrors the helper in test_calculate_skill.py / test_dev_agent.py."""
-    try:
-        subprocess.run(
-            ['docker', 'run', '--rm', '-v', f'{path}:/cleanup', 'alpine',
-             'sh', '-c', 'chmod -R 777 /cleanup 2>/dev/null; rm -rf /cleanup/*'],
-            check=False, timeout=60,
-            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    except Exception:
-        pass
-    shutil.rmtree(path, ignore_errors=True)
+from .utils import cleanup_workspace, executed_commands, skill_was_loaded
 
 
 class TestElispSkillSandbox(TestCase):
@@ -93,7 +47,7 @@ class TestElispSkillSandbox(TestCase):
 
     def tearDown(self):
         SandboxManager.cleanup(self.workspace)
-        _cleanup_workspace(self.workspace)
+        cleanup_workspace(self.workspace)
 
     # Markers of an action that actually loads/compiles/checks a file, so
     # `target` appearing merely as a positional file argument (which Emacs does
@@ -107,7 +61,7 @@ class TestElispSkillSandbox(TestCase):
         check action (byte-compile / load / ERT / checkdoc), not some unrelated
         file, a bare positional visit, or a no-op like ``--version``. The exact
         form is the model's choice."""
-        for cmd in _executed_commands(agent):
+        for cmd in executed_commands(agent):
             if not (re.search(r"\bemacs\b", cmd)
                     and ("--batch" in cmd or "-batch" in cmd)
                     and target in cmd):
@@ -125,7 +79,7 @@ class TestElispSkillSandbox(TestCase):
             "works."
         )
         self.assertTrue(
-            _skill_was_loaded(agent, "elisp"),
+            skill_was_loaded(agent, "elisp"),
             "agent did not load the elisp skill for an Emacs-Lisp authoring task",
         )
         self.assertTrue(
@@ -151,14 +105,17 @@ class TestElispSkillSandbox(TestCase):
         just that the agent ran something."""
         agent = AgentHarness(create_agent(
             self.model, self.workspace, sandbox_backend=self.sandbox))
+        # No quality directions in the prompt (no "byte-compile cleanly", no
+        # "add a Commentary section") — those must come from the SKILL. The
+        # assertions below independently verify the artifact is well-formed and
+        # working, so a pass means the skill induced that, not the prompt.
         agent.message(
             "Create an Emacs Lisp file `mathy.el` that provides a function "
             "`mathy-factorial` taking one non-negative integer N and returning "
-            "N factorial — so (mathy-factorial 5) returns 120. Give the file a "
-            "proper Commentary section. Make sure it byte-compiles cleanly."
+            "N factorial — so (mathy-factorial 5) returns 120."
         )
         self.assertTrue(
-            _skill_was_loaded(agent, "elisp"),
+            skill_was_loaded(agent, "elisp"),
             "agent did not load the elisp skill for an Emacs-Lisp authoring task",
         )
         path = os.path.join(self.workspace, "mathy.el")
@@ -217,6 +174,6 @@ class TestElispSkillAntiTrigger(TestCase):
             "numbers, and add a quick test for it."
         )
         self.assertFalse(
-            _skill_was_loaded(agent, "elisp"),
+            skill_was_loaded(agent, "elisp"),
             "elisp skill loaded on a pure Python task — its trigger is too broad",
         )

--- a/edd/eval/test_elisp_skill.py
+++ b/edd/eval/test_elisp_skill.py
@@ -171,10 +171,14 @@ class TestElispSkillSandbox(TestCase):
         bc = self._sandbox_sh(
             "emacs --batch -Q --eval '(setq byte-compile-error-on-warn t)' "
             "-f batch-byte-compile mathy.el 2>&1; echo EXIT:$?")
+        self.assertEqual(
+            bc.returncode, 0,
+            f"sandbox byte-compile run failed to launch (docker/mount issue?):\n"
+            f"stdout:\n{bc.stdout}\nstderr:\n{bc.stderr}")
         self.assertIn(
             "EXIT:0", bc.stdout,
             f"mathy.el did not byte-compile cleanly (warnings count as "
-            f"errors):\n{bc.stdout}")
+            f"errors):\nstdout:\n{bc.stdout}\nstderr:\n{bc.stderr}")
 
         # ...and computes the right answer.
         run = self._sandbox_sh(

--- a/edd/eval/test_elisp_skill.py
+++ b/edd/eval/test_elisp_skill.py
@@ -14,6 +14,7 @@ is *behavioral*: the agent must actually run emacs to verify, which needs a real
 - ``test_does_not_load_on_python_task`` (no sandbox) — anti-test pinning the
   trigger: a Python task must not load the elisp skill.
 """
+import os
 import re
 import shutil
 import subprocess
@@ -120,6 +121,58 @@ class TestElispSkillSandbox(TestCase):
             self._ran_emacs_batch(agent),
             "elisp skill loaded but the agent never ran emacs to verify — it "
             "should byte-compile / run ERT, not just emit elisp and trust it",
+        )
+
+    def _sandbox_sh(self, script: str) -> subprocess.CompletedProcess:
+        """Run a shell snippet in a fresh sandbox container against the
+        workspace, capturing output — used to independently verify the elisp
+        the agent produced (not to drive the agent)."""
+        return subprocess.run(
+            ['docker', 'run', '--rm', '-v', f'{self.workspace}:/workspace',
+             '-w', '/workspace', 'assist-sandbox', 'bash', '-c', script],
+            capture_output=True, text=True, timeout=120)
+
+    def test_writes_wellformed_elisp(self):
+        """The skill's payoff: the agent produces elisp that is well-formed and
+        actually works. We pin the file/function names, then INDEPENDENTLY
+        byte-compile the artifact and run it — the eval verifies the output, not
+        just that the agent ran something."""
+        agent = AgentHarness(create_agent(
+            self.model, self.workspace, sandbox_backend=self.sandbox))
+        agent.message(
+            "Create an Emacs Lisp file `mathy.el` that provides a function "
+            "`mathy-factorial` taking one non-negative integer N and returning "
+            "N factorial — so (mathy-factorial 5) returns 120. Give the file a "
+            "proper Commentary section. Make sure it byte-compiles cleanly."
+        )
+        self.assertTrue(
+            _skill_was_loaded(agent, "elisp"),
+            "agent did not load the elisp skill for an Emacs-Lisp authoring task",
+        )
+        path = os.path.join(self.workspace, "mathy.el")
+        self.assertTrue(os.path.exists(path), "agent did not write mathy.el")
+
+        # Well-formed: lexical-binding cookie present.
+        src = open(path).read()
+        self.assertRegex(
+            src, r"lexical-binding:\s*t",
+            "mathy.el is missing the `lexical-binding: t` file-local cookie",
+        )
+
+        # Well-formed + working: byte-compiles with no error...
+        bc = self._sandbox_sh(
+            "emacs --batch -Q -f batch-byte-compile mathy.el 2>&1; echo EXIT:$?")
+        self.assertIn("EXIT:0", bc.stdout,
+                      f"mathy.el did not byte-compile cleanly:\n{bc.stdout}")
+        self.assertNotIn("Error", bc.stdout,
+                         f"byte-compile reported an error:\n{bc.stdout}")
+
+        # ...and computes the right answer.
+        run = self._sandbox_sh(
+            "emacs --batch -Q -l mathy.el --eval '(princ (mathy-factorial 5))'")
+        self.assertIn(
+            "120", run.stdout,
+            f"(mathy-factorial 5) did not return 120:\n{run.stdout}\n{run.stderr}",
         )
 
 

--- a/edd/eval/test_elisp_skill.py
+++ b/edd/eval/test_elisp_skill.py
@@ -95,17 +95,16 @@ class TestElispSkillSandbox(TestCase):
         SandboxManager.cleanup(self.workspace)
         _cleanup_workspace(self.workspace)
 
-    def _ran_emacs_batch(self, agent) -> bool:
-        """True iff the agent VERIFIED the code in ``emacs --batch`` — the call
-        must actually touch elisp (a ``.el`` file, or a byte-compile / ERT /
-        checkdoc action), so a no-op like ``emacs --batch --version`` does not
-        count. The exact form is the model's choice."""
+    def _verified_file_in_emacs(self, agent, target: str) -> bool:
+        """True iff the agent ran an ``emacs --batch`` command that references
+        ``target`` — the file it was asked to write — so it verified THAT code
+        (byte-compile / load / ERT loading it), not some unrelated file or a
+        no-op like ``emacs --batch --version``. The exact form (compile vs test
+        vs load-and-eval) is the model's choice."""
         for cmd in _executed_commands(agent):
-            if not (re.search(r"\bemacs\b", cmd)
-                    and ("--batch" in cmd or "-batch" in cmd)):
-                continue
-            if (".el" in cmd or "byte-compile" in cmd
-                    or "ert-run-tests" in cmd or "checkdoc" in cmd):
+            if (re.search(r"\bemacs\b", cmd)
+                    and ("--batch" in cmd or "-batch" in cmd)
+                    and target in cmd):
                 return True
         return False
 
@@ -122,9 +121,10 @@ class TestElispSkillSandbox(TestCase):
             "agent did not load the elisp skill for an Emacs-Lisp authoring task",
         )
         self.assertTrue(
-            self._ran_emacs_batch(agent),
-            "elisp skill loaded but the agent never ran emacs to verify — it "
-            "should byte-compile / run ERT, not just emit elisp and trust it",
+            self._verified_file_in_emacs(agent, "sum.el"),
+            "elisp skill loaded but the agent never verified sum.el in "
+            "emacs --batch (byte-compile / ERT / load) — it should not just "
+            "emit elisp and trust it",
         )
 
     def _sandbox_sh(self, script: str) -> subprocess.CompletedProcess:

--- a/edd/eval/utils.py
+++ b/edd/eval/utils.py
@@ -1,4 +1,6 @@
 import os
+import shutil
+import subprocess
 from unittest import TestCase
 from langchain_core.messages import ToolMessage, AIMessage
 
@@ -130,6 +132,65 @@ def read_file(path: str) -> str:
 def files_in_directory(path: str) -> list[str]:
     """Returns the files in path as a list"""
     return os.listdir(path)
+
+def skill_was_loaded(agent, skill_name: str) -> bool:
+    """True iff a tool call loaded the named skill's body.
+
+    Recognizes both routes the SkillsMiddleware exposes:
+
+    - ``load_skill(name=skill_name)`` — the small-model tool registered by
+      ``SmallModelSkillsMiddleware``.
+    - ``read_file`` / ``read`` with a path containing ``/skills/<name>/`` —
+      the upstream deepagents path.
+
+    Shared by the skill-loading evals; grep tool-call args rather than results,
+    since the model proves intent the moment it issues the call.
+    """
+    path_needle = f"/skills/{skill_name}/"
+    for m in agent.all_messages():
+        if not isinstance(m, AIMessage) or not m.tool_calls:
+            continue
+        for tc in m.tool_calls:
+            args = tc.get("args") or {}
+            if tc.get("name") == "load_skill" and args.get("name") == skill_name:
+                return True
+            for v in args.values():
+                if isinstance(v, str) and path_needle in v:
+                    return True
+    return False
+
+
+def executed_commands(agent) -> list[str]:
+    """Command strings from every ``execute`` tool call, in order."""
+    cmds = []
+    for m in agent.all_messages():
+        if not isinstance(m, AIMessage) or not m.tool_calls:
+            continue
+        for tc in m.tool_calls:
+            if tc.get("name") == "execute":
+                cmd = (tc.get("args") or {}).get("command", "")
+                if cmd:
+                    cmds.append(cmd)
+    return cmds
+
+
+def cleanup_workspace(path: str) -> None:
+    """Remove a sandbox workspace, using Docker to delete root-owned files.
+
+    Sandbox commands (pip, pytest, emacs, ...) write files as root inside the
+    bind mount; a plain ``shutil.rmtree`` fails on those without an
+    intermediate chmod, so run one in a throwaway alpine container first.
+    """
+    try:
+        subprocess.run(
+            ['docker', 'run', '--rm', '-v', f'{path}:/cleanup', 'alpine',
+             'sh', '-c', 'chmod -R 777 /cleanup 2>/dev/null; rm -rf /cleanup/*'],
+            check=False, timeout=60,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception:
+        pass
+    shutil.rmtree(path, ignore_errors=True)
+
 
 def create_filesystem(root_dir: str,
                       structure: dict):


### PR DESCRIPTION
Adds a generic, built-in **`elisp`** skill — guidance for writing Emacs Lisp — plus evals.

## Why in assist (not a repo)
Unlike the gtd/org skill (personal config → lives in the domain repo), this is **generic craft with zero personal data and an immediate real consumer**: domain repos that ship elisp (e.g. an org-agenda `agenda.el`) need the agent to write/extend elisp well. It's the right shape for a built-in — a language-specific complement to `dev`, like `org-format` and `pdf`.

## What the skill covers (`assist/skills/elisp/SKILL.md`)
- **Structure** — lexical-binding header, `;;; Commentary:`/`;;; Code:` markers (what `checkdoc` expects), `(provide)` footer, namespacing, pure functions, and `expand-file-name`-from-a-known-root (relative `org-agenda-files` expand against `~/org`, not the cwd).
- **Run it headless without hanging** — `emacs --batch -Q`; never block on prompts (a missing file hangs batch on `[R]emove/[A]bort`); `princ`→stdout vs `message`→stderr.
- **Lint** — `batch-byte-compile`, `checkdoc`. **Test** — ERT batch. **Docs** — `(documentation 'fn)` headless, `apropos`, the Elisp manual.
- **Always verify** — the headline: the small model's elisp recall is weak, so the contract is *run emacs to check it*, not trust the code. Stock-emacs tooling only (no external linter deps).

Every command in the skill was verified working in the sandbox image (which already ships Emacs 30.2).

## Evals (`edd/eval/test_elisp_skill.py`)
- **`test_loads_and_verifies`** (sandbox) — a non-telegraphing "write this elisp and make sure it works" prompt; asserts the skill loads AND the agent actually verified in `emacs --batch`. **N=3 → 3/3.**
- **`test_writes_wellformed_elisp`** (sandbox) — the agent writes a pinned function; the eval *independently* byte-compiles the artifact (clean) and runs it (`(mathy-factorial 5)` == 120) and checks the lexical-binding cookie. Tests output quality, not just that a command ran.
- **`test_does_not_load_on_python_task`** (no sandbox) — anti-test: a Python task must not load the elisp skill.

## Notes
- The batch gotchas encoded in the skill (relative-path expansion; missing-file hang) are real ones hit while building a gtd demo skill that drives org-agenda headless.
- No production-code change — a new skill is auto-discovered via the `/skills/` source; the only files are the SKILL.md and the eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)