### PR TITLE
retention: purge orphaned checkpoints (threads.db growth fix)

### DIFF
--- a/assist/retention.py
+++ b/assist/retention.py
@@ -102,7 +102,10 @@ def prune_to_n_threads(
             continue
         candidates.append((name, mtime))
 
-    candidates.sort(key=lambda x: x[1], reverse=True)
+    # Tiebreak by name: candidates come from a set (unstable iteration order),
+    # so equal-mtime dirs must sort deterministically or the prune boundary
+    # could keep different threads across runs.
+    candidates.sort(key=lambda x: (x[1], x[0]), reverse=True)
 
     if len(candidates) <= min_threads:
         logger.info(
@@ -159,10 +162,12 @@ def purge_orphaned_checkpoints(
         rows = manager.conn.execute(
             "SELECT DISTINCT thread_id FROM checkpoints"
         ).fetchall()
-    except sqlite3.OperationalError:
-        # Fresh db whose checkpoints table doesn't exist yet (a deploy's first
-        # sweep before any thread) — nothing to purge.
-        return []
+    except sqlite3.OperationalError as e:
+        if "no such table" in str(e).lower():
+            # Fresh db whose checkpoints table doesn't exist yet (a deploy's
+            # first sweep before any thread) — nothing to purge.
+            return []
+        raise  # a real fault (locked/corrupt) must surface, not look like success
     orphans = sorted({row[0] for row in rows} - live)
     purged: list[str] = []
     for tid in orphans:

--- a/assist/retention.py
+++ b/assist/retention.py
@@ -172,17 +172,20 @@ def purge_orphaned_checkpoints(
     purged: list[str] = []
     for tid in orphans:
         try:
-            n, nbytes = manager.conn.execute(
-                "SELECT count(*), coalesce(sum(length(checkpoint)), 0) "
-                "FROM checkpoints WHERE thread_id = ?", (tid,)
-            ).fetchone()
-            if n > 1000 or nbytes > 1_000_000_000:
+            # count(*) is an index-range count (thread_id leads the PK) — the
+            # size signal without scanning the rows we're about to delete.
+            n = manager.conn.execute(
+                "SELECT count(*) FROM checkpoints WHERE thread_id = ?", (tid,)
+            ).fetchone()[0]
+            if n > 1000:
                 logger.warning(
-                    "Purging large orphan %s: %d checkpoints, %.1f GB "
-                    "(batched delete)", tid, n, nbytes / 1e9,
+                    "Purging large orphan %s: %d checkpoints (batched delete)",
+                    tid, n,
                 )
             _delete_thread_in_batches(manager.conn, tid)
             purged.append(tid)
+        except sqlite3.Error:
+            raise  # a DB fault (locked/corrupt) must surface, not be masked
         except Exception as e:
             logger.warning("purge failed for orphan %s: %s", tid, e)
     logger.info(

--- a/assist/retention.py
+++ b/assist/retention.py
@@ -103,7 +103,8 @@ def prune_to_n_threads(
         try:
             mtime = os.path.getmtime(os.path.join(threads_root, name))
         except OSError as e:
-            logger.warning("Skipping %s: stat failed: %s", name, e)
+            logger.warning("Skipping %s: stat failed: %s",
+                           os.path.join(threads_root, name), e)
             continue
         candidates.append((name, mtime))
 

--- a/assist/retention.py
+++ b/assist/retention.py
@@ -55,8 +55,13 @@ def _delete_thread_in_batches(conn, tid: str, batch: int = _DELETE_BATCH) -> Non
     """Delete a thread's ``checkpoints`` + ``writes`` rows in separately
     committed batches, so one giant orphan can't hold a single multi-GB
     transaction. ``thread_id`` leads both tables' primary key, so the LIMIT
-    subquery is an index range scan."""
-    for table in ("checkpoints", "writes"):
+    subquery is an index range scan.
+
+    Deletes ``writes`` before ``checkpoints``: if interrupted mid-thread, the
+    thread is still present in ``checkpoints`` (the orphan-enumeration key), so
+    the next sweep rediscovers and finishes it — never stranding a writes-only
+    orphan that enumeration could no longer see."""
+    for table in ("writes", "checkpoints"):
         while True:
             cur = conn.execute(
                 f"DELETE FROM {table} WHERE rowid IN "

--- a/assist/retention.py
+++ b/assist/retention.py
@@ -29,6 +29,44 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MIN_THREADS = 100
 
+# Deleting a thread's rows in one transaction is unbounded for a huge orphan
+# (2026-06-24: a 101GB / 24k-checkpoint thread thrashed a single delete for
+# 75 min / 488GB read). Bound each transaction to this many rows.
+_DELETE_BATCH = 2000
+
+
+def _thread_dirs(threads_root: str) -> set[str]:
+    """The on-disk thread directory names — the set of LIVE thread ids.
+
+    One definition shared by ``prune_to_n_threads`` (which ranks these by
+    mtime) and ``purge_orphaned_checkpoints`` (which treats any checkpoint
+    thread_id NOT in this set as deletable); they must agree on what 'live'
+    means."""
+    if not os.path.isdir(threads_root):
+        return set()
+    return {
+        name for name in os.listdir(threads_root)
+        if name != "__pycache__"
+        and os.path.isdir(os.path.join(threads_root, name))
+    }
+
+
+def _delete_thread_in_batches(conn, tid: str, batch: int = _DELETE_BATCH) -> None:
+    """Delete a thread's ``checkpoints`` + ``writes`` rows in separately
+    committed batches, so one giant orphan can't hold a single multi-GB
+    transaction. ``thread_id`` leads both tables' primary key, so the LIMIT
+    subquery is an index range scan."""
+    for table in ("checkpoints", "writes"):
+        while True:
+            cur = conn.execute(
+                f"DELETE FROM {table} WHERE rowid IN "
+                f"(SELECT rowid FROM {table} WHERE thread_id = ? LIMIT ?)",
+                (tid, batch),
+            )
+            conn.commit()
+            if cur.rowcount < batch:
+                break
+
 
 def prune_to_n_threads(
     threads_root: str,
@@ -56,14 +94,11 @@ def prune_to_n_threads(
         return []
 
     candidates: list[tuple[str, float]] = []
-    for name in os.listdir(threads_root):
-        dpath = os.path.join(threads_root, name)
-        if not os.path.isdir(dpath) or name == "__pycache__":
-            continue
+    for name in _thread_dirs(threads_root):
         try:
-            mtime = os.path.getmtime(dpath)
+            mtime = os.path.getmtime(os.path.join(threads_root, name))
         except OSError as e:
-            logger.warning("Skipping %s: stat failed: %s", dpath, e)
+            logger.warning("Skipping %s: stat failed: %s", name, e)
             continue
         candidates.append((name, mtime))
 
@@ -95,51 +130,56 @@ def purge_orphaned_checkpoints(
     threads_root: str,
     manager: ThreadManager,
 ) -> List[str]:
-    """Delete checkpoint rows whose ``thread_id`` has no live thread dir.
+    """Delete checkpoint+writes rows whose ``thread_id`` has no live thread dir.
 
-    The web app's thread_id IS its directory name, and ``hard_delete``
-    purges checkpoints by that id.  But sub-agent runs checkpoint under
-    their own (UUID) thread_ids in the SAME db — no directory tracks
-    them and ``hard_delete`` never deletes them, so they orphan and
-    accumulate.  This was the real threads.db growth driver (found
-    2026-06-24: one runaway sub-agent thread held 101 GB across 24k
-    checkpoints, ~60% of the DB; 166 of 262 checkpoint thread_ids had
-    no dir).  Thread-count retention can't see them.
+    The web app derives a thread's directory name AND its checkpoint
+    ``thread_id`` from one id (``ThreadManager.get`` / ``new``), so every LIVE
+    web thread has a matching dir and is never touched here. Orphans are
+    checkpoint thread_ids with no dir: leftovers from threads deleted before
+    checkpoint-purging existed, plus non-web invocations that share this db
+    under their own ids (e.g. an ``AgentHarness`` run that defaults
+    ``thread_id`` to a ``uuid``). These accumulate unseen by thread-count
+    retention — the 2026-06-24 incident found 166 of 262 checkpoint thread_ids
+    had no dir, one holding 101 GB across 24k checkpoints.
 
-    Sweeps every checkpoint thread_id with no matching directory via
-    the same atomic ``checkpointer.delete_thread`` hard_delete uses.
-    The caller must have stopped concurrent writers (same contract as
-    ``prune_to_n_threads``); with the writer stopped a sub-agent thread
-    is never mid-run, and its intermediate checkpoints are not needed to
-    resume its parent's next turn.
+    (Sub-agent runs are NOT orphans: deepagents reuses the parent's
+    ``thread_id`` with a derived ``checkpoint_ns``, so their rows carry the
+    live parent's dir name and are kept. Enumeration is keyed on the
+    ``checkpoints`` table; a thread_id present only in ``writes`` — not an
+    observed state — is not swept.)
 
-    Returns the purged thread_ids.
+    Caller must have stopped concurrent writers (same contract as
+    ``prune_to_n_threads``: ``main`` runs after the cron stops assist-web and
+    behind the lsof foreign-writer guard). Deletes run in bounded batches so
+    one giant orphan can't hold a multi-GB transaction. Returns the purged
+    thread_ids.
     """
-    if not os.path.isdir(threads_root):
-        return []
-
-    live = {
-        name for name in os.listdir(threads_root)
-        if os.path.isdir(os.path.join(threads_root, name))
-        and name != "__pycache__"
-    }
+    live = _thread_dirs(threads_root)
     try:
         rows = manager.conn.execute(
             "SELECT DISTINCT thread_id FROM checkpoints"
         ).fetchall()
     except sqlite3.OperationalError:
-        # No checkpoints table yet (a fresh db that has never been written
-        # to) — nothing to purge.
+        # Fresh db whose checkpoints table doesn't exist yet (a deploy's first
+        # sweep before any thread) — nothing to purge.
         return []
-    ckpt_threads = {row[0] for row in rows}
-    orphans = sorted(ckpt_threads - live)
+    orphans = sorted({row[0] for row in rows} - live)
     purged: list[str] = []
     for tid in orphans:
         try:
-            manager.checkpointer.delete_thread(tid)
+            n, nbytes = manager.conn.execute(
+                "SELECT count(*), coalesce(sum(length(checkpoint)), 0) "
+                "FROM checkpoints WHERE thread_id = ?", (tid,)
+            ).fetchone()
+            if n > 1000 or nbytes > 1_000_000_000:
+                logger.warning(
+                    "Purging large orphan %s: %d checkpoints, %.1f GB "
+                    "(batched delete)", tid, n, nbytes / 1e9,
+                )
+            _delete_thread_in_batches(manager.conn, tid)
             purged.append(tid)
         except Exception as e:
-            logger.warning("delete_thread failed for orphan %s: %s", tid, e)
+            logger.warning("purge failed for orphan %s: %s", tid, e)
     logger.info(
         "Purged %d/%d orphaned checkpoint-threads (no live dir)",
         len(purged), len(orphans),

--- a/assist/retention.py
+++ b/assist/retention.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sqlite3
 import subprocess
 import sys
 from typing import List
@@ -88,6 +89,62 @@ def prune_to_n_threads(
         len(deleted), len(candidates), min_threads,
     )
     return deleted
+
+
+def purge_orphaned_checkpoints(
+    threads_root: str,
+    manager: ThreadManager,
+) -> List[str]:
+    """Delete checkpoint rows whose ``thread_id`` has no live thread dir.
+
+    The web app's thread_id IS its directory name, and ``hard_delete``
+    purges checkpoints by that id.  But sub-agent runs checkpoint under
+    their own (UUID) thread_ids in the SAME db — no directory tracks
+    them and ``hard_delete`` never deletes them, so they orphan and
+    accumulate.  This was the real threads.db growth driver (found
+    2026-06-24: one runaway sub-agent thread held 101 GB across 24k
+    checkpoints, ~60% of the DB; 166 of 262 checkpoint thread_ids had
+    no dir).  Thread-count retention can't see them.
+
+    Sweeps every checkpoint thread_id with no matching directory via
+    the same atomic ``checkpointer.delete_thread`` hard_delete uses.
+    The caller must have stopped concurrent writers (same contract as
+    ``prune_to_n_threads``); with the writer stopped a sub-agent thread
+    is never mid-run, and its intermediate checkpoints are not needed to
+    resume its parent's next turn.
+
+    Returns the purged thread_ids.
+    """
+    if not os.path.isdir(threads_root):
+        return []
+
+    live = {
+        name for name in os.listdir(threads_root)
+        if os.path.isdir(os.path.join(threads_root, name))
+        and name != "__pycache__"
+    }
+    try:
+        rows = manager.conn.execute(
+            "SELECT DISTINCT thread_id FROM checkpoints"
+        ).fetchall()
+    except sqlite3.OperationalError:
+        # No checkpoints table yet (a fresh db that has never been written
+        # to) — nothing to purge.
+        return []
+    ckpt_threads = {row[0] for row in rows}
+    orphans = sorted(ckpt_threads - live)
+    purged: list[str] = []
+    for tid in orphans:
+        try:
+            manager.checkpointer.delete_thread(tid)
+            purged.append(tid)
+        except Exception as e:
+            logger.warning("delete_thread failed for orphan %s: %s", tid, e)
+    logger.info(
+        "Purged %d/%d orphaned checkpoint-threads (no live dir)",
+        len(purged), len(orphans),
+    )
+    return purged
 
 
 def _check_no_foreign_writers(db_path: str) -> None:
@@ -225,11 +282,13 @@ def main() -> int:
     manager = ThreadManager(threads_root)
     try:
         deleted = prune_to_n_threads(threads_root, min_threads, manager)
+        purged = purge_orphaned_checkpoints(threads_root, manager)
     finally:
         manager.close()
 
     print(
         f"[retention] pruned {len(deleted)} threads; "
+        f"purged {len(purged)} orphaned checkpoint-threads; "
         f"kept most-recent {min_threads}"
     )
     return 0

--- a/tests/test_retention_sweep.py
+++ b/tests/test_retention_sweep.py
@@ -9,9 +9,10 @@ import os
 import shutil
 import subprocess
 import sys
+import sqlite3
 import tempfile
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from assist import retention
 from assist.thread_manager import ThreadManager
@@ -236,7 +237,7 @@ class TestPurgeOrphanedCheckpoints(TestCase):
                 ck = {r[0] for r in mgr.conn.execute("SELECT DISTINCT thread_id FROM checkpoints")}
                 wr = {r[0] for r in mgr.conn.execute("SELECT DISTINCT thread_id FROM writes")}
                 self.assertEqual(ck, {"live-thread"})
-                self.assertEqual(wr, {"live-thread"})  # delete_thread covers writes too
+                self.assertEqual(wr, {"live-thread"})  # batched delete removes writes rows too
             finally:
                 mgr.close()
 
@@ -304,6 +305,22 @@ class TestPurgeOrphanedCheckpoints(TestCase):
                 ck = {r[0] for r in mgr.conn.execute(
                     "SELECT DISTINCT thread_id FROM checkpoints")}
                 self.assertEqual(ck, {"live"})
+            finally:
+                mgr.close()
+
+    def test_real_db_error_is_not_swallowed(self):
+        # A non-"no such table" OperationalError (locked/corrupt) must surface,
+        # not be reported as a clean no-op sweep (Copilot PR #142 review).
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "live", "domain"), exist_ok=True)
+            mgr = ThreadManager(root_dir=tmp)
+            try:
+                mgr.checkpointer.setup()
+                fake = MagicMock()
+                fake.execute.side_effect = sqlite3.OperationalError("database is locked")
+                with patch.object(mgr, "conn", fake):
+                    with self.assertRaises(sqlite3.OperationalError):
+                        retention.purge_orphaned_checkpoints(tmp, mgr)
             finally:
                 mgr.close()
 

--- a/tests/test_retention_sweep.py
+++ b/tests/test_retention_sweep.py
@@ -205,3 +205,51 @@ class TestForeignWriterGuard(TestCase):
         # lsof returns 1 when no process holds the file.
         rc, _ = self._run_cli({}, "", lsof_rc=1)
         self.assertEqual(rc, 0)
+
+
+class TestPurgeOrphanedCheckpoints(TestCase):
+    """purge_orphaned_checkpoints deletes checkpoint-threads that have no
+    on-disk dir (deleted threads' leftovers + sub-agent UUID checkpoints),
+    and leaves live (dir-having) threads untouched."""
+
+    def _seed(self, mgr, tid):
+        mgr.conn.execute(
+            "INSERT INTO checkpoints (thread_id, checkpoint_ns, checkpoint_id, "
+            "type, checkpoint, metadata) VALUES (?, '', 'c1', '', ?, ?)",
+            (tid, b"{}", b"{}"))
+        mgr.conn.execute(
+            "INSERT INTO writes (thread_id, checkpoint_ns, checkpoint_id, "
+            "task_id, idx, channel, type, value) VALUES (?, '', 'c1', 't', 0, 'ch', '', ?)",
+            (tid, b"{}"))
+
+    def test_purges_threads_without_a_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "live-thread", "domain"), exist_ok=True)
+            mgr = ThreadManager(root_dir=tmp)
+            try:
+                mgr.checkpointer.setup()
+                for tid in ("live-thread", "orphan-subagent-uuid", "deleted-thread"):
+                    self._seed(mgr, tid)
+                mgr.conn.commit()
+                purged = retention.purge_orphaned_checkpoints(tmp, mgr)
+                self.assertEqual(set(purged), {"orphan-subagent-uuid", "deleted-thread"})
+                ck = {r[0] for r in mgr.conn.execute("SELECT DISTINCT thread_id FROM checkpoints")}
+                wr = {r[0] for r in mgr.conn.execute("SELECT DISTINCT thread_id FROM writes")}
+                self.assertEqual(ck, {"live-thread"})
+                self.assertEqual(wr, {"live-thread"})  # delete_thread covers writes too
+            finally:
+                mgr.close()
+
+    def test_no_orphans_is_noop(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "only-live", "domain"), exist_ok=True)
+            mgr = ThreadManager(root_dir=tmp)
+            try:
+                mgr.checkpointer.setup()
+                self._seed(mgr, "only-live")
+                mgr.conn.commit()
+                self.assertEqual(retention.purge_orphaned_checkpoints(tmp, mgr), [])
+                ck = {r[0] for r in mgr.conn.execute("SELECT DISTINCT thread_id FROM checkpoints")}
+                self.assertEqual(ck, {"only-live"})
+            finally:
+                mgr.close()

--- a/tests/test_retention_sweep.py
+++ b/tests/test_retention_sweep.py
@@ -208,20 +208,37 @@ class TestForeignWriterGuard(TestCase):
         self.assertEqual(rc, 0)
 
 
+def _insert_checkpoint(conn, tid, ckpt_id="c1"):
+    """Insert one checkpoints row, introspecting columns via PRAGMA so the seed
+    survives upstream SqliteSaver schema changes (repo convention — see
+    test_thread_manager_hard_delete._seed_thread)."""
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(checkpoints)")]
+    vals = [tid if c == "thread_id" else (ckpt_id if c == "checkpoint_id" else "")
+            for c in cols]
+    conn.execute(
+        f"INSERT INTO checkpoints ({', '.join(cols)}) "
+        f"VALUES ({', '.join('?' * len(cols))})", vals)
+
+
+def _insert_write(conn, tid, ckpt_id="c1"):
+    """Insert one writes row (schema-introspected; see _insert_checkpoint)."""
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(writes)")]
+    vals = [tid if c == "thread_id"
+            else (ckpt_id if c == "checkpoint_id" else (0 if c == "idx" else ""))
+            for c in cols]
+    conn.execute(
+        f"INSERT INTO writes ({', '.join(cols)}) "
+        f"VALUES ({', '.join('?' * len(cols))})", vals)
+
+
 class TestPurgeOrphanedCheckpoints(TestCase):
     """purge_orphaned_checkpoints deletes checkpoint-threads that have no
     on-disk dir (deleted threads' leftovers + sub-agent UUID checkpoints),
     and leaves live (dir-having) threads untouched."""
 
     def _seed(self, mgr, tid):
-        mgr.conn.execute(
-            "INSERT INTO checkpoints (thread_id, checkpoint_ns, checkpoint_id, "
-            "type, checkpoint, metadata) VALUES (?, '', 'c1', '', ?, ?)",
-            (tid, b"{}", b"{}"))
-        mgr.conn.execute(
-            "INSERT INTO writes (thread_id, checkpoint_ns, checkpoint_id, "
-            "task_id, idx, channel, type, value) VALUES (?, '', 'c1', 't', 0, 'ch', '', ?)",
-            (tid, b"{}"))
+        _insert_checkpoint(mgr.conn, tid)
+        _insert_write(mgr.conn, tid)
 
     def test_purges_threads_without_a_dir(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -348,11 +365,8 @@ class TestPurgeOrphanedCheckpoints(TestCase):
             try:
                 mgr.checkpointer.setup()
                 n = retention._DELETE_BATCH + 37
-                mgr.conn.executemany(
-                    "INSERT INTO checkpoints (thread_id, checkpoint_ns, "
-                    "checkpoint_id, type, checkpoint, metadata) "
-                    "VALUES ('big', '', ?, '', ?, ?)",
-                    [(f"c{i}", b"{}", b"{}") for i in range(n)])
+                for i in range(n):
+                    _insert_checkpoint(mgr.conn, "big", ckpt_id=f"c{i}")
                 mgr.conn.commit()
                 self.assertEqual(
                     retention.purge_orphaned_checkpoints(tmp, mgr), ["big"])

--- a/tests/test_retention_sweep.py
+++ b/tests/test_retention_sweep.py
@@ -253,3 +253,79 @@ class TestPurgeOrphanedCheckpoints(TestCase):
                 self.assertEqual(ck, {"only-live"})
             finally:
                 mgr.close()
+
+    def test_keeps_all_live_threads_with_many_orphans(self):
+        # Load-bearing safety property: NO live thread is purged, regardless of
+        # how many orphans surround it.
+        with tempfile.TemporaryDirectory() as tmp:
+            live = [f"live-{i}" for i in range(5)]
+            orphans = [f"orphan-{i}" for i in range(5)]
+            for t in live:
+                os.makedirs(os.path.join(tmp, t, "domain"), exist_ok=True)
+            mgr = ThreadManager(root_dir=tmp)
+            try:
+                mgr.checkpointer.setup()
+                for t in live + orphans:
+                    self._seed(mgr, t)
+                mgr.conn.commit()
+                purged = retention.purge_orphaned_checkpoints(tmp, mgr)
+                self.assertEqual(set(purged), set(orphans))
+                ck = {r[0] for r in mgr.conn.execute(
+                    "SELECT DISTINCT thread_id FROM checkpoints")}
+                self.assertEqual(ck, set(live))
+            finally:
+                mgr.close()
+
+    def test_returns_empty_when_no_checkpoints_table(self):
+        # Fresh db (checkpointer never set up) has no checkpoints table; the
+        # sweep must no-op, not raise.
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "live", "domain"), exist_ok=True)
+            mgr = ThreadManager(root_dir=tmp)
+            try:
+                self.assertEqual(retention.purge_orphaned_checkpoints(tmp, mgr), [])
+            finally:
+                mgr.close()
+
+    def test_ignores_non_directory_entries(self):
+        # A plain file in threads_root (the db itself, a lock) must not be
+        # treated as a live thread or break the sweep.
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "live", "domain"), exist_ok=True)
+            mgr = ThreadManager(root_dir=tmp)
+            try:
+                mgr.checkpointer.setup()
+                open(os.path.join(tmp, "stray.txt"), "w").close()
+                for t in ("live", "orphan"):
+                    self._seed(mgr, t)
+                mgr.conn.commit()
+                self.assertEqual(
+                    retention.purge_orphaned_checkpoints(tmp, mgr), ["orphan"])
+                ck = {r[0] for r in mgr.conn.execute(
+                    "SELECT DISTINCT thread_id FROM checkpoints")}
+                self.assertEqual(ck, {"live"})
+            finally:
+                mgr.close()
+
+    def test_batched_delete_removes_all_rows_of_a_large_orphan(self):
+        # The batch loop must terminate and delete every row of an orphan that
+        # exceeds _DELETE_BATCH (the 101GB-incident shape, in miniature).
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr = ThreadManager(root_dir=tmp)
+            try:
+                mgr.checkpointer.setup()
+                n = retention._DELETE_BATCH + 37
+                mgr.conn.executemany(
+                    "INSERT INTO checkpoints (thread_id, checkpoint_ns, "
+                    "checkpoint_id, type, checkpoint, metadata) "
+                    "VALUES ('big', '', ?, '', ?, ?)",
+                    [(f"c{i}", b"{}", b"{}") for i in range(n)])
+                mgr.conn.commit()
+                self.assertEqual(
+                    retention.purge_orphaned_checkpoints(tmp, mgr), ["big"])
+                left = mgr.conn.execute(
+                    "SELECT count(*) FROM checkpoints WHERE thread_id='big'"
+                ).fetchone()[0]
+                self.assertEqual(left, 0)
+            finally:
+                mgr.close()

