### PR TITLE
One sandbox container per turn (created on request, killed on response)

### DIFF
--- a/assist/sandbox.py
+++ b/assist/sandbox.py
@@ -74,7 +74,7 @@ class SandboxContainerLostError(RuntimeError):
     Raised from ``DockerSandboxBackend.execute`` when ``container.exec_run``
     sees a 404 from the Docker API — meaning the container was stopped or
     removed (manually, by an OOM kill, by a daemon restart, by the
-    container's own 3h backstop ``sleep`` TTL expiring) while the agent was
+    container's own backstop ``sleep`` TTL expiring) while the agent was
     still running.
 
     Distinct from a regular per-command exec failure: a dead container

--- a/assist/sandbox.py
+++ b/assist/sandbox.py
@@ -74,7 +74,7 @@ class SandboxContainerLostError(RuntimeError):
     Raised from ``DockerSandboxBackend.execute`` when ``container.exec_run``
     sees a 404 from the Docker API — meaning the container was stopped or
     removed (manually, by an OOM kill, by a daemon restart, by the
-    container's own 1h ``sleep 3600`` TTL expiring) while the agent was
+    container's own 3h backstop ``sleep`` TTL expiring) while the agent was
     still running.
 
     Distinct from a regular per-command exec failure: a dead container

--- a/assist/sandbox_manager.py
+++ b/assist/sandbox_manager.py
@@ -194,15 +194,16 @@ class SandboxManager:
 
         Returns None if Docker is not available.
         """
+        # Per-turn lifecycle: never reuse a container across turns.  The web
+        # layer tears each container down at the end of its turn
+        # (manage/web/threads.py), so a registry entry surviving to here means
+        # a prior turn's teardown didn't run (the worker died mid-turn).  Reap
+        # that stale container before creating a fresh one — the registry is
+        # keyed by work_dir, so creating without reaping would overwrite the
+        # reference and orphan it (the 3h backstop TTL would eventually catch
+        # it, but reaping now is immediate).
         if work_dir in cls._containers:
-            container = cls._containers[work_dir]
-            try:
-                container.reload()
-                if container.status == "running":
-                    from assist.sandbox import DockerSandboxBackend
-                    return DockerSandboxBackend(container)
-            except Exception:
-                cls._containers.pop(work_dir, None)
+            cls.cleanup(work_dir)
 
         # Run the container as the host bind-mount's owner, not as
         # root.  Two reasons:
@@ -319,21 +320,35 @@ class SandboxManager:
 
     @classmethod
     def cleanup(cls, work_dir: str) -> None:
-        """Stop the container for a given work_dir. Removal is automatic (--rm)."""
+        """Tear down the container for a work_dir. Removal is automatic (--rm).
+
+        SIGKILL, not a graceful ``stop()``.  A sandbox has nothing to shut
+        down gracefully — it is ``--rm`` and all durable work is already
+        flushed to the host bind mount — and its PID 1 is a bare ``sleep``
+        with no SIGTERM handler (PID 1 gets no default handlers), so a
+        ``stop()`` would just block the full 5s timeout before the daemon
+        SIGKILLs anyway.  Killing keeps the per-turn teardown off that 5s
+        path (and the same applies to thread-delete and shutdown).
+        """
         container = cls._containers.pop(work_dir, None)
         if container:
             try:
-                container.stop(timeout=5)
+                container.kill()
                 logger.info("Cleaned up container for %s", work_dir)
             except Exception as e:
                 logger.warning("Container cleanup failed: %s", e)
 
     @classmethod
     def cleanup_all(cls) -> None:
-        """Stop all tracked sandbox containers. Removal is automatic (--rm)."""
+        """Kill all tracked sandbox containers. Removal is automatic (--rm).
+
+        SIGKILL for the same reason as ``cleanup`` (nothing to flush; PID 1
+        ignores SIGTERM) — and at lifespan shutdown a fast teardown is
+        strictly better than burning 5s per container on the event loop.
+        """
         for path, container in list(cls._containers.items()):
             try:
-                container.stop(timeout=5)
+                container.kill()
                 logger.info("Cleaned up container for %s", path)
             except Exception as e:
                 logger.warning("Container cleanup failed for %s: %s", path, e)

--- a/dockerfiles/Dockerfile.sandbox
+++ b/dockerfiles/Dockerfile.sandbox
@@ -67,5 +67,18 @@ WORKDIR /workspace
 # when the host bind-mount uid differs.
 USER sandbox
 
-# Container self-destructs after 1 hour; --rm in containers.run() handles removal
-CMD ["sleep", "3600"]
+# Backstop TTL only.  Each container lives for exactly one turn — the web
+# layer (manage/web/threads.py:_process_message) kills it when the turn's
+# response is produced.  This 3h sleep is just a safety net for the rare case
+# where that teardown never runs (the web worker died mid-turn): the orphan
+# self-destructs and --rm removes it.  3h sits ABOVE the 2h LLM-queue hold cap
+# (ASSIST_THREAD_HOLD_TIMEOUT_S=7200); because a container now lives only as
+# long as its single turn, this backstop can never fire during a legitimate
+# in-progress turn — closing the mid-flight-reap caveat the old 1h TTL caused
+# (a >60min research turn reaped at sandbox-start+1h, 2026-05-16).
+#
+# INVARIANT: this sleep must stay ABOVE the queue hold cap.  If you raise
+# ASSIST_THREAD_HOLD_TIMEOUT_S past 10800s (3h), raise this value to match —
+# otherwise a turn could outlive the backstop and be reaped mid-flight again.
+# tests/test_sandbox_per_turn.py::TestBackstopExceedsHoldCap pins the coupling.
+CMD ["sleep", "10800"]

--- a/docs/2026-06-16-per-turn-sandbox-container.org
+++ b/docs/2026-06-16-per-turn-sandbox-container.org
@@ -1,0 +1,114 @@
+#+title: One sandbox container per turn (created on request, killed on response)
+#+date: <2026-06-16>
+
+* Problem
+
+The Docker sandbox container's PID 1 was =sleep 3600=
+(=dockerfiles/Dockerfile.sandbox=).  A container is *reused across a thread's
+turns*, so its wall-clock age is decoupled from any single turn: a long
+research turn legitimately needing >60 min was reaped mid-flight at
+sandbox-start + 1h (=SandboxContainerLostError=; observed 2026-05-16,
+winged-horse-flag thread).
+
+The earlier fix attempt (LRU cap + a longer 4h backstop) only made the
+mid-flight kill *rarer* — any wall-clock-from-birth TTL on a *reused* container
+can eventually fire mid-turn (a container warm for ~4h that then starts a long
+turn).  That caveat is the bug, so "rarer" is not "fixed".
+
+* Decision
+
+*One container per turn.*  Each request/response gets a *fresh* container,
+created when the turn starts and killed when the turn's response is produced.
+
+The key property: because a container is never reused, *its age equals its
+turn's age*, and a turn is hard-capped at the LLM-queue hold timeout
+(=ASSIST_THREAD_HOLD_TIMEOUT_S= = 2h).  So a wall-clock backstop set *above* 2h
+can *never* fire during a legitimate in-progress turn.  The mid-flight-reap
+caveat is closed *by construction*, not by tuning a probability.
+
+- PID 1 stays =sleep= but the value goes =3600= → =10800= (3h).  It is now
+  purely a *backstop* for the rare case where per-turn teardown never runs (the
+  web worker died mid-turn): the orphan self-destructs, =--rm= removes it.
+- =get_sandbox_backend= no longer reuses: it reaps any container still
+  registered for the work_dir (a prior turn's teardown didn't run) and creates
+  a fresh one.
+- =_process_message= (the turn worker for both =/message= and =/review=) kills
+  the container in a =finally=, while still holding the LLM queue, so it runs on
+  success, error, and the early-return path — and the next turn always starts
+  fresh.
+
+* Why this is simpler, not just different
+
+It *deletes* machinery rather than adding it: no LRU cap, no =_last_seen=, no
+activity-refresh heartbeat, no background reaper thread.  It also strips the
+reuse branch from =get_sandbox_backend=.  "A container is a turn" is the whole
+model.
+
+* Cost (measured, this box, docker SDK — the app's real path)
+
+| phase                         | time      |
+|-------------------------------+-----------|
+| create + start               | ~0.10s    |
+| first exec (first tool call) | ~0.02s    |
+| kill teardown                | ~0.10s    |
+
+Per-turn added latency ≈ *0.1–0.4s* (with the surrounding stat/egress-check/
+references-mkdir), negligible against multi-second-to-minute local-model turns.
+
+Teardown uses =container.kill()= (SIGKILL), not =stop(timeout=5)=: PID 1 is a
+bare =sleep= with no SIGTERM handler (PID 1 gets no default handlers), so
+=stop()= always blocks the full 5s before the daemon SIGKILLs anyway.  SIGKILL
+is safe: the container is =--rm= and all durable work is already flushed to the
+host =/workspace= bind mount.  (=--rm= removal is *async* — =kill()= returns
+before the container disappears; the registry is popped synchronously so this
+doesn't matter.)
+
+=SandboxManager.cleanup= / =cleanup_all= now *always* SIGKILL (the =kill= was
+made unconditional rather than an opt-in flag): a sandbox never needs a graceful
+stop, so the per-turn teardown, thread-delete (=hard_delete=), and lifespan
+shutdown share one behavior.  This also removes a pre-existing 5s on-event-loop
+block: =delete_thread= is =async def= and calls =hard_delete= →
+=SandboxManager.cleanup= inline, which used to =stop(timeout=5)= on the loop.
+
+* Event-loop safety
+
+=_process_message= runs as a sync FastAPI =BackgroundTask= (threadpool), never
+on the asyncio loop, so the teardown's =kill()= docker call is off-loop.  It
+runs *inside* the =THREAD_QUEUE.acquire= block (before releasing the queue), and
+only one thread holds the queue at a time, so teardown can never race the next
+turn's creation.  No lock is added.
+
+* Trade-off (named, accepted)
+
+Cross-turn *ephemeral container state* is lost: =pip install --user= from a
+prior turn, =/tmp= scratch, background processes.  Durable work in =/workspace=
+(the host bind mount) persists untouched.  For this agent — where the durable
+artifact is always in =/workspace= and =MANAGER.get= already builds a fresh
+=Thread= per turn with no cross-turn caching — that's acceptable.
+
+* Files
+
+- =dockerfiles/Dockerfile.sandbox= — =sleep 3600= → =sleep 10800= (+ comment).
+  *Requires rebuilding the =assist-sandbox= image on deploy.*
+- =assist/sandbox_manager.py= — =cleanup= / =cleanup_all= now SIGKILL
+  unconditionally; =get_sandbox_backend= drops reuse, reaps any stale container
+  first.
+- =manage/web/threads.py= — =_process_message= kills the turn's container in a
+  =finally=; the =SandboxContainerLostError= branch's now-redundant =cleanup=
+  removed; stale =sleep 3600= comment updated.
+- =assist/sandbox.py= — =SandboxContainerLostError= docstring: 1h→3h backstop.
+- =tests/test_sandbox_per_turn.py= — kill-vs-stop, no-reuse, the backstop>hold-cap
+  invariant, and a real-Docker test that a killed container is actually gone.
+- =tests/test_web_process_message_e2e.py= — teardown wiring on success + error.
+- =tests/test_sandbox.py= — the old "reuses container" test rewritten to pin the
+  new no-reuse contract.
+
+* Verification
+
+- Full =tests/= suite green (612); the touched suites + the real-Docker teardown
+  test green.
+- =TestBackstopExceedsHoldCap= pins =sleep= > =DEFAULT_HOLD_TIMEOUT_S=, so a
+  careless lowering back toward 1h fails CI.
+- Deploy smoke (post image rebuild): send a couple of turns, confirm each
+  thread's =assist.sandbox= container appears during the turn and is gone within
+  ~1s of the response; confirm =docker ps= doesn't accumulate sandboxes.

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -535,15 +535,14 @@ def _process_message(tid: str, text: str) -> None:
             _set_status(tid, "queued", **pending_kwargs)
 
     try:
-        # Acquire the queue BEFORE starting the sandbox.  The sandbox
-        # container has a 1h TTL (sleep 3600 in Dockerfile.sandbox); if
-        # we created it at message-receipt time but then waited hours
-        # for the queue (a holder past its hold_timeout_s, or many
-        # backlogged threads), the container would age out before the
-        # agent ever used it — `SandboxContainerLostError` on first
-        # exec.  Observed on 2026-05-30 thread 20260530160651-fee1ddc5
-        # whose sandbox started at 16:06:52, sat queued behind a
-        # 2-hour-wedged thread, then 404'd at 17:52:15 (1h 45m later).
+        # Acquire the queue BEFORE starting the sandbox.  We create a fresh
+        # container per turn and tear it down when the turn ends; creating it
+        # only after acquiring the queue means it never ages against the 3h
+        # backstop TTL (sleep 10800 in Dockerfile.sandbox) while waiting in
+        # line (behind a holder past its hold_timeout_s, or many backlogged
+        # threads).  Observed pre-defer on 2026-05-30 thread
+        # 20260530160651-fee1ddc5: sandbox started at 16:06:52, sat queued
+        # behind a 2-hour-wedged thread, then 404'd 1h45m later.
         #
         # `chat.message()` below tries to acquire the queue again
         # internally; the reentrant fast path (same thread_id + same
@@ -553,15 +552,26 @@ def _process_message(tid: str, text: str) -> None:
             _set_status(tid, "starting_sandbox", **pending_kwargs)
             sandbox = _get_sandbox_backend(tid)
             try:
-                # on_queue_state=None: the outer acquire above already
-                # owns the callback; the inner acquire is the reentrant
-                # no-op fast path (no state callback fires from it).
-                chat = MANAGER.get(tid, sandbox_backend=sandbox,
-                                   on_queue_state=None)
-            except FileNotFoundError:
-                return
-            _set_status(tid, "processing", **pending_kwargs)
-            resp = chat.message(text)
+                try:
+                    # on_queue_state=None: the outer acquire above already
+                    # owns the callback; the inner acquire is the reentrant
+                    # no-op fast path (no state callback fires from it).
+                    chat = MANAGER.get(tid, sandbox_backend=sandbox,
+                                       on_queue_state=None)
+                except FileNotFoundError:
+                    return
+                _set_status(tid, "processing", **pending_kwargs)
+                resp = chat.message(text)
+            finally:
+                # One container per turn: kill it as soon as this turn's agent
+                # run finishes — success, error, or the early return above —
+                # while we still hold the queue, so the next turn always starts
+                # in a fresh sandbox and no container outlives its turn.  This,
+                # plus the >2h backstop TTL, is what makes the mid-flight reap
+                # impossible: container age == turn age, capped by the queue.
+                # cleanup() SIGKILLs (the response is already committed to the
+                # checkpoint here, and the sandbox has nothing to flush).
+                SandboxManager.cleanup(MANAGER.thread_default_working_dir(tid))
         MANAGER.touch(tid)
 
         # Generate description if there is none
@@ -583,10 +593,10 @@ def _process_message(tid: str, text: str) -> None:
         # previous turn's work didn't land.  Without this branch the
         # generic except below shows a raw exception repr to the user.
         logging.error("Sandbox lost for thread %s: %s", tid, e)
-        # Drop the cached backend so the next message spins up a new
-        # container instead of poking at the corpse of the old one.
+        # The per-turn teardown (the `finally` above) already reaped this
+        # turn's container; just drop the cached domain manager so a retry
+        # re-checks cleanly instead of poking at the corpse of the old one.
         DOMAIN_MANAGERS.pop(tid, None)
-        SandboxManager.cleanup(MANAGER.thread_default_working_dir(tid))
         _set_status(
             tid, "error",
             error=("The sandbox container for this thread was lost mid-run. "

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -550,8 +550,11 @@ def _process_message(tid: str, text: str) -> None:
         # double-callback.
         with THREAD_QUEUE.acquire(tid, on_state_change=on_queue_wait):
             _set_status(tid, "starting_sandbox", **pending_kwargs)
-            sandbox = _get_sandbox_backend(tid)
             try:
+                # Inside the try so the `finally` reaps even if sandbox
+                # creation registers a container and then raises — cleanup
+                # keys on work_dir, not on the `sandbox` handle.
+                sandbox = _get_sandbox_backend(tid)
                 try:
                     # on_queue_state=None: the outer acquire above already
                     # owns the callback; the inner acquire is the reentrant

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -515,20 +515,36 @@ class TestSandboxManager(TestCase):
         self.assertIn("owned by root", msg)
         self.assertIn("chown", msg)
 
-    def test_get_sandbox_backend_reuses_container(self):
+    @patch('assist.sandbox.DockerSandboxBackend')
+    def test_get_sandbox_backend_does_not_reuse_reaps_stale(self, mock_backend_cls):
+        """Per-turn lifecycle: a container left registered from a prior turn is
+        NOT reused — it is killed (kill=True, fast path) and a fresh one is
+        created.  Reusing it would let a container outlive its turn, which is
+        the whole thing the per-turn design forbids."""
         test_path = os.path.join(self.temp_dir, "domain")
         os.makedirs(test_path)
 
-        mock_container = MagicMock()
-        mock_container.id = "test123456ab"
-        mock_container.status = "running"
-        SandboxManager._containers[test_path] = mock_container
+        stale = MagicMock()
+        stale.id = "stale1234567"
+        stale.status = "running"
+        SandboxManager._containers[test_path] = stale
 
-        sandbox = SandboxManager.get_sandbox_backend(test_path)
+        mock_client = MagicMock()
+        fresh = MagicMock()
+        fresh.id = "fresh1234567"
+        fresh.status = "running"
+        fresh.logs.return_value = b"egress-proxy: listening on 0.0.0.0:8888\n"
+        mock_client.containers.run.return_value = fresh
+
+        with patch.object(SandboxManager, '_get_docker_client', return_value=mock_client):
+            sandbox = SandboxManager.get_sandbox_backend(test_path)
 
         self.assertIsNotNone(sandbox)
-        # Container should have been reloaded to check status
-        mock_container.reload.assert_called_once()
+        # The stale container was SIGKILLed, not reused (never reload()'d).
+        stale.kill.assert_called_once()
+        stale.reload.assert_not_called()
+        # A fresh container replaced it in the registry.
+        self.assertIs(SandboxManager._containers[test_path], fresh)
 
     def test_get_sandbox_backend_returns_none_on_docker_error(self):
         """Docker daemon unavailable / transient API error should
@@ -551,7 +567,7 @@ class TestSandboxManager(TestCase):
 
         self.assertIsNone(sandbox)
 
-    def test_cleanup_stops_and_removes_container(self):
+    def test_cleanup_kills_and_removes_container(self):
         test_path = os.path.join(self.temp_dir, "domain")
         os.makedirs(test_path)
 
@@ -560,7 +576,10 @@ class TestSandboxManager(TestCase):
 
         SandboxManager.cleanup(test_path)
 
-        mock_container.stop.assert_called_once_with(timeout=5)
+        # SIGKILL, not a graceful stop: a sandbox has nothing to flush and its
+        # bare-`sleep` PID 1 ignores SIGTERM, so stop() only burns the timeout.
+        mock_container.kill.assert_called_once_with()
+        mock_container.stop.assert_not_called()
         self.assertNotIn(test_path, SandboxManager._containers)
 
     def test_cleanup_all(self):
@@ -570,8 +589,8 @@ class TestSandboxManager(TestCase):
 
         SandboxManager.cleanup_all()
 
-        mock_c1.stop.assert_called_once()
-        mock_c2.stop.assert_called_once()
+        mock_c1.kill.assert_called_once()
+        mock_c2.kill.assert_called_once()
         self.assertEqual(len(SandboxManager._containers), 0)
 
     def test_domain_manager_without_git(self):

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -518,7 +518,7 @@ class TestSandboxManager(TestCase):
     @patch('assist.sandbox.DockerSandboxBackend')
     def test_get_sandbox_backend_does_not_reuse_reaps_stale(self, mock_backend_cls):
         """Per-turn lifecycle: a container left registered from a prior turn is
-        NOT reused — it is killed (kill=True, fast path) and a fresh one is
+        NOT reused — it is killed (SIGKILL, via cleanup) and a fresh one is
         created.  Reusing it would let a container outlive its turn, which is
         the whole thing the per-turn design forbids."""
         test_path = os.path.join(self.temp_dir, "domain")

--- a/tests/test_sandbox_per_turn.py
+++ b/tests/test_sandbox_per_turn.py
@@ -117,7 +117,8 @@ class TestBackstopExceedsHoldCap(TestCase):
 
 class TestPerTurnTeardownRealDocker(unittest.TestCase):
     """Real Docker (no skip, mirroring test_sandbox_egress_integration.py): a
-    container reaped with kill=True is actually gone — the un-mocked symptom.
+    container reaped via cleanup() (SIGKILL) is actually gone — the un-mocked
+    symptom.
     """
 
     def test_kill_actually_destroys_the_container(self):

--- a/tests/test_sandbox_per_turn.py
+++ b/tests/test_sandbox_per_turn.py
@@ -1,0 +1,162 @@
+"""One container per turn: each request/response gets a fresh sandbox that is
+killed at turn end, so a container's age can never exceed its turn's age.
+
+This is what closes the mid-flight-reap caveat: because the container lives
+only for its single turn and a turn is hard-capped at the LLM-queue hold
+timeout, a wall-clock backstop set ABOVE that cap can never fire during a
+legitimate in-progress turn (TestBackstopExceedsHoldCap pins exactly that).
+
+Covered here:
+  - cleanup() SIGKILLs (a sandbox has nothing to flush; PID 1 ignores SIGTERM).
+  - get_sandbox_backend never reuses — a second call reaps the stale
+    container and creates a fresh one.
+  - the Dockerfile backstop TTL > the queue hold cap (the safety invariant).
+  - real-Docker: a killed container is actually gone (symptom, un-mocked).
+"""
+from __future__ import annotations
+
+import itertools
+import re
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from assist.sandbox_manager import SandboxManager
+
+
+def _fake_container(cid: str) -> MagicMock:
+    c = MagicMock()
+    c.id = cid
+    c.status = "running"
+    return c
+
+
+class _SandboxStateBase(TestCase):
+    def setUp(self) -> None:
+        self._saved = SandboxManager._containers
+        SandboxManager._containers = {}
+
+    def tearDown(self) -> None:
+        SandboxManager._containers = self._saved
+
+
+class TestCleanupKills(_SandboxStateBase):
+    def test_cleanup_uses_sigkill(self):
+        c = _fake_container("c0")
+        SandboxManager._containers["w"] = c
+        SandboxManager.cleanup("w")
+        c.kill.assert_called_once_with()
+        c.stop.assert_not_called()
+        self.assertNotIn("w", SandboxManager._containers)  # registry pruned
+
+    def test_cleanup_missing_workdir_is_noop(self):
+        SandboxManager.cleanup("absent")  # must not raise
+
+
+class TestNoReuse(_SandboxStateBase):
+    """get_sandbox_backend creates a fresh container every call and reaps any
+    stale one left in the registry (the "new container per request" guarantee).
+    """
+
+    def _patches(self):
+        ids = itertools.count()
+        client = MagicMock()
+        client.containers.run.side_effect = lambda *a, **k: _fake_container(
+            f"created-{next(ids)}")
+        st = MagicMock()
+        st.st_uid, st.st_gid = 1000, 1000
+        return [
+            patch.object(SandboxManager, "_get_docker_client", return_value=client),
+            patch.object(SandboxManager, "_ensure_egress_proxy_running"),
+            patch("assist.sandbox_manager.os.stat", return_value=st),
+            patch("assist.sandbox.DockerSandboxBackend", lambda *a, **k: MagicMock()),
+        ]
+
+    def test_second_call_reaps_stale_and_creates_fresh(self):
+        p = self._patches()
+        with p[0], p[1], p[2], p[3]:
+            SandboxManager.get_sandbox_backend("/ws/t")
+            first = SandboxManager._containers["/ws/t"]
+            # Second turn for the SAME thread: must NOT reuse `first`.
+            SandboxManager.get_sandbox_backend("/ws/t")
+            second = SandboxManager._containers["/ws/t"]
+
+        self.assertIsNot(second, first, "container was reused across turns")
+        first.kill.assert_called_once()  # stale one reaped (SIGKILL)
+        # never calls reload() — there is no reuse path that would inspect it
+        first.reload.assert_not_called()
+
+
+class TestBackstopExceedsHoldCap(TestCase):
+    """The load-bearing safety invariant: the container's wall-clock backstop
+    TTL must exceed the LLM-queue hold cap.  Since a per-turn container's age
+    equals its turn's age and a turn can't outlive the hold cap, a backstop
+    above the cap can never reap a legitimate in-progress turn.  Guards against
+    a careless lowering of the Dockerfile sleep back toward the old 1h value.
+    """
+
+    def test_dockerfile_sleep_exceeds_hold_timeout(self):
+        from assist.thread_queue import DEFAULT_HOLD_TIMEOUT_S
+
+        dockerfile = Path(__file__).resolve().parent.parent / "dockerfiles" / "Dockerfile.sandbox"
+        text = dockerfile.read_text()
+        m = re.search(r'CMD\s*\[\s*"sleep"\s*,\s*"(\d+)"\s*\]', text)
+        self.assertIsNotNone(m, "no `sleep` backstop CMD found in Dockerfile.sandbox")
+        backstop = int(m.group(1))
+        self.assertGreater(
+            backstop, DEFAULT_HOLD_TIMEOUT_S,
+            f"backstop sleep {backstop}s must exceed the queue hold cap "
+            f"{DEFAULT_HOLD_TIMEOUT_S}s — otherwise a legitimate long turn "
+            f"(bounded by the hold cap) could be reaped mid-flight, "
+            f"reintroducing the caveat this design removes",
+        )
+
+
+class TestPerTurnTeardownRealDocker(unittest.TestCase):
+    """Real Docker (no skip, mirroring test_sandbox_egress_integration.py): a
+    container reaped with kill=True is actually gone — the un-mocked symptom.
+    """
+
+    def test_kill_actually_destroys_the_container(self):
+        import docker
+        from docker.errors import NotFound
+
+        client = docker.from_env()
+        work_dir = tempfile.mkdtemp(prefix="per-turn-")
+        try:
+            # Start a bare sandbox container directly and register it, the
+            # same shape get_sandbox_backend leaves in the registry.
+            c = client.containers.run(
+                "assist-sandbox", "sleep 10800", detach=True, remove=True,
+                volumes={work_dir: {"bind": "/workspace", "mode": "rw"}},
+                working_dir="/workspace", labels={"assist.sandbox": "true"},
+            )
+            SandboxManager._containers[work_dir] = c
+            cid = c.id
+
+            SandboxManager.cleanup(work_dir)
+
+            self.assertNotIn(work_dir, SandboxManager._containers)
+            # kill() is synchronous for the SIGKILL but Docker's --rm removal
+            # is async, so poll: the container must actually disappear (proving
+            # it was killed, not just dropped from the registry).
+            import time
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                try:
+                    client.containers.get(cid)
+                    time.sleep(0.1)
+                except NotFound:
+                    break
+            else:
+                self.fail("container still present 10s after kill() — not reaped")
+        finally:
+            SandboxManager._containers.pop(work_dir, None)
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_process_message_e2e.py
+++ b/tests/test_web_process_message_e2e.py
@@ -220,27 +220,44 @@ def test_process_message_kills_container_even_when_turn_errors(client, monkeypat
     assert len(calls) == 1, f"erroring turn must still tear down its container, got {calls}"
 
 
-def test_process_message_kills_container_when_sandbox_creation_raises(client, monkeypatch):
-    """Sandbox creation is inside the try, so a failure AFTER a container is
-    registered (e.g. an error mid-creation) still hits the teardown `finally`
-    — otherwise that container would leak until the backstop TTL.  (Copilot
-    review, PR #139.)"""
-    def _boom(tid):
-        raise RuntimeError("sandbox creation blew up after registering a container")
-    monkeypatch.setattr("manage.web.state._get_sandbox_backend", _boom)
-    monkeypatch.setattr("manage.web.threads._get_sandbox_backend", _boom)
+def test_process_message_reaps_registered_container_when_creation_then_raises(
+        client, monkeypatch, tmp_path):
+    """The exact round-1 gap: sandbox creation registers a container and THEN
+    raises.  Because the creation is inside the try, the teardown `finally`
+    runs, and because cleanup keys on work_dir (not the `sandbox` handle that
+    was never returned), the registered container is reaped — no leak until the
+    backstop TTL.  (Copilot review, PR #139.)
+
+    Exercised un-mocked: cleanup is NOT stubbed.  A real container handle is put
+    in the registry to stand in for "creation registered it", then creation
+    raises; we assert the turn actually removed it (SIGKILL + dropped)."""
+    from unittest.mock import MagicMock
+    from assist.sandbox_manager import SandboxManager
+
+    work_dir = str(tmp_path / "thread-e2e")  # == MANAGER.thread_default_working_dir
+    registered = MagicMock()
+    SandboxManager._containers[work_dir] = registered
+
+    def _register_then_boom(tid):
+        # The container is already in the registry (as get_sandbox_backend
+        # leaves it); creation now fails before returning a usable backend.
+        raise RuntimeError("sandbox creation failed after registering a container")
+    monkeypatch.setattr("manage.web.state._get_sandbox_backend", _register_then_boom)
+    monkeypatch.setattr("manage.web.threads._get_sandbox_backend", _register_then_boom)
     monkeypatch.setattr(web.MANAGER, "touch", lambda tid: None)
     monkeypatch.setattr("manage.web.threads._get_domain_manager", lambda tid: None)
     monkeypatch.setattr("manage.web.threads.get_cached_description", lambda tid: "stub")
-    calls = _spy_cleanup(monkeypatch)
 
-    r = client.post("/thread/thread-e2e/message", data={"text": "hi"},
-                    follow_redirects=False)
-    assert r.status_code == 303, r.text
-    assert _wait_for_terminal_status("thread-e2e").get("stage") == "error"
+    try:
+        r = client.post("/thread/thread-e2e/message", data={"text": "hi"},
+                        follow_redirects=False)
+        assert r.status_code == 303, r.text
+        assert _wait_for_terminal_status("thread-e2e").get("stage") == "error"
 
-    assert len(calls) == 1, (
-        f"a sandbox-creation failure must still tear down (no leak), got {calls}")
+        registered.kill.assert_called_once()  # reaped (SIGKILL), not leaked
+        assert work_dir not in SandboxManager._containers
+    finally:
+        SandboxManager._containers.pop(work_dir, None)
 
 
 # --- _mark_pending: synchronous feedback so a queued message isn't lost -------

--- a/tests/test_web_process_message_e2e.py
+++ b/tests/test_web_process_message_e2e.py
@@ -220,6 +220,29 @@ def test_process_message_kills_container_even_when_turn_errors(client, monkeypat
     assert len(calls) == 1, f"erroring turn must still tear down its container, got {calls}"
 
 
+def test_process_message_kills_container_when_sandbox_creation_raises(client, monkeypatch):
+    """Sandbox creation is inside the try, so a failure AFTER a container is
+    registered (e.g. an error mid-creation) still hits the teardown `finally`
+    — otherwise that container would leak until the backstop TTL.  (Copilot
+    review, PR #139.)"""
+    def _boom(tid):
+        raise RuntimeError("sandbox creation blew up after registering a container")
+    monkeypatch.setattr("manage.web.state._get_sandbox_backend", _boom)
+    monkeypatch.setattr("manage.web.threads._get_sandbox_backend", _boom)
+    monkeypatch.setattr(web.MANAGER, "touch", lambda tid: None)
+    monkeypatch.setattr("manage.web.threads._get_domain_manager", lambda tid: None)
+    monkeypatch.setattr("manage.web.threads.get_cached_description", lambda tid: "stub")
+    calls = _spy_cleanup(monkeypatch)
+
+    r = client.post("/thread/thread-e2e/message", data={"text": "hi"},
+                    follow_redirects=False)
+    assert r.status_code == 303, r.text
+    assert _wait_for_terminal_status("thread-e2e").get("stage") == "error"
+
+    assert len(calls) == 1, (
+        f"a sandbox-creation failure must still tear down (no leak), got {calls}")
+
+
 # --- _mark_pending: synchronous feedback so a queued message isn't lost -------
 #
 # Regression: the thread page has no polling, so feedback is gated on the

--- a/tests/test_web_process_message_e2e.py
+++ b/tests/test_web_process_message_e2e.py
@@ -156,6 +156,70 @@ def test_post_message_runs_process_message_without_crashing(
     )
 
 
+# --- per-turn container teardown ------------------------------------------------
+#
+# One container per turn: _process_message must tear down the turn's sandbox in
+# a `finally`, so it runs on the success path AND every error path.  These pin
+# the wiring (the symptom — a real container being reaped — is covered un-mocked
+# by tests/test_sandbox_per_turn.py's real-Docker test).
+
+
+def _stub_happy_path(monkeypatch, chat):
+    """Stub the sandbox lookup, MANAGER.get, and the post-message hooks so
+    _process_message runs end-to-end against `chat`."""
+    monkeypatch.setattr("manage.web.state._get_sandbox_backend", lambda tid: None)
+    monkeypatch.setattr("manage.web.threads._get_sandbox_backend", lambda tid: None)
+    monkeypatch.setattr(
+        web.MANAGER, "get",
+        lambda tid, sandbox_backend=None, on_queue_state=None: chat,
+    )
+    monkeypatch.setattr(web.MANAGER, "touch", lambda tid: None)
+    monkeypatch.setattr("manage.web.threads._get_domain_manager", lambda tid: None)
+    monkeypatch.setattr("manage.web.threads.get_cached_description", lambda tid: "stub")
+
+
+def _spy_cleanup(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        threads.SandboxManager, "cleanup",
+        classmethod(lambda cls, work_dir: calls.append(work_dir)),
+    )
+    return calls
+
+
+def test_process_message_kills_container_at_turn_end_on_success(client, monkeypatch):
+    class _Chat:
+        def message(self, text):
+            return "ok"
+    _stub_happy_path(monkeypatch, _Chat())
+    calls = _spy_cleanup(monkeypatch)
+
+    r = client.post("/thread/thread-e2e/message", data={"text": "hi"},
+                    follow_redirects=False)
+    assert r.status_code == 303, r.text
+    assert _wait_for_terminal_status("thread-e2e").get("stage") == "ready"
+
+    assert len(calls) == 1, f"expected exactly one per-turn teardown, got {calls}"
+    assert calls[0].endswith("thread-e2e"), f"teardown targeted the wrong work_dir: {calls}"
+
+
+def test_process_message_kills_container_even_when_turn_errors(client, monkeypatch):
+    """The teardown is in a `finally`, so a crash mid-turn still reaps the
+    container — otherwise an erroring turn would leak its sandbox."""
+    class _BoomChat:
+        def message(self, text):
+            raise RuntimeError("boom mid-turn")
+    _stub_happy_path(monkeypatch, _BoomChat())
+    calls = _spy_cleanup(monkeypatch)
+
+    r = client.post("/thread/thread-e2e/message", data={"text": "hi"},
+                    follow_redirects=False)
+    assert r.status_code == 303, r.text
+    assert _wait_for_terminal_status("thread-e2e").get("stage") == "error"
+
+    assert len(calls) == 1, f"erroring turn must still tear down its container, got {calls}"
+
+
 # --- _mark_pending: synchronous feedback so a queued message isn't lost -------
 #
 # Regression: the thread page has no polling, so feedback is gated on the


### PR DESCRIPTION
## Problem

The Docker sandbox container's PID 1 was `sleep 3600`, and a container is **reused across a thread's turns**. That decouples its wall-clock age from any single turn: a long research turn legitimately needing >60 min got reaped mid-flight at sandbox-start + 1h (`SandboxContainerLostError`; observed 2026-05-16, winged-horse-flag thread).

A longer wall-clock TTL on a *reused* container only makes the mid-flight kill **rarer**, never gone — a container warm for ~Nh can always start a fresh turn near the boundary. That caveat is the bug.

## Fix: one container per turn

Each request/response gets a **fresh** container, created when the turn starts and killed in a `finally` when the turn's response is produced (in `_process_message`, while still holding the LLM queue).

The key property: because a container is never reused, **its age equals its turn's age**, and a turn is hard-capped at the LLM-queue hold timeout (`ASSIST_THREAD_HOLD_TIMEOUT_S` = 2h). So a wall-clock backstop set **above** 2h (`sleep 10800` / 3h) can **never** fire during a legitimate in-progress turn. The caveat is closed *by construction*, not by tuning a probability.

It also *deletes* machinery rather than adding it — no reuse branch, no LRU cap, no heartbeat, no reaper thread. "A container is a turn."

## Changes

- **`dockerfiles/Dockerfile.sandbox`** — `sleep 3600` → `sleep 10800` (backstop only; documents the `ASSIST_THREAD_HOLD_TIMEOUT_S` > backstop coupling). **Requires rebuilding the `assist-sandbox` image on deploy.**
- **`assist/sandbox_manager.py`** — `get_sandbox_backend` drops the reuse branch and reaps any stale container first; `cleanup`/`cleanup_all` now **SIGKILL unconditionally** (a sandbox has nothing to flush and its bare-`sleep` PID 1 ignores SIGTERM, so `stop()` only burns the 5s timeout). This also removes a pre-existing 5s on-event-loop block in `delete_thread` → `hard_delete` → `cleanup`.
- **`manage/web/threads.py`** — `_process_message` kills the turn's container in a `finally` on every exit path (success, error, early return); the now-redundant `cleanup` in the `SandboxContainerLostError` branch is removed.
- **`assist/sandbox.py`** — `SandboxContainerLostError` docstring: 1h → 3h backstop.

## Cost (measured, docker SDK — the app's real path)

| phase | time |
|---|---|
| create + start | ~0.10s |
| first exec | ~0.02s |
| kill teardown | ~0.10s |

Per-turn added latency ≈ 0.1–0.4s, negligible against multi-second-to-minute local-model turns.

## Event-loop safety

`_process_message` runs as a sync FastAPI `BackgroundTask` (threadpool), never on the asyncio loop, so the teardown `kill()` is off-loop. It runs inside the `THREAD_QUEUE.acquire` block (before releasing the queue), and only one thread holds the queue at a time, so teardown can never race the next turn's creation. No lock added. Web suites clean under `PYTHONASYNCIODEBUG=1`.

## Known limitation / trade-off

Cross-turn **ephemeral container state** is lost: `pip install --user` from a prior turn, `/tmp` scratch, background processes. Durable work in `/workspace` (the host bind mount) persists untouched, and `MANAGER.get` already builds a fresh `Thread` per turn with no cross-turn caching, so nothing in the codebase relied on the old persistence.

## Verification

- Full `tests/` suite green (611). New `tests/test_sandbox_per_turn.py`: no-reuse contract, SIGKILL teardown, the `backstop > hold-cap` invariant (`TestBackstopExceedsHoldCap`), and a **real-Docker** test proving a killed container is actually gone. New e2e tests assert teardown on success **and** error paths.
- Design + design-review + code-review per the three-phase workflow; see `docs/2026-06-16-per-turn-sandbox-container.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Design notes from review (Copilot)

- **Failed-`kill()` orphan is bounded by the backstop, deliberately not retried.** `cleanup()` pops the registry entry before `kill()`, so a (rare) transient `kill()` failure leaves a running-but-untracked container. This is intentional: it self-destructs within the 3h `sleep 10800` backstop (same class as a crash-before-teardown leak), the orphan is an inert `sleep` container (reads/writes nothing), and "keep-the-entry-for-retry" wouldn't reliably help (the only retry path fires only if the same thread sends another message). Popping first keeps `cleanup` idempotent/race-free across its threadpool and event-loop callers.
