### PR TITLE
show_file: steer the model to call it + map agent /workspace paths

### DIFF
--- a/assist/templates/deepagents/general_instructions.md.j2
+++ b/assist/templates/deepagents/general_instructions.md.j2
@@ -59,6 +59,10 @@ Once the sub-agents return, pick the action pattern that fits.
 **Questions answerable from local files:**
 → Answer from the context-agent's response and reference the relevant files
 
+**Requests to show, open, view, or display a file** — "show me X", "open X", "let me see X", "pull up the X file":
+→ Call `show_file(path)` with the file's path so it renders in the user's web view (`.org`/`.md` as formatted HTML, `.pdf` in the browser viewer). The user asked to SEE the file — do NOT read it and summarize it instead.
+→ For a file type `show_file` can't render, then read and summarize it.
+
 **Questions requiring external knowledge** (technical how-tos, factual questions, "how do I..." questions, anything about history, science, etc.):
 → Answer from the research-agent's findings — NEVER answer from your own knowledge
 → If the context-agent found a topically-related local file (e.g., `paris.org` for a Paris question), use `edit_file` to APPEND a summary of the research findings to that file. This step is mandatory — always persist research results into relevant local files.
@@ -85,6 +89,7 @@ Once the sub-agents return, pick the action pattern that fits.
 - Call each sub-agent ONCE per user request, then proceed to action. Do not call them in a loop.
 - NEVER answer questions from your own knowledge when the research-agent could answer them instead.
 - If a sub-agent reports an external dependency is unavailable, tell the user it's unavailable and STOP — do not re-dispatch it or answer from memory.
+- When the user asks to SEE a file (show / open / view / display / "pull up"), call `show_file` with its path — don't substitute a read-and-summarize.
 - ALWAYS write results into files when creating plans, researching, or generating content
 - When adding entries to existing files, append new content — never remove or overwrite existing entries
 - Be concise and direct

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -281,13 +281,14 @@ _SHOWABLE_EXTS = (".org", ".md", ".pdf")
 
 
 def show_file(path: str) -> str:
-    """Render a file in the user's web view so they can read it well-formatted.
+    """Show a file to the user in their web view, rendered well-formatted.
 