--- a/tests/test_retention_sweep.py
+++ b/tests/test_retention_sweep.py
@@ -324,6 +324,22 @@ class TestPurgeOrphanedCheckpoints(TestCase):
             finally:
                 mgr.close()
 
+    def test_db_error_during_orphan_delete_propagates(self):
+        # The per-orphan loop must NOT swallow a DB fault (locked/corrupt) — it
+        # would report a clean sweep while skipping orphans (Copilot #142 rd2).
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr = ThreadManager(root_dir=tmp)
+            try:
+                mgr.checkpointer.setup()
+                self._seed(mgr, "orphan")
+                mgr.conn.commit()
+                with patch.object(retention, "_delete_thread_in_batches",
+                                  side_effect=sqlite3.OperationalError("database is locked")):
+                    with self.assertRaises(sqlite3.OperationalError):
+                        retention.purge_orphaned_checkpoints(tmp, mgr)
+            finally:
+                mgr.close()
+
     def test_batched_delete_removes_all_rows_of_a_large_orphan(self):
         # The batch loop must terminate and delete every row of an orphan that
         # exceeds _DELETE_BATCH (the 101GB-incident shape, in miniature).


### PR DESCRIPTION
## What
Adds `purge_orphaned_checkpoints` to the retention sweep: deletes `checkpoints`/`writes` rows for any `thread_id` with **no on-disk thread directory**, and wires it into `assist.retention`'s `main()` after the thread-count prune.

