### PR TITLE
read_url: main-content extraction via stdlib html.parser

### DIFF
--- a/assist/tools.py
+++ b/assist/tools.py
@@ -23,6 +23,7 @@ import os
 import re
 import time
 import threading
+from html.parser import HTMLParser
 from urllib.parse import urlparse
 
 import requests
@@ -91,8 +92,76 @@ def _host_throttle(host: str) -> None:
                     del _host_last_call[h]
 
 
+# Tags whose TEXT is never readable content. Kept minimal and matched to the
+# prior whole-page strip (script/style only) so the no-article path cannot
+# regress. We deliberately KEEP <noscript>: read_url runs no JS, so a page's
+# no-JS fallback content is exactly what we want (a real fetch of a JS-gated
+# forum returned only its <noscript> text — dropping it returned nothing).
+_NOISE_TAGS = {"script", "style"}
+# Page regions that mark the main article body when present.
+_MAIN_TAGS = {"article", "main"}
+
+
+class _MainContentExtractor(HTMLParser):
+    """One-pass HTML → text that prefers the marked main article.
+
+    Collects two text streams while parsing: ``main`` (text inside
+    ``<article>``/``<main>``, kept WITH that region's own heading/byline/footer)
+    and ``body`` (all page text minus ``_NOISE_TAGS``). ``text()`` returns the
+    main stream when the page marked one, else the body stream — so a page with
+    no ``<article>`` degrades to the same whole-page strip as before, never less.
+
+    Using the stdlib parser (not regex) handles nesting, quoted attributes
+    containing ``>``, comments, and entities by construction — the failure
+    classes a regex tag-stripper gets wrong."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._noise = 0
+        self._main = 0
+        self._main_text: list[str] = []
+        self._body_text: list[str] = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag in _NOISE_TAGS:
+            self._noise += 1
+        elif tag in _MAIN_TAGS:
+            self._main += 1
+
+    def handle_endtag(self, tag):
+        if tag in _NOISE_TAGS and self._noise:
+            self._noise -= 1
+        elif tag in _MAIN_TAGS and self._main:
+            self._main -= 1
+
+    def handle_data(self, data):
+        if self._noise:
+            return
+        self._body_text.append(data)
+        if self._main:
+            self._main_text.append(data)
+
+    def text(self) -> str:
+        chosen = (self._main_text if any(s.strip() for s in self._main_text)
+                  else self._body_text)
+        return re.sub(r"\s+", " ", "".join(chosen)).strip()
+
+
+def _extract_main_content(html: str) -> str:
+    """Article text where the page marks one (``<article>``/``<main>``), else the
+    whole-page text with scripts/styles removed. See ``_MainContentExtractor``."""
+    parser = _MainContentExtractor()
+    parser.feed(html)
+    return parser.text()
+
+
 def read_url(url: str) -> str:
-    """Extract the content from the given url.
+    """Extract the readable content from the given url.
+
+    Returns the page's main article text where the page marks one
+    (``<article>``/``<main>``) so the char budget holds signal, not nav/footer
+    chrome; degrades to a whole-page text strip (scripts/styles removed) when
+    the page marks no article. Capped at 4000 chars.
 
     Per-host throttled (~1s between calls to the same host) so a burst of
     fetches to different sites isn't artificially serialised, but a tight
@@ -108,11 +177,7 @@ def read_url(url: str) -> str:
             timeout=15,
         )
         resp.raise_for_status()
-        text = resp.text
-        text = re.sub(r"<script[\s\S]*?</script>|<style[\s\S]*?</style>", " ", text, flags=re.IGNORECASE)
-        text = re.sub(r"<[^>]+>", " ", text)
-        text = re.sub(r"\s+", " ", text).strip()
-        return text[:4000]
+        return _extract_main_content(resp.text)[:4000]
     except Exception as e:
         return f"Error fetching URL: {e}"
 

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -127,12 +127,25 @@ class _MainContentExtractor(HTMLParser):
             self._noise += 1
         elif tag in _MAIN_TAGS:
             self._main += 1
+        self._boundary()
 
     def handle_endtag(self, tag):
         if tag in _NOISE_TAGS and self._noise:
             self._noise -= 1
         elif tag in _MAIN_TAGS and self._main:
             self._main -= 1
+        self._boundary()
+
+    def _boundary(self):
+        # A tag transition is a word boundary: adjacent elements' text must not
+        # fuse ("<p>one</p><p>two</p>" -> "one two", not "onetwo"). Mirrors the
+        # old strip's "every tag -> space"; the final whitespace-collapse in
+        # text() absorbs the extra spaces.
+        if self._noise:
+            return
+        self._body_text.append(" ")
+        if self._main:
+            self._main_text.append(" ")
 
     def handle_data(self, data):
         if self._noise:
@@ -152,6 +165,7 @@ def _extract_main_content(html: str) -> str:
     whole-page text with scripts/styles removed. See ``_MainContentExtractor``."""
     parser = _MainContentExtractor()
     parser.feed(html)
