### PR TITLE
show_file: render a workspace file (org/md/pdf) in the web UI

### DIFF
--- a/assist/thread.py
+++ b/assist/thread.py
@@ -16,8 +16,14 @@ from assist.thread_queue import THREAD_QUEUE
 logger = logging.getLogger(__name__)
 
 def render_tool_calls(message: AIMessage) -> str:
-    return _render_calls(getattr(message, "tool_calls", None) or [],
-                         getattr(message, "content", None))
+    """The tool-call text line for a message's calls, or "" when it has none.
+    The CLI prints this for every AIMessage, so a message with no tool calls
+    must render empty — otherwise its plain content (already streamed/printed
+    separately) would be duplicated."""
+    calls = getattr(message, "tool_calls", None)
+    if not calls:
+        return ""
+    return _render_calls(calls, getattr(message, "content", None))
 
 
 def _messages_to_dicts(raw: list) -> list[dict]:
@@ -40,8 +46,10 @@ def _messages_to_dicts(raw: list) -> list[dict]:
                                  "content": _render_calls(non_show, m.content)})
                 for c in calls:
                     if c.get("name") == "show_file":
+                        # args are untrusted model output: a non-string path
+                        # (list/dict) would crash the renderer's urllib.quote.
                         path = (c.get("args") or {}).get("path", "")
-                        if path:
+                        if path and isinstance(path, str):
                             msgs.append({"role": "show_file", "path": path})
             elif m.content:
                 msgs.append({"role": "assistant", "content": m.content})

--- a/assist/thread.py
+++ b/assist/thread.py
@@ -16,14 +16,8 @@ from assist.thread_queue import THREAD_QUEUE
 logger = logging.getLogger(__name__)
 
 def render_tool_calls(message: AIMessage) -> str:
-    calls = getattr(message, "tool_calls", None)
-    if calls:
-        calls_str = " -- ".join(map(lambda c: render_tool_call(c), calls))
-        if getattr(message, "content", None):
-            return f"{calls_str} \n> {message.content}"
-
-        return calls_str
-    return ""
+    return _render_calls(getattr(message, "tool_calls", None) or [],
+                         getattr(message, "content", None))
 
 
 def _messages_to_dicts(raw: list) -> list[dict]:

--- a/assist/thread.py
+++ b/assist/thread.py
@@ -1,5 +1,6 @@
 import contextvars
 import logging
+import os
 from datetime import datetime
 from typing import Any, Callable, List, Iterator, Mapping
 
@@ -10,6 +11,7 @@ from assist.promptable import base_prompt_for
 from assist.model_manager import select_assistant_model
 from assist.agent import create_agent
 from assist.spec import AgentSpec
+from assist.tools import _SHOWABLE_EXTS
 from assist.checkpoint_rollback import invoke_with_rollback
 from assist.thread_queue import THREAD_QUEUE
 
@@ -26,13 +28,30 @@ def render_tool_calls(message: AIMessage) -> str:
     return _render_calls(calls, getattr(message, "content", None))
 
 
