### PR TITLE
Keep threads on a thread branch; never strand HEAD on main

### DIFF
--- a/assist/domain_manager.py
+++ b/assist/domain_manager.py
@@ -38,6 +38,29 @@ class Change(BaseModel):
     diff: str
 
 
+def current_branch(repo_dir: str) -> str:
+    """Return the checked-out branch name.
+
+    ``git rev-parse --abbrev-ref HEAD`` returns the branch name, the
+    literal ``HEAD`` when detached, and we return '' when the ref can't
+    be read at all (e.g. not a git repo).  Callers compare against
+    ``'main'`` and treat everything else as "leave it alone".
+    """
+    result = subprocess.run(
+        ['git', '-C', repo_dir, 'rev-parse', '--abbrev-ref', 'HEAD'],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ''
+
+
+def _branch_exists(repo_dir: str, name: str) -> bool:
+    """True if a local branch ``name`` already exists in ``repo_dir``."""
+    return subprocess.run(
+        ['git', '-C', repo_dir, 'show-ref', '--verify', '--quiet', f'refs/heads/{name}'],
+        check=False,
+    ).returncode == 0
+
+
 def create_timestamped_branch(repo_dir: str, suffix: str | None = None) -> str:
     """Create and checkout a new assist/[timestamp][-suffix] branch from main.
 
@@ -49,9 +72,48 @@ def create_timestamped_branch(repo_dir: str, suffix: str | None = None) -> str:
     """
     from datetime import timezone
     ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-    branch_name = f'assist/{ts}-{suffix}' if suffix else f'assist/{ts}'
+    base = f'assist/{ts}-{suffix}' if suffix else f'assist/{ts}'
+    # Second-resolution timestamps plus a per-thread-constant suffix can
+    # still collide when two branches are cut within the same UTC second
+    # (e.g. a heal firing in the same second as a merge re-branch).
+    # ``checkout -b`` fails hard on an existing name, which would abort
+    # the turn and strand the work on whatever branch HEAD is on, so
+    # disambiguate with a counter rather than letting it raise.
+    branch_name = base
+    n = 1
+    while _branch_exists(repo_dir, branch_name):
+        branch_name = f'{base}-{n}'
+        n += 1
     subprocess.run(['git', '-C', repo_dir, 'checkout', '-b', branch_name, 'main'], check=True)
     return branch_name
+
+
+def ensure_thread_branch(repo_dir: str, suffix: str | None = None) -> str:
+    """Guarantee HEAD is on a thread branch so per-turn commits stay reviewable.
+
+    The web flow renders ``git diff main...HEAD`` and only shows the
+    Review / Merge buttons when that diff is non-empty.  If a thread is
+    left on ``main`` — a merge that failed between checking out ``main``
+    and re-branching, or an older flow that stranded it — every later
+    commit lands on ``main``, the diff is always empty, and the work can
+    never be reviewed.
+
+    When HEAD is on ``main``, re-branch onto a fresh ``assist/<ts>``
+    branch off ``main``.  ``git checkout -b`` carries the working tree's
+    uncommitted edits forward, so an in-flight turn lands on the new
+    branch.  Any other state — already on a thread branch, on some other
+    branch, or detached — is left untouched.  Returns the branch HEAD
+    ends up on.
+    """
+    branch = current_branch(repo_dir)
+    if branch != 'main':
+        return branch
+    new_branch = create_timestamped_branch(repo_dir, suffix=suffix)
+    logger.warning(
+        "Thread was stranded on main; re-branched to %s so its work stays reviewable",
+        new_branch,
+    )
+    return new_branch
 
 
 def clone_repo(repo_url: str, dest_dir: str, branch_suffix: str | None = None) -> None:
@@ -347,7 +409,13 @@ class DomainManager:
         return self.repo_path
 
     def sync(self, commit_message: str) -> None:
-        """Commit any pending work on the thread branch.  Does NOT push.
+        """Restore the thread-branch invariant, then commit pending work.
+
+        Before committing we ensure HEAD is on an ``assist/<ts>`` thread
+        branch (see :func:`ensure_thread_branch`): if a prior flow left
+        the thread on ``main``, the commit would otherwise land on
+        ``main`` and the work would never render in the review UI.  Does
+        NOT push.
 
         Pushes are gated to the user-initiated merge → push-main flow;
         the agent must not be able to publish to ``origin`` directly,
@@ -358,6 +426,7 @@ class DomainManager:
         """
         if not self.repo:
             return
+        ensure_thread_branch(self.repo_path, suffix=self.branch_suffix)
         git_commit(self.repo_path, commit_message)
 
     def merge_to_main(self, summary_model=None) -> str:
@@ -366,23 +435,29 @@ class DomainManager:
 
         Sequence:
 
-        1. Generate the merge commit summary from the diff (model
-           invocation, optional fallback).
-        2. ``git fetch origin``.
-        3. Refuse if local ``main`` has unpushed commits from a previous
+        1. ``git fetch origin``.
+        2. Refuse if local ``main`` has unpushed commits from a previous
            merge — the user must push to ``origin`` before another
            merge can land cleanly on top.
-        4. ``git rebase origin/main`` on the thread branch.  On
+        3. ``git rebase origin/main`` on the thread branch.  On
            conflict: abort the rebase and raise
            :class:`MergeConflictError` with the unmerged file list.
-        5. ``git checkout main`` and ``git reset --hard origin/main``
-           (safe — step 3 verified local ``main`` had no extra
+        4. ``git checkout main`` and ``git reset --hard origin/main``
+           (safe — step 2 verified local ``main`` had no extra
            commits).
-        6. ``git merge --squash <thread-branch>`` and commit with the
-           summary.
-        7. Re-create a fresh ``assist/<ts>-<suffix>`` thread branch off
+        5. ``git merge --squash <thread-branch>``, generate the AI
+           summary from the diff (model invocation, optional fallback —
+           done late so a failed merge never burns a model call), and
+           commit with that summary.
+        6. Re-create a fresh ``assist/<ts>-<suffix>`` thread branch off
            ``main`` so the user can keep chatting in the same thread
            after the merge.
+
+        Steps 4-6 are wrapped so a failure anywhere in that window never
+        leaves the thread stranded on ``main`` (the state that hides its
+        work from the review UI): if the squash already committed, the
+        thread is re-branched off ``main`` (the merge is preserved);
+        otherwise HEAD is restored to the thread branch.
 
         Does **not** push — that's the caller's job, via
         :meth:`push_main`, gated to a user-initiated UI action.
@@ -397,13 +472,9 @@ class DomainManager:
                 branch in a clean state.
             subprocess.CalledProcessError: any other git failure.
         """
-        cur = subprocess.run(
-            ['git', '-C', self.repo_path, 'rev-parse', '--abbrev-ref', 'HEAD'],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True
-        )
-        current_branch = cur.stdout.strip()
+        branch_name = current_branch(self.repo_path)
 
-        if current_branch == 'main':
+        if branch_name == 'main':
             raise ValueError("Already on main branch - nothing to merge")
 
         diffs = self.main_diff()
@@ -446,7 +517,7 @@ class DomainManager:
             conflicted = [l.strip() for l in unmerged.stdout.splitlines() if l.strip()]
             subprocess.run(['git', '-C', self.repo_path, 'rebase', '--abort'], check=False)
             if conflicted:
-                raise MergeConflictError(current_branch, conflicted)
+                raise MergeConflictError(branch_name, conflicted)
             # Non-conflict rebase failure (e.g. dirty working tree at
             # merge time, corrupt branch state).  Don't paper this
             # over as a "conflict" — the agent would chase a
@@ -460,26 +531,57 @@ class DomainManager:
             )
 
         # Switch to main and bring it level with origin/main before