+    parser.close()  # flush any token left dangling at end-of-document
     return parser.text()
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -36,6 +36,14 @@ def _resp(json_payload):
     return r
 
 
+def _html_resp(html):
+    """A fake requests.Response carrying HTML in ``.text`` (for read_url)."""
+    r = MagicMock()
+    r.text = html
+    r.raise_for_status.return_value = None
+    return r
+
+
 # -------------------- _host_throttle (read_url) -------------------------
 
 class TestHostThrottle:
@@ -213,3 +221,110 @@ class TestSearchInternet:
         with patch.object(tools, "requests") as req:
             req.get.return_value = bad
             assert tools.search_internet("q") == tools._SEARCH_UNAVAILABLE_MESSAGE
+
+
+
+# -------------------- read_url main-content extraction -------------------
+
+class TestReadUrlExtraction:
+    """read_url returns the marked <article>/<main> body (WITH its own
+    heading/byline/footer) and drops outside chrome; a page with no article
+    degrades to whole-page text minus scripts (no regression). Parser-based, so
+    nested tags / attributes-containing-'>' / comments / entities are handled."""
+
+    ARTICLE_PAGE = (
+        "<html><head><title>T</title>"
+        "<style>.x{color:red}</style><script>track('noise')</script></head>"
+        "<body>"
+        "<nav>Home About Contact</nav>"
+        "<article><header><h1>Real Title</h1><span>By Sam</span></header>"
+        "<p>The actual article body has the facts.</p>"
+        "<ul><li>point one</li><li>point two</li></ul>"
+        "<footer>Citations example.org</footer></article>"
+        "<aside>Related links ad slot</aside>"
+        "<footer>Site copyright</footer></body></html>"
+    )
+
+    def _read(self, html):
+        with patch.object(tools, "requests") as rq, \
+                patch.object(tools, "_host_throttle"):
+            rq.get.return_value = _html_resp(html)
+            return tools.read_url("https://example.com/x")
+
+    def test_returns_article_body(self):
+        out = self._read(self.ARTICLE_PAGE)
+        assert "The actual article body has the facts." in out
+        assert "point one" in out and "point two" in out
+
+    def test_keeps_article_own_header_and_footer(self):
+        # The BLOCKER the review caught: title/byline/citations live in the
+        # article's OWN <header>/<footer> and must survive extraction.
+        out = self._read(self.ARTICLE_PAGE)
+        assert "Real Title" in out and "By Sam" in out
+        assert "Citations example.org" in out
+
+    def test_drops_outside_chrome(self):
+        out = self._read(self.ARTICLE_PAGE)
+        for chrome in ("Home About Contact", "Related links", "Site copyright",
+                       "track(", "color:red"):
+            assert chrome not in out
+
+    def test_concatenates_multiple_articles(self):
+        # Multi-article pages: keep all regions, not just the largest.
+        html = ("<body><article>" + ("filler " * 50) + "</article>"
+                "<article>the real answer is 42</article></body>")
+        assert "the real answer is 42" in self._read(html)
+
+    def test_no_article_degrades_to_whole_page_minus_scripts(self):
+        # No <article>: same as the old whole-page strip (no regression),
+        # chrome text included — but scripts/styles still removed.
+        html = ("<body><nav>menu items</nav>"
+                "<script>var leak='secret'</script>"
+                "<div><p>Body paragraph content.</p></div></body>")
+        out = self._read(html)
+        assert "Body paragraph content." in out
+        assert "menu items" in out                 # no article -> nothing dropped
+        assert "leak" not in out and "var leak" not in out  # script gone
+
+    def test_attribute_with_gt_does_not_corrupt(self):
+        # The regex tag-stripper leaked `b">` here; the parser handles it.
+        html = '<article><p data-x="a>b">hello world facts</p></article>'
+        out = self._read(html)
+        assert "hello world facts" in out
+        assert 'b">' not in out and "a>b" not in out
+
+    def test_html_comment_dropped(self):
+        html = "<article><!-- tracker > pixel --><p>visible text</p></article>"
+        out = self._read(html)
+        assert "visible text" in out
+        assert "tracker" not in out and "pixel" not in out
+
+    def test_entities_decoded(self):
+        assert self._read("<article><p>a &amp; b &lt; c</p></article>") == "a & b < c"
+
+    def test_noscript_fallback_kept(self):
+        # read_url runs no JS, so <noscript> is the page's no-JS fallback —
+        # the relevant content for us. A real fetch of a JS-gated forum showed
+        # dropping it returned empty; keep it.
+        out = self._read("<body><noscript>real fallback content</noscript></body>")
+        assert "real fallback content" in out
+
+    def test_script_inside_article_dropped(self):
+        html = "<article><script>var s='leak'</script><p>kept</p></article>"
+        out = self._read(html)
+        assert "kept" in out and "leak" not in out
+
+    def test_truncates_to_4000(self):
+        assert len(self._read("<article><p>" + ("x" * 9000) + "</p></article>")) == 4000
+
+    def test_error_path_unchanged(self):
+        with patch.object(tools, "requests") as rq, \
+                patch.object(tools, "_host_throttle"):
+            rq.get.side_effect = RuntimeError("boom")
+            out = tools.read_url("https://example.com/err")
+        assert out.startswith("Error fetching URL:")
+
+    def test_extract_main_content_helper(self):
+        assert tools._extract_main_content(
+            "<article><p>just this</p></article><footer>not this</footer>"
+        ) == "just this"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -314,6 +314,17 @@ class TestReadUrlExtraction:
         out = self._read(html)
         assert "kept" in out and "leak" not in out
 