+def _showable_path(call: dict) -> str | None:
+    """The path a ``show_file`` CALL should render inline, or ``None`` when the
+    call can't (wrong tool, or — args are untrusted model output — a path that
+    isn't a non-empty string with a showable extension).  A show_file call that
+    returns None here falls back to the normal tool-call text line, so an
+    out-of-spec call never embeds the viewer route (which would render a 415)."""
+    if call.get("name") != "show_file":
+        return None
+    path = (call.get("args") or {}).get("path")
+    if (isinstance(path, str) and path
+            and os.path.splitext(path)[1].lower() in _SHOWABLE_EXTS):
+        return path
+    return None
+
+
 def _messages_to_dicts(raw: list) -> list[dict]:
     """Convert checkpointer messages to the role/content dicts the web UI renders.
 
-    Pure (no agent/state access) so it's unit-testable. AIMessages with a
-    ``show_file`` tool call yield a structured ``{"role": "show_file", "path": …}``
-    directive (the web UI embeds the file); any other calls stay as the
-    ``"tools"`` text line, and plain content is an ``"assistant"`` message."""
+    Pure (no agent/state access) so it's unit-testable. A ``show_file`` call with
+    a renderable path yields a ``{"role": "show_file", "path": …}`` directive (the
+    web UI embeds the file); every other tool call — including a show_file call
+    that can't render — becomes the ``"tools"`` text line, which also carries the
+    message's own content when it has calls. A message with content and no tool
+    calls is an ``"assistant"`` message; a HumanMessage is ``"user"``."""
     msgs: list[dict] = []
     for m in raw:
         if isinstance(m, HumanMessage):
@@ -40,17 +59,15 @@ def _messages_to_dicts(raw: list) -> list[dict]:
         elif isinstance(m, AIMessage):
             calls = getattr(m, "tool_calls", None)
             if calls:
-                non_show = [c for c in calls if c.get("name") != "show_file"]
-                if non_show or m.content:
-                    msgs.append({"role": "tools",
-                                 "content": _render_calls(non_show, m.content)})
+                shown, other = [], []
                 for c in calls:
-                    if c.get("name") == "show_file":
-                        # args are untrusted model output: a non-string path
-                        # (list/dict) would crash the renderer's urllib.quote.
-                        path = (c.get("args") or {}).get("path", "")
-                        if path and isinstance(path, str):
-                            msgs.append({"role": "show_file", "path": path})
+                    path = _showable_path(c)
+                    (shown if path else other).append(path or c)
+                if other or m.content:
+                    msgs.append({"role": "tools",
+                                 "content": _render_calls(other, m.content)})
+                for path in shown:
+                    msgs.append({"role": "show_file", "path": path})
             elif m.content:
                 msgs.append({"role": "assistant", "content": m.content})
     return msgs

--- a/assist/thread.py
+++ b/assist/thread.py
@@ -26,6 +26,45 @@ def render_tool_calls(message: AIMessage) -> str:
     return ""
 
 
+def _messages_to_dicts(raw: list) -> list[dict]:
+    """Convert checkpointer messages to the role/content dicts the web UI renders.
+
+    Pure (no agent/state access) so it's unit-testable. AIMessages with a
+    ``show_file`` tool call yield a structured ``{"role": "show_file", "path": …}``
+    directive (the web UI embeds the file); any other calls stay as the
+    ``"tools"`` text line, and plain content is an ``"assistant"`` message."""
+    msgs: list[dict] = []
+    for m in raw:
+        if isinstance(m, HumanMessage):
+            msgs.append({"role": "user", "content": m.content})
+        elif isinstance(m, AIMessage):
+            calls = getattr(m, "tool_calls", None)
+            if calls:
+                non_show = [c for c in calls if c.get("name") != "show_file"]
+                if non_show or m.content:
+                    msgs.append({"role": "tools",
+                                 "content": _render_calls(non_show, m.content)})
+                for c in calls:
+                    if c.get("name") == "show_file":
+                        path = (c.get("args") or {}).get("path", "")
+                        if path:
+                            msgs.append({"role": "show_file", "path": path})
+            elif m.content:
+                msgs.append({"role": "assistant", "content": m.content})
+    return msgs
+
+
+def _render_calls(calls: list, content) -> str:
+    """The tool-call text line for a subset of an AIMessage's calls (+ optional
+    prose).  Same shape as ``render_tool_calls`` but over an explicit call list,
+    so ``get_messages`` can render the non-show_file calls separately from the
+    show_file render directives."""
+    s = " -- ".join(render_tool_call(c) for c in calls)
+    if content:
+        return f"{s} \n> {content}" if s else str(content)
+    return s
+
+
 def render_tool_call(call: dict) -> str:
     name = call.get("name", "none")
     args = call.get("args", {})
@@ -227,18 +266,7 @@ class Thread:
     def get_messages(self) -> list[dict]:
         """Return user/assistant messages from checkpointer state as role/content dicts."""
         state = self.agent.get_state(self.runconfig)
-        msgs = []
-        for m in state.values.get("messages", []):
-            if isinstance(m, HumanMessage):
-                msgs.append({"role": "user", "content": m.content})
-            elif isinstance(m, AIMessage):
-                calls = getattr(m, "tool_calls", None)
-                if calls:
-                    msgs.append({"role": "tools",
-                                 "content": render_tool_calls(m)})
-                elif m.content:
-                    msgs.append({"role": "assistant", "content": m.content})
-        return msgs
+        return _messages_to_dicts(state.values.get("messages", []))
 
 
     def get_raw_messages(self) -> List[AnyMessage]:

--- a/assist/thread_manager.py
+++ b/assist/thread_manager.py
@@ -44,8 +44,10 @@ logger = logging.getLogger(__name__)
 # here BY DESIGN: ThreadManager is the web app's agent builder (emacsos builds
 # its own Thread/spec; the eval harness uses create_agent directly), so the
 # web-only show_file tool rides the web-only builder rather than a universal
-# default that would also reach surfaces with no web view.
-_WEB_SPEC = AgentSpec(tools=(show_file,))
+# default that would also reach surfaces with no web view.  The AgentSpec is
+# constructed per-call (in get/new) — its docstring cautions against caching a
+# spec as a module constant — though this one closes over no per-request state.
+_WEB_TOOLS = (show_file,)
 
 
 class InvalidThreadId(ValueError):
@@ -233,7 +235,7 @@ class ThreadManager:
                       model=self.model,
                       sandbox_backend=sandbox_backend,
                       on_queue_state=on_queue_state,
-                      spec=_WEB_SPEC)
+                      spec=AgentSpec(tools=_WEB_TOOLS))
 
     def remove(self, thread_id: str) -> None:
         tdir = self.thread_dir(thread_id)
@@ -266,7 +268,7 @@ class ThreadManager:
 
         return Thread(working_dir, thread_id=tid, checkpointer=self.checkpointer,
                       model=self.model, sandbox_backend=sandbox_backend,
-                      on_queue_state=on_queue_state, spec=_WEB_SPEC)
+                      on_queue_state=on_queue_state, spec=AgentSpec(tools=_WEB_TOOLS))
 
     def close(self) -> None:
         try:

--- a/assist/thread_manager.py
+++ b/assist/thread_manager.py
@@ -34,9 +34,18 @@ from langgraph.checkpoint.sqlite import SqliteSaver
 
 from assist.model_manager import select_assistant_model
 from assist.sandbox_manager import SandboxManager
+from assist.spec import AgentSpec
 from assist.thread import Thread
+from assist.tools import show_file
 
 logger = logging.getLogger(__name__)
+
+# The web app's main agent gets show_file (render a file in the web UI).  Scoped
+# here BY DESIGN: ThreadManager is the web app's agent builder (emacsos builds
+# its own Thread/spec; the eval harness uses create_agent directly), so the
+# web-only show_file tool rides the web-only builder rather than a universal
+# default that would also reach surfaces with no web view.
+_WEB_SPEC = AgentSpec(tools=(show_file,))
 
 
 class InvalidThreadId(ValueError):
@@ -223,7 +232,8 @@ class ThreadManager:
                       checkpointer=self.checkpointer,
                       model=self.model,
                       sandbox_backend=sandbox_backend,
-                      on_queue_state=on_queue_state)
+                      on_queue_state=on_queue_state,
+                      spec=_WEB_SPEC)
 
     def remove(self, thread_id: str) -> None:
         tdir = self.thread_dir(thread_id)
@@ -256,7 +266,7 @@ class ThreadManager:
 
         return Thread(working_dir, thread_id=tid, checkpointer=self.checkpointer,
                       model=self.model, sandbox_backend=sandbox_backend,
-                      on_queue_state=on_queue_state)
+                      on_queue_state=on_queue_state, spec=_WEB_SPEC)
 
     def close(self) -> None:
         try:

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -271,9 +271,9 @@ def search_internet(
     return str(normalized)
 
 
-# Extensions show_file can render in the web UI.  Kept here as the single source
-# of truth; the web layer (manage/web) renders each.
-_SHOWABLE_EXTS = (".org", ".md", ".markdown", ".pdf")
+# Extensions show_file accepts (the tool's gate).  The web /show route dispatches
+# each of these (md/org/pdf); keep the two lists in sync by hand.
+_SHOWABLE_EXTS = (".org", ".md", ".pdf")
 
 
 def show_file(path: str) -> str:

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -271,8 +271,12 @@ def search_internet(
     return str(normalized)
 
 
-# Extensions show_file accepts (the tool's gate).  The web /show route dispatches
-# each of these (md/org/pdf); keep the two lists in sync by hand.
+# Extensions show_file accepts — the SINGLE source for the tool's gate, the web
+# UI's show-directive gate (thread._showable_path), and the /show route's
+# renderable set.  The route dispatches per type (md/org/pdf) and 415s anything
+# else, so it can't silently mis-render; test_route_renders_every_showable_ext
+# pins that the route renders every ext here, so the sets can't drift into a
+# directive the route would 415.
 _SHOWABLE_EXTS = (".org", ".md", ".pdf")
 
 

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -269,3 +269,27 @@ def search_internet(
         for r in results[:max_results]
     ]
     return str(normalized)
+
+
+# Extensions show_file can render in the web UI.  Kept here as the single source
+# of truth; the web layer (manage/web) renders each.
+_SHOWABLE_EXTS = (".org", ".md", ".markdown", ".pdf")
+
+
+def show_file(path: str) -> str:
+    """Render a file in the user's web view so they can read it well-formatted.
+
+    Use this to SHOW the user a file you produced or found — a report, notes, a
+    PDF — instead of pasting its raw contents into the chat.  Pass the path to
+    the file in your workspace.  Supported: ``.org`` and ``.md`` (rendered as
+    formatted HTML) and ``.pdf`` (shown in the browser's PDF viewer); other
+    types aren't shown — read and summarize those instead.
+
+    The file appears embedded in the conversation.  Returns a short confirmation,
+    or a note when the extension isn't one this can display.
+    """
+    ext = os.path.splitext(path)[1].lower()
+    if ext not in _SHOWABLE_EXTS:
+        return (f"show_file can't display '{path}': only .org, .md, and .pdf are "
+                "supported. For other files, read and summarize them instead.")
+    return f"Showing {path} in the web view."

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -288,6 +288,11 @@ def show_file(path: str) -> str:
     The file appears embedded in the conversation.  Returns a short confirmation,
     or a note when the extension isn't one this can display.
     """
+    # args are untrusted model output: a non-string/empty path would raise in
+    # os.path.splitext — return guidance so the model can self-correct instead.
+    if not isinstance(path, str) or not path:
+        return ("show_file needs a single file path as a string — pass the path "
+                "to a .org, .md, or .pdf file in your workspace.")
     ext = os.path.splitext(path)[1].lower()
     if ext not in _SHOWABLE_EXTS:
         return (f"show_file can't display '{path}': only .org, .md, and .pdf are "

--- a/docs/2026-06-27-show-file.org
+++ b/docs/2026-06-27-show-file.org
@@ -49,11 +49,16 @@ browser's viewer — instead of pasting raw contents into the chat.
 - *Inline embed* (user's pick) over a link-only card: the file shows where the
   agent called it; the slow org conversion stays off the page-render path (it's
   in the iframe's own async route request).
-- *md/org iframe is ~sandbox="allow-popups"~* (no ~allow-scripts~): the embedded
-  page is static, so no JS runs even if agent-generated content carries a
-  ~<script>~/~onerror~. Defence-in-depth over the org renderer's escaping, and
-  it covers the md path too (the markdown lib passes raw HTML through). The
-  ~allow-popups~ token keeps ~target=_blank~ links in the content clickable.
+- *Script execution is unreachable on the /show route, by CSP.* The md path
+  (python-markdown) passes raw HTML through, so agent-generated md could carry
+  ~<script>~/~onerror~/~javascript:~. The route response sets
+  ~Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline';
+  img-src 'self' data: https:; object-src 'none'; base-uri 'none'~ (+ ~nosniff~):
+  no script source => nothing executes, for BOTH the inline embed AND the
+  caption link that opens the same route as a top-level document (the
+  iframe ~sandbox~ only covers the embed — Copilot rd2 caught that the
+  standalone open was still in the app origin). The md/org iframe also keeps
+  ~sandbox="allow-popups"~ as layered defence.
 - *Tool doesn't validate existence* (no working-dir handle): a missing file
   surfaces as the route's 404 in the embed, not a tool error. Acceptable v1.
 

--- a/docs/2026-06-27-show-file.org
+++ b/docs/2026-06-27-show-file.org
@@ -9,11 +9,12 @@ browser's viewer — instead of pasting raw contents into the chat.
 
 * Design (as built)
 - *Tool* (=assist/tools.py=): ~show_file(path)~ validates the extension
-  (.org/.md/.markdown/.pdf) and returns a confirmation string; unsupported types
+  (.org/.md/.pdf) and returns a confirmation string; unsupported types
   get a "read and summarize instead" note. It does NOT read the file — the web
   layer renders it (the tool has no thread/working-dir handle).
-- *Registration* (=assist/thread_manager.py=): added to ~_WEB_SPEC =
-  AgentSpec(tools=(show_file,))~, passed to both ~ThreadManager.get/new~.
+- *Registration* (=assist/thread_manager.py=): an ~AgentSpec(tools=_WEB_TOOLS)~
+  (=_WEB_TOOLS = (show_file,)=) constructed per-call and passed to both
+  ~ThreadManager.get/new~.
   Scoped here BY DESIGN — ThreadManager is the *web app's* agent builder
   (emacsos builds its own Thread/spec; the eval harness uses ~create_agent~
   directly), so a web-only tool doesn't leak onto surfaces with no web view nor
@@ -48,6 +49,11 @@ browser's viewer — instead of pasting raw contents into the chat.
 - *Inline embed* (user's pick) over a link-only card: the file shows where the
   agent called it; the slow org conversion stays off the page-render path (it's
   in the iframe's own async route request).
+- *md/org iframe is ~sandbox="allow-popups"~* (no ~allow-scripts~): the embedded
+  page is static, so no JS runs even if agent-generated content carries a
+  ~<script>~/~onerror~. Defence-in-depth over the org renderer's escaping, and
+  it covers the md path too (the markdown lib passes raw HTML through). The
+  ~allow-popups~ token keeps ~target=_blank~ links in the content clickable.
 - *Tool doesn't validate existence* (no working-dir handle): a missing file
   surfaces as the route's 404 in the embed, not a tool error. Acceptable v1.
 
@@ -60,6 +66,6 @@ browser's viewer — instead of pasting raw contents into the chat.
   agent calls show_file → embed renders). Covered structurally by the unit tests.
 
 * Critical files
-- =assist/tools.py= (show_file), =assist/thread_manager.py= (_WEB_SPEC),
+- =assist/tools.py= (show_file), =assist/thread_manager.py= (_WEB_TOOLS),
   =assist/thread.py= (_messages_to_dicts), =manage/web/threads.py= (route +
   render + org export), =tests/test_show_file.py=.

--- a/docs/2026-06-27-show-file.org
+++ b/docs/2026-06-27-show-file.org
@@ -1,0 +1,57 @@
+#+TITLE: show_file — render a workspace file (org/md/pdf) in the web UI
+#+DATE: <2026-06-27>
+#+STATUS: built (CPU-tested; live agent-invocation deferred — GPU down)
+
+* Goal
+A ~show_file(path)~ agent tool that displays a file in the assist web UI,
+rendered well for the web — org and markdown as formatted HTML, PDF in the
+browser's viewer — instead of pasting raw contents into the chat.
+
+* Design (as built)
+- *Tool* (=assist/tools.py=): ~show_file(path)~ validates the extension
+  (.org/.md/.markdown/.pdf) and returns a confirmation string; unsupported types
+  get a "read and summarize instead" note. It does NOT read the file — the web
+  layer renders it (the tool has no thread/working-dir handle).
+- *Registration* (=assist/thread_manager.py=): added to ~_WEB_SPEC =
+  AgentSpec(tools=(show_file,))~, passed to both ~ThreadManager.get/new~.
+  Scoped here BY DESIGN — ThreadManager is the *web app's* agent builder
+  (emacsos builds its own Thread/spec; the eval harness uses ~create_agent~
+  directly), so a web-only tool doesn't leak onto surfaces with no web view nor
+  onto the eval agents.
+- *Surface* (=assist/thread.py=): ~get_messages~ (via the new pure
+  ~_messages_to_dicts~) turns a ~show_file~ tool call into a structured
+  ~{"role":"show_file","path":…}~ directive; other calls stay as the "tools"
+  text line. (No event channel in assist's web UI; the tool *call* persists in
+  the message, and the server re-renders from it.)
+- *Render* (=manage/web/threads.py=): ~render_thread~ emits an inline embed for
+  a show_file directive — ~<embed>~ (pdf) / ~<iframe>~ (md/org) pointing at a
+  viewer route, plus a caption link. CSS ~.show-file~ gives it a sane height.
+- *Viewer route* ~GET /thread/{tid}/show?path=…~: pdf → ~FileResponse~ (browser
+  viewer); md → ~markdown~ lib → styled HTML page; org → emacs export (below).
+  Path resolved traversal-safe within the thread's agent working dir
+  (~_safe_workspace_file~, realpath-child check — same lesson as the tid guard).
+
+* Decisions / trade-offs
+- *org → HTML via emacs* (=_org_to_html=): no Python org lib / no pandoc on the
+  host; emacs is present (same engine as larochelle.io). Run in a *threadpool*
+  (~run_in_threadpool~) so the ~1-2 s emacs subprocess never blocks the
+  single-worker event loop. Security: ~org-export-use-babel nil~ (no code eval
+  on export) and ~#+INCLUDE:~ lines stripped before export (so agent-written org
+  can't read arbitrary host files into the output). ~-Q~ for a clean emacs.
+- *Inline embed* (user's pick) over a link-only card: the file shows where the
+  agent called it; the slow org conversion stays off the page-render path (it's
+  in the iframe's own async route request).
+- *Tool doesn't validate existence* (no working-dir handle): a missing file
+  surfaces as the route's 404 in the embed, not a tool error. Acceptable v1.
+
+* Validation
+- 20 unit tests (tool gating, traversal-safety, render embed, the /show route for
+  md/pdf/missing/traversal/unsupported, real org export + #+INCLUDE stripping,
+  _messages_to_dicts). 682 unit tests green. All CPU — no model.
+- Deferred (needs the model, GPU down): the live agent-driven flow (user asks →
+  agent calls show_file → embed renders). Covered structurally by the unit tests.
+
+* Critical files
+- =assist/tools.py= (show_file), =assist/thread_manager.py= (_WEB_SPEC),
+  =assist/thread.py= (_messages_to_dicts), =manage/web/threads.py= (route +
+  render + org export), =tests/test_show_file.py=.

--- a/docs/2026-06-27-show-file.org
+++ b/docs/2026-06-27-show-file.org
@@ -27,17 +27,24 @@ browser's viewer — instead of pasting raw contents into the chat.
   a show_file directive — ~<embed>~ (pdf) / ~<iframe>~ (md/org) pointing at a
   viewer route, plus a caption link. CSS ~.show-file~ gives it a sane height.
 - *Viewer route* ~GET /thread/{tid}/show?path=…~: pdf → ~FileResponse~ (browser
-  viewer); md → ~markdown~ lib → styled HTML page; org → emacs export (below).
-  Path resolved traversal-safe within the thread's agent working dir
-  (~_safe_workspace_file~, realpath-child check — same lesson as the tid guard).
+  viewer); md → ~markdown~ lib → styled HTML page; org → a pure-Python renderer
+  (below). Path resolved traversal-safe within the thread's agent working dir
+  (~_safe_workspace_file~, realpath-child check — same lesson as the tid guard;
+  a malformed path / embedded NUL returns None → 404, not a 500).
 
 * Decisions / trade-offs
-- *org → HTML via emacs* (=_org_to_html=): no Python org lib / no pandoc on the
-  host; emacs is present (same engine as larochelle.io). Run in a *threadpool*
-  (~run_in_threadpool~) so the ~1-2 s emacs subprocess never blocks the
-  single-worker event loop. Security: ~org-export-use-babel nil~ (no code eval
-  on export) and ~#+INCLUDE:~ lines stripped before export (so agent-written org
-  can't read arbitrary host files into the output). ~-Q~ for a clean emacs.
+- *org → HTML via a pure, escape-first Python renderer* (=_org_to_html=), NOT
+  emacs. Code review (rightly) flagged that ~org-export-string-as~ EXECUTES
+  elisp during export even with babel disabled — ~#+MACRO: x (eval …)~ + ~{{{x}}}~
+  runs arbitrary shell on the host (verified), and a deny-list of org's eval
+  surfaces (macros, ~#+CALL:~, table formulas, ~#+BIND:~) leaks. Since org files
+  are agent-generated (possibly from fetched web content), that's a
+  prompt-injection→RCE chain. The by-construction fix: don't run emacs at all —
+  a small renderer that html-escapes every character first and only emits its
+  own tags (headings, lists, tables, src/example blocks, inline emphasis,
+  links). No eval, no subprocess, no XSS; richer org degrades to readable text.
+  Bonus: removes the threadpool/timeout/babel/include complexity (it's pure +
+  fast, so it runs inline like the markdown path).
 - *Inline embed* (user's pick) over a link-only card: the file shows where the
   agent called it; the slow org conversion stays off the page-render path (it's
   in the iframe's own async route request).
@@ -45,9 +52,10 @@ browser's viewer — instead of pasting raw contents into the chat.
   surfaces as the route's 404 in the embed, not a tool error. Acceptable v1.
 
 * Validation
-- 20 unit tests (tool gating, traversal-safety, render embed, the /show route for
-  md/pdf/missing/traversal/unsupported, real org export + #+INCLUDE stripping,
-  _messages_to_dicts). 682 unit tests green. All CPU — no model.
+- 22 unit tests (tool gating, traversal-safety incl. NUL, render embed, the /show
+  route for md/pdf/missing/traversal/unsupported, the org renderer incl.
+  macro-(eval)-does-not-execute / #+INCLUDE-not-expanded / content-escaped,
+  _messages_to_dicts). 684 unit tests green. All CPU — no model.
 - Deferred (needs the model, GPU down): the live agent-driven flow (user asks →
   agent calls show_file → embed renders). Covered structurally by the unit tests.
 

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -1038,10 +1038,14 @@ def _render_show_file(tid: str, path: str) -> str:
 
 
 @app.get("/thread/{tid}/show")
-async def show_file_view(tid: str, path: str):
+def show_file_view(tid: str, path: str):
     """Render a file from the thread's agent workspace for embedding: pdf as
-    bytes (browser viewer), md/org as a styled HTML page.  Pure renderers (no
-    subprocess), so safe to run inline on the event loop."""
+    bytes (browser viewer), md/org as a styled HTML page.
+
+    Declared SYNC (not ``async def``) on purpose: the file read and the
+    markdown/org conversion are blocking CPU/IO and a shown file can be large,
+    so FastAPI runs this in its threadpool, keeping the single-worker event
+    loop free (the repo's event-loop-liveness rule)."""
     _existing_thread_dir(tid)  # 404 on a bad/missing tid (traversal-safe)
     fpath = _safe_workspace_file(tid, path)
     if fpath is None or not os.path.isfile(fpath):

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -12,10 +12,17 @@ import json
 import logging
 import os
 import subprocess
+import urllib.parse
 
 import markdown
 from fastapi import BackgroundTasks, Form, HTTPException
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.concurrency import run_in_threadpool
+from fastapi.responses import (
+    FileResponse,
+    HTMLResponse,
+    JSONResponse,
+    RedirectResponse,
+)
 
 from assist.domain_manager import (
     Change,
@@ -374,6 +381,9 @@ def render_thread(
 
     rendered = []
     for m in reversed(msgs):
+        if m.get("role") == "show_file":
+            rendered.append(_render_show_file(tid, m.get("path", "")))
+            continue
         role = html.escape(m.get("role", ""))
         raw = str(m.get("content", ""))
         if role == "assistant" or role == "tools":
@@ -443,6 +453,10 @@ def render_thread(
           .msg {{ margin: .6rem 0; padding: .6rem .8rem; border-radius: 8px; max-width: 100%; word-wrap: break-word; overflow-wrap: anywhere; }}
           .msg.user {{ background: #e6f3ff; border: 1px solid #b5dbff; }}
           .msg.assistant {{ background: #f6f6f6; border: 1px solid #ddd; }}
+          .msg.show {{ background: #fff; border: 1px solid #ddd; }}
+          /* Embedded shown file (org/md rendered page, or pdf viewer). */
+          .show-file {{ width: 100%; height: 65vh; border: 1px solid #e3e3e3; border-radius: 6px; background: #fff; }}
+          .show-cap {{ font-size: .85rem; margin-top: .3rem; }}
           .role {{ font-size: .8rem; color: #555; margin-bottom: .2rem; text-transform: uppercase; }}
           /* font-size: 16px on every editable form input — prevents iOS
              Safari from auto-zooming into the field on focus.  Anything
@@ -836,6 +850,106 @@ def _existing_thread_dir(tid: str) -> str:
     if not os.path.isdir(tdir):
         raise HTTPException(status_code=404, detail="Thread not found")
     return tdir
+
+
+# ---- show_file: render a workspace file (org/md/pdf) in the web UI ----
+
+_SHOW_PAGE_CSS = (
+    "body{font-family:sans-serif;max-width:780px;margin:1rem auto;padding:0 1rem;"
+    "line-height:1.55;color:#222}pre,code{background:#f5f5f5;border-radius:4px}"
+    "pre{padding:.6rem;overflow:auto}table{border-collapse:collapse}"
+    "td,th{border:1px solid #ccc;padding:.3rem .5rem}img{max-width:100%}"
+)
+
+
+def _safe_workspace_file(tid: str, path: str) -> str | None:
+    """Resolve PATH against the thread's agent working dir, traversal-safe.
+    Returns the absolute host path, or None if it would escape the workspace.
+    (Same realpath-child check as the tid guard — a crafted ``../`` can't read
+    outside the agent's own files.)"""
+    base = os.path.realpath(MANAGER.thread_default_working_dir(tid))
+    target = os.path.realpath(os.path.join(base, path))
+    if target != base and not target.startswith(base + os.sep):
+        return None
+    return target
+
+
+def _org_to_html(fpath: str) -> str:
+    """Export an org file to body HTML via emacs (the only org engine available;
+    no Python org lib).  Off the event loop — emacs is a ~1-2s subprocess.
+    Babel is disabled and ``#+INCLUDE:`` lines are stripped so exporting an
+    agent-written org file can't execute code or read arbitrary host files."""
+    try:
+        src = open(fpath, encoding="utf-8", errors="replace").read()
+    except OSError as e:
+        return f"<p><em>Could not read file: {html.escape(str(e))}</em></p>"
+    # Strip include directives before handing the string to org (defense in
+    # depth against #+INCLUDE: /etc/passwd in agent-generated content).
+    src = "\n".join(
+        ln for ln in src.splitlines()
+        if not ln.lstrip().lower().startswith("#+include:"))
+    elisp = (
+        '(progn (require (quote ox-html)) (setq org-export-use-babel nil)'
+        ' (princ (org-export-string-as (getenv "ORG_SRC") (quote html) t)))'
+    )
+    try:
+        r = subprocess.run(
+            ["emacs", "-Q", "--batch", "--eval", elisp],
+            env={**os.environ, "ORG_SRC": src},
+            capture_output=True, text=True, timeout=20,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        return f"<p><em>Could not render org ({type(e).__name__}).</em></p>"
+    if r.returncode != 0:
+        return f"<pre>{html.escape((r.stderr or 'org export failed')[-2000:])}</pre>"
+    return r.stdout
+
+
+def _render_show_file(tid: str, path: str) -> str:
+    """The transcript bubble for a show_file call: the file embedded inline
+    (pdf in the browser viewer, md/org as a rendered HTML page in an iframe),
+    plus a caption link that opens it in its own tab."""
+    if not path:
+        return ""
+    src = f"/thread/{tid}/show?path={urllib.parse.quote(path)}"
+    ext = os.path.splitext(path)[1].lower()
+    label = html.escape(path)
+    if ext == ".pdf":
+        viewer = f'<embed class="show-file" type="application/pdf" src="{src}" />'
+    else:
+        viewer = f'<iframe class="show-file" src="{src}" loading="lazy"></iframe>'
+    return (
+        '<div class="msg show"><div class="role">shown</div>'
+        f'<div class="content">{viewer}'
+        f'<div class="show-cap"><a href="{src}" target="_blank" rel="noopener">'
+        f'{label} ↗</a></div></div></div>'
+    )
+
+
+@app.get("/thread/{tid}/show")
+async def show_file_view(tid: str, path: str):
+    """Render a file from the thread's agent workspace for embedding: pdf as
+    bytes (browser viewer), md/org as a styled HTML page.  The org export runs
+    in a threadpool so its emacs subprocess never blocks the event loop."""
+    _existing_thread_dir(tid)  # 404 on a bad/missing tid (traversal-safe)
+    fpath = _safe_workspace_file(tid, path)
+    if fpath is None or not os.path.isfile(fpath):
+        raise HTTPException(status_code=404, detail="file not found")
+    ext = os.path.splitext(fpath)[1].lower()
+    if ext == ".pdf":
+        return FileResponse(fpath, media_type="application/pdf")
+    if ext in (".md", ".markdown"):
+        with open(fpath, encoding="utf-8", errors="replace") as f:
+            body = markdown.markdown(f.read(), extensions=["fenced_code", "tables"])
+    elif ext == ".org":
+        body = await run_in_threadpool(_org_to_html, fpath)
+    else:
+        raise HTTPException(status_code=415,
+                            detail="show supports .org, .md, .pdf")
+    return HTMLResponse(
+        f"<!doctype html><html><head><meta charset=utf-8>"
+        f'<meta name=viewport content="width=device-width, initial-scale=1">'
+        f"<style>{_SHOW_PAGE_CSS}</style></head><body>{body}</body></html>")
 
 
 @app.post("/thread/{tid}/delete")

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -905,7 +905,10 @@ def _safe_workspace_file(tid: str, path: str) -> str | None:
 # this function's own tags, so no markup (or eval) in the file can take effect.
 # Covers the common constructs (headings, lists, tables, src/example blocks,
 # inline emphasis, links); richer org degrades to readable text.
-_ORG_LIST_RE = re.compile(r"\s*([-+]|\d+[.)])\s+(.*)")
+# Bullets -, +, * (org's three) and numbered.  '*' is safe here because the
+# heading check runs first and consumes a column-0 '*'; only an INDENTED '* '
+# (a real list bullet, never a heading) reaches this.
+_ORG_LIST_RE = re.compile(r"\s*([-+*]|\d+[.)])\s+(.*)")
 _ORG_HEADING_RE = re.compile(r"(\*+)\s+(.*)")
 # One combined inline pattern, applied in a SINGLE left-to-right pass so a
 # substitution's output (e.g. the "/" in an inserted "</b>") is never re-scanned

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -864,6 +864,23 @@ _SHOW_PAGE_CSS = (
     "td,th{border:1px solid #ccc;padding:.3rem .5rem}img{max-width:100%}"
 )
 
+# The /show page renders AGENT-generated md/org.  The md path (python-markdown)
+# passes raw HTML through, so a malicious .md could carry <script>/onerror/
+# javascript:.  The inline embed is a sandboxed iframe, but the caption link
+# opens this same route as a TOP-LEVEL document in the app origin — so harden
+# the response itself: a CSP with no script source makes script execution
+# unreachable for BOTH entry points (embedded and standalone), regardless of
+# content.  default-src 'none' => scripts/objects/frames blocked; we only allow
+# our own inline <style> and content images.  nosniff stops MIME-confusion.
+_SHOW_CSP = (
+    "default-src 'none'; style-src 'unsafe-inline'; img-src 'self' data: https:; "
+    "object-src 'none'; base-uri 'none'"
+)
+_SHOW_SECURITY_HEADERS = {
+    "Content-Security-Policy": _SHOW_CSP,
+    "X-Content-Type-Options": "nosniff",
+}
+
 
 def _safe_workspace_file(tid: str, path: str) -> str | None:
     """Resolve PATH against the thread's agent working dir, traversal-safe.
@@ -1031,7 +1048,8 @@ async def show_file_view(tid: str, path: str):
         raise HTTPException(status_code=404, detail="file not found")
     ext = os.path.splitext(fpath)[1].lower()
     if ext == ".pdf":
-        return FileResponse(fpath, media_type="application/pdf")
+        return FileResponse(fpath, media_type="application/pdf",
+                            headers={"X-Content-Type-Options": "nosniff"})
     with open(fpath, encoding="utf-8", errors="replace") as f:
         src = f.read()
     if ext == ".md":
@@ -1044,7 +1062,8 @@ async def show_file_view(tid: str, path: str):
     return HTMLResponse(
         f"<!doctype html><html><head><meta charset=utf-8>"
         f'<meta name=viewport content="width=device-width, initial-scale=1">'
-        f"<style>{_SHOW_PAGE_CSS}</style></head><body>{body}</body></html>")
+        f"<style>{_SHOW_PAGE_CSS}</style></head><body>{body}</body></html>",
+        headers=_SHOW_SECURITY_HEADERS)
 
 
 @app.post("/thread/{tid}/delete")

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -1005,7 +1005,13 @@ def _render_show_file(tid: str, path: str) -> str:
     if ext == ".pdf":
         viewer = f'<embed class="show-file" type="application/pdf" src="{src}" />'
     else:
-        viewer = f'<iframe class="show-file" src="{src}" loading="lazy"></iframe>'
+        # sandbox WITHOUT allow-scripts: the embedded md/org page is static, so
+        # any <script>/onerror in agent-generated content can't execute (defence
+        # in depth over the org renderer's escaping — and it covers the md path,
+        # whose markdown lib passes raw HTML through).  allow-popups keeps
+        # target=_blank links in the content working.
+        viewer = (f'<iframe class="show-file" src="{src}" loading="lazy" '
+                  f'sandbox="allow-popups"></iframe>')
     return (
         '<div class="msg show"><div class="role">shown</div>'
         f'<div class="content">{viewer}'
@@ -1026,7 +1032,8 @@ async def show_file_view(tid: str, path: str):
     ext = os.path.splitext(fpath)[1].lower()
     if ext == ".pdf":
         return FileResponse(fpath, media_type="application/pdf")
-    src = open(fpath, encoding="utf-8", errors="replace").read()
+    with open(fpath, encoding="utf-8", errors="replace") as f:
+        src = f.read()
     if ext == ".md":
         body = markdown.markdown(src, extensions=_MD_EXTENSIONS)
     elif ext == ".org":

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -11,12 +11,12 @@ import html
 import json
 import logging
 import os
+import re
 import subprocess
 import urllib.parse
 
 import markdown
 from fastapi import BackgroundTasks, Form, HTTPException
-from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import (
     FileResponse,
     HTMLResponse,
@@ -69,6 +69,9 @@ async def _invalid_thread_id(request, exc):
     # A crafted tid (traversal/separator) reaching any tid-based route surfaces
     # here from ThreadManager.thread_dir — map it to a clean 404 everywhere.
     return HTMLResponse("Thread not found", status_code=404)
+
+
+_MD_EXTENSIONS = ["fenced_code", "tables"]
 
 
 def render_index(query: str = "") -> str:
@@ -388,12 +391,12 @@ def render_thread(
         raw = str(m.get("content", ""))
         if role == "assistant" or role == "tools":
             # Render assistant and tool content as Markdown to HTML
-            content_html = markdown.markdown(raw, extensions=["fenced_code", "tables"])
+            content_html = markdown.markdown(raw, extensions=_MD_EXTENSIONS)
         elif role == "user" and raw.startswith(_REVIEW_HEADER):
             # Review submissions are markdown-formatted (headers, fenced
             # blocks).  Render them as such so the user sees the same
             # structure the agent receives, instead of escaped backticks.
-            content_html = markdown.markdown(raw, extensions=["fenced_code", "tables"])
+            content_html = markdown.markdown(raw, extensions=_MD_EXTENSIONS)
         else:
             # Human/user content is plain text with basic escaping
             content_html = html.escape(raw).replace("\n", "<br/>")
@@ -864,45 +867,130 @@ _SHOW_PAGE_CSS = (
 
 def _safe_workspace_file(tid: str, path: str) -> str | None:
     """Resolve PATH against the thread's agent working dir, traversal-safe.
-    Returns the absolute host path, or None if it would escape the workspace.
-    (Same realpath-child check as the tid guard — a crafted ``../`` can't read
-    outside the agent's own files.)"""
+    Returns the absolute host path, or None if it would escape the workspace
+    (or is malformed, e.g. an embedded NUL).  Same realpath-child check as the
+    tid guard — a crafted ``../`` can't read outside the agent's own files."""
     base = os.path.realpath(MANAGER.thread_default_working_dir(tid))
-    target = os.path.realpath(os.path.join(base, path))
+    try:
+        target = os.path.realpath(os.path.join(base, path))
+    except ValueError:  # embedded NUL etc. -> treat as not-found, not a 500
+        return None
     if target != base and not target.startswith(base + os.sep):
         return None
     return target
 
 
-def _org_to_html(fpath: str) -> str:
-    """Export an org file to body HTML via emacs (the only org engine available;
-    no Python org lib).  Off the event loop — emacs is a ~1-2s subprocess.
-    Babel is disabled and ``#+INCLUDE:`` lines are stripped so exporting an
-    agent-written org file can't execute code or read arbitrary host files."""
-    try:
-        src = open(fpath, encoding="utf-8", errors="replace").read()
-    except OSError as e:
-        return f"<p><em>Could not read file: {html.escape(str(e))}</em></p>"
-    # Strip include directives before handing the string to org (defense in
-    # depth against #+INCLUDE: /etc/passwd in agent-generated content).
-    src = "\n".join(
-        ln for ln in src.splitlines()
-        if not ln.lstrip().lower().startswith("#+include:"))
-    elisp = (
-        '(progn (require (quote ox-html)) (setq org-export-use-babel nil)'
-        ' (princ (org-export-string-as (getenv "ORG_SRC") (quote html) t)))'
-    )
-    try:
-        r = subprocess.run(
-            ["emacs", "-Q", "--batch", "--eval", elisp],
-            env={**os.environ, "ORG_SRC": src},
-            capture_output=True, text=True, timeout=20,
-        )
-    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
-        return f"<p><em>Could not render org ({type(e).__name__}).</em></p>"
-    if r.returncode != 0:
-        return f"<pre>{html.escape((r.stderr or 'org export failed')[-2000:])}</pre>"
-    return r.stdout
+# Org files are AGENT-generated (possibly from fetched web content), so they are
+# rendered by this pure, escape-first converter — NEVER by emacs/org-export,
+# which executes elisp during export (babel, AND #+MACRO: (eval ...), #+CALL:,
+# table formulas) and is therefore a host-RCE vector on untrusted org.  Here
+# every character of the file is html-escaped first; the only HTML emitted is
+# this function's own tags, so no markup (or eval) in the file can take effect.
+# Covers the common constructs (headings, lists, tables, src/example blocks,
+# inline emphasis, links); richer org degrades to readable text.
+_ORG_LIST_RE = re.compile(r"\s*([-+]|\d+[.)])\s+(.*)")
+_ORG_HEADING_RE = re.compile(r"(\*+)\s+(.*)")
+# One combined inline pattern, applied in a SINGLE left-to-right pass so a
+# substitution's output (e.g. the "/" in an inserted "</b>") is never re-scanned
+# by a later rule.  Order in the alternation = match priority.
+_ORG_INLINE_RE = re.compile(
+    r"\[\[(?P<lt>[^\]]+?)\](?:\[(?P<ll>[^\]]*?)\])?\]"      # [[link]] / [[link][label]]
+    r"|(?<![\w*])\*(?P<b>\S(?:.*?\S)?)\*(?![\w*])"           # *bold*
+    r"|(?<![\w/])/(?P<i>\S(?:.*?\S)?)/(?![\w/])"             # /italic/
+    r"|(?<![\w=])=(?P<c>\S(?:.*?\S)?)=(?![\w=])"             # =code=
+    r"|(?<![\w~])~(?P<v>\S(?:.*?\S)?)~(?![\w~])"             # ~verbatim~
+)
+
+
+def _org_inline_sub(m: re.Match) -> str:
+    if m.group("lt") is not None:
+        target = m.group("lt")
+        label = m.group("ll") if m.group("ll") else target
+        scheme_ok = re.match(r"(https?:|mailto:|/|\.|#)", html.unescape(target))
+        href = target if scheme_ok else "#"
+        return f'<a href="{href}" target="_blank" rel="noopener">{label}</a>'
+    if m.group("b") is not None:
+        return f"<b>{m.group('b')}</b>"
+    if m.group("i") is not None:
+        return f"<i>{m.group('i')}</i>"
+    code = m.group("c") if m.group("c") is not None else m.group("v")
+    return f"<code>{code}</code>"
+
+
+def _org_inline(text: str) -> str:
+    """Escape TEXT (so file content can't inject HTML), then apply org inline
+    markup in one pass over the escaped string."""
+    return _ORG_INLINE_RE.sub(_org_inline_sub, html.escape(text))
+
+
+def _org_table(rows: list[str]) -> str:
+    out = ["<table>"]
+    for r in rows:
+        if set(r) <= set("|-+ "):   # separator row
+            continue
+        cells = [c.strip() for c in r.strip().strip("|").split("|")]
+        out.append("<tr>" + "".join(f"<td>{_org_inline(c)}</td>" for c in cells) + "</tr>")
+    out.append("</table>")
+    return "\n".join(out)
+
+
+def _org_to_html(src: str) -> str:
+    """Render an org SOURCE STRING to body HTML, safely (see the note above)."""
+    lines = src.splitlines()
+    parts: list[str] = []
+    para: list[str] = []
+    open_list: str | None = None
+
+    def flush_para():
+        if para:
+            parts.append("<p>" + _org_inline(" ".join(para)) + "</p>")
+            para.clear()
+
+    def close_list():
+        nonlocal open_list
+        if open_list:
+            parts.append(f"</{open_list}>")
+            open_list = None
+
+    i = 0
+    while i < len(lines):
+        line, stripped = lines[i], lines[i].strip()
+        if re.match(r"#\+BEGIN_(SRC|EXAMPLE)", stripped, re.I):
+            flush_para(); close_list()
+            block, i = [], i + 1
+            while i < len(lines) and not re.match(r"#\+END_", lines[i].strip(), re.I):
+                block.append(lines[i]); i += 1
+            i += 1  # skip the END line
+            parts.append("<pre><code>" + html.escape("\n".join(block)) + "</code></pre>")
+            continue
+        if stripped.startswith("#+") or stripped.startswith("# "):
+            flush_para(); i += 1; continue  # keyword/comment line: drop (never eval)
+        hm = _ORG_HEADING_RE.match(line)
+        if hm:
+            flush_para(); close_list()
+            lvl = min(len(hm.group(1)), 6)
+            parts.append(f"<h{lvl}>{_org_inline(hm.group(2).strip())}</h{lvl}>")
+            i += 1; continue
+        if stripped.startswith("|"):
+            flush_para(); close_list()
+            rows = []
+            while i < len(lines) and lines[i].strip().startswith("|"):
+                rows.append(lines[i]); i += 1
+            parts.append(_org_table(rows))
+            continue
+        lm = _ORG_LIST_RE.fullmatch(line)
+        if lm:
+            flush_para()
+            tag = "ol" if lm.group(1)[0].isdigit() else "ul"
+            if open_list != tag:
+                close_list(); parts.append(f"<{tag}>"); open_list = tag
+            parts.append(f"<li>{_org_inline(lm.group(2).strip())}</li>")
+            i += 1; continue
+        if not stripped:
+            flush_para(); close_list(); i += 1; continue
+        para.append(stripped); i += 1
+    flush_para(); close_list()
+    return "\n".join(parts)
 
 
 def _render_show_file(tid: str, path: str) -> str:
@@ -929,8 +1017,8 @@ def _render_show_file(tid: str, path: str) -> str:
 @app.get("/thread/{tid}/show")
 async def show_file_view(tid: str, path: str):
     """Render a file from the thread's agent workspace for embedding: pdf as
-    bytes (browser viewer), md/org as a styled HTML page.  The org export runs
-    in a threadpool so its emacs subprocess never blocks the event loop."""
+    bytes (browser viewer), md/org as a styled HTML page.  Pure renderers (no
+    subprocess), so safe to run inline on the event loop."""
     _existing_thread_dir(tid)  # 404 on a bad/missing tid (traversal-safe)
     fpath = _safe_workspace_file(tid, path)
     if fpath is None or not os.path.isfile(fpath):
@@ -938,11 +1026,11 @@ async def show_file_view(tid: str, path: str):
     ext = os.path.splitext(fpath)[1].lower()
     if ext == ".pdf":
         return FileResponse(fpath, media_type="application/pdf")
-    if ext in (".md", ".markdown"):
-        with open(fpath, encoding="utf-8", errors="replace") as f:
-            body = markdown.markdown(f.read(), extensions=["fenced_code", "tables"])
+    src = open(fpath, encoding="utf-8", errors="replace").read()
+    if ext == ".md":
+        body = markdown.markdown(src, extensions=_MD_EXTENSIONS)
     elif ext == ".org":
-        body = await run_in_threadpool(_org_to_html, fpath)
+        body = _org_to_html(src)
     else:
         raise HTTPException(status_code=415,
                             detail="show supports .org, .md, .pdf")

--- a/tests/test_show_file.py
+++ b/tests/test_show_file.py
@@ -1,0 +1,151 @@
+"""Tests for the show_file tool + the /thread/{tid}/show viewer route.
+
+CPU/no-model: the tool returns a string; the route renders md (markdown lib),
+pdf (FileResponse bytes), and org (emacs, skipped if emacs is absent). The
+agent-driven end-to-end (agent calls show_file) needs the model — out of scope.
+"""
+import os
+import shutil
+
+import pytest
+from fastapi.testclient import TestClient
+
+from assist.tools import show_file
+from manage import web
+from manage.web.threads import _render_show_file, _safe_workspace_file
+
+
+class TestShowFileTool:
+    def test_supported_extensions_confirm(self):
+        for p in ("report.org", "notes.md", "a.markdown", "doc.pdf"):
+            assert show_file(p).startswith("Showing")
+
+    def test_unsupported_extension_explains(self):
+        out = show_file("data.txt")
+        assert "can't display" in out
+        assert ".org, .md, and .pdf" in out
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    monkeypatch.setattr(web.MANAGER, "root_dir", str(tmp_path))
+    wd = tmp_path / "t1" / "domain"   # == thread_default_working_dir("t1")
+    wd.mkdir(parents=True)
+    return wd
+
+
+class TestSafeWorkspaceFile:
+    def test_resolves_inside_workspace(self, workspace):
+        (workspace / "a.md").write_text("hi")
+        got = _safe_workspace_file("t1", "a.md")
+        assert got == os.path.realpath(str(workspace / "a.md"))
+
+    @pytest.mark.parametrize("path", ["../../etc/passwd", "../secret", "/etc/passwd"])
+    def test_rejects_traversal(self, workspace, path):
+        # ../ escapes the workspace -> None; an absolute path resolves outside too.
+        assert _safe_workspace_file("t1", path) is None
+
+
+class TestRenderShowFile:
+    def test_pdf_uses_embed(self):
+        h = _render_show_file("t1", "doc.pdf")
+        assert "<embed" in h and 'type="application/pdf"' in h
+        assert "/thread/t1/show?path=doc.pdf" in h
+
+    def test_md_uses_iframe(self):
+        h = _render_show_file("t1", "notes.md")
+        assert "<iframe" in h
+        assert "/thread/t1/show?path=notes.md" in h
+
+    def test_path_is_url_quoted(self):
+        h = _render_show_file("t1", "my report.org")
+        assert "my%20report.org" in h
+
+
+class TestShowRoute:
+    def test_markdown_renders_to_html(self, workspace):
+        (workspace / "n.md").write_text("# Title\n\n- a\n- b\n")
+        r = TestClient(web.app).get("/thread/t1/show", params={"path": "n.md"})
+        assert r.status_code == 200
+        assert "<h1>Title</h1>" in r.text
+        assert "<li>a</li>" in r.text
+
+    def test_pdf_served_as_bytes(self, workspace):
+        (workspace / "d.pdf").write_bytes(b"%PDF-1.4 fake bytes")
+        r = TestClient(web.app).get("/thread/t1/show", params={"path": "d.pdf"})
+        assert r.status_code == 200
+        assert r.headers["content-type"] == "application/pdf"
+        assert r.content == b"%PDF-1.4 fake bytes"
+
+    def test_missing_file_404(self, workspace):
+        r = TestClient(web.app, raise_server_exceptions=False).get(
+            "/thread/t1/show", params={"path": "nope.md"})
+        assert r.status_code == 404
+
+    def test_traversal_404(self, workspace):
+        (workspace.parent.parent / "secret.md").write_text("secret")  # outside the workspace
+        r = TestClient(web.app, raise_server_exceptions=False).get(
+            "/thread/t1/show", params={"path": "../../secret.md"})
+        assert r.status_code == 404
+
+    def test_unsupported_extension_415(self, workspace):
+        (workspace / "x.txt").write_text("plain")
+        r = TestClient(web.app, raise_server_exceptions=False).get(
+            "/thread/t1/show", params={"path": "x.txt"})
+        assert r.status_code == 415
+
+
+@pytest.mark.skipif(not shutil.which("emacs"), reason="emacs not available for org export")
+class TestOrgRender:
+    def test_org_exports_to_html(self, workspace):
+        (workspace / "r.org").write_text("* Heading\n\nSome *bold* text.\n")
+        r = TestClient(web.app).get("/thread/t1/show", params={"path": "r.org"})
+        assert r.status_code == 200
+        assert "Heading" in r.text
+        assert "<b>bold</b>" in r.text or "bold" in r.text  # org emphasis -> bold
+
+    def test_org_include_directive_is_stripped(self, workspace):
+        # A #+INCLUDE pointing at a host file must NOT be expanded into the output.
+        secret = workspace.parent.parent / "secret.txt"
+        secret.write_text("TOPSECRET")
+        (workspace / "evil.org").write_text(
+            f"* Doc\n#+INCLUDE: \"{secret}\"\n")
+        r = TestClient(web.app).get("/thread/t1/show", params={"path": "evil.org"})
+        assert r.status_code == 200
+        assert "TOPSECRET" not in r.text
+
+
+class TestMessagesToDicts:
+    """The get_messages logic that turns a show_file tool call into a structured
+    render directive (vs other calls staying as the 'tools' text line)."""
+
+    def _ai(self, content="", tool_calls=None):
+        from langchain_core.messages import AIMessage
+        return AIMessage(content=content, tool_calls=tool_calls or [])
+
+    def test_show_file_call_becomes_directive(self):
+        from assist.thread import _messages_to_dicts
+        m = self._ai(tool_calls=[{"name": "show_file", "args": {"path": "r.org"}, "id": "1"}])
+        assert _messages_to_dicts([m]) == [{"role": "show_file", "path": "r.org"}]
+
+    def test_show_file_alongside_other_call(self):
+        from assist.thread import _messages_to_dicts
+        m = self._ai(tool_calls=[
+            {"name": "read_file", "args": {"path": "x"}, "id": "1"},
+            {"name": "show_file", "args": {"path": "r.md"}, "id": "2"}])
+        out = _messages_to_dicts([m])
+        tools = next(d for d in out if d["role"] == "tools")
+        assert "read_file" in tools["content"] and "show_file" not in tools["content"]
+        assert {"role": "show_file", "path": "r.md"} in out
+
+    def test_plain_user_and_assistant_unchanged(self):
+        from assist.thread import _messages_to_dicts
+        from langchain_core.messages import HumanMessage
+        out = _messages_to_dicts([HumanMessage(content="hi"), self._ai(content="hello")])
+        assert out == [{"role": "user", "content": "hi"},
+                       {"role": "assistant", "content": "hello"}]
+
+    def test_show_file_empty_path_skipped(self):
+        from assist.thread import _messages_to_dicts
+        assert _messages_to_dicts([self._ai(tool_calls=[
+            {"name": "show_file", "args": {}, "id": "1"}])]) == []

--- a/tests/test_show_file.py
+++ b/tests/test_show_file.py
@@ -198,17 +198,26 @@ class TestMessagesToDicts:
         assert out == [{"role": "user", "content": "hi"},
                        {"role": "assistant", "content": "hello"}]
 
-    def test_show_file_empty_path_skipped(self):
+    def _no_directive(self, args):
         from assist.thread import _messages_to_dicts
-        assert _messages_to_dicts([self._ai(tool_calls=[
-            {"name": "show_file", "args": {}, "id": "1"}])]) == []
+        out = _messages_to_dicts([self._ai(tool_calls=[
+            {"name": "show_file", "args": args, "id": "1"}])])
+        assert not any(d["role"] == "show_file" for d in out)
+        return out
 
-    def test_show_file_non_string_path_skipped(self):
-        # args are untrusted model output; a non-string path must not become a
-        # directive (it would crash the renderer's urllib.quote).
-        from assist.thread import _messages_to_dicts
-        assert _messages_to_dicts([self._ai(tool_calls=[
-            {"name": "show_file", "args": {"path": ["a", "b"]}, "id": "1"}])]) == []
+    def test_show_file_empty_path_no_directive(self):
+        self._no_directive({})
+
+    def test_show_file_non_string_path_no_directive(self):
+        # untrusted model output; a non-string path must not become a directive
+        # (it would crash the renderer's urllib.quote).
+        self._no_directive({"path": ["a", "b"]})
+
+    def test_show_file_unsupported_ext_falls_back_to_tools_line(self):
+        # An out-of-spec show_file (e.g. .txt) must NOT embed the viewer route
+        # (which would render a 415) — it shows as a normal tool-call line.
+        out = self._no_directive({"path": "notes.txt"})
+        assert any(d["role"] == "tools" and "show_file" in d["content"] for d in out)
 
     def test_render_tool_calls_empty_when_no_calls(self):
         # The CLI prints this per AIMessage; a plain assistant message must

--- a/tests/test_show_file.py
+++ b/tests/test_show_file.py
@@ -24,6 +24,12 @@ class TestShowFileTool:
         assert "can't display" in out
         assert ".org, .md, and .pdf" in out
 
+    @pytest.mark.parametrize("bad", [None, ["a.md"], {"path": "a.md"}, ""])
+    def test_non_string_or_empty_path_returns_guidance(self, bad):
+        # untrusted model args: must not raise (os.path.splitext TypeError).
+        out = show_file(bad)
+        assert "needs a single file path" in out
+
 
 @pytest.fixture
 def workspace(tmp_path, monkeypatch):
@@ -128,6 +134,13 @@ class TestOrgRender:
         assert "<h1>Heading</h1>" in r.text
         assert "<b>bold</b>" in r.text and "<i>italic</i>" in r.text
         assert "<li>a</li>" in r.text
+
+    def test_org_star_bullets(self, workspace):
+        # Indented '* ' is an org list bullet (column-0 '*' stays a heading).
+        (workspace / "s.org").write_text("* Top\n\n  * one\n  * two\n")
+        r = TestClient(web.app).get("/thread/t1/show", params={"path": "s.org"})
+        assert "<h1>Top</h1>" in r.text            # column-0 * -> heading
+        assert "<li>one</li>" in r.text and "<li>two</li>" in r.text  # indented * -> list
 
     def test_org_macro_eval_does_not_execute(self, workspace):
         # The reason org is NOT rendered via emacs: org export would eval a

--- a/tests/test_show_file.py
+++ b/tests/test_show_file.py
@@ -1,11 +1,10 @@
 """Tests for the show_file tool + the /thread/{tid}/show viewer route.
 
 CPU/no-model: the tool returns a string; the route renders md (markdown lib),
-pdf (FileResponse bytes), and org (emacs, skipped if emacs is absent). The
+pdf (FileResponse bytes), and org (a pure-Python renderer — no emacs/eval). The
 agent-driven end-to-end (agent calls show_file) needs the model — out of scope.
 """
 import os
-import shutil
 
 import pytest
 from fastapi.testclient import TestClient
@@ -17,7 +16,7 @@ from manage.web.threads import _render_show_file, _safe_workspace_file
 
 class TestShowFileTool:
     def test_supported_extensions_confirm(self):
-        for p in ("report.org", "notes.md", "a.markdown", "doc.pdf"):
+        for p in ("report.org", "notes.md", "doc.pdf"):
             assert show_file(p).startswith("Showing")
 
     def test_unsupported_extension_explains(self):
@@ -95,24 +94,42 @@ class TestShowRoute:
         assert r.status_code == 415
 
 
-@pytest.mark.skipif(not shutil.which("emacs"), reason="emacs not available for org export")
 class TestOrgRender:
-    def test_org_exports_to_html(self, workspace):
-        (workspace / "r.org").write_text("* Heading\n\nSome *bold* text.\n")
+    """Pure-Python org renderer (no emacs — see the security note in threads.py)."""
+
+    def test_org_headings_emphasis_lists(self, workspace):
+        (workspace / "r.org").write_text(
+            "* Heading\n\nSome *bold* and /italic/ text.\n\n- a\n- b\n")
         r = TestClient(web.app).get("/thread/t1/show", params={"path": "r.org"})
         assert r.status_code == 200
-        assert "Heading" in r.text
-        assert "<b>bold</b>" in r.text or "bold" in r.text  # org emphasis -> bold
+        assert "<h1>Heading</h1>" in r.text
+        assert "<b>bold</b>" in r.text and "<i>italic</i>" in r.text
+        assert "<li>a</li>" in r.text
 
-    def test_org_include_directive_is_stripped(self, workspace):
-        # A #+INCLUDE pointing at a host file must NOT be expanded into the output.
-        secret = workspace.parent.parent / "secret.txt"
-        secret.write_text("TOPSECRET")
+    def test_org_macro_eval_does_not_execute(self, workspace):
+        # The reason org is NOT rendered via emacs: org export would eval a
+        # macro's (eval ...) form (host RCE).  The pure renderer must not run it.
         (workspace / "evil.org").write_text(
-            f"* Doc\n#+INCLUDE: \"{secret}\"\n")
+            '#+MACRO: pwn (eval (shell-command-to-string "id"))\n{{{pwn}}}\n')
         r = TestClient(web.app).get("/thread/t1/show", params={"path": "evil.org"})
         assert r.status_code == 200
+        assert "uid=" not in r.text          # the `id` command never ran
+        assert "shell-command-to-string" not in r.text  # #+MACRO line dropped
+
+    def test_org_include_directive_not_expanded(self, workspace):
+        # A #+INCLUDE pointing at a host file must NOT pull its contents in.
+        secret = workspace.parent.parent / "secret.txt"
+        secret.write_text("TOPSECRET")
+        (workspace / "inc.org").write_text(f"* Doc\n#+INCLUDE: \"{secret}\"\n")
+        r = TestClient(web.app).get("/thread/t1/show", params={"path": "inc.org"})
+        assert r.status_code == 200
         assert "TOPSECRET" not in r.text
+
+    def test_org_content_is_escaped(self, workspace):
+        (workspace / "x.org").write_text("Plain <script>alert(1)</script> text\n")
+        r = TestClient(web.app).get("/thread/t1/show", params={"path": "x.org"})
+        assert "<script>alert(1)</script>" not in r.text
+        assert "&lt;script&gt;" in r.text
 
 
 class TestMessagesToDicts:

--- a/tests/test_show_file.py
+++ b/tests/test_show_file.py
@@ -116,6 +116,19 @@ class TestShowRoute:
         assert "default-src 'none'" in csp and "script-src" not in csp
         assert r.headers.get("x-content-type-options") == "nosniff"
 
+    def test_route_renders_every_showable_ext(self, workspace):
+        # Drift guard: _SHOWABLE_EXTS is the single allow-list for the tool, the
+        # show-directive gate, AND this route. If the set ever lists an extension
+        # the route's dispatch doesn't handle, that ext would 415 inside the
+        # embedded viewer — so assert the route renders (never 415s) each member.
+        from assist.tools import _SHOWABLE_EXTS
+        for ext in _SHOWABLE_EXTS:
+            name = f"drift{ext}"
+            (workspace / name).write_text("# hi\n" if ext != ".pdf" else "%PDF-1.4 x")
+            r = TestClient(web.app, raise_server_exceptions=False).get(
+                "/thread/t1/show", params={"path": name})
+            assert r.status_code != 415, f"{ext} -> {r.status_code}"
+
     def test_unsupported_extension_415(self, workspace):
         (workspace / "x.txt").write_text("plain")
         r = TestClient(web.app, raise_server_exceptions=False).get(

--- a/tests/test_show_file.py
+++ b/tests/test_show_file.py
@@ -98,6 +98,16 @@ class TestShowRoute:
             "/thread/t1/show", params={"path": "../../secret.md"})
         assert r.status_code == 404
 
+    def test_md_response_has_script_blocking_csp(self, workspace):
+        # The caption link opens this route as a top-level doc in the app origin;
+        # the md path passes raw HTML through, so the response must carry a CSP
+        # with no script source so scripts can't run even standalone.
+        (workspace / "x.md").write_text("# hi\n<script>alert(1)</script>\n")
+        r = TestClient(web.app).get("/thread/t1/show", params={"path": "x.md"})
+        csp = r.headers.get("content-security-policy", "")
+        assert "default-src 'none'" in csp and "script-src" not in csp
+        assert r.headers.get("x-content-type-options") == "nosniff"
+
     def test_unsupported_extension_415(self, workspace):
         (workspace / "x.txt").write_text("plain")
         r = TestClient(web.app, raise_server_exceptions=False).get(

--- a/tests/test_show_file.py
+++ b/tests/test_show_file.py
@@ -28,7 +28,9 @@ class TestShowFileTool:
 @pytest.fixture
 def workspace(tmp_path, monkeypatch):
     monkeypatch.setattr(web.MANAGER, "root_dir", str(tmp_path))
-    wd = tmp_path / "t1" / "domain"   # == thread_default_working_dir("t1")
+    # == thread_default_working_dir("t1"); use the constant so the test tracks
+    # the default working-dir name if it ever changes.
+    wd = tmp_path / "t1" / web.MANAGER.DEFAULT_THREAD_WORKING_DIRECTORY
     wd.mkdir(parents=True)
     return wd
 
@@ -187,3 +189,16 @@ class TestMessagesToDicts:
         from assist.thread import _messages_to_dicts
         assert _messages_to_dicts([self._ai(tool_calls=[
             {"name": "show_file", "args": {}, "id": "1"}])]) == []
+
+    def test_show_file_non_string_path_skipped(self):
+        # args are untrusted model output; a non-string path must not become a
+        # directive (it would crash the renderer's urllib.quote).
+        from assist.thread import _messages_to_dicts
+        assert _messages_to_dicts([self._ai(tool_calls=[
+            {"name": "show_file", "args": {"path": ["a", "b"]}, "id": "1"}])]) == []
+
+    def test_render_tool_calls_empty_when_no_calls(self):
+        # The CLI prints this per AIMessage; a plain assistant message must
+        # render empty so its content isn't duplicated.
+        from assist.thread import render_tool_calls
+        assert render_tool_calls(self._ai(content="hello, no tools")) == ""

--- a/tests/test_show_file.py
+++ b/tests/test_show_file.py
@@ -44,6 +44,11 @@ class TestSafeWorkspaceFile:
         # ../ escapes the workspace -> None; an absolute path resolves outside too.
         assert _safe_workspace_file("t1", path) is None
 
+    def test_embedded_nul_is_none_not_error(self, workspace):
+        # An embedded NUL makes realpath raise ValueError; it must resolve to
+        # None -> 404, never bubble a 500.
+        assert _safe_workspace_file("t1", "a\x00.md") is None
+
 
 class TestRenderShowFile:
     def test_pdf_uses_embed(self):
@@ -55,6 +60,12 @@ class TestRenderShowFile:
         h = _render_show_file("t1", "notes.md")
         assert "<iframe" in h
         assert "/thread/t1/show?path=notes.md" in h
+
+    def test_iframe_is_sandboxed_no_scripts(self):
+        # The md/org iframe must carry a sandbox WITHOUT allow-scripts so
+        # agent-generated content can't run JS in it (the md path emits raw HTML).
+        h = _render_show_file("t1", "notes.md")
+        assert "sandbox=" in h and "allow-scripts" not in h
 
     def test_path_is_url_quoted(self):
         h = _render_show_file("t1", "my report.org")


### PR DESCRIPTION
## What
A `show_file(path)` agent tool that displays a file in the assist web UI — **org** and **markdown** as formatted HTML, **PDF** in the browser's viewer — instead of pasting raw contents into the chat. The file renders **inline** in the transcript where the agent shows it.

- **Tool** (`assist/tools.py`): extension-gated (`.org`/`.md`/`.pdf`), guards a non-string/empty path. `_SHOWABLE_EXTS` is the single source for the tool gate, the show-directive gate, and the route.
- **Registration** (`assist/thread_manager.py`): web-scoped — an `AgentSpec(tools=_WEB_TOOLS)` constructed per-call in `get`/`new` (emacsos builds its own spec; evals use `create_agent` directly).
- **Surface** (`assist/thread.py`): a `show_file` call with a *renderable* path becomes a `{"role":"show_file","path":…}` directive (pure `_messages_to_dicts` / `_showable_path`); an out-of-spec call falls back to the normal tool-call line.
- **Render** (`manage/web/threads.py`): `render_thread` emits an inline `<iframe>`/`<embed>` → a traversal-safe **sync** `GET /thread/{tid}/show` route (pdf → FileResponse, md → markdown lib, org → pure renderer).

## Security (caught by local review + Copilot)
- The first cut rendered org via emacs `org-export` — which **executes elisp during export even with babel disabled** (`#+MACRO: x (eval …)` → host RCE; verified). Org is agent-generated (possibly from fetched web content) → a prompt-injection→RCE chain. **Fixed by construction:** org renders via a **pure, escape-first Python renderer** — no eval, no subprocess.
- **XSS by construction:** the md path passes raw HTML through, so the embedded page can't run scripts — the `/show` response sets a `Content-Security-Policy` with no script source (+ `nosniff`), covering both the inline (sandboxed) iframe **and** the caption link that opens the route standalone in the app origin. (Copilot rd1–2.)
- Path access is realpath-child confined to the thread's agent workspace (NUL/`../`/absolute → 404).
- **Event-loop liveness:** the route is a sync `def` so FastAPI runs the blocking file read + md/org conversion in its threadpool, off the single-worker event loop. (Copilot rd3.)

## Validation
**696 tests green** — all CPU/no-model (tool gating + non-string-path guard, traversal incl. NUL, the route for md/pdf/missing/traversal/unsupported + CSP, the org renderer incl. macro-(eval)-does-not-execute / `#+INCLUDE`-not-expanded / content-escaped / `*`-bullets, `_messages_to_dicts` directive gating, the `_SHOWABLE_EXTS`↔route drift guard).

## Design decisions from review
- **Declined (false positive):** broadening `_safe_workspace_file`'s `except` to `OSError` for ENAMETOOLONG — verified `os.path.realpath(strict=False)` *swallows* OSError (over-long names already 404 via `isfile`); only an embedded NUL raises (ValueError, caught). Adding `except OSError` would guard a case that can't occur (the repo's no-theoretical-code rule).
- **Declined the literal fix, addressed the risk differently:** Copilot suggested gating the `/show` route on `ext in _SHOWABLE_EXTS`. A membership gate + md/org ternary would *silently mis-render* a future 4th extension as org; the route's explicit per-type dispatch (unknown → 415) is drift-*safe*. The directive-vs-route drift risk is instead pinned by `test_route_renders_every_showable_ext` (red if the sets diverge).

## Known limitations
The live agent-driven flow (user asks → agent calls show_file → embed renders) needs the local model, currently down (GPU fans) — deferred; covered structurally by the unit tests. Design doc: `docs/2026-06-27-show-file.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)