### PR TITLE
web: thread search + renameable thread descriptions

### DIFF
--- a/assist/thread_manager.py
+++ b/assist/thread_manager.py
@@ -39,6 +39,13 @@ from assist.thread import Thread
 logger = logging.getLogger(__name__)
 
 
+class InvalidThreadId(ValueError):
+    """A thread id that isn't a single safe path segment (traversal/separator).
+
+    Raised by ``ThreadManager.thread_dir`` so every tid->path method rejects a
+    crafted id by construction; the web layer maps it to 404."""
+
+
 class ThreadManager:
     """Manage ``Thread`` instances persisted under a directory tree.
 
@@ -91,7 +98,7 @@ class ThreadManager:
 
     def soft_delete(self, thread_id: str) -> None:
         """Mark a thread as deleted by writing a .deleted marker file."""
-        tdir = os.path.join(self.root_dir, thread_id)
+        tdir = self.thread_dir(thread_id)
         if os.path.isdir(tdir):
             marker = os.path.join(tdir, ".deleted")
             with open(marker, "w") as f:
@@ -126,7 +133,7 @@ class ThreadManager:
            in-process domain/description caches; the retention CLI
            passes none.
         """
-        tdir = os.path.join(self.root_dir, tid)
+        tdir = self.thread_dir(tid)
         work_dir = self.thread_default_working_dir(tid)
 
         # 1. Stop the sandbox container before yanking its bind mount.
@@ -196,7 +203,7 @@ class ThreadManager:
 
     def touch(self, thread_id: str) -> None:
         """Update mtime of thread dir so it sorts to the top of list()."""
-        tdir = os.path.join(self.root_dir, thread_id)
+        tdir = self.thread_dir(thread_id)
         if os.path.isdir(tdir):
             os.utime(tdir, None)
 
@@ -205,7 +212,7 @@ class ThreadManager:
             working_dir: str | None = None,
             sandbox_backend=None,
             on_queue_state: Callable[[str], None] | None = None) -> Thread:
-        tdir = os.path.join(self.root_dir, thread_id)
+        tdir = self.thread_dir(thread_id)
         if not os.path.isdir(tdir):
             raise FileNotFoundError(f"thread directory not found: {thread_id}, {tdir}")
         if not working_dir:
@@ -219,7 +226,7 @@ class ThreadManager:
                       on_queue_state=on_queue_state)
 
     def remove(self, thread_id: str) -> None:
-        tdir = os.path.join(self.root_dir, thread_id)
+        tdir = self.thread_dir(thread_id)
         if os.path.isdir(tdir):
             # Best-effort delete
             for root, dirs, files in os.walk(tdir, topdown=False):
@@ -259,10 +266,15 @@ class ThreadManager:
             pass
 
     def thread_dir(self, tid: str) -> str:
+        # Validate by construction: a thread id is a single path segment, so a
+        # crafted id ("..", "a/b", a NUL) can't escape root_dir in any caller's
+        # filesystem op. Every tid->path method below routes through here.
+        if tid in ("", ".", "..") or "/" in tid or "\\" in tid or "\0" in tid:
+            raise InvalidThreadId(f"invalid thread id: {tid!r}")
         return os.path.join(self.root_dir, tid)
 
     def thread_default_working_dir(self, tid: str) -> str:
