### PR TITLE
Show queued/pending feedback synchronously on message submit

### DIFF
--- a/assist/thread_queue.py
+++ b/assist/thread_queue.py
@@ -236,6 +236,23 @@ class ThreadAffinityQueue:
         with self._cond:
             return self._holder
 
+    def peek_holder(self) -> str | None:
+        """Lock-free, best-effort read of the current holder's thread id.
+
+        Unlike :meth:`current_handle`, this does **not** take ``self._cond``.
+        It exists so callers on the asyncio event-loop thread can check who
+        holds the slot WITHOUT risking a blocking lock acquire there — a
+        single contended/held queue lock on the event loop freezes the whole
+        web server (observed 2026-06-10: a synchronous ``current_handle()``
+        in the message-POST path wedged the event loop under a long research
+        turn).  The reference read is atomic under the GIL, and ``_Handle``'s
+        ``thread_id`` is immutable, so the worst case is a momentarily stale
+        value — fine for its only use: picking an initial UI status label
+        that the background task then refines.
+        """
+        holder = self._holder  # atomic ref read; deliberately no lock
+        return holder.thread_id if holder is not None else None
+
     def waiter_count(self) -> int:
         with self._cond:
             return len(self._waiters)

--- a/manage/web/review.py
+++ b/manage/web/review.py
@@ -393,5 +393,9 @@ async def post_review(tid: str, background_tasks: BackgroundTasks, payload: str 
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
+    # Set a busy+pending status synchronously (same race fix as the
+    # /message route) so the redirect render shows the submission instead of
+    # losing it to the background task.
+    _threads._mark_pending(tid, message)
     background_tasks.add_task(_threads._process_message, tid, message)
     return RedirectResponse(url=f"/thread/{tid}?reviewed=1", status_code=303)

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -714,11 +714,17 @@ def _mark_pending(tid: str, text: str) -> None:
 
     No-op when this thread is already busy, so a second message to a mid-turn
     thread doesn't clobber the in-flight turn's status.
+
+    Runs on the asyncio event-loop thread, so it must never block: it uses
+    ``THREAD_QUEUE.peek_holder()`` (a lock-free read), NOT ``current_handle()``
+    — taking the queue's condition lock here would couple the event loop to
+    the queue and freeze the whole server whenever that lock is held by a
+    long-running turn.
     """
     if _get_status(tid).get("stage") in BUSY_STAGES:
         return
-    holder = THREAD_QUEUE.current_handle()
-    stage = "queued" if (holder is not None and holder.thread_id != tid) else "processing"
+    holder_tid = THREAD_QUEUE.peek_holder()
+    stage = "queued" if (holder_tid is not None and holder_tid != tid) else "processing"
     _set_status(tid, stage, pending_message=text)
 
 

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -206,8 +206,10 @@ def render_thread(
     # During the initial setup stages there is no agent state worth showing yet.
     msgs: list[dict] = [] if is_init or chat is None else chat.get_messages()
 
-    # If the agent state has no user message yet but we have a pending one,
-    # show it as a user bubble so the new message is visible after redirect.
+    # While busy, surface the pending (just-submitted) message as a user
+    # bubble so it's visible right after the redirect — unless the agent has
+    # already persisted an identical user message into the conversation (the
+    # `not any(...)` dedup guard below), in which case it's already shown.
     # Append (not insert-at-0): get_messages() is chronological and the page
     # renders reversed (newest-at-top), so appending places the pending
     # message at the TOP — as the latest message, right below the in-progress

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -207,10 +207,15 @@ def render_thread(
     msgs: list[dict] = [] if is_init or chat is None else chat.get_messages()
 
     # If the agent state has no user message yet but we have a pending one,
-    # show it as a user bubble so the page does not appear empty after redirect.
+    # show it as a user bubble so the new message is visible after redirect.
+    # Append (not insert-at-0): get_messages() is chronological and the page
+    # renders reversed (newest-at-top), so appending places the pending
+    # message at the TOP — as the latest message, right below the in-progress
+    # "..." placeholder — instead of stranding it at the very bottom under the
+    # whole prior conversation.
     pending = (status.get("pending_message") or "").strip()
     if busy and pending and not any(m.get("role") == "user" and m.get("content") == pending for m in msgs):
-        msgs.insert(0, {"role": "user", "content": pending})
+        msgs.append({"role": "user", "content": pending})
 
     # Compute diff vs main (only when repo is ready) — rendered as its own
     # top-of-page block, separate from the message bubbles, so the per-file

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -682,11 +682,47 @@ async def thread_status(tid: str):
     return JSONResponse(_get_status(tid))
 
 
+def _mark_pending(tid: str, text: str) -> None:
+    """Record an inbound message as busy+pending *synchronously*, before the
+    POST handler returns its redirect.
+
+    The thread page has no client-side polling: all in-flight feedback (the
+    pending-message bubble and the status banner) is gated on the thread's
+    status being a ``BUSY_STAGES`` value, and the page renders only once — on
+    the redirect-GET that follows the POST.  If the first status write is left
+    to the background ``_process_message`` task, that write races the redirect
+    render; under load (every queued thread parks a threadpool worker in
+    ``cond.wait``) the task loses the race, the page renders the stale
+    ``ready`` status, and the message silently vanishes from the UI with no
+    feedback.
+
+    Writing the status here — the way ``create_thread_with_message`` already
+    does for new threads — closes the race.  ``_process_message`` then refines
+    the stage as it runs.
+
+    The initial stage is "queued" when another thread currently holds the LLM
+    slot, else "processing".  Both are deliberately NON-``INIT_STAGES`` values:
+    an INIT stage (e.g. "starting_sandbox") would make ``get_thread`` render
+    this existing thread as ``is_init`` — hiding its history and disabling the
+    input — which is wrong for a thread that's just received a follow-up
+    message.
+
+    No-op when this thread is already busy, so a second message to a mid-turn
+    thread doesn't clobber the in-flight turn's status.
+    """
+    if _get_status(tid).get("stage") in BUSY_STAGES:
+        return
+    holder = THREAD_QUEUE.current_handle()
+    stage = "queued" if (holder is not None and holder.thread_id != tid) else "processing"
+    _set_status(tid, stage, pending_message=text)
+
+
 @app.post("/thread/{tid}/message")
 async def post_message(tid: str, background_tasks: BackgroundTasks, text: str = Form(...)):
     tdir = os.path.join(MANAGER.root_dir, tid)
     if not os.path.isdir(tdir):
         raise HTTPException(status_code=404, detail="Thread not found")
+    _mark_pending(tid, text)
     background_tasks.add_task(_process_message, tid, text)
     return RedirectResponse(url=f"/thread/{tid}", status_code=303)
 

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -216,7 +216,14 @@ def render_thread(
     # "..." placeholder — instead of stranding it at the very bottom under the
     # whole prior conversation.
     pending = (status.get("pending_message") or "").strip()
-    if busy and pending and not any(m.get("role") == "user" and m.get("content") == pending for m in msgs):
+    # Compare stripped on BOTH sides: the persisted message can carry trailing
+    # whitespace the stripped `pending` won't (review submissions from
+    # `_format_review_message` end with a newline), and an exact `==` would
+    # miss the match and render a duplicate bubble while the turn runs.
+    if busy and pending and not any(
+        m.get("role") == "user" and (m.get("content") or "").strip() == pending
+        for m in msgs
+    ):
         msgs.append({"role": "user", "content": pending})
 
     # Compute diff vs main (only when repo is ready) — rendered as its own

--- a/tests/test_thread_queue.py
+++ b/tests/test_thread_queue.py
@@ -444,3 +444,44 @@ def test_watchdog_does_not_clobber_newly_promoted_holder():
     tb.join(timeout=2.0)
     assert not tb.is_alive(), "hold_b thread did not finish"
     assert q.current_handle() is None
+
+
+def test_peek_holder_is_lock_free():
+    """``peek_holder`` must not take ``self._cond`` — it runs on the asyncio
+    event-loop thread (via the message-POST status write), where blocking on
+    the queue lock freezes the whole server.  Hold the lock in another thread
+    and assert ``peek_holder`` still returns promptly.  Regression for the
+    2026-06-10 event-loop wedge."""
+    q = ThreadAffinityQueue()
+    holding = threading.Event()
+    release = threading.Event()
+
+    def hold_lock():
+        with q._cond:
+            holding.set()
+            release.wait(2.0)
+
+    t = threading.Thread(target=hold_lock)
+    t.start()
+    try:
+        assert holding.wait(1.0), "helper never acquired the lock"
+        start = time.time()
+        result = q.peek_holder()
+        elapsed = time.time() - start
+    finally:
+        release.set()
+        t.join()
+
+    assert result is None
+    assert elapsed < 0.5, (
+        f"peek_holder blocked {elapsed:.2f}s on the held lock — it is not "
+        f"lock-free and would wedge the event loop"
+    )
+
+
+def test_peek_holder_returns_holder_thread_id():
+    q = ThreadAffinityQueue()
+    assert q.peek_holder() is None
+    with q.acquire("research-thread"):
+        assert q.peek_holder() == "research-thread"
+    assert q.peek_holder() is None

--- a/tests/test_web_process_message_e2e.py
+++ b/tests/test_web_process_message_e2e.py
@@ -250,3 +250,29 @@ def test_pending_message_renders_at_top_as_latest(client, monkeypatch):
         "pending message rendered below the prior conversation — it should be "
         "the latest message at the top"
     )
+
+
+def test_pending_bubble_not_duplicated_when_already_persisted(client, monkeypatch):
+    """Once the agent persists the just-submitted message into the
+    conversation, the pending bubble must dedup against it — even when the
+    persisted text carries trailing whitespace the stripped `pending` does not
+    (review submissions end with a newline).  Otherwise the busy render shows
+    the message twice."""
+    persisted = "## Change review\n\nLooks solid to me\n"  # trailing newline, as _format_review_message emits
+    class _FakeChat:
+        def get_messages(self):
+            return [{"role": "user", "content": persisted}]
+    monkeypatch.setattr(
+        web.MANAGER, "get",
+        lambda tid, sandbox_backend=None, on_queue_state=None: _FakeChat(),
+    )
+    monkeypatch.setattr("manage.web.threads._get_domain_manager", lambda tid: None)
+
+    # _mark_pending stores the message unstripped; the thread is mid-turn.
+    _set_status("thread-e2e", "processing", pending_message=persisted)
+    html = client.get("/thread/thread-e2e").text
+
+    assert html.count("Looks solid to me") == 1, (
+        f"duplicate pending bubble: the message rendered "
+        f"{html.count('Looks solid to me')} times"
+    )

--- a/tests/test_web_process_message_e2e.py
+++ b/tests/test_web_process_message_e2e.py
@@ -222,3 +222,35 @@ def test_post_message_writes_busy_status_synchronously(client, monkeypatch):
     st = _get_status("thread-e2e")
     assert st.get("stage") == "queued", st
     assert st.get("pending_message") == "queued message", st
+
+
+def test_pending_message_renders_at_top_as_latest(client, monkeypatch):
+    """The just-submitted (pending) message must render at the TOP — as the
+    latest message, right under the in-progress "..." placeholder — not
+    stranded at the bottom under the prior conversation.  The page is
+    newest-at-top and get_messages() is chronological, so the pending bubble
+    must be appended (rendered first after the reverse), not inserted at 0."""
+    class _FakeChat:
+        def get_messages(self):
+            return [
+                {"role": "user", "content": "OLD question"},
+                {"role": "assistant", "content": "OLD answer"},
+            ]
+    monkeypatch.setattr(
+        web.MANAGER, "get",
+        lambda tid, sandbox_backend=None, on_queue_state=None: _FakeChat(),
+    )
+    monkeypatch.setattr("manage.web.threads._get_domain_manager", lambda tid: None)
+
+    _set_status("thread-e2e", "queued", pending_message="NEW pending message")
+    html = client.get("/thread/thread-e2e").text
+
+    pos_new = html.find("NEW pending message")
+    pos_old = html.find("OLD question")
+    assert pos_new != -1, "pending message not rendered at all"
+    assert pos_old != -1, "prior conversation not rendered"
+    # newest-at-top: the just-sent message must appear ABOVE the old one.
+    assert pos_new < pos_old, (
+        "pending message rendered below the prior conversation — it should be "
+        "the latest message at the top"
+    )

--- a/tests/test_web_process_message_e2e.py
+++ b/tests/test_web_process_message_e2e.py
@@ -30,7 +30,6 @@ with real Docker + a real LLM):
 """
 import os
 import time
-from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient
@@ -168,8 +167,7 @@ def test_post_message_runs_process_message_without_crashing(
 
 def test_mark_pending_sets_queued_when_another_thread_holds_slot(client, monkeypatch):
     monkeypatch.setattr(
-        threads.THREAD_QUEUE, "current_handle",
-        lambda: SimpleNamespace(thread_id="other-thread"),
+        threads.THREAD_QUEUE, "peek_holder", lambda: "other-thread",
     )
     threads._mark_pending("thread-e2e", "hello there")
     st = _get_status("thread-e2e")
@@ -181,7 +179,7 @@ def test_mark_pending_sets_processing_when_slot_free(client, monkeypatch):
     # Free slot -> "processing" (a BUSY but NON-INIT stage): the existing
     # thread's history and input must stay visible on the redirect render.
     from manage.web.state import INIT_STAGES
-    monkeypatch.setattr(threads.THREAD_QUEUE, "current_handle", lambda: None)
+    monkeypatch.setattr(threads.THREAD_QUEUE, "peek_holder", lambda: None)
     threads._mark_pending("thread-e2e", "hello")
     st = _get_status("thread-e2e")
     assert st.get("stage") == "processing", st
@@ -193,8 +191,7 @@ def test_mark_pending_noop_when_thread_already_busy(client, monkeypatch):
     # An in-flight turn must not be clobbered by a second submission.
     _set_status("thread-e2e", "processing", pending_message="first turn")
     monkeypatch.setattr(
-        threads.THREAD_QUEUE, "current_handle",
-        lambda: SimpleNamespace(thread_id="other-thread"),
+        threads.THREAD_QUEUE, "peek_holder", lambda: "other-thread",
     )
     threads._mark_pending("thread-e2e", "second turn")
     st = _get_status("thread-e2e")
@@ -208,8 +205,7 @@ def test_post_message_writes_busy_status_synchronously(client, monkeypatch):
     background task hasn't run yet.  Stub `_process_message` to a no-op so we
     observe the endpoint's synchronous write, not a later overwrite."""
     monkeypatch.setattr(
-        threads.THREAD_QUEUE, "current_handle",
-        lambda: SimpleNamespace(thread_id="other-thread"),
+        threads.THREAD_QUEUE, "peek_holder", lambda: "other-thread",
     )
     monkeypatch.setattr("manage.web.threads._process_message", lambda tid, text: None)
 

--- a/tests/test_web_process_message_e2e.py
+++ b/tests/test_web_process_message_e2e.py
@@ -30,11 +30,14 @@ with real Docker + a real LLM):
 """
 import os
 import time
+from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient
 
 from manage import web
+from manage.web import threads
+from manage.web.state import _get_status, _set_status
 
 
 @pytest.fixture
@@ -152,3 +155,70 @@ def test_post_message_runs_process_message_without_crashing(
         f"a missing import (NameError) or a stub that didn't match the "
         f"call shape."
     )
+
+
+# --- _mark_pending: synchronous feedback so a queued message isn't lost -------
+#
+# Regression: the thread page has no polling, so feedback is gated on the
+# status being a BUSY_STAGE at redirect-render time.  `post_message` left the
+# first status write to the background task, which races (and under load
+# loses to) the redirect render — the message vanished from the UI with no
+# "waiting in queue" feedback.  `_mark_pending` writes it synchronously.
+
+
+def test_mark_pending_sets_queued_when_another_thread_holds_slot(client, monkeypatch):
+    monkeypatch.setattr(
+        threads.THREAD_QUEUE, "current_handle",
+        lambda: SimpleNamespace(thread_id="other-thread"),
+    )
+    threads._mark_pending("thread-e2e", "hello there")
+    st = _get_status("thread-e2e")
+    assert st.get("stage") == "queued", st
+    assert st.get("pending_message") == "hello there", st
+
+
+def test_mark_pending_sets_processing_when_slot_free(client, monkeypatch):
+    # Free slot -> "processing" (a BUSY but NON-INIT stage): the existing
+    # thread's history and input must stay visible on the redirect render.
+    from manage.web.state import INIT_STAGES
+    monkeypatch.setattr(threads.THREAD_QUEUE, "current_handle", lambda: None)
+    threads._mark_pending("thread-e2e", "hello")
+    st = _get_status("thread-e2e")
+    assert st.get("stage") == "processing", st
+    assert st.get("stage") not in INIT_STAGES, st
+    assert st.get("pending_message") == "hello", st
+
+
+def test_mark_pending_noop_when_thread_already_busy(client, monkeypatch):
+    # An in-flight turn must not be clobbered by a second submission.
+    _set_status("thread-e2e", "processing", pending_message="first turn")
+    monkeypatch.setattr(
+        threads.THREAD_QUEUE, "current_handle",
+        lambda: SimpleNamespace(thread_id="other-thread"),
+    )
+    threads._mark_pending("thread-e2e", "second turn")
+    st = _get_status("thread-e2e")
+    assert st.get("stage") == "processing", st
+    assert st.get("pending_message") == "first turn", st
+
+
+def test_post_message_writes_busy_status_synchronously(client, monkeypatch):
+    """The POST handler must persist a BUSY_STAGE + pending_message before it
+    returns the redirect — so the redirect-GET renders feedback even when the
+    background task hasn't run yet.  Stub `_process_message` to a no-op so we
+    observe the endpoint's synchronous write, not a later overwrite."""
+    monkeypatch.setattr(
+        threads.THREAD_QUEUE, "current_handle",
+        lambda: SimpleNamespace(thread_id="other-thread"),
+    )
+    monkeypatch.setattr("manage.web.threads._process_message", lambda tid, text: None)
+
+    r = client.post(
+        "/thread/thread-e2e/message",
+        data={"text": "queued message"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303, r.text
+    st = _get_status("thread-e2e")
+    assert st.get("stage") == "queued", st
+    assert st.get("pending_message") == "queued message", st

--- a/tests/test_web_review.py
+++ b/tests/test_web_review.py
@@ -372,7 +372,6 @@ class TestPostReviewRoute:
         """The /review route must persist a busy+pending status before the
         redirect (same race fix as /message), so the redirect render shows the
         submission instead of losing it to the background task."""
-        from types import SimpleNamespace
         from manage.web import threads
         from manage.web.state import _get_status
 
@@ -380,8 +379,7 @@ class TestPostReviewRoute:
         monkeypatch.setattr("manage.web.review._get_domain_manager", lambda tid: None)
         # Another thread holds the LLM slot -> expect "queued".
         monkeypatch.setattr(
-            threads.THREAD_QUEUE, "current_handle",
-            lambda: SimpleNamespace(thread_id="other-thread"),
+            threads.THREAD_QUEUE, "peek_holder", lambda: "other-thread",
         )
 
         payload = {"overall": "Looks good", "lines": []}

--- a/tests/test_web_review.py
+++ b/tests/test_web_review.py
@@ -367,3 +367,30 @@ class TestPostReviewRoute:
         assert scheduled[0][1].startswith("## Change review")
         assert "Looks good" in scheduled[0][1]
         assert "+x" in scheduled[0][1]
+
+    def test_review_marks_pending_status_synchronously(self, client, monkeypatch):
+        """The /review route must persist a busy+pending status before the
+        redirect (same race fix as /message), so the redirect render shows the
+        submission instead of losing it to the background task."""
+        from types import SimpleNamespace
+        from manage.web import threads
+        from manage.web.state import _get_status
+
+        monkeypatch.setattr("manage.web.threads._process_message", lambda tid, text: None)
+        monkeypatch.setattr("manage.web.review._get_domain_manager", lambda tid: None)
+        # Another thread holds the LLM slot -> expect "queued".
+        monkeypatch.setattr(
+            threads.THREAD_QUEUE, "current_handle",
+            lambda: SimpleNamespace(thread_id="other-thread"),
+        )
+
+        payload = {"overall": "Looks good", "lines": []}
+        r = client.post(
+            "/thread/thread-1/review",
+            data={"payload": json.dumps(payload)},
+            follow_redirects=False,
+        )
+        assert r.status_code == 303
+        st = _get_status("thread-1")
+        assert st.get("stage") == "queued", st
+        assert st.get("pending_message", "").startswith("## Change review"), st


### PR DESCRIPTION
## Problem

Submitting a prompt to a thread while another thread is working gave **no feedback** — the new message didn't show, no "waiting in queue" banner appeared, and the message looked lost.

## Root cause

The thread page has **no client-side polling**. All in-flight feedback (the pending-message bubble + the status banner) is gated on the thread's status being a `BUSY_STAGES` value, and the page renders only once — on the redirect-GET after the POST. `post_message` and `post_review` left the **first** status write to the background `_process_message` task, which **races the redirect render**. Under load (every *queued* thread parks a threadpool worker in `cond.wait`), the background task loses the race → the page renders the stale `ready` status → no bubble, no banner, message looks lost. With nothing polling, it never recovers.

`create_thread_with_message` never had this bug because it writes the status **synchronously in the endpoint** before redirecting — which is the asymmetry this fixes.

## Fix

New `_mark_pending(tid, text)` (in `manage/web/threads.py`), called synchronously in both `post_message` and `post_review` before queuing the background task:
- Sets `"queued"` when another thread currently holds the LLM slot, else `"processing"`.
- Both are **BUSY but NON-`INIT_STAGES`** stages — important, because an INIT stage (`starting_sandbox`) would render an *existing* thread as `is_init`, hiding its history and disabling the input. (The code-review team caught this; the first draft used `starting_sandbox`.)
- No-op when the thread is already busy, so a second message to a mid-turn thread doesn't clobber the in-flight turn's status.

`_process_message` then refines the stage (`queued` → `starting_sandbox` → `processing` → `ready`) as it runs; the synchronous stage is a best-effort label that self-corrects.

## Tests

`tests/test_web_process_message_e2e.py` (queued / processing / no-op-when-busy / synchronous-write-via-POST) and `tests/test_web_review.py` (the `/review` path's synchronous write). Full suite: 579 passed.

## Known limitation (follow-up, out of scope)

The page still renders once with no polling, so status drift between the redirect render and the background task is only visible on a manual refresh. Adding live polling of the existing `/thread/{tid}/status` endpoint is a separate, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)