-    Use this to SHOW the user a file you produced or found — a report, notes, a
-    PDF — instead of pasting its raw contents into the chat.  Pass the path to
-    the file in your workspace.  Supported: ``.org`` and ``.md`` (rendered as
-    formatted HTML) and ``.pdf`` (shown in the browser's PDF viewer); other
-    types aren't shown — read and summarize those instead.
+    Call this whenever the user asks to SHOW, OPEN, VIEW, DISPLAY, or "pull up" a
+    file (e.g. "show me fitness.org", "open my notes") — render it for them
+    instead of reading it and summarizing its contents in the chat.  Pass the
+    path to the file in your workspace.  Supported: ``.org`` and ``.md``
+    (rendered as formatted HTML) and ``.pdf`` (shown in the browser's PDF
+    viewer); other types aren't shown — read and summarize those instead.
 
     The file appears embedded in the conversation.  Returns a short confirmation,
     or a note when the extension isn't one this can display.

--- a/docs/2026-06-27-show-file.org
+++ b/docs/2026-06-27-show-file.org
@@ -62,13 +62,33 @@ browser's viewer — instead of pasting raw contents into the chat.
 - *Tool doesn't validate existence* (no working-dir handle): a missing file
   surfaces as the route's 404 in the embed, not a tool error. Acceptable v1.
 
+* Follow-up — make it work end-to-end (2026-06-27, after a live test)
+A live thread ("Show me the one named fitness.org") exposed two gaps the
+unit-tested merge missed:
+- *The model didn't call show_file at all* — it read_file'd and summarized. The
+  general prompt never mentioned show_file and steered "questions answerable from
+  local files" toward summarizing. *Fix (guidance-first):* a "show/open/view a
+  file" action pattern + a rule in =general_instructions.md.j2=, and SHOW/OPEN/
+  VIEW trigger words in show_file's description. A single live turn now calls
+  ~show_file~ directly (no read+summarize).
+- *Path-space mismatch* — the agent addresses files in the sandbox's /workspace
+  space (~/workspace/fitness.org~), but =_safe_workspace_file= resolved against
+  the HOST working dir and rejected absolutes as traversal → the embed would
+  404. The unit tests only used relative paths, so they missed it. *Fix:*
+  =_safe_workspace_file= maps ~/workspace/x~, ~/x~ and ~x~ to ~<workdir>/x~
+  (still realpath-child-confined; ~../~ escapes still → None).
+Lesson: a tool whose path argument comes from the agent must be tested in the
+agent's path space, not just with tidy relative fixtures.
+
 * Validation
-- 22 unit tests (tool gating, traversal-safety incl. NUL, render embed, the /show
-  route for md/pdf/missing/traversal/unsupported, the org renderer incl.
-  macro-(eval)-does-not-execute / #+INCLUDE-not-expanded / content-escaped,
-  _messages_to_dicts). 684 unit tests green. All CPU — no model.
-- Deferred (needs the model, GPU down): the live agent-driven flow (user asks →
-  agent calls show_file → embed renders). Covered structurally by the unit tests.
+- 38 show_file tests (tool gating + non-string guard, traversal incl. NUL,
+  /workspace-path mapping, render embed + iframe sandbox, the /show route for
+  md/pdf/missing/traversal/unsupported/CSP, the org renderer incl.
+  macro-(eval)-does-not-execute / #+INCLUDE-not-expanded / content-escaped /
+  *-bullets, _messages_to_dicts directive gating, the _SHOWABLE_EXTS drift
+  guard). 700 unit tests green. All CPU.
+- Live (light, fans-limited): one turn confirmed the agent now calls show_file
+  for a "show me <file>" request. Full N-trial eval validation deferred to fans-up.
 
 * Critical files
 - =assist/tools.py= (show_file), =assist/thread_manager.py= (_WEB_TOOLS),

--- a/edd/eval/test_show_file_agent.py
+++ b/edd/eval/test_show_file_agent.py
@@ -1,0 +1,101 @@
+"""Eval: the general agent calls `show_file` when the user asks to SEE a file.
+
+Regression for a live thread (20260627170138-b912f542) where the user said
+"Show me the one with the name 'fitness.org'" and the agent ran read_file +
+summarized instead of calling show_file.  The focal test mirrors that thread's
+shape: a realistic, multi-file personal workspace, then a "show me <named file>"
+request.  Spot-checks cover other verbs/extensions for generality.
+
+Real-LLM eval (small model) — run with the deploy venv; partial pass rates are
+expected.  See assist/CLAUDE.md eval cadence.
+"""
+import tempfile
+from textwrap import dedent
+from unittest import TestCase
+
+from assist.agent import create_agent, AgentHarness
+from assist.model_manager import select_assistant_model
+from assist.spec import AgentSpec
+from assist.tools import show_file
+
+from .utils import create_filesystem
+
+
+# A realistic personal workspace (subset of the real thread's shape): the
+# fitness file lives among many swim/health files AND unrelated notes, so
+# "show me fitness.org" is a genuine selection, not the only candidate.
+def _personal_workspace() -> dict:
+    return {
+        "README.org": "Personal notes. Fitness in fitness.org, recipes in recipes.org.",
+        "fitness.org": dedent("""\
+            * Swimming
+            ** 2026
+            | date | dist (yd) | time | weight |
+            |------+-----------+------+--------|
+            | 1/5  |      2600 | 1h   |  168.4 |
+            | 1/7  |      2650 | 55m  |  169.8 |
+            """),
+        "swim-workouts.org": "* Swim Workouts\n** 6/9/26 Mixed Stroke (~3000 yd)\n",
+        "swim-prehab-routine.org": "#+TITLE: Prehab\n* Morning\n- 90/90 breathing\n",
+        "health.org": "* Wellness visits\n| Test | 2024 |\n|------+------|\n| LDL | 129 |\n",
+        "roman-swim.org": "* Log\n** 2025-01-12 @ UCSF\nEntered without issue.\n",
+        "references": {
+            "swim-workout-best-practices.org": "* Swim Best Practices\n** Warm-Up\n",
+        },
+        "journal.org": "* 2026\nA normal day.\n",
+        "recipes.org": "* Recipes\n** Pancakes\n- flour, eggs\n",
+        "french.org": "* French\n- bonjour = hello\n",
+        "financial.org": "* Accounts\n- checking\n",
+    }
+
+
+class TestShowFileAgent(TestCase):
+    def setUp(self):
+        self.model = select_assistant_model(0.1)
+
+    def create_agent(self, filesystem: dict):
+        root = tempfile.mkdtemp()
+        create_filesystem(root, filesystem)
+        spec = AgentSpec(tools=(show_file,))
+        return AgentHarness(create_agent(self.model, root, spec=spec)), root
+
+    def _show_file_paths(self, agent) -> list:
+        paths = []
+        for m in agent.all_messages():
+            for c in (getattr(m, "tool_calls", None) or []):
+                if c.get("name") == "show_file":
+                    paths.append((c.get("args") or {}).get("path", ""))
+        return paths
+
+    def test_shows_named_file_in_personal_workspace(self):
+        """Example-thread shape: a realistic workspace + 'show me <named file>'
+        must call show_file for that file, not read+summarize."""
+        agent, _ = self.create_agent(_personal_workspace())
+        agent.message("Show me the file with the name fitness.org")
+        paths = self._show_file_paths(agent)
+        self.assertTrue(
+            any("fitness.org" in p for p in paths),
+            f"expected show_file called for fitness.org; show_file calls: {paths}",
+        )
+
+    def test_opens_file_alternate_phrasing(self):
+        """Generality: a different verb ('open') + a different file."""
+        agent, _ = self.create_agent(_personal_workspace())
+        agent.message("Open my recipes.org")
+        paths = self._show_file_paths(agent)
+        self.assertTrue(
+            any("recipes.org" in p for p in paths),
+            f"expected show_file called for recipes.org; show_file calls: {paths}",
+        )
+
+    def test_shows_pdf(self):
+        """Generality: a PDF + 'view'."""
+        fs = _personal_workspace()
+        fs["property-tax-receipt.pdf"] = "%PDF-1.4 fake receipt bytes"
+        agent, _ = self.create_agent(fs)
+        agent.message("View my property-tax-receipt.pdf")
+        paths = self._show_file_paths(agent)
+        self.assertTrue(
+            any("property-tax-receipt.pdf" in p for p in paths),
+            f"expected show_file called for the pdf; show_file calls: {paths}",
+        )

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -882,14 +882,26 @@ _SHOW_SECURITY_HEADERS = {
 }
 
 
+# The sandbox bind-mounts the thread's host working dir at /workspace
+# (sandbox_manager.py: volumes {work_dir: "/workspace"}, working_dir="/workspace"),
+# so the AGENT addresses files in that space — show_file is called with paths like
+# "/workspace/fitness.org", "/fitness.org", or "fitness.org".  All three name the
+# same host file under the working dir; map them before resolving.
+_SANDBOX_MOUNT = "/workspace"
+
+
 def _safe_workspace_file(tid: str, path: str) -> str | None:
-    """Resolve PATH against the thread's agent working dir, traversal-safe.
-    Returns the absolute host path, or None if it would escape the workspace
-    (or is malformed, e.g. an embedded NUL).  Same realpath-child check as the
-    tid guard — a crafted ``../`` can't read outside the agent's own files."""
+    """Resolve an AGENT path (in /workspace space) against the thread's host
+    agent working dir, traversal-safe.  Accepts ``/workspace/x``, ``/x`` and
+    ``x`` (all → ``<workdir>/x``).  Returns the host path, or None if it would
+    escape the workspace (a crafted ``../``) or is malformed (embedded NUL)."""
     base = os.path.realpath(MANAGER.thread_default_working_dir(tid))
+    rel = path
+    if rel == _SANDBOX_MOUNT or rel.startswith(_SANDBOX_MOUNT + "/"):
+        rel = rel[len(_SANDBOX_MOUNT):]
+    rel = rel.lstrip("/")  # treat as relative to the workspace root
     try:
-        target = os.path.realpath(os.path.join(base, path))
+        target = os.path.realpath(os.path.join(base, rel))
     except ValueError:  # embedded NUL etc. -> treat as not-found, not a 500
         return None
     if target != base and not target.startswith(base + os.sep):

--- a/tests/test_show_file.py
+++ b/tests/test_show_file.py
@@ -47,10 +47,17 @@ class TestSafeWorkspaceFile:
         got = _safe_workspace_file("t1", "a.md")
         assert got == os.path.realpath(str(workspace / "a.md"))
 
-    @pytest.mark.parametrize("path", ["../../etc/passwd", "../secret", "/etc/passwd"])
+    @pytest.mark.parametrize("path", ["../../etc/passwd", "../secret", "../../secret.md"])
     def test_rejects_traversal(self, workspace, path):
-        # ../ escapes the workspace -> None; an absolute path resolves outside too.
+        # ../ escapes the workspace -> None.
         assert _safe_workspace_file("t1", path) is None
+
+    @pytest.mark.parametrize("path", ["a.md", "/a.md", "/workspace/a.md"])
+    def test_maps_agent_workspace_paths(self, workspace, path):
+        # The agent addresses files in /workspace space; all three forms name the
+        # same host file under the working dir.
+        (workspace / "a.md").write_text("hi")
+        assert _safe_workspace_file("t1", path) == os.path.realpath(str(workspace / "a.md"))
 
     def test_embedded_nul_is_none_not_error(self, workspace):
         # An embedded NUL makes realpath raise ValueError; it must resolve to
@@ -87,6 +94,14 @@ class TestShowRoute:
         assert r.status_code == 200
         assert "<h1>Title</h1>" in r.text
         assert "<li>a</li>" in r.text
+
+    def test_workspace_prefixed_path_renders(self, workspace):
+        # End-to-end: the agent calls show_file("/workspace/n.md"); the route must
+        # map it to the host file and render, not 404.
+        (workspace / "n.md").write_text("# Title\n")
+        r = TestClient(web.app).get("/thread/t1/show", params={"path": "/workspace/n.md"})
+        assert r.status_code == 200
+        assert "<h1>Title</h1>" in r.text
 
     def test_pdf_served_as_bytes(self, workspace):
         (workspace / "d.pdf").write_bytes(b"%PDF-1.4 fake bytes")


### PR DESCRIPTION
## Why
Follow-up to #144. A live thread (\`20260627170138-b912f542\`) showed the agent run \`read_file\` + summarize when the user said *"Show me the one with the name 'fitness.org'"* — it never called \`show_file\`. Two end-to-end gaps the unit-tested merge missed:

1. **The model never called \`show_file\`.** It *was* wired/offered (verified) — but the general prompt never mentioned it and steered "questions answerable from local files → summarize". Guidance gap.
2. **Even if called, the embed would 404.** The agent addresses files in the sandbox's \`/workspace\` space (\`/workspace/fitness.org\`), but \`_safe_workspace_file\` resolved against the host working dir and rejected absolutes as traversal. Unit tests only used relative paths, so they missed it.

## Changes
- **Steering** (guidance-first): a "show/open/view a file → call \`show_file\`" action pattern + a rule in \`general_instructions.md.j2\`, and SHOW/OPEN/VIEW trigger words in \`show_file\`'s description.
- **Path mapping**: \`_safe_workspace_file\` maps \`/workspace/x\`, \`/x\`, and \`x\` all to \`<workdir>/x\` (still realpath-child confined; \`../\` escapes still rejected).

## Validation
- **700 unit tests green** (CPU) incl. new \`/workspace\`-path mapping + end-to-end route render.
- **Live eval (deploy venv, fans-limited light load)**: focal test mirroring the example thread (multi-file workspace → "show me fitness.org") **3/3** — the model globs the file then calls \`show_file\`. Generality: "open recipes.org" passes; PDF "view" calls \`show_file\` correctly (one run hit a transient model 400 — pre-existing small-model flakiness, unrelated).
- Local review loop: 3 lenses (security/traversal, correctness/edge, simplicity/steering) — 0 blockers, 0 important, 3 acceptable NITs.

## Known limitations
Full N-trial eval (N=5/10) deferred until the GPU fans are replaced; focal n=3 + spot-checks done under the light-load allowance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)