-        return os.path.join(os.path.join(self.root_dir, tid),
+        return os.path.join(self.thread_dir(tid),
                             self.DEFAULT_THREAD_WORKING_DIRECTORY)
 
     def make_default_working_dir(self, tdir: str) -> str:

--- a/manage/web/state.py
+++ b/manage/web/state.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import sys
+import tempfile
 import threading
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -205,18 +206,32 @@ def _get_conflict(tid: str) -> dict | None:
         return None
 
 
-def _set_conflict(tid: str, branch: str, files: list[str]) -> None:
-    path = _conflict_path(tid)
+def _atomic_write(path: str, data: str) -> None:
+    """Write ``data`` to ``path`` atomically: a uniquely-named temp file in the
+    same directory + os.replace. The unique temp name means concurrent writers
+    for the same path can't clobber a shared temp or leave a half-written file."""
     os.makedirs(os.path.dirname(path), exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path),
+                               prefix=os.path.basename(path) + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(data)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _set_conflict(tid: str, branch: str, files: list[str]) -> None:
     data = {
         "branch": branch,
         "files": files,
         "raised_at": datetime.now().isoformat(timespec="seconds"),
     }
-    tmp = path + ".tmp"
-    with open(tmp, "w") as f:
-        json.dump(data, f)
-    os.replace(tmp, path)
+    _atomic_write(_conflict_path(tid), json.dumps(data))
 
 
 def _clear_conflict(tid: str) -> None:
@@ -274,13 +289,7 @@ def _get_status(tid: str) -> dict:
 
 
 def _set_status(tid: str, stage: str, **kwargs) -> None:
-    path = _status_path(tid)
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    data = {"stage": stage, **kwargs}
-    tmp = path + ".tmp"
-    with open(tmp, "w") as f:
-        json.dump(data, f)
-    os.replace(tmp, path)
+    _atomic_write(_status_path(tid), json.dumps({"stage": stage, **kwargs}))
 
 
 def _thread_title(tid: str) -> str:
@@ -319,12 +328,7 @@ def set_description(tid: str, description: str) -> None:
     the cache. Because ``get_cached_description`` only generates when
     description.txt is ABSENT, a value written here is never auto-regenerated —
     the rename sticks across later turns."""
-    description_file = os.path.join(MANAGER.thread_dir(tid), "description.txt")
-    os.makedirs(os.path.dirname(description_file), exist_ok=True)
-    tmp = description_file + ".tmp"
-    with open(tmp, "w") as f:
-        f.write(description)
-    os.replace(tmp, description_file)  # atomic — never leave a half-written title
+    _atomic_write(os.path.join(MANAGER.thread_dir(tid), "description.txt"), description)
     DESCRIPTION_CACHE[tid] = description
 
 

--- a/manage/web/state.py
+++ b/manage/web/state.py
@@ -300,23 +300,32 @@ def get_cached_description(tid: str) -> str:
     if tid in DESCRIPTION_CACHE:
         return DESCRIPTION_CACHE[tid]
 
-    # Cache miss - read from FS or thread and cache
+    # Cache miss - read the saved description, else generate one (which also
+    # writes + caches it via set_description, so the two write paths stay one).
     try:
-        chat = MANAGER.get(tid)
-        thread_dir = MANAGER.thread_dir(tid)
-        description_file = os.path.join(thread_dir, "description.txt")
+        description_file = os.path.join(MANAGER.thread_dir(tid), "description.txt")
         if os.path.isfile(description_file):
             with open(description_file, 'r') as f:
-                description = f.read()
+                DESCRIPTION_CACHE[tid] = f.read()
         else:
-            description = chat.description()
-            os.makedirs(os.path.dirname(description_file), exist_ok=True)
-            with open(description_file, 'w') as f:
-                f.write(description)
-        DESCRIPTION_CACHE[tid] = description
-        return description
+            set_description(tid, MANAGER.get(tid).description())
+        return DESCRIPTION_CACHE[tid]
     except Exception:
         return tid
+
+
+def set_description(tid: str, description: str) -> None:
+    """Persist a user-set thread description (the displayed title) and refresh
+    the cache. Because ``get_cached_description`` only generates when
+    description.txt is ABSENT, a value written here is never auto-regenerated —
+    the rename sticks across later turns."""
+    description_file = os.path.join(MANAGER.thread_dir(tid), "description.txt")
+    os.makedirs(os.path.dirname(description_file), exist_ok=True)
+    tmp = description_file + ".tmp"
+    with open(tmp, "w") as f:
+        f.write(description)
+    os.replace(tmp, description_file)  # atomic — never leave a half-written title
+    DESCRIPTION_CACHE[tid] = description
 
 
 @asynccontextmanager

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -818,9 +818,7 @@ def _mark_pending(tid: str, text: str) -> None:
 
 @app.post("/thread/{tid}/message")
 async def post_message(tid: str, background_tasks: BackgroundTasks, text: str = Form(...)):
-    tdir = os.path.join(MANAGER.root_dir, tid)
-    if not os.path.isdir(tdir):
-        raise HTTPException(status_code=404, detail="Thread not found")
+    _existing_thread_dir(tid)  # validates tid (404 on traversal/NUL) + existence
     _mark_pending(tid, text)
     background_tasks.add_task(_process_message, tid, text)
     return RedirectResponse(url=f"/thread/{tid}", status_code=303)

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -52,59 +52,74 @@ from manage.web.state import (
     _thread_domain_html,
     _thread_title,
     get_cached_description,
+    set_description,
 )
 
 
-def render_index() -> str:
+def render_index(query: str = "") -> str:
+    q = (query or "").strip()
+    ql = q.lower()
     items = []
-    tids = MANAGER.list()
-    if not tids:
-        items.append("<li><em>No threads yet</em></li>")
-    else:
-        for tid in tids:
-            title = _thread_title(tid)
-            status = _get_status(tid)
-            stage = status.get("stage", "ready")
-            badge = ""
-            if stage == "queued":
-                # Distinguish "queued" visually from other busy stages so
-                # the user can tell their message is held behind another
-                # thread (vs. actively running).
-                badge = (
-                    f'<span style="font-size:.7rem; color:#1e3a5f; background:#e1ecf4;'
-                    f' border:1px solid #b6d4ef; padding:.1rem .4rem; border-radius:10px;'
-                    f' margin-right:.4rem;">{html.escape(STAGE_LABELS.get(stage, stage))}</span>'
-                )
-            elif stage in BUSY_STAGES:
-                badge = (
-                    f'<span style="font-size:.7rem; color:#555; background:#fff3cd;'
-                    f' border:1px solid #ffeeba; padding:.1rem .4rem; border-radius:10px;'
-                    f' margin-right:.4rem;">{html.escape(STAGE_LABELS.get(stage, stage))}</span>'
-                )
-            elif stage == "error":
-                badge = (
-                    '<span style="font-size:.7rem; color:#721c24; background:#f8d7da;'
-                    ' border:1px solid #f5c6cb; padding:.1rem .4rem; border-radius:10px;'
-                    ' margin-right:.4rem;">error</span>'
-                )
-            elif _has_unmerged_changes(tid):
-                # Soft amber, distinct from yellow (busy) and red (error).
-                # Strictly secondary to the process-state badges above —
-                # only shows when the thread is otherwise idle.
-                badge = (
-                    '<span style="font-size:.7rem; color:#7c4a1d; background:#fef0e0;'
-                    ' border:1px solid #fbcfa0; padding:.1rem .4rem; border-radius:10px;'
-                    ' margin-right:.4rem;">unmerged</span>'
-                )
-            items.append(
-                f'<li>'
-                f'<a class="thread-link" href="/thread/{tid}">{badge}{html.escape(title)}</a>'
-                f'<form action="/thread/{tid}/delete" method="post" style="margin:0">'
-                f'<button type="submit" class="del-btn" aria-label="Delete thread" '
-                f'onclick="return confirm(\'Permanently delete this thread? This cannot be undone.\')">&#x2715;</button>'
-                f'</form></li>'
+    for tid in MANAGER.list():
+        title = _thread_title(tid)
+        # Search matches the displayed title (== the thread's description),
+        # case-insensitive substring — the text the user actually sees and types.
+        if ql and ql not in title.lower():
+            continue
+        status = _get_status(tid)
+        stage = status.get("stage", "ready")
+        badge = ""
+        if stage == "queued":
+            # Distinguish "queued" visually from other busy stages so
+            # the user can tell their message is held behind another
+            # thread (vs. actively running).
+            badge = (
+                f'<span style="font-size:.7rem; color:#1e3a5f; background:#e1ecf4;'
+                f' border:1px solid #b6d4ef; padding:.1rem .4rem; border-radius:10px;'
+                f' margin-right:.4rem;">{html.escape(STAGE_LABELS.get(stage, stage))}</span>'
             )
+        elif stage in BUSY_STAGES:
+            badge = (
+                f'<span style="font-size:.7rem; color:#555; background:#fff3cd;'
+                f' border:1px solid #ffeeba; padding:.1rem .4rem; border-radius:10px;'
+                f' margin-right:.4rem;">{html.escape(STAGE_LABELS.get(stage, stage))}</span>'
+            )
+        elif stage == "error":
+            badge = (
+                '<span style="font-size:.7rem; color:#721c24; background:#f8d7da;'
+                ' border:1px solid #f5c6cb; padding:.1rem .4rem; border-radius:10px;'
+                ' margin-right:.4rem;">error</span>'
+            )
+        elif _has_unmerged_changes(tid):
+            # Soft amber, distinct from yellow (busy) and red (error).
+            # Strictly secondary to the process-state badges above —
+            # only shows when the thread is otherwise idle.
+            badge = (
+                '<span style="font-size:.7rem; color:#7c4a1d; background:#fef0e0;'
+                ' border:1px solid #fbcfa0; padding:.1rem .4rem; border-radius:10px;'
+                ' margin-right:.4rem;">unmerged</span>'
+            )
+        items.append(
+            f'<li>'
+            f'<a class="thread-link" href="/thread/{tid}">{badge}{html.escape(title)}</a>'
+            f'<form action="/thread/{tid}/delete" method="post" style="margin:0">'
+            f'<button type="submit" class="del-btn" aria-label="Delete thread" '
+            f'onclick="return confirm(\'Permanently delete this thread? This cannot be undone.\')">&#x2715;</button>'
+            f'</form></li>'
+        )
+    matched = len(items)
+    if not items:
+        items.append(
+            f'<li><em>No threads match &ldquo;{html.escape(q)}&rdquo;.</em> '
+            f'<a href="/">clear</a></li>'
+            if ql else "<li><em>No threads yet</em></li>"
+        )
     items_html = "\n".join(items)
+    search_status = (
+        f'<p style="font-size:.85rem; color:#666; margin:.2rem 0 .6rem;">'
+        f'{matched} match{"" if matched == 1 else "es"} for '
+        f'&ldquo;{html.escape(q)}&rdquo; &middot; <a href="/">clear</a></p>'
+    ) if q else ""
     return f"""
     <html>
       <head>
@@ -165,6 +180,12 @@ def render_index() -> str:
           </div>
 
           <h2 style="font-size:1.2rem">Threads</h2>
+          <form method="get" action="/" style="margin:0 0 .6rem;">
+            <input type="search" name="q" value="{html.escape(q)}"
+                   placeholder="Search threads..." aria-label="Search threads"
+                   style="width:100%; box-sizing:border-box; padding:.7rem .8rem; font-size:16px; border:1px solid #ccc; border-radius:6px;" />
+          </form>
+          {search_status}
           <ul>
             {items_html}
           </ul>
@@ -202,6 +223,28 @@ def render_thread(
     busy = stage in BUSY_STAGES
     is_init = stage in INIT_STAGES
     title = _thread_title(tid)
+
+    # Rename is only offered when idle: while busy/initializing the displayed
+    # title is the pending-message snippet, not the description, so editing it
+    # then would bake that snippet (with its "...") in as the permanent title.
+    can_rename = not (busy or is_init)
+    rename_button = (
+        '<button type="button" onclick="showRename()" aria-label="Rename thread" '
+        'style="background:none; border:none; color:#999; cursor:pointer; '
+        'font-size:1rem; padding:.2rem .4rem; line-height:1;">&#x270e;</button>'
+    ) if can_rename else ""
+    rename_form = (
+        f'<form id="titleEdit" action="/thread/{tid}/rename" method="post" '
+        f'style="display:none; gap:.4rem; align-items:center; margin:.2rem 0;">'
+        f'<input type="text" name="description" value="{html.escape(title)}" '
+        f'maxlength="120" required aria-label="Thread name" '
+        f'style="flex:1; min-width:0; box-sizing:border-box; padding:.5rem .6rem; '
+        f'font-size:16px; border:1px solid #ccc; border-radius:6px;" />'
+        f'<button class="btn" type="submit" style="min-height:auto; padding:.5rem .8rem;">Save</button>'
+        f'<button class="btn btn-secondary" type="button" onclick="hideRename()" '
+        f'style="min-height:auto; padding:.5rem .8rem;">Cancel</button>'
+        f'</form>'
+    ) if can_rename else ""
 
     # During the initial setup stages there is no agent state worth showing yet.
     msgs: list[dict] = [] if is_init or chat is None else chat.get_messages()
@@ -435,7 +478,11 @@ def render_thread(
       <body>
         <div class="container">
           <div class="nav"><a href="/">← All threads</a></div>
-          <h2 style="font-size:1.2rem">{html.escape(title)}</h2>
+          <div id="titleView" style="display:flex; align-items:center; gap:.3rem;">
+            <h2 style="font-size:1.2rem; margin:0">{html.escape(title)}</h2>
+            {rename_button}
+          </div>
+          {rename_form}
           {_thread_domain_html(tid)}
           {status_banner}
           {"<div class='success-msg'>Conversation capture started! This will complete in the background.</div>" if captured else ""}
@@ -471,6 +518,17 @@ def render_thread(
           </div>
 
           <script>
+            function showRename() {{
+              document.getElementById('titleView').style.display = 'none';
+              const f = document.getElementById('titleEdit');
+              f.style.display = 'flex';
+              const inp = f.querySelector('input[name=description]');
+              inp.focus(); inp.select();
+            }}
+            function hideRename() {{
+              document.getElementById('titleEdit').style.display = 'none';
+              document.getElementById('titleView').style.display = 'flex';
+            }}
             function showCaptureModal() {{
               document.getElementById('captureModal').style.display = 'block';
             }}
@@ -636,8 +694,8 @@ def _capture_conversation(tid: str, reason: str) -> None:
 # --- Routes -------------------------------------------------------------
 
 @app.get("/", response_class=HTMLResponse)
-async def index() -> str:
-    return render_index()
+async def index(q: str = "") -> str:
+    return render_index(q)
 
 
 @app.post("/threads")
@@ -760,13 +818,32 @@ async def post_message(tid: str, background_tasks: BackgroundTasks, text: str = 
     return RedirectResponse(url=f"/thread/{tid}", status_code=303)
 
 
-@app.post("/thread/{tid}/delete")
-async def delete_thread(tid: str):
+def _existing_thread_dir(tid: str) -> str:
+    """Return the thread's dir, or raise 404. Rejects a traversal/separator tid
+    (e.g. an encoded ``..``) BY CONSTRUCTION so a crafted id can't escape the
+    threads root in a filesystem op (rename writes, delete rmtree's)."""
+    if tid in ("", ".", "..") or "/" in tid or "\\" in tid or "\0" in tid:
+        raise HTTPException(status_code=404, detail="Thread not found")
     tdir = os.path.join(MANAGER.root_dir, tid)
     if not os.path.isdir(tdir):
         raise HTTPException(status_code=404, detail="Thread not found")
+    return tdir
+
+
+@app.post("/thread/{tid}/delete")
+async def delete_thread(tid: str):
+    _existing_thread_dir(tid)
     MANAGER.hard_delete(tid, on_delete=[_evict_caches])
     return RedirectResponse(url="/", status_code=303)
+
+
+@app.post("/thread/{tid}/rename")
+async def rename_thread(tid: str, description: str = Form("")):
+    _existing_thread_dir(tid)
+    new = description.strip()[:120]
+    if new:  # ignore an empty rename — keep the existing title
+        set_description(tid, new)
+    return RedirectResponse(url=f"/thread/{tid}", status_code=303)
 
 
 @app.post("/thread/{tid}/capture")

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -29,6 +29,14 @@ from assist.thread import Thread
 from assist.thread_queue import THREAD_QUEUE
 
 from manage.web.app import app
+from assist.thread_manager import InvalidThreadId
+
+
+@app.exception_handler(InvalidThreadId)
+async def _invalid_thread_id(request, exc):
+    # A crafted tid (traversal/separator) reaching any tid-based route surfaces
+    # here from ThreadManager.thread_dir — map it to a clean 404 everywhere.
+    return HTMLResponse("Thread not found", status_code=404)
 from manage.web.diff import _DIFF_CSS, _render_inline_diffs
 from manage.web.state import (
     BUSY_STAGES,
@@ -819,12 +827,10 @@ async def post_message(tid: str, background_tasks: BackgroundTasks, text: str = 
 
 
 def _existing_thread_dir(tid: str) -> str:
-    """Return the thread's dir, or raise 404. Rejects a traversal/separator tid
-    (e.g. an encoded ``..``) BY CONSTRUCTION so a crafted id can't escape the
-    threads root in a filesystem op (rename writes, delete rmtree's)."""
-    if tid in ("", ".", "..") or "/" in tid or "\\" in tid or "\0" in tid:
-        raise HTTPException(status_code=404, detail="Thread not found")
-    tdir = os.path.join(MANAGER.root_dir, tid)
+    """Return the thread's dir, or 404 if it doesn't exist. ``MANAGER.thread_dir``
+    validates the tid (a traversal/separator id raises InvalidThreadId, mapped to
+    404 by the handler above), so this only adds the existence check."""
+    tdir = MANAGER.thread_dir(tid)
     if not os.path.isdir(tdir):
         raise HTTPException(status_code=404, detail="Thread not found")
     return tdir

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -26,17 +26,10 @@ from assist.domain_manager import (
 from assist.sandbox import SandboxContainerLostError
 from assist.sandbox_manager import SandboxManager
 from assist.thread import Thread
+from assist.thread_manager import InvalidThreadId
 from assist.thread_queue import THREAD_QUEUE
 
 from manage.web.app import app
-from assist.thread_manager import InvalidThreadId
-
-
-@app.exception_handler(InvalidThreadId)
-async def _invalid_thread_id(request, exc):
-    # A crafted tid (traversal/separator) reaching any tid-based route surfaces
-    # here from ThreadManager.thread_dir — map it to a clean 404 everywhere.
-    return HTMLResponse("Thread not found", status_code=404)
 from manage.web.diff import _DIFF_CSS, _render_inline_diffs
 from manage.web.state import (
     BUSY_STAGES,
@@ -62,6 +55,13 @@ from manage.web.state import (
     get_cached_description,
     set_description,
 )
+
+
+@app.exception_handler(InvalidThreadId)
+async def _invalid_thread_id(request, exc):
+    # A crafted tid (traversal/separator) reaching any tid-based route surfaces
+    # here from ThreadManager.thread_dir — map it to a clean 404 everywhere.
+    return HTMLResponse("Thread not found", status_code=404)
 
 
 def render_index(query: str = "") -> str:

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -241,16 +241,20 @@ def render_thread(
         'style="background:none; border:none; color:#999; cursor:pointer; '
         'font-size:1rem; padding:.2rem .4rem; line-height:1;">&#x270e;</button>'
     ) if can_rename else ""
+    # Stacked: full-width input on its own line, Save/Cancel on the line below
+    # (showRename() flips display to flex; flex-direction:column does the stack).
     rename_form = (
         f'<form id="titleEdit" action="/thread/{tid}/rename" method="post" '
-        f'style="display:none; gap:.4rem; align-items:center; margin:.2rem 0;">'
+        f'style="display:none; flex-direction:column; gap:.5rem; margin:.3rem 0;">'
         f'<input type="text" name="description" value="{html.escape(title)}" '
         f'maxlength="120" required aria-label="Thread name" '
-        f'style="flex:1; min-width:0; box-sizing:border-box; padding:.5rem .6rem; '
+        f'style="width:100%; box-sizing:border-box; padding:.6rem .7rem; '
         f'font-size:16px; border:1px solid #ccc; border-radius:6px;" />'
-        f'<button class="btn" type="submit" style="min-height:auto; padding:.5rem .8rem;">Save</button>'
+        f'<div style="display:flex; gap:.5rem;">'
+        f'<button class="btn" type="submit" style="min-height:auto; padding:.5rem 1rem;">Save</button>'
         f'<button class="btn btn-secondary" type="button" onclick="hideRename()" '
-        f'style="min-height:auto; padding:.5rem .8rem;">Cancel</button>'
+        f'style="min-height:auto; padding:.5rem 1rem;">Cancel</button>'
+        f'</div>'
         f'</form>'
     ) if can_rename else ""
 

--- a/tests/test_web_thread_search_rename.py
+++ b/tests/test_web_thread_search_rename.py
@@ -67,6 +67,31 @@ class TestSetDescription:
         assert (threads_root / "t1" / "description.txt").read_text() == "My renamed thread"
         assert state.DESCRIPTION_CACHE["t1"] == "My renamed thread"
 
+    def test_concurrent_set_description_no_corruption(self, threads_root):
+        # Un-mocked concurrency: many writers for the same thread must never
+        # produce a torn/empty description.txt (Copilot #143 r4 — a shared temp
+        # path would let one writer truncate another's). The final value is
+        # always one complete write, and no temp files leak.
+        import threading as _t
+        os.makedirs(threads_root / "t1", exist_ok=True)
+        values = [f"description-number-{i:03d}" for i in range(50)]
+        barrier = _t.Barrier(len(values))
+
+        def writer(v):
+            barrier.wait()  # maximize overlap
+            state.set_description("t1", v)
+
+        threads = [_t.Thread(target=writer, args=(v,)) for v in values]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        final = (threads_root / "t1" / "description.txt").read_text()
+        assert final in values, f"torn/corrupt write: {final!r}"
+        leftover = [f for f in os.listdir(threads_root / "t1") if f.endswith(".tmp")]
+        assert leftover == [], f"temp files leaked: {leftover}"
+
     def test_rename_sticks_without_regeneration(self, threads_root, monkeypatch):
         # The load-bearing contract: once description.txt exists, the title is
         # READ from disk, never regenerated via the model.

--- a/tests/test_web_thread_search_rename.py
+++ b/tests/test_web_thread_search_rename.py
@@ -134,13 +134,22 @@ class TestTidValidation:
             _existing_thread_dir("does-not-exist")
         assert ei.value.status_code == 404
 
-    def test_traversal_tid_on_a_route_404s_and_writes_nothing(self, threads_root):
-        # The InvalidThreadId handler maps a crafted tid to 404 on ANY route
-        # (here rename), and nothing is written outside the threads root.
+    @pytest.mark.parametrize("method,path,data", [
+        ("post", "/thread/%2e%2e/rename", {"description": "pwn"}),
+        ("post", "/thread/%2e%2e/message", {"text": "pwn"}),
+        ("post", "/thread/%2e%2e/delete", None),
+        ("get", "/thread/%2e%2e/status", None),
+        ("get", "/thread/%2e%2e", None),
+    ])
+    def test_traversal_tid_404s_on_every_route(self, threads_root, method, path, data):
+        # The InvalidThreadId handler maps a crafted tid to a clean 404 (never a
+        # 500) on EVERY tid route — not just rename/delete (Copilot #143).
         client = TestClient(web.app, raise_server_exceptions=False)
-        r = client.post("/thread/%2e%2e/rename", data={"description": "pwn"},
-                        follow_redirects=False)
-        assert r.status_code == 404
+        kwargs = {"follow_redirects": False}
+        if data is not None:
+            kwargs["data"] = data
+        r = getattr(client, method)(path, **kwargs)
+        assert r.status_code == 404, f"{method} {path} -> {r.status_code}"
         assert not (threads_root.parent / "description.txt").exists()
 
 

--- a/tests/test_web_thread_search_rename.py
+++ b/tests/test_web_thread_search_rename.py
@@ -1,0 +1,154 @@
+"""Tests for thread search (index filter) and thread rename (description edit).
+
+No model/GPU: titles are seeded into DESCRIPTION_CACHE (or description.txt is
+pre-written), so neither MANAGER.get nor chat.description() is exercised.
+"""
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from manage import web
+from manage.web import state
+from manage.web.threads import render_index
+
+
+@pytest.fixture
+def threads_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(web.MANAGER, "root_dir", str(tmp_path))
+    monkeypatch.setattr(web.MANAGER, "thread_dir", lambda tid: str(tmp_path / tid))
+    # render_index reaches _has_unmerged_changes (git I/O) for idle threads.
+    monkeypatch.setattr("manage.web.threads._has_unmerged_changes", lambda tid: False)
+    state.DESCRIPTION_CACHE.clear()
+    yield tmp_path
+    state.DESCRIPTION_CACHE.clear()
+
+
+def _make_thread(root, tid, title):
+    os.makedirs(root / tid, exist_ok=True)
+    state.DESCRIPTION_CACHE[tid] = title  # title == cached description; no model
+
+
+class TestThreadSearch:
+    def test_filters_by_title_substring_case_insensitive(self, threads_root):
+        _make_thread(threads_root, "t1", "Apple pie recipe")
+        _make_thread(threads_root, "t2", "Banana bread")
+        _make_thread(threads_root, "t3", "apple cider notes")
+        html = render_index("apple")
+        assert "Apple pie recipe" in html
+        assert "apple cider notes" in html
+        assert "Banana bread" not in html
+
+    def test_empty_query_shows_all(self, threads_root):
+        _make_thread(threads_root, "t1", "Apple pie")
+        _make_thread(threads_root, "t2", "Banana bread")
+        html = render_index("")
+        assert "Apple pie" in html
+        assert "Banana bread" in html
+
+    def test_no_match_shows_message_and_no_rows(self, threads_root):
+        _make_thread(threads_root, "t1", "Apple pie")
+        html = render_index("zzzznope")
+        assert "No threads match" in html
+        assert "Apple pie" not in html
+
+    def test_query_is_escaped_in_search_box(self, threads_root):
+        _make_thread(threads_root, "t1", "Apple")
+        html = render_index('foo<bar"')
+        # The raw query must not appear unescaped (XSS via the value attribute).
+        assert 'foo<bar"' not in html
+        assert "foo&lt;bar" in html
+
+
+class TestSetDescription:
+    def test_writes_file_and_updates_cache(self, threads_root):
+        os.makedirs(threads_root / "t1", exist_ok=True)
+        state.set_description("t1", "My renamed thread")
+        assert (threads_root / "t1" / "description.txt").read_text() == "My renamed thread"
+        assert state.DESCRIPTION_CACHE["t1"] == "My renamed thread"
+
+    def test_rename_sticks_without_regeneration(self, threads_root, monkeypatch):
+        # The load-bearing contract: once description.txt exists, the title is
+        # READ from disk, never regenerated via the model.
+        os.makedirs(threads_root / "t1", exist_ok=True)
+        state.set_description("t1", "Sticky name")
+        state.DESCRIPTION_CACHE.clear()  # force the FS path on next read
+
+        class _Chat:
+            def description(self):
+                raise AssertionError("must not regenerate when description.txt exists")
+
+        monkeypatch.setattr(web.MANAGER, "get", lambda tid: _Chat())
+        assert state.get_cached_description("t1") == "Sticky name"
+
+
+class TestRenameRoute:
+    def test_writes_and_redirects(self, threads_root):
+        os.makedirs(threads_root / "t1", exist_ok=True)
+        client = TestClient(web.app)
+        r = client.post("/thread/t1/rename", data={"description": "Renamed via route"},
+                        follow_redirects=False)
+        assert r.status_code == 303
+        assert r.headers["location"] == "/thread/t1"
+        assert (threads_root / "t1" / "description.txt").read_text() == "Renamed via route"
+
+    def test_empty_rename_is_noop(self, threads_root):
+        os.makedirs(threads_root / "t1", exist_ok=True)
+        client = TestClient(web.app)
+        r = client.post("/thread/t1/rename", data={"description": "   "},
+                        follow_redirects=False)
+        assert r.status_code == 303
+        assert not (threads_root / "t1" / "description.txt").exists()
+
+    def test_truncates_overlong_name(self, threads_root):
+        os.makedirs(threads_root / "t1", exist_ok=True)
+        client = TestClient(web.app)
+        client.post("/thread/t1/rename", data={"description": "x" * 200},
+                    follow_redirects=False)
+        assert len((threads_root / "t1" / "description.txt").read_text()) == 120
+
+    def test_missing_thread_is_404(self, threads_root):
+        client = TestClient(web.app)
+        r = client.post("/thread/nope/rename", data={"description": "x"},
+                        follow_redirects=False)
+        assert r.status_code == 404
+
+
+class TestTidValidation:
+    """The rename/delete routes must reject a traversal/separator tid by
+    construction so a crafted id can't escape the threads root."""
+
+    def test_existing_thread_dir_accepts_valid(self, threads_root):
+        from manage.web.threads import _existing_thread_dir
+        os.makedirs(threads_root / "good", exist_ok=True)
+        assert _existing_thread_dir("good") == str(threads_root / "good")
+
+    @pytest.mark.parametrize("bad", ["..", ".", "", "../etc", "a/b", "a\\b", "x\x00y"])
+    def test_existing_thread_dir_rejects_traversal(self, threads_root, bad):
+        from fastapi import HTTPException
+        from manage.web.threads import _existing_thread_dir
+        with pytest.raises(HTTPException) as ei:
+            _existing_thread_dir(bad)
+        assert ei.value.status_code == 404
+
+
+class TestRenameVisibility:
+    def test_rename_control_shown_when_idle(self, threads_root):
+        from manage.web.threads import render_thread
+        os.makedirs(threads_root / "t1", exist_ok=True)
+        state.DESCRIPTION_CACHE["t1"] = "Idle title"
+        html = render_thread("t1", None)
+        assert 'id="titleEdit"' in html
+        assert 'onclick="showRename()"' in html
+
+    def test_rename_control_hidden_while_busy(self, threads_root, monkeypatch):
+        from manage.web.state import BUSY_STAGES
+        from manage.web.threads import render_thread
+        os.makedirs(threads_root / "t1", exist_ok=True)
+        state.DESCRIPTION_CACHE["t1"] = "Busy title"
+        busy_stage = sorted(BUSY_STAGES)[0]
+        monkeypatch.setattr("manage.web.threads._get_status",
+                            lambda tid: {"stage": busy_stage, "pending_message": "hi"})
+        html = render_thread("t1", None)
+        assert 'id="titleEdit"' not in html
+        assert 'onclick="showRename()"' not in html

--- a/tests/test_web_thread_search_rename.py
+++ b/tests/test_web_thread_search_rename.py
@@ -16,7 +16,7 @@ from manage.web.threads import render_index
 @pytest.fixture
 def threads_root(tmp_path, monkeypatch):
     monkeypatch.setattr(web.MANAGER, "root_dir", str(tmp_path))
-    monkeypatch.setattr(web.MANAGER, "thread_dir", lambda tid: str(tmp_path / tid))
+    # Use the REAL thread_dir (root_dir-based) so its tid validation is exercised.
     # render_index reaches _has_unmerged_changes (git I/O) for idle threads.
     monkeypatch.setattr("manage.web.threads._has_unmerged_changes", lambda tid: False)
     state.DESCRIPTION_CACHE.clear()
@@ -115,21 +115,33 @@ class TestRenameRoute:
 
 
 class TestTidValidation:
-    """The rename/delete routes must reject a traversal/separator tid by
-    construction so a crafted id can't escape the threads root."""
+    """tid traversal is rejected BY CONSTRUCTION at the source (ThreadManager),
+    so every tid-based route is covered, not just rename/delete."""
 
-    def test_existing_thread_dir_accepts_valid(self, threads_root):
-        from manage.web.threads import _existing_thread_dir
-        os.makedirs(threads_root / "good", exist_ok=True)
-        assert _existing_thread_dir("good") == str(threads_root / "good")
+    def test_thread_dir_accepts_valid(self, threads_root):
+        assert web.MANAGER.thread_dir("good") == os.path.join(str(threads_root), "good")
 
     @pytest.mark.parametrize("bad", ["..", ".", "", "../etc", "a/b", "a\\b", "x\x00y"])
-    def test_existing_thread_dir_rejects_traversal(self, threads_root, bad):
+    def test_thread_dir_rejects_traversal(self, threads_root, bad):
+        from assist.thread_manager import InvalidThreadId
+        with pytest.raises(InvalidThreadId):
+            web.MANAGER.thread_dir(bad)
+
+    def test_existing_thread_dir_404_for_missing(self, threads_root):
         from fastapi import HTTPException
         from manage.web.threads import _existing_thread_dir
         with pytest.raises(HTTPException) as ei:
-            _existing_thread_dir(bad)
+            _existing_thread_dir("does-not-exist")
         assert ei.value.status_code == 404
+
+    def test_traversal_tid_on_a_route_404s_and_writes_nothing(self, threads_root):
+        # The InvalidThreadId handler maps a crafted tid to 404 on ANY route
+        # (here rename), and nothing is written outside the threads root.
+        client = TestClient(web.app, raise_server_exceptions=False)
+        r = client.post("/thread/%2e%2e/rename", data={"description": "pwn"},
+                        follow_redirects=False)
+        assert r.status_code == 404
+        assert not (threads_root.parent / "description.txt").exists()
 
 
 class TestRenameVisibility:


### PR DESCRIPTION
## What
Two web-UI quality-of-life features:

- **Thread search** — a search box on the index; `GET /?q=…` filters the thread list by displayed title/description (case-insensitive substring). Server-rendered, no JS; shows a match count + clear link, and a no-match message.
- **Renameable descriptions** — an inline ✎ edit next to the title on the thread view → input → Save; `POST /thread/{tid}/rename` writes `description.txt`. The rename **sticks** because `get_cached_description` only generates when the file is absent. The control is hidden while a thread is busy/initializing (the displayed title is the pending-message snippet then, not the description).

Note: in this app the **title *is* the description** (one auto-generated field), so both features act on that single field.

## Review (done locally before this PR)
Three adversarial lenses (correctness/event-loop, security, simplicity/patterns). Fixes applied:
- **Security:** `_existing_thread_dir()` rejects a traversal/separator `tid` by construction — an encoded `..` previously passed the `isdir` guard and could write outside the threads root. Applied to rename **and** the pre-existing `delete_thread` route (which `rmtree`'d), closing the same hole.
- `get_cached_description` now persists via `set_description` — a single atomic write path (the auto-generate write was non-atomic before), and it no longer loads the Thread when `description.txt` already exists.
- Rename hidden while busy so the pending-message snippet can't be baked in as a permanent title.

## Tests
20 new (search filter/escaping/no-match, `set_description` + no-regeneration stickiness, rename route empty/truncate/404, tid traversal rejection, rename visibility). **655 unit tests green.** No model/GPU touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Design decisions from review
- **Declined (theoretical):** Copilot suggested content-negotiating the `InvalidThreadId` 404 handler so JSON routes (e.g. `/status`) return JSON, not HTML. Declined per the repo's no-theoretical-code rule: that handler fires only for a traversal/NUL tid (a malicious request); the real `/status` poller always sends a valid tid, and a nonexistent valid tid returns FastAPI's default JSON 404 — so no real client is affected. Adding content-negotiation would be machinery for a malicious-only path.