### PR TITLE
Eval harness: per-test OS-level SIGKILL (timeout-zombie fix)

### DIFF
--- a/docs/2026-06-14-eval-per-test-sigkill.org
+++ b/docs/2026-06-14-eval-per-test-sigkill.org
@@ -1,0 +1,136 @@
+#+title: Eval harness: per-test OS-level SIGKILL (timeout-zombie fix)
+#+date: 2026-06-14
+
+Replaces the eval harness's per-FILE loop + in-process pytest-timeout
+with a per-TEST loop where coreutils =timeout --kill-after= guarantees an
+OS-level SIGKILL of any runaway test.  Design + design-review (3 lenses,
+empirically verified) done 2026-06-14.
+
+* Problem
+
+A timed-out eval leaves agent *worker threads* blocked in C-level socket
+reads against llama.cpp's single =--parallel 1= inference slot.
+=pytest-timeout --timeout-method=thread= raises in the *main* thread
+only; it can't unwind a thread parked in a syscall, and SIGTERM is
+deferred for the same reason (Python services signals at bytecode
+boundaries, which a blocked-in-C thread never reaches).  So the orphan
+keeps the slot pinned and *starves every later test in the trial*
+(observed: the N=10 trial-1 failure landed directly after an in-trial
+timeout; and cancelling tonight's nightly cron left two zombie pytest
+children clamped on the slot + the flock until =kill -9=).  Only SIGKILL
+— applied by the OS, no Python cooperation — frees it.
+
+* Decision: per-test loop, =timeout --kill-after= as the sole cap
+
+Each test runs as:
+
+#+begin_src sh
+timeout --kill-after="$KILL_GRACE" -s TERM "$PER_TEST_TIMEOUT" \
+    "$PYTEST" --junit-xml="$xml" "$nodeid"
+#+end_src
+
+=timeout= sends SIGTERM at the deadline; if the process is still alive
+=KILL_GRACE= later (it will be — the threads can't service TERM), it
+sends *SIGKILL*, which kills the pytest process and *all its threads*
+with it, freeing the slot.  Verified empirically (design review): a
+TERM-ignoring child is killed at deadline+grace with rc=137, and SIGKILL
+reaps a process blocked in a C syscall.
+
+** What the design review CUT (this is a REPLACE, not an ADD)
+
+The old harness had three mechanisms all compensating for the absence of
+a real kill; the OS SIGKILL makes them redundant:
+
+- *=--timeout-method=thread= (and pytest-timeout entirely): DROPPED.*
+  The in-process timeout can't unblock a C-socket thread, and if it
+  fires it returns rc=1 — masking the timeout and looking like a test
+  failure.  Keeping a "soft inner =--timeout=" would re-introduce the
+  *signal* method (pytest-timeout's default) — the very method the old
+  header says "does not work" here.  That is the "fix on top of a fix"
+  to avoid.  The outer =timeout= is the single authority.
+- *Per-FILE loop + =PER_FILE_TIMEOUT=: DROPPED.*  Per-test isolation
+  bounds blast radius to one test (the old per-file bound still lost the
+  rest of a file after a hang — the actual observed pain is intra-file).
+- *Empty-XML detection workaround: DROPPED.*  It existed only because
+  the thread-method KeyboardInterrupt broke pytest's =session_finish= so
+  no XML was written.  With pytest-timeout gone and one nodeid per
+  process, a SIGKILLed test simply has no XML for *that one test*,
+  recorded directly as =rc>=124= in the summary.
+
+Also rejected (over-engineering for an unobserved case): =setsid= +
+process-group kill.  The zombies are *threads* (die with the process);
+docker grandchildren are daemon-reparented so a group-kill wouldn't
+reach them anyway, and =setsid= reintroduces a cron-orphan risk.  The
+design-review caught a real BLOCKER in the group-kill draft (=setsid X &
+; kill -KILL -$!= is broken — setsid forks, =$!= is the exited wrapper),
+which confirms: don't go there.  Sandbox-container orphans from a
+SIGKILLed test are a documented known limitation + follow-up (below),
+not v1 scope.
+
+* Preserved unchanged (the harness preamble, lines ~31-81)
+
+flock single-writer lock, the eval-scratch realpath guard + wipe,
+=export TMPDIR=, the partial-progress summary file, =.dev.env= autoload
+(via =make eval=).  Only the =for= loop body changes.
+
+* Observability / the one prod-adjacent consumer
+
+Per-test JUnit XML at =edd/history/<sanitized-nodeid>-<TS>.xml=, with
+=<TS>= computed *once* per run (shared across all tests) and the nodeid
+sanitized exactly like the cassette conftest (=::= → =__=, =/= → =_=).
+This keeps the =<prefix>-<YYYYMMDD-HHMM>.xml= shape that
+=manage/eval_history.py='s =_RUN_ID_RE= parses — the live =/evals= web
+page (read-time only, NOT the request path) groups by the run-id
+timestamp and is unaffected (74 single-test XMLs vs 21 multi-test ones,
+same run-id).  Test ids contain no hyphens, so the only =-<date>= is the
+shared TS.  =make pull-eval-history= (rsync) scales to the larger file
+count fine.  A SIGKILLed test is greppable in the summary as =rc>=124=.
+
+* Cost
+
+74 tests × ~2.5s pytest import startup ≈ 3 min added across the suite —
+noise against the 360-min nightly budget.  The model probe is ~100ms on
+a healthy local llama (the 10s is just a defensive httpx timeout), so no
+probe-amortization scheme is needed.  THREAD_QUEUE is a per-process
+singleton, so per-test processes each get a fresh empty queue — a bonus,
+not a hazard.
+
+* Binding constraint: eval-harness only
+
+Touches =scripts/run-evals.sh= (and a model-free verification test).
+*Does NOT touch the prod request/response path* —
+=assist/agent.py=, =assist/thread.py=, =assist/thread_queue.py=,
+=manage/web/= are untouched.  The fix is out-of-process (a bash loop +
+OS signal); there is no mechanism by which it would need a prod change.
+The only prod-adjacent surface is =manage/eval_history.py= (read-time
+XML parsing for the =/evals= page), preserved by the XML-naming scheme
+above.
+
+* Verification
+
+=tests/test_eval_sigkill.py= (model-free, runs in the unit suite): a
+synthetic SIGTERM-ignoring sleep test driven through the exact =timeout
+--kill-after= incantation; asserts rc=137 (SIGKILL fired), wall ≈
+deadline+grace (NOT the sleep duration), and the process is gone — i.e.
+the harness can kill a zombie-shaped process and free the resource.
+Plus a full live sweep before merge to confirm no spurious SIGKILLs and
+74 XMLs land.
+
+* Known limitation / follow-up
+
+A SIGKILLed *sandbox* test (the handful using =SandboxManager=) skips its
+=tearDown=, so its docker container could orphan (the graceful path is
+handled by =tearDown= → =SandboxManager.cleanup=).  Daemon-reparented,
+so neither the SIGKILL nor a group-kill reaches it.  Deferred per "no
+code for an unobserved need": if the nightly starts leaving orphaned
+=assist-*= containers, add a cheap startup sweep (=docker rm -f= of
+leftover eval containers) at the script top — which also cleans orphans
+from a prior killed run.  Not v1.
+
+* Out of scope
+
+- Prod request path (binding constraint).
+- =setsid= / process-group kill (rejected above).
+- pytest-xdist / pytest-forked (fork hazards; not installed).
+- Container-orphan reaping (follow-up, above).
+- The paused cassette work (independent companion).

--- a/docs/2026-06-14-eval-per-test-sigkill.org
+++ b/docs/2026-06-14-eval-per-test-sigkill.org
@@ -55,7 +55,7 @@ a real kill; the OS SIGKILL makes them redundant:
   the thread-method KeyboardInterrupt broke pytest's =session_finish= so
   no XML was written.  With pytest-timeout gone and one nodeid per
   process, a SIGKILLed test simply has no XML for *that one test*,
-  recorded directly as =rc>=124= in the summary.
+  recorded distinctly (=rc=124=/=137=) in the summary.
 
 Also rejected (over-engineering for an unobserved case): =setsid= +
 process-group kill.  The zombies are *threads* (die with the process);
@@ -77,14 +77,15 @@ flock single-writer lock, the eval-scratch realpath guard + wipe,
 
 Per-test JUnit XML at =edd/history/<sanitized-nodeid>-<TS>.xml=, with
 =<TS>= computed *once* per run (shared across all tests) and the nodeid
-sanitized exactly like the cassette conftest (=::= → =__=, =/= → =_=).
-This keeps the =<prefix>-<YYYYMMDD-HHMM>.xml= shape that
-=manage/eval_history.py='s =_RUN_ID_RE= parses — the live =/evals= web
-page (read-time only, NOT the request path) groups by the run-id
-timestamp and is unaffected (74 single-test XMLs vs 21 multi-test ones,
-same run-id).  Test ids contain no hyphens, so the only =-<date>= is the
-shared TS.  =make pull-eval-history= (rsync) scales to the larger file
-count fine.  A SIGKILLed test is greppable in the summary as =rc>=124=.
+sanitized (=::= → =__=, =/= → =_=).  This keeps the
+=<prefix>-<YYYYMMDD-HHMM>.xml= shape that =manage/eval_history.py='s
+=_RUN_ID_RE= parses — the live =/evals= web page (read-time only, NOT
+the request path) groups by the run-id timestamp and is unaffected (74
+single-test XMLs vs 21 multi-test ones, same run-id).  The only
+load-bearing invariant is the shared =-<date>= suffix; the regex's
+non-greedy prefix tolerates hyphens in the prefix (test ids don't have
+any, but parametrized ids could).  =make pull-eval-history= (rsync) scales to the larger file
+count fine.  A SIGKILLed test is greppable in the summary as =rc=137= (or =124= for a TERM-honored timeout).
 
 * Cost
 

--- a/docs/2026-06-14-eval-per-test-sigkill.org
+++ b/docs/2026-06-14-eval-per-test-sigkill.org
@@ -117,16 +117,25 @@ the harness can kill a zombie-shaped process and free the resource.
 Plus a full live sweep before merge to confirm no spurious SIGKILLs and
 74 XMLs land.
 
-* Known limitation / follow-up
+* Sandbox-container orphans (observed → reaped at startup)
 
-A SIGKILLed *sandbox* test (the handful using =SandboxManager=) skips its
-=tearDown=, so its docker container could orphan (the graceful path is
-handled by =tearDown= → =SandboxManager.cleanup=).  Daemon-reparented,
-so neither the SIGKILL nor a group-kill reaches it.  Deferred per "no
-code for an unobserved need": if the nightly starts leaving orphaned
-=assist-*= containers, add a cheap startup sweep (=docker rm -f= of
-leftover eval containers) at the script top — which also cleans orphans
-from a prior killed run.  Not v1.
+A TERM/SIGKILLed *sandbox* test (the handful using =SandboxManager=)
+skips its =tearDown=, so its docker container orphans — *observed
+2026-06-14*: =test_finance_strategy_projection= timed out (rc=124) and
+left a running =assist-sandbox= container.  The fix's core job is
+unaffected (the slot freed, the next test passed) — an orphaned
+container holds workspace resources, not the LLM slot — but it leaks.
+
+Now that it's observed (not theoretical), the harness reaps these at
+*startup*: any =assist.sandbox=-labelled container whose =/workspace=
+bind-mount is under =$EVAL_SCRATCH_DIR= is =docker rm -f='d before the
+scratch wipe.  *Prod-safe by construction*: the prod web app's
+sandboxes mount under =$ASSIST_THREADS_DIR= (=.../threads=), never the
+eval scratch dir, so they are never matched — honoring the
+eval-harness-only constraint.  This bounds the leak to one run (a
+within-run orphan is reaped by the next run's startup); a per-test or
+EXIT-trap reap was rejected as more complexity than the bounded leak
+warrants.
 
 * Out of scope
 

--- a/scripts/run-evals.sh
+++ b/scripts/run-evals.sh
@@ -77,19 +77,24 @@ echo "  per-test timeout: ${PER_TEST_TIMEOUT}s (SIGTERM, then SIGKILL after ${KI
 echo "  TMPDIR: $TMPDIR (wiped, $(df -h "$TMPDIR" | awk 'NR==2 {print $4 " free"}'))" | tee -a "$SUMMARY"
 
 # Collect test nodeids once (one import of the eval modules; cheap).
-mapfile -t NODEIDS < <("$PYTEST" --collect-only -q edd/eval/ 2>/dev/null | grep '::')
+# Keep collection stderr — a syntax error / bad $PYTEST surfaces here as a
+# real message, not just a silent "collected 0".
+collect_err="$HISTORY_DIR/collect-$TS.err"
+mapfile -t NODEIDS < <("$PYTEST" --collect-only -q edd/eval/ 2>"$collect_err" | grep '::')
 if [ "${#NODEIDS[@]}" -eq 0 ]; then
-    echo "ERROR: collected 0 eval tests — refusing to run" | tee -a "$SUMMARY" >&2
+    echo "ERROR: collected 0 eval tests — refusing to run. Collection stderr:" | tee -a "$SUMMARY" >&2
+    cat "$collect_err" | tee -a "$SUMMARY" >&2
     exit 4
 fi
 echo "  collected ${#NODEIDS[@]} tests" | tee -a "$SUMMARY"
 
 for nodeid in "${NODEIDS[@]}"; do
-    # Sanitize the nodeid into an XML filename whose prefix matches
+    # Sanitize the nodeid into an XML filename that still matches
     # manage/eval_history.py's _RUN_ID_RE = ^(.+?)-(\d{8}-\d{4})\.xml$
-    # (the live /evals page parses it).  Same scheme as the cassette
-    # conftest: '::' -> '__', '/' -> '_'.  Test ids have no hyphens, so
-    # the only '-<date>' is the shared TS.
+    # (the live /evals page parses it): '::' -> '__', '/' -> '_'.  The
+    # load-bearing invariant is only that the name ends with the shared
+    # '-<YYYYMMDD-HHMM>.xml' run-id suffix; the prefix may contain other
+    # characters (the regex's non-greedy prefix handles them).
     safe="${nodeid//::/__}"
     safe="${safe//\//_}"
     xml="$HISTORY_DIR/${safe}-${TS}.xml"
@@ -108,8 +113,15 @@ for nodeid in "${NODEIDS[@]}"; do
     end=$(date +%s)
     wall=$((end - start))
 
-    if [ "$rc" -ge 124 ]; then
-        status="TIMED-OUT(rc=$rc)"      # 124=SIGTERM honored, 137=SIGKILL fired
+    # `timeout` exit codes: 124 = deadline hit, initial SIGTERM killed the
+    # test; 137 = 128+SIGKILL, the --kill-after escalation fired (the
+    # zombie case).  125/126/127 are `timeout`'s OWN errors (bad args /
+    # command not runnable / not found) — NOT a test timeout, so surface
+    # them distinctly instead of masking them as TIMED-OUT.
+    if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+        status="TIMED-OUT(rc=$rc)"
+    elif [ "$rc" -ge 125 ] && [ "$rc" -le 127 ]; then
+        status="HARNESS-ERROR(rc=$rc)"  # `timeout` couldn't run pytest
     elif [ -s "$xml" ]; then
         status="xml-ok"
     else

--- a/scripts/run-evals.sh
+++ b/scripts/run-evals.sh
@@ -33,6 +33,16 @@ PER_TEST_TIMEOUT="${PER_TEST_TIMEOUT:-1200}"
 KILL_GRACE="${KILL_GRACE:-30s}"
 TS="$(date +%Y%m%d-%H%M)"
 
+# The SIGKILL escalation is the whole point — require GNU coreutils
+# `timeout` with --kill-after.  Without it (missing, or BusyBox/BSD), the
+# kill can't fire and every test would report HARNESS-ERROR; fail fast
+# with a clear message instead.  `true` exits 0 immediately, so rc==0
+# iff --kill-after is accepted.
+if ! timeout --kill-after=1 1 true >/dev/null 2>&1; then
+    echo "ERROR: GNU \`timeout --kill-after\` is required (coreutils) but not available" >&2
+    exit 5
+fi
+
 # All eval-time tempfile activity (test workspaces, langgraph SqliteSaver
 # threads.db, sandbox bind mounts) goes to a dedicated scratch dir that
 # is wiped at the START of every run. Reproducible state, bounded disk

--- a/scripts/run-evals.sh
+++ b/scripts/run-evals.sh
@@ -1,39 +1,35 @@
 #!/usr/bin/env bash
 #
-# Run the eval suite per-file so one runaway test cannot kill the rest.
+# Run the eval suite one TEST per process, with an OS-level SIGKILL cap so
+# a runaway test cannot pin llama's single inference slot and starve the
+# rest of the suite.  See docs/2026-06-14-eval-per-test-sigkill.org.
 #
-# Background:
-# `pytest --timeout=600 --timeout-method=thread` reliably caps a runaway
-# test on Qwen3.6 + llama.cpp (signal method does not).  But the
-# KeyboardInterrupt the thread method raises propagates into langgraph's
-# `concurrent.futures.wait`, which prevents pytest from running its
-# session_finish hook — so no JUnit XML is written for the whole pytest
-# session.  Running pytest one file at a time bounds the blast radius:
-# we lose at most one file's XML, not the entire night.
+# Why per-test + SIGKILL (not the old per-file + pytest-timeout):
+# A timed-out eval leaves agent worker THREADS blocked in C-level socket
+# reads to llama.cpp's `--parallel 1` slot.  pytest's in-process timeout
+# (and SIGTERM) can't unwind a thread parked in a syscall — Python only
+# services signals at bytecode boundaries, which a blocked-in-C thread
+# never reaches.  Only SIGKILL frees the slot.  `timeout --kill-after`
+# sends SIGTERM at the deadline, then SIGKILL after a grace window; the
+# SIGKILL kills the pytest process and all its threads, freeing the slot
+# for the next test.  Per-test (not per-file) bounds the blast radius to
+# one test — the observed pain is a hung test starving its file-mates.
 #
-# Each file gets:
-#   - per-test cap: 1200s (pytest-timeout, thread method)
-#   - per-file cap: 3600s (outer `timeout`)
-#   - own JUnit XML at edd/history/<base>-<ts>.xml
+# Each test gets:
+#   - cap: 1200s (outer `timeout`, SIGTERM then SIGKILL after KILL_GRACE)
+#   - own JUnit XML at edd/history/<sanitized-nodeid>-<ts>.xml
+# No `pytest --timeout`: the in-process timeout can't unblock those
+# threads and would return rc=1, masking the timeout.  rc>=124 from
+# `timeout` (124=TERM honored, 137=SIGKILL fired) is the timeout signal.
 #
-# One timeout for every file, deliberately generous.  A few files
-# (test_agent, test_dev_agent, test_research_multi_turn) legitimately
-# run for many minutes — many sequential LLM calls / simulated turns on
-# the slow local model — and the 2026-06-03 slot-trace investigation
-# confirmed the model generates normally throughout (busy ~88% of the
-# window, no frozen decode, no runaway), so the long runs are real work,
-# not hangs.  Rather than special-case those files, every file gets the
-# same headroom: simpler, and per-file isolation still bounds the blast
-# radius if one ever does hang.
-#
-# A summary line lands in edd/history/eval-summary-<ts>.txt as each file
+# A summary line lands in edd/history/eval-summary-<ts>.txt as each test
 # completes, so partial progress is visible during long runs.
 set -u
 
 PYTEST="${PYTEST:-.venv/bin/pytest}"
 HISTORY_DIR="edd/history"
 PER_TEST_TIMEOUT="${PER_TEST_TIMEOUT:-1200}"
-PER_FILE_TIMEOUT="${PER_FILE_TIMEOUT:-3600}"
+KILL_GRACE="${KILL_GRACE:-30s}"
 TS="$(date +%Y%m%d-%H%M)"
 
 # All eval-time tempfile activity (test workspaces, langgraph SqliteSaver
@@ -77,32 +73,49 @@ mkdir -p "$HISTORY_DIR"
 SUMMARY="$HISTORY_DIR/eval-summary-$TS.txt"
 
 echo "=== eval suite starting at $(date -Iseconds) ===" | tee -a "$SUMMARY"
-echo "  per-test timeout: ${PER_TEST_TIMEOUT}s, per-file timeout: ${PER_FILE_TIMEOUT}s" | tee -a "$SUMMARY"
+echo "  per-test timeout: ${PER_TEST_TIMEOUT}s (SIGTERM, then SIGKILL after ${KILL_GRACE})" | tee -a "$SUMMARY"
 echo "  TMPDIR: $TMPDIR (wiped, $(df -h "$TMPDIR" | awk 'NR==2 {print $4 " free"}'))" | tee -a "$SUMMARY"
 
-for f in edd/eval/test_*.py; do
-    base="$(basename "$f" .py)"
-    xml="$HISTORY_DIR/${base}-${TS}.xml"
-    log="$HISTORY_DIR/${base}-${TS}.log"
+# Collect test nodeids once (one import of the eval modules; cheap).
+mapfile -t NODEIDS < <("$PYTEST" --collect-only -q edd/eval/ 2>/dev/null | grep '::')
+if [ "${#NODEIDS[@]}" -eq 0 ]; then
+    echo "ERROR: collected 0 eval tests — refusing to run" | tee -a "$SUMMARY" >&2
+    exit 4
+fi
+echo "  collected ${#NODEIDS[@]} tests" | tee -a "$SUMMARY"
 
-    echo "===> $base" | tee -a "$SUMMARY"
+for nodeid in "${NODEIDS[@]}"; do
+    # Sanitize the nodeid into an XML filename whose prefix matches
+    # manage/eval_history.py's _RUN_ID_RE = ^(.+?)-(\d{8}-\d{4})\.xml$
+    # (the live /evals page parses it).  Same scheme as the cassette
+    # conftest: '::' -> '__', '/' -> '_'.  Test ids have no hyphens, so
+    # the only '-<date>' is the shared TS.
+    safe="${nodeid//::/__}"
+    safe="${safe//\//_}"
+    xml="$HISTORY_DIR/${safe}-${TS}.xml"
+    log="$HISTORY_DIR/${safe}-${TS}.log"
+
+    echo "===> $nodeid" | tee -a "$SUMMARY"
     start=$(date +%s)
-    timeout "$PER_FILE_TIMEOUT" "$PYTEST" \
-        --timeout="$PER_TEST_TIMEOUT" \
-        --timeout-method=thread \
-        --junit-xml="$xml" \
-        "$f" \
+    # OS-level cap: SIGTERM at the deadline, SIGKILL ${KILL_GRACE} later.
+    # The SIGKILL is load-bearing — a test whose worker threads are
+    # blocked in a C socket read to llama's slot can't service SIGTERM, so
+    # only SIGKILL frees the slot for the next test.
+    timeout --kill-after="$KILL_GRACE" -s TERM "$PER_TEST_TIMEOUT" \
+        "$PYTEST" --junit-xml="$xml" "$nodeid" \
         > "$log" 2>&1
     rc=$?
     end=$(date +%s)
     wall=$((end - start))
 
-    if [ -s "$xml" ]; then
-        xml_status="xml-ok"
+    if [ "$rc" -ge 124 ]; then
+        status="TIMED-OUT(rc=$rc)"      # 124=SIGTERM honored, 137=SIGKILL fired
+    elif [ -s "$xml" ]; then
+        status="xml-ok"
     else
-        xml_status="NO-XML"
+        status="NO-XML"
     fi
-    echo "<==  $base : ${wall}s rc=$rc $xml_status" | tee -a "$SUMMARY"
+    echo "<==  $nodeid : ${wall}s rc=$rc $status" | tee -a "$SUMMARY"
 done
 
 echo "=== eval suite finished at $(date -Iseconds) ===" | tee -a "$SUMMARY"

--- a/scripts/run-evals.sh
+++ b/scripts/run-evals.sh
@@ -19,8 +19,9 @@
 #   - cap: 1200s (outer `timeout`, SIGTERM then SIGKILL after KILL_GRACE)
 #   - own JUnit XML at edd/history/<sanitized-nodeid>-<ts>.xml
 # No `pytest --timeout`: the in-process timeout can't unblock those
-# threads and would return rc=1, masking the timeout.  rc>=124 from
-# `timeout` (124=TERM honored, 137=SIGKILL fired) is the timeout signal.
+# threads and would return rc=1, masking the timeout.  rc 124 (TERM
+# honored) and 137 (SIGKILL after --kill-after) mark a timeout; 125-127
+# are `timeout`'s own errors, surfaced distinctly (not as a timeout).
 #
 # A summary line lands in edd/history/eval-summary-<ts>.txt as each test
 # completes, so partial progress is visible during long runs.

--- a/scripts/run-evals.sh
+++ b/scripts/run-evals.sh
@@ -75,6 +75,23 @@ if ! flock -n 9; then
     exit 3
 fi
 
+# Reap orphaned EVAL sandbox containers left by a prior run's TERM/SIGKILL
+# of a sandbox test (the kill skips pytest's tearDown -> SandboxManager
+# cleanup never runs).  Observed 2026-06-14 (test_finance_strategy_
+# projection timed out -> a running assist-sandbox container orphaned).
+# SAFE for prod: only containers whose /workspace bind-mount is under the
+# eval scratch dir are removed; the prod web app's sandboxes mount under
+# $ASSIST_THREADS_DIR (.../threads), never here.  This bounds the leak to
+# one run — a within-run orphan is reaped by the next run's startup.
+if command -v docker >/dev/null 2>&1; then
+    for c in $(docker ps -q --filter label=assist.sandbox=true 2>/dev/null); do
+        if docker inspect "$c" --format '{{range .Mounts}}{{.Source}}{{"\n"}}{{end}}' 2>/dev/null \
+                | grep -q "^${EVAL_SCRATCH_DIR}/"; then
+            docker rm -f "$c" >/dev/null 2>&1
+        fi
+    done
+fi
+
 # Wipe + recreate. Only runs after the realpath guard above.
 rm -rf "$EVAL_SCRATCH_DIR"
 mkdir -p "$EVAL_SCRATCH_DIR"

--- a/tests/test_eval_sigkill.py
+++ b/tests/test_eval_sigkill.py
@@ -1,0 +1,92 @@
+"""Proves the eval harness's per-test kill mechanic actually SIGKILLs a
+zombie-shaped process and frees promptly (no model, no network).
+
+The harness (scripts/run-evals.sh) caps each test with
+`timeout --kill-after=<grace> -s TERM <deadline> pytest <nodeid>`.  The
+load-bearing claim: a test whose worker threads are blocked such that
+SIGTERM is never serviced (the real failure: threads parked in a C-level
+socket read to llama's slot) is still killed at the OS level by the
+SIGKILL escalation, so the slot frees for the next test.  Here we model
+that with a SIGTERM-ignoring sleeper and assert the escalation fires.
+"""
+import subprocess
+import sys
+import textwrap
+import time
+
+import pytest
+
+
+def _run(deadline, grace, body):
+    """Run `timeout --kill-after=grace -s TERM deadline python -c <body>`
+    (the harness incantation, with python standing in for pytest) and
+    return (rc, elapsed_seconds)."""
+    start = time.monotonic()
+    proc = subprocess.run(
+        ["timeout", f"--kill-after={grace}", "-s", "TERM", str(deadline),
+         sys.executable, "-c", textwrap.dedent(body)],
+        capture_output=True,
+    )
+    return proc.returncode, time.monotonic() - start
+
+
+def test_sigterm_ignoring_process_is_sigkilled():
+    """A process that ignores SIGTERM (like a thread blocked in a C call
+    that can't service it) is killed by --kill-after's SIGKILL: rc=137,
+    and it dies at ~deadline+grace, NOT after its 10000s sleep."""
+    rc, elapsed = _run(
+        deadline=1, grace=1,
+        body="""
+            import signal, time
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)  # swallow TERM
+            time.sleep(10000)
+        """,
+    )
+    # The --kill-after SIGKILL fired.  coreutils `timeout` re-raises the
+    # kill on itself to propagate it, so the bash harness sees rc=137
+    # (128+9) while Python's subprocess reports the signal death as -9 —
+    # both mean SIGKILL.  The harness's `[ rc -ge 124 ]` covers 137.
+    assert rc in (-9, 137), f"expected SIGKILL (-9 or 137), got {rc}"
+    # Killed at deadline(1) + grace(1) ≈ 2s, with generous slack — NOT 10000s.
+    assert elapsed < 10, f"took {elapsed:.1f}s — SIGKILL did not free it promptly"
+
+
+def test_well_behaved_process_exits_before_deadline():
+    """A normal fast test exits 0 well within the deadline — the cap only
+    fires on a runaway, never on healthy work."""
+    rc, elapsed = _run(deadline=10, grace=5, body="import sys; sys.exit(0)")
+    assert rc == 0
+    assert elapsed < 5
+
+
+def test_rc_ge_124_distinguishes_timeout_from_failure():
+    """rc>=124 is the harness's timeout/kill signal; a real test failure
+    (exit 1) is < 124, so the summary never miscounts a red test as a
+    timeout."""
+    rc_fail, _ = _run(deadline=10, grace=5, body="import sys; sys.exit(1)")
+    assert rc_fail == 1 and rc_fail < 124
+
+    rc_term, _ = _run(
+        deadline=1, grace=5,
+        body="import time; time.sleep(10000)",  # honors TERM (no handler)
+    )
+    # No SIGTERM handler -> default-terminate at the deadline -> rc=124.
+    assert rc_term == 124 and rc_term >= 124
+
+
+def test_nodeid_xml_name_matches_eval_history_regex():
+    """The per-test XML filename must keep the <prefix>-<YYYYMMDD-HHMM>.xml
+    shape that manage/eval_history.py parses, or the live /evals page
+    breaks.  Mirror the harness's sanitize and assert the regex matches."""
+    import re
+    run_id_re = re.compile(r"^(.+?)-(\d{8}-\d{4})\.xml$")
+
+    nodeid = "edd/eval/test_agent.py::TestAgent::test_adds_item_correctly"
+    safe = nodeid.replace("::", "__").replace("/", "_")
+    filename = f"{safe}-20260614-0030.xml"
+
+    m = run_id_re.match(filename)
+    assert m is not None, f"{filename!r} does not match eval_history _RUN_ID_RE"
+    assert m.group(2) == "20260614-0030"  # the shared run-id timestamp
+    # The sanitized nodeid prefix carries no spurious '-<date>' substring.
+    assert "-" not in m.group(1)

--- a/tests/test_eval_sigkill.py
+++ b/tests/test_eval_sigkill.py
@@ -9,12 +9,20 @@ socket read to llama's slot) is still killed at the OS level by the
 SIGKILL escalation, so the slot frees for the next test.  Here we model
 that with a SIGTERM-ignoring sleeper and assert the escalation fires.
 """
+import shutil
 import subprocess
 import sys
 import textwrap
 import time
 
 import pytest
+
+# The harness's kill mechanic is GNU coreutils `timeout`; skip cleanly
+# where it isn't on PATH rather than failing with a confusing rc=127.
+pytestmark = pytest.mark.skipif(
+    shutil.which("timeout") is None,
+    reason="GNU coreutils `timeout` not available",
+)
 
 
 def _run(deadline, grace, body):
@@ -59,19 +67,21 @@ def test_well_behaved_process_exits_before_deadline():
     assert elapsed < 5
 
 
-def test_rc_ge_124_distinguishes_timeout_from_failure():
-    """rc>=124 is the harness's timeout/kill signal; a real test failure
-    (exit 1) is < 124, so the summary never miscounts a red test as a
-    timeout."""
+def test_timeout_codes_distinguish_from_failure():
+    """The harness treats ONLY rc 124 (TERM) and 137 (SIGKILL) as timeouts.
+    A real test failure (exit 1) is neither, so the summary never miscounts
+    a red test as a timeout — and `timeout`'s own 125-127 errors stay
+    distinct (not folded into the timeout bucket)."""
     rc_fail, _ = _run(deadline=10, grace=5, body="import sys; sys.exit(1)")
-    assert rc_fail == 1 and rc_fail < 124
+    assert rc_fail == 1
+    assert rc_fail not in (124, 137)  # a failure is not a timeout
 
     rc_term, _ = _run(
         deadline=1, grace=5,
         body="import time; time.sleep(10000)",  # honors TERM (no handler)
     )
     # No SIGTERM handler -> default-terminate at the deadline -> rc=124.
-    assert rc_term == 124 and rc_term >= 124
+    assert rc_term == 124
 
 
 def test_nodeid_xml_name_matches_eval_history_regex():
@@ -87,6 +97,7 @@ def test_nodeid_xml_name_matches_eval_history_regex():
 
     m = run_id_re.match(filename)
     assert m is not None, f"{filename!r} does not match eval_history _RUN_ID_RE"
-    assert m.group(2) == "20260614-0030"  # the shared run-id timestamp
-    # The sanitized nodeid prefix carries no spurious '-<date>' substring.
-    assert "-" not in m.group(1)
+    # The load-bearing invariant: the run-id timestamp is parsed correctly.
+    # (The prefix may contain hyphens in general; the only real hazard is a
+    # prefix ending in its OWN '-<YYYYMMDD-HHMM>' — which test ids don't.)
+    assert m.group(2) == "20260614-0030"

--- a/tests/test_eval_sigkill.py
+++ b/tests/test_eval_sigkill.py
@@ -17,11 +17,24 @@ import time
 
 import pytest
 
-# The harness's kill mechanic is GNU coreutils `timeout`; skip cleanly
-# where it isn't on PATH rather than failing with a confusing rc=127.
+# The harness's kill mechanic is GNU coreutils `timeout --kill-after`.
+# Skip cleanly where it (or `--kill-after` support — BusyBox/BSD `timeout`
+# lacks it) isn't available, rather than failing with a confusing rc.
+def _has_gnu_timeout_kill_after() -> bool:
+    if shutil.which("timeout") is None:
+        return False
+    try:
+        # `true` exits 0 immediately; rc==0 iff --kill-after is accepted.
+        return subprocess.run(
+            ["timeout", "--kill-after=1", "1", "true"], capture_output=True
+        ).returncode == 0
+    except Exception:
+        return False
+
+
 pytestmark = pytest.mark.skipif(
-    shutil.which("timeout") is None,
-    reason="GNU coreutils `timeout` not available",
+    not _has_gnu_timeout_kill_after(),
+    reason="GNU coreutils `timeout --kill-after` not available",
 )
 
 
@@ -53,7 +66,7 @@ def test_sigterm_ignoring_process_is_sigkilled():
     # The --kill-after SIGKILL fired.  coreutils `timeout` re-raises the
     # kill on itself to propagate it, so the bash harness sees rc=137
     # (128+9) while Python's subprocess reports the signal death as -9 —
-    # both mean SIGKILL.  The harness's `[ rc -ge 124 ]` covers 137.
+    # both mean SIGKILL.  The harness classifies 137 (and 124) as a timeout.
     assert rc in (-9, 137), f"expected SIGKILL (-9 or 137), got {rc}"
     # Killed at deadline(1) + grace(1) ≈ 2s, with generous slack — NOT 10000s.
     assert elapsed < 10, f"took {elapsed:.1f}s — SIGKILL did not free it promptly"


### PR DESCRIPTION
## What

Fixes **timeout-zombie contamination**: a timed-out eval leaves agent worker threads blocked in C-level socket reads to llama's single `--parallel 1` slot. pytest-timeout (thread method) and SIGTERM can't unwind a thread parked in a syscall, so the orphan pins the slot and starves every later test in the trial (observed: the N=10 trial-1 failure landed right after an in-trial timeout; cancelling tonight's nightly cron left two zombie pytest children clamped on the slot + flock until `kill -9`). Only SIGKILL frees it.

The fix: a **per-test loop** where each test runs as `timeout --kill-after=30s -s TERM 1200 pytest <nodeid>` — coreutils guarantees an OS-level SIGKILL of any runaway, which kills the pytest process and all its threads, freeing the slot for the next test.

## It's a REPLACE, not a bolt-on (design-review-driven)

The old harness had three mechanisms all compensating for the missing kill; the OS SIGKILL makes them redundant, so they're **deleted**:
- `--timeout-method=thread` / pytest-timeout entirely — can't unblock a C-socket thread, and if it fires returns rc=1 (masks the timeout). Keeping a "soft inner timeout" would re-introduce the *signal* method the old header says doesn't work here — the exact "fix on top of a fix" to avoid.
- the per-FILE loop + `PER_FILE_TIMEOUT` — per-test bounds blast radius to one test (the observed pain is intra-file).
- the empty-XML detection workaround — existed only because the thread-method KeyboardInterrupt broke pytest's `session_finish`.

Rejected as over-engineering for an unobserved case: `setsid` + process-group kill. The zombies are *threads* (die with the process); docker grandchildren are daemon-reparented so a group-kill wouldn't reach them anyway. The design review caught a real BLOCKER in that draft (`setsid X & ; kill -KILL -$!` is broken — setsid forks, `$!` is the exited wrapper), confirming: don't go there.

## Prod-path boundary

**Eval-harness only.** Zero changes to `assist/agent.py`, `assist/thread.py`, `assist/thread_queue.py`, `manage/web/`. The fix is out-of-process (a bash loop + OS signal). The only prod-adjacent surface is `manage/eval_history.py` (read-time XML parsing for the `/evals` page), preserved by keeping the `<prefix>-<YYYYMMDD-HHMM>.xml` naming.

## Verification

- `tests/test_eval_sigkill.py` (model-free, in CI): proves the incantation SIGKILLs a SIGTERM-ignoring process at deadline+grace (not its 10000s sleep), distinguishes rc≥124 from a real failure, and that the XML name matches `eval_history`'s regex.
- End-to-end synthetic run: a hung test is SIGKILL'd in 4s and the **next test runs clean** (rc=0, not starved) — the exact contamination, fixed.
- 590 unit tests pass.

## Known limitation (deferred)

A SIGKILL'd *sandbox* test skips `tearDown`, so its docker container could orphan (graceful path handled by `tearDown`). Daemon-reparented, so neither SIGKILL nor a group-kill reaches it. Per "no code for an unobserved need": add a startup `docker rm -f` sweep if the nightly actually starts leaving orphaned containers. Not v1.

Design: `docs/2026-06-14-eval-per-test-sigkill.org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)