-        # squashing the rebased thread branch on top.
-        subprocess.run(['git', '-C', self.repo_path, 'checkout', 'main'], check=True)
-        subprocess.run(['git', '-C', self.repo_path, 'reset', '--hard', 'origin/main'], check=True)
-        subprocess.run(
-            ['git', '-C', self.repo_path, 'merge', '--squash', current_branch],
-            check=True,
-        )
+        # squashing the rebased thread branch on top.  From the checkout
+        # below until the post-merge re-branch, HEAD sits on ``main``; if
+        # any step in between raises (squash, the LLM summary call, the
+        # commit, or the re-branch), we must not return with the thread
+        # stranded on ``main`` — that's the exact state that makes work
+        # unreviewable.  The ``squashed`` flag tells the recovery path
+        # whether a real merge landed on ``main`` (keep it, just put the
+        # thread on a fresh branch) or not (return to the thread branch
+        # so its work is preserved).
+        squashed = False
+        try:
+            subprocess.run(['git', '-C', self.repo_path, 'checkout', 'main'], check=True)
+            subprocess.run(['git', '-C', self.repo_path, 'reset', '--hard', 'origin/main'], check=True)
+            subprocess.run(
+                ['git', '-C', self.repo_path, 'merge', '--squash', branch_name],
+                check=True,
+            )
 
