### PR TITLE
Drop the dead vgrep→torch CUDA chain (6.7G venv reclaim) + unused loguru

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     # langgraph.types.Overwrite chunk shape (assist.stream_chunks) require it.
     "langgraph>=1.2",
     "langgraph-checkpoint-sqlite",
-    "loguru",
     "Markdown",
     "openai",
     "pydantic",

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ brotli==1.2.0
 certifi==2026.1.4
 cffi==2.0.0
 charset-normalizer==3.4.4
-chromadb==0.3.23
 click==8.3.1
 clickhouse-connect==0.10.0
 cryptography==48.0.0
@@ -86,21 +85,6 @@ mpmath==1.3.0
 multidict==6.7.0
 networkx==3.6.1
 numpy==2.4.1
-nvidia-cublas-cu12==12.8.4.1
-nvidia-cuda-cupti-cu12==12.8.90
-nvidia-cuda-nvrtc-cu12==12.8.93
-nvidia-cuda-runtime-cu12==12.8.90
-nvidia-cudnn-cu12==9.10.2.21
-nvidia-cufft-cu12==11.3.3.83
-nvidia-cufile-cu12==1.13.1.3
-nvidia-curand-cu12==10.3.9.90
-nvidia-cusolver-cu12==11.7.3.90
-nvidia-cusparse-cu12==12.5.8.93
-nvidia-cusparselt-cu12==0.7.1
-nvidia-nccl-cu12==2.27.5
-nvidia-nvjitlink-cu12==12.8.93
-nvidia-nvshmem-cu12==3.3.20
-nvidia-nvtx-cu12==12.8.90
 openai==2.15.0
 orjson==3.11.5
 ormsgpack==1.12.1
@@ -146,7 +130,6 @@ rsa==4.9.1
 safetensors==0.7.0
 scikit-learn==1.8.0
 scipy==1.17.0
-sentence-transformers==5.2.0
 setuptools==80.9.0
 shellingham==1.5.4
 six==1.17.0
@@ -155,7 +138,6 @@ socksio==1.0.0
 sqlite-vec==0.1.6
 stack-data==0.6.3
 starlette==0.50.0
-sympy==1.14.0
 tavily==1.1.0
 tenacity==9.1.2
 text-unidecode==1.3
@@ -163,11 +145,8 @@ threadpoolctl==3.6.0
 tiktoken==0.12.0
 tokenizers==0.22.2
 tomlkit==0.14.0
-torch==2.9.1
 tqdm==4.67.1
 traitlets==5.14.3
-transformers==4.57.5
-triton==3.5.1
 typer==0.21.1
 typing-inspection==0.4.2
 typing_extensions==4.15.0
@@ -177,7 +156,6 @@ urllib3==2.6.3
 uuid_utils==0.13.0
 uvicorn==0.40.0
 uvloop==0.22.1
-vgrep==0.1.4
 watchfiles==1.1.1
 wcmatch==10.1
 wcwidth==0.2.14


### PR DESCRIPTION
## What

The assist venv was **7.8G**; ~6.6G of that is the CUDA PyTorch stack
(`nvidia-*` 4.3G + `torch` 1.7G + `triton` 0.6G). **None of it is used.**

It hangs entirely off a single dead dependency:
```
vgrep → chromadb → sentence-transformers → torch → nvidia-* (CUDA)
```
`vgrep` ("vector-based grep") is **never imported anywhere** in the repo — it
only appeared in the requirements freeze (and as a stale `Requires-Dist` in the
editable install's metadata, from an older pyproject). assist talks to the model
over HTTP (llama.cpp serving the Qwen GGUF), so it needs neither in-process
PyTorch nor a vector store.

## Changes

- **requirements.txt**: remove the 22 dead-chain lines — `vgrep`, `chromadb`,
  `sentence-transformers`, `transformers`, `torch`, `triton`, `sympy`, and 15×
  `nvidia-*`.
- **pyproject.toml**: drop `loguru` — declared but **never imported anywhere**
  (surfaced when refreshing the editable-install metadata made `pip check`
  honest). Trivially re-added if it's wanted for future use.

## Verification

- `pip check` → **No broken requirements found.**
- Import smoke: `import manage.web; import assist.agent` OK.
- Full unit suite: **612 passed**.
- Venv: **7.8G → 1.1G** (−6.7G).

## Deploy note

Reclaiming the existing 6.7G **on prod** needs a venv **rebuild** —
`pip install -r requirements.txt` (what `deploy-install` runs) does *not* prune
already-installed packages. This PR prevents future bloat and slims any fresh
venv; reclaiming prod's existing venv is a separate, deliberate rebuild step.

(emacsos's `server/.venv` is 7.7G with almost certainly the same root cause — a
follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)