+    def test_adjacent_tags_keep_word_boundary(self):
+        # Round-2 BLOCKER: text nodes must not fuse across tags. The old strip
+        # put a space at every tag; the parser must too.
+        assert "one two" in self._read("<p>one</p><p>two</p>")
+        assert "a b c" in self._read("<div>a<b>b</b>c</div>")
+
+    def test_flushes_dangling_trailing_token(self):
+        # feed() buffers an incomplete trailing token; close() must flush it,
+        # else a doc ending mid-token (here a bare entity) returns empty.
+        assert "tail text" in tools._extract_main_content("<article>tail text &amp")
+
     def test_truncates_to_4000(self):
         assert len(self._read("<article><p>" + ("x" * 9000) + "</p></article>")) == 4000
 


### PR DESCRIPTION
## What
`read_url` now returns the page's marked main article (`<article>`/`<main>`, keeping its own heading/byline/footer) and drops outside chrome (nav/footer), so the 4000-char budget holds signal not boilerplate (roadmap: *signal-per-token*). Pages with no article degrade to the old whole-page strip (script/style removed, word boundaries preserved) — **no regression on the non-article path by construction**.

Implemented with a one-pass `html.parser.HTMLParser` subclass (not regex), which handles nesting, quoted attributes containing `>`, comments, and entities by construction. Keeps `<noscript>` (read_url runs no JS, so it's the relevant fallback).

## Why parser, not regex
An initial regex version was caught in local review corrupting output on attributes-with-`>`, dropping article titles nested in `<header>`, leaking HTML comments, and mishandling nested boilerplate. The parser eliminates that whole class.

## Validation
- New unit tests cover: article body + own header/footer kept, outside chrome dropped, multi-article concatenation, attribute-`>`, comments, entities, noscript fallback, word boundaries, dangling-token flush, 4000 cap, no-article parity. Full unit suite green (627).
- Compared old vs new on a sample of real recently-fetched URLs: parity on non-article/plain pages, no content loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)