-        # Generate the AI summary as late as possible — directly
-        # before the commit it labels.  Every git step before this
-        # could fail (network on fetch, conflict on rebase, dirty
-        # state on checkout, etc.); spending an LLM round-trip only
-        # after they've all succeeded means a failed merge never
-        # burns a model call.
-        summary = self._summarize_merge(diffs, current_branch, summary_model)
-        subprocess.run(['git', '-C', self.repo_path, 'commit', '-m', summary], check=True)
+            # Generate the AI summary as late as possible — directly
+            # before the commit it labels.  Every git step before this
+            # could fail (network on fetch, conflict on rebase, dirty
+            # state on checkout, etc.); spending an LLM round-trip only
+            # after they've all succeeded means a failed merge never
+            # burns a model call.
+            summary = self._summarize_merge(diffs, branch_name, summary_model)
+            subprocess.run(['git', '-C', self.repo_path, 'commit', '-m', summary], check=True)
+            squashed = True
 
-        # Roll the thread forward onto a new branch off main so the
-        # user can keep chatting; preserves pre-feature UX.
-        create_timestamped_branch(self.repo_path, suffix=self.branch_suffix)
+            # Roll the thread forward onto a new branch off main so the
+            # user can keep chatting; preserves pre-feature UX.
+            create_timestamped_branch(self.repo_path, suffix=self.branch_suffix)
+        except Exception:
+            try:
+                if squashed:
+                    # The squash committed onto main (a real merge that
+                    # just needs pushing); only the re-branch failed.
+                    # Put the thread on a fresh branch off main.
+                    ensure_thread_branch(self.repo_path, suffix=self.branch_suffix)
+                else:
+                    # The merge never committed; main is back at
+                    # origin/main.  Force-return to the thread branch so
+                    # its (committed) work stays intact and reviewable —
+                    # ``-f`` discards the transient squash staging, which
+                    # is just a duplicate of that branch's own diff.
+                    subprocess.run(
+                        ['git', '-C', self.repo_path, 'checkout', '-f', branch_name],
+                        check=False,
+                    )
+            except Exception:
+                logger.exception("Failed to restore thread branch after merge error")
+            raise
 
         return summary
 

--- a/tests/test_domain_merge.py
+++ b/tests/test_domain_merge.py
@@ -3,22 +3,27 @@ import subprocess
 import tempfile
 import unittest
 
+from unittest.mock import MagicMock, patch
+
 from assist.domain_manager import (
     DomainManager,
     MergeConflictError,
     OriginAdvancedError,
+    create_timestamped_branch,
+    current_branch,
+    ensure_thread_branch,
 )
 
 
-class TestDomainMerge(unittest.TestCase):
-    """Exercises the rebase-then-squash merge contract introduced by the
-    per-thread web git isolation work (see
-    ``docs/2026-05-07-per-thread-web-git-isolation.org``).
+class _DomainGitFixture(unittest.TestCase):
+    """Bare-remote + working-clone git fixture shared by the merge and
+    thread-branch-invariant suites.
 