## Why
`threads.db` had grown to **167 GB**. Root cause: a thread's checkpoint `thread_id` is its dir name, and `hard_delete` only purges by that id — but **non-web/harness invocations** (e.g. an `AgentHarness` run defaulting `thread_id` to a `uuid`) and **leftovers from deletes that predate checkpoint-purging** write checkpoints under ids no directory tracks. They accumulate forever, invisible to thread-count retention. One orphan held **101 GB across 24k checkpoints** (60% of the DB).

(Sub-agents are *not* the cause — deepagents reuses the parent `thread_id` with a derived `checkpoint_ns`, so their rows carry the live parent's dir name and are kept.)

## Safety
The web app derives both the dir name and the checkpoint `thread_id` from one id, so every **live** thread has a matching dir and is never touched. Runs under the existing stop-writers contract (cron stops `assist-web` + `lsof` foreign-writer guard in `main()`). Deletes run in **bounded batches** so a giant orphan can't hold one multi-GB transaction.

## Known limitation / follow-up
Batching bounds the *transaction*, not total work — an orphan that grows huge before a sweep still takes a long delete. The **by-construction** fix is Layer 2 (per-thread checkpoint cap at `put()`-time), still not started (`docs/2026-05-04-threads-db-layer-2-checkpoint-pruning.org`).

## Validation
- New tests: no live thread purged amid many orphans; no-checkpoints-table guard; non-dir entries ignored; batched delete of a `>_DELETE_BATCH` orphan. Full unit suite green (633).
- Ran in prod: `threads.db` 167 GB → 8.4 GB (purge + a follow-up selective rebuild). Local adversarial review (data-safety / simplicity / tests+ops) passed; findings addressed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)