-    Fixture layout: a bare ``remote.git`` plus two clones —
-    ``self.repo_path`` is the deploy-box working clone (under test);
-    ``self._external_clone()`` returns a separate clone that simulates
-    a different machine pushing to the shared remote.
+    Layout: a bare ``remote.git`` plus two clones — ``self.repo_path`` is
+    the deploy-box working clone (under test), seeded on a ``feature/test``
+    thread branch with one unmerged commit; ``self._external_clone()``
+    returns a separate clone that simulates a different machine pushing to
+    the shared remote.
     """
 
     def setUp(self):
@@ -85,6 +90,13 @@ class TestDomainMerge(unittest.TestCase):
             stdout=subprocess.PIPE, text=True, check=True,
         )
         return result.stdout.split()[0] if result.stdout else ""
+
+
+class TestDomainMerge(_DomainGitFixture):
+    """Exercises the rebase-then-squash merge contract introduced by the
+    per-thread web git isolation work (see
+    ``docs/2026-05-07-per-thread-web-git-isolation.org``).
+    """
 
     # --- Pre-existing contract regressions ----------------------------------
 
@@ -279,6 +291,141 @@ class TestDomainMerge(unittest.TestCase):
 
         with self.assertRaises(OriginAdvancedError):
             dm.push_main()
+
+
+class TestThreadBranchInvariant(_DomainGitFixture):
+    """The 'HEAD is always on a thread branch' invariant: per-turn
+    ``sync()`` must never let work accumulate on ``main`` (which makes it
+    invisible to the ``git diff main...HEAD`` review UI), and a merge that
+    fails mid-flight must not strand the thread on ``main``.
+    """
+
+    def _on_main(self) -> None:
+        subprocess.run(
+            ['git', '-C', self.repo_path, 'checkout', 'main'],
+            check=True, capture_output=True,
+        )
+
+    def test_sync_on_main_rebranches_and_keeps_work_reviewable(self):
+        """A thread stranded on ``main`` heals on its next ``sync()``: the
+        turn's edit lands on a fresh ``assist/*`` branch and shows up in
+        ``main_diff()`` so the user can review it.
+        """
+        self._on_main()
+        with open(os.path.join(self.repo_path, "turn.txt"), 'w') as f:
+            f.write("work produced while stranded on main\n")
+
+        dm = DomainManager(repo_path=self.repo_path, repo=self.remote_dir,
+                           branch_suffix='abcd')
+        dm.sync("a turn's worth of work")
+
+        cur = current_branch(self.repo_path)
+        self.assertTrue(cur.startswith('assist/'), f"expected assist/* branch, got: {cur}")
+
+        # The work is committed on the thread branch and is reviewable
+        # (non-empty diff vs main) — the whole point of the invariant.
+        self.assertGreater(len(dm.main_diff()), 0)
+
+        # main itself did not gain the commit.
+        self.assertNotIn('turn.txt', subprocess.run(
+            ['git', '-C', self.repo_path, 'ls-tree', '--name-only', 'main'],
+            stdout=subprocess.PIPE, text=True, check=True,
+        ).stdout)
+
+    def test_sync_is_noop_on_an_existing_thread_branch(self):
+        """On a non-``main`` branch, ``sync()`` commits in place and does
+        not re-branch (it must not rename ``feature/test`` -> ``assist/*``).
+        """
+        before = current_branch(self.repo_path)
+        self.assertEqual(before, 'feature/test')
+        with open(os.path.join(self.repo_path, "more.txt"), 'w') as f:
+            f.write("more work\n")
+
+        dm = DomainManager(repo_path=self.repo_path, repo=self.remote_dir,
+                           branch_suffix='abcd')
+        dm.sync("more work on the thread branch")
+
+        self.assertEqual(current_branch(self.repo_path), 'feature/test')
+
+    def test_ensure_thread_branch_heals_only_main(self):
+        """Direct unit check: re-branch off ``main``; no-op on any other
+        branch (returns the unchanged branch name)."""
+        # No-op on the feature branch.
+        self.assertEqual(
+            ensure_thread_branch(self.repo_path, suffix='abcd'), 'feature/test')
+
+        # Heals on main.
+        self._on_main()
+        healed = ensure_thread_branch(self.repo_path, suffix='abcd')
+        self.assertTrue(healed.startswith('assist/'))
+        self.assertEqual(current_branch(self.repo_path), healed)
+
+    def test_create_timestamped_branch_disambiguates_on_collision(self):
+        """Two branches cut in the same UTC second must not collide — the
+        second gets a counter suffix instead of aborting with ``checkout
+        -b`` failing on an existing name.
+        """
+        fixed = MagicMock()
+        fixed.strftime.return_value = "20260101-000000"
+        with patch('assist.domain_manager.datetime') as mock_dt:
+            mock_dt.now.return_value = fixed
+            first = create_timestamped_branch(self.repo_path, suffix='abcd')
+            second = create_timestamped_branch(self.repo_path, suffix='abcd')
+
+        self.assertEqual(first, 'assist/20260101-000000-abcd')
+        self.assertEqual(second, 'assist/20260101-000000-abcd-1')
+
+    def test_merge_summary_failure_does_not_strand_on_main(self):
+        """If the LLM summary call raises mid-merge (after checkout main,
+        before the squash commit), the thread must be restored to its
+        branch with its work intact — never left on ``main``.
+        """
+        class _RaisingModel:
+            def invoke(self, _messages):
+                raise RuntimeError("LLM unavailable")
+
+        dm = DomainManager(repo_path=self.repo_path, repo=self.remote_dir)
+        with self.assertRaises(RuntimeError):
+            dm.merge_to_main(summary_model=_RaisingModel())
+
+        # Not stranded on main; back on the thread branch, work reviewable.
+        self.assertEqual(current_branch(self.repo_path), 'feature/test')
+        self.assertGreater(len(dm.main_diff()), 0)
+
+    def test_merge_rebranch_failure_keeps_squash_and_heals(self):
+        """If the post-merge re-branch fails *after* the squash committed,
+        the merge must stay on ``main`` and HEAD must still be moved off
+        ``main`` onto a fresh thread branch (not restored to the old one,
+        which would discard the just-landed merge).
+        """
+        import assist.domain_manager as dmod
+        real = dmod.create_timestamped_branch
+        state = {'calls': 0}
+
+        def flaky(repo_dir, suffix=None):
+            # Fail the first call (the happy-path re-branch at the end of
+            # merge_to_main); let the recovery's re-branch succeed.
+            state['calls'] += 1
+            if state['calls'] == 1:
+                raise RuntimeError("re-branch failed")
+            return real(repo_dir, suffix=suffix)
+
+        dm = DomainManager(repo_path=self.repo_path, repo=self.remote_dir,
+                           branch_suffix='abcd')
+        with patch('assist.domain_manager.create_timestamped_branch', side_effect=flaky):
+            with self.assertRaises(RuntimeError):
+                dm.merge_to_main(summary_model=None)
+
+        # HEAD healed off main onto a fresh thread branch.
+        cur = current_branch(self.repo_path)
+        self.assertTrue(cur.startswith('assist/'), f"expected assist/* branch, got: {cur}")
+
+        # The squash merge is preserved on local main (it just needs a push).
+        self.assertTrue(dm.has_unpushed_main())
+        subprocess.run(['git', '-C', self.repo_path, 'checkout', 'main'],
+                       check=True, capture_output=True)
+        with open(os.path.join(self.repo_path, "README.md")) as f:
+            self.assertIn('Feature 1', f.read())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

The per-thread domain git flow renders `git diff main...HEAD` and only shows the **Review** / **Merge to Main** buttons when that diff is non-empty. Nothing guaranteed HEAD was on an `assist/<ts>` thread branch. Once a thread was left on `main` — by an older merge path, or a merge that failed between `git checkout main` and the post-merge re-branch — every turn's `sync()` committed straight to `main`, so `main...HEAD` was always empty and the work could never be reviewed (the UI shows only "Push to origin"). One real thread hit exactly this and had multiple turns of work accumulate invisibly on local `main`.

## Root cause

There was no invariant enforcing "HEAD is on a thread branch." `sync()` → `git_commit()` commits to whatever branch HEAD points at, with no check, and `DomainManager.__init__` only branches on a fresh clone — attaching to an existing repo never heals a stranded HEAD.

## Fix

Enforce the invariant at the two places HEAD can reach `main`:

- **`ensure_thread_branch()`** (new module helper) re-branches off `main` *only* when stranded there, and is called at the top of `sync()` before committing. `git checkout -b` carries the in-flight turn's uncommitted edits forward, so the work lands on the new branch. This also **self-heals** any already-stranded thread on its next turn.
- **`merge_to_main`** now wraps its `checkout main → reset → squash → summary → commit → re-branch` window so a failure never returns with HEAD on `main`: if the squash already committed, it re-branches off `main` (the merge is preserved, just needs a push); otherwise it force-restores the thread branch with its work intact.
- **`create_timestamped_branch`** disambiguates on a branch-name collision (same-UTC-second cut) instead of letting `checkout -b` fail and abort the turn.
- Extracted `current_branch()` (now shared with `merge_to_main`) and `_branch_exists()` helpers.

The heal re-branches **off `main` only** — it deliberately does NOT reset `main` to `origin/main` or rescue commits already on `main`, because a post-commit merge failure can leave a *legitimate* squash merge on `main` that resetting would discard.

## Process

Went through the three-phase workflow: design + 4-lens design review (which caught the merge-strand-on-main root cause and the branch-name-collision footgun), implementation, then 3-lens code review (which added the `squashed=True` recovery-arm test and the fixture refactor below). All findings addressed; reviewers returned "ship it."

## Known limitations

- If the post-merge re-branch fails *and* the recovery re-branch also fails (e.g. disk/ref-lock contention), the thread is briefly left on `main` — but the merged work is safe on `main`, and the next `sync()` heals HEAD. No data loss.
- The one already-stranded production thread was recovered manually (its local-only `main` commits moved onto a fresh thread branch, `main` reset to `origin/main`) so it's reviewable as if the flow had worked; the new guard prevents recurrence.

## Test plan

- New thread-branch-invariant suite: heal-on-`main`, no-op off-`main`, the collision loop, and **both** merge-failure recovery arms (summary-raise → restore thread branch; re-branch-fail-after-commit → keep merge on `main`, heal HEAD).
- Refactored the shared bare-remote fixture into a base class so the merge contract tests don't run twice.
- `574 passed` across the full unit suite; web package import smoke clean. This is deterministic git plumbing with no small-model behavior to probe, so no `edd/eval` LLM trials were added (the unit tests are the contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)