### PR TITLE
render section: lines (org/md) / pages (pdf) + range-aware full-page link

### DIFF
--- a/assist/web_skills/render/SKILL.md
+++ b/assist/web_skills/render/SKILL.md
@@ -19,25 +19,35 @@ example `path: /workspace/fitness.org`).
 
 ## Showing only part of a file
 
-When the user asks for a specific part — "lines 10-40 of notes.org", "page 3 of
-the report", "the second page of receipt.pdf" — add a range to the block:
+The user often asks for part of a file. They may say it **explicitly** ("lines
+10-40 of notes.org", "page 3 of the report") OR **by description** ("show me the
+section about backups", "the part on swimming drills", "the chapter on dosage").
+Either way the render block must carry a concrete numeric range — `lines: N-M`
+for org/md, `pages: N-M` for pdf. So **resolve a description into a range first**.
 
-- **org / md → by line:** add `lines: N-M` (a 1-based inclusive line range):
-  ```render
-  type: file
-  path: /workspace/notes.org
-  lines: 10-40
-  ```
-- **pdf → by page:** add `pages: N-M` (a 1-based inclusive page range):
-  ```render
-  type: file
-  path: /workspace/report.pdf
-  pages: 2-5
-  ```
+**Explicit range — use it directly:**
+```render
+type: file
+path: /workspace/notes.org
+lines: 10-40
+```
+
+**Described section — find it in the file, THEN emit the range:**
+
+- *org / md:* `read_file` the file, find the heading (or text) for the topic the
+  user named, and use the line range that section spans — from its heading line
+  through the line just before the next heading at the same or a higher level
+  (end of file if it's the last). Emit `lines: START-END`.
+  - e.g. user: "show the section about backups in notes.org" → you read it, see
+    `* Backups` starts at line 42 and the next `*`/`**` heading is line 58 → emit
+    `path: /workspace/notes.org` with `lines: 42-57`.
+- *pdf:* load the `pdf` skill and use its tools to read the pdf's text and find
+  which page(s) cover the topic, then emit `pages: N-M` for those pages.
 
 Use `lines:` for org/md and `pages:` for pdf. Always write a range as `N-M` (for
-a single line or page use the same number twice, e.g. `pages: 3-3`). Omit the
-range to show the whole file.
+a single line or page use the same number twice, e.g. `pages: 3-3`). The range in
+the block must be numbers you resolved — never put a description like
+`lines: the backups section` in the block. Omit the range to show the whole file.
 
 ## Rules
 

--- a/assist/web_skills/render/SKILL.md
+++ b/assist/web_skills/render/SKILL.md
@@ -17,6 +17,28 @@ path: /workspace/PATH-TO-THE-FILE
 Replace `PATH-TO-THE-FILE` with the real file in the user's workspace (for
 example `path: /workspace/fitness.org`).
 
+## Showing only part of a file
+
+When the user asks for a specific part — "lines 10-40 of notes.org", "page 3 of
+the report", "the second page of receipt.pdf" — add a range to the block:
+
+- **org / md → by line:** add `lines: N-M` (a 1-based inclusive line range):
+  ```render
+  type: file
+  path: /workspace/notes.org
+  lines: 10-40
+  ```
+- **pdf → by page:** add `pages: N-M` (a 1-based inclusive page range):
+  ```render
+  type: file
+  path: /workspace/report.pdf
+  pages: 2-5
+  ```
+
+Use `lines:` for org/md and `pages:` for pdf. Always write a range as `N-M` (for
+a single line or page use the same number twice, e.g. `pages: 3-3`). Omit the
+range to show the whole file.
+
 ## Rules
 
 - Emit the render block **instead of** reading the file and summarizing or

--- a/docs/2026-06-28-render-section.org
+++ b/docs/2026-06-28-render-section.org
@@ -70,9 +70,17 @@ lines: 10-40
   string that reaches the filesystem, via the unchanged ``_safe_workspace_file``).
 
 ** Skill (assist/web_skills/render/SKILL.md)
-Add: when the user asks for a specific part — "lines 10-40 of X", "page 3 of the
-report" — include the range in the block (``lines:`` for org/md, ``pages:`` for
-pdf). Keep it generalizable (don't overfit to one phrasing).
+The skill handles BOTH ways a user asks for part of a file (Pierre: he usually
+asks for a *section*, not numbers):
+- *Explicit range* — "lines 10-40 of X", "page 3 of the report" → use it directly.
+- *Described section* — "the section about backups", "the part on swimming" → the
+  agent RESOLVES the description into a concrete range first: for org/md it
+  ``read_file``s and uses the named heading's line span (heading line → just
+  before the next same-or-higher heading); for pdf it loads the ``pdf`` skill to
+  find the page(s). The block always carries numbers, never a description.
+Keep it generalizable (don't overfit to one phrasing). The route is unchanged —
+it always receives a concrete ``N-M``; resolution lives in the agent (guidance,
+not code), which is the right lever for this small-model behavior.
 
 ** /show route (manage/web/threads.py)
 Gains query params ``lines`` / ``pages`` (e.g. ``?path=…&lines=10-40``):

--- a/docs/2026-06-28-render-section.org
+++ b/docs/2026-06-28-render-section.org
@@ -1,0 +1,123 @@
+#+TITLE: render a SECTION of a file + a per-embed full-page link
+#+DATE: <2026-06-28>
+#+STATUS: design+build (Phase 1 review done; implementing)
+
+* Design-review outcomes (folded in)
+Four-lens design review (simplicity, security/correctness, intention, clean
+interfaces). Decisions:
+- *PDF extraction is bounded BY CONSTRUCTION* (security B1/B2). Extraction only
+  runs when the input file is ≤ ~25 MB AND the clamped page-span is ≤ 25 pages;
+  otherwise serve the WHOLE file via ~FileResponse~ (streamed, bounded — the
+  existing safe path). pypdf ~PdfWriter~ materializes selected pages in memory, so
+  "catch → fall back" is NOT enough for the non-raising resource-exhaustion case;
+  coarse real bounds make the bad state unreachable. The extracted-bytes response
+  is a ~Response(..., media_type="application/pdf", headers={nosniff})~ — must
+  carry ``X-Content-Type-Options: nosniff`` like the whole-file ~FileResponse~
+  branch (tested on that branch). A corrupt/encrypted pdf → pypdf raises → caught
+  → serve the whole file (no new 404 path).
+- *Both-keys resolution by construction:* the route picks the range key by file
+  extension (.pdf → ``pages``, else ``lines``); the other key is simply unread.
+  No "ignore wrong key" branch/test — it's the absence of code.
+- *Drop the documented single-value knob:* the skill always emits ``N-M``; a bare
+  ``N`` may fall out of the parser for free but is not a specified/tested contract.
+- *Build the query suffix ONCE* (a ``_show_src(tid, path, lines, pages)`` helper)
+  and feed BOTH the embed ``src`` and the caption ``href`` — so they can't diverge
+  and ``_file_embed_html`` doesn't grow a long parameter list. URL-encode via
+  ``urllib.parse.urlencode``.
+- *``_parse_range(s, hi)`` encodes its own out-of-range contract:* reversed /
+  malformed / ``start > hi`` → None → whole file.
+- *org/md line slice DoS:* the existing whole-file /show already reads the whole
+  file, so slicing is no worse for text — no new bound needed there (the page case
+  is where the span cap is mandatory).
+- *Doc accuracy:* ``pypdf`` goes into the runtime ``dependencies`` (it was only a
+  dev/fixture dep); ``_parse_render_block`` + ``_RENDER_BLOCK_RE`` are UNCHANGED
+  (the new keys flow through the existing key:value parser for free).
+- *Test the link guarantee:* assert EVERY embed branch (pdf + md/org) emits a
+  ``show-cap`` href, so a future refactor can't silently drop the full-page link.
+
+* Goal
+Extend the render skill (docs/2026-06-28-render-skill.org, PR #146) two ways:
+
+1. **Render a SECTION of a file**, not just the whole file:
+   - **org / md → by line:** ``lines: 10-40`` (literal 1-based inclusive line range).
+   - **pdf → by page:** ``pages: 2-5`` (1-based inclusive page range), **extracted**
+     server-side (pypdf) so only those pages are served.
+2. **A per-embed full-page link (UI-only, NOT agent-driven):** every rendered
+   embed already carries a caption link to the standalone /show page; make it a
+   clear "view on its own page" affordance and **carry the section range into that
+   link** so a ``pages: 2-5`` embed opens full-page at pages 2-5.
+
+Pierre's calls: PDF "by page" = **extract the range** (not a ``#page=N`` jump);
+line range is **literal**; full-page is **UI-only** (the render layer decorates
+every embed; the agent does nothing for it).
+
+* Design
+** The render block (extends the existing format)
+Keeps the kept invariant ``type: file`` + ``path:``; gains an OPTIONAL range key:
+#+begin_example
+```render
+type: file
+path: /workspace/notes.org
+lines: 10-40
+```
+#+end_example
+- ``lines: N-M`` for org/md; ``pages: N-M`` for pdf. A bare ``N`` means ``N-N``.
+- The wrong-mode key is ignored (``lines`` on a pdf / ``pages`` on org/md).
+- Range is untrusted model output → parsed defensively (ints only; malformed →
+  ignored → whole file). No new injection surface (the path is still the only
+  string that reaches the filesystem, via the unchanged ``_safe_workspace_file``).
+
+** Skill (assist/web_skills/render/SKILL.md)
+Add: when the user asks for a specific part — "lines 10-40 of X", "page 3 of the
+report" — include the range in the block (``lines:`` for org/md, ``pages:`` for
+pdf). Keep it generalizable (don't overfit to one phrasing).
+
+** /show route (manage/web/threads.py)
+Gains query params ``lines`` / ``pages`` (e.g. ``?path=…&lines=10-40``):
+- A pure ``_parse_range(s, hi)`` → ``(start, end)`` clamped to ``[1, hi]`` or None
+  (empty/malformed/reversed → None → whole file). Unit-tested in isolation.
+- **org/md + lines:** read the file, slice ``lines[start-1:end]``, render that
+  slice through the existing md / pure-org renderer (unchanged).
+- **pdf + pages:** ``pypdf`` reads the file, a ``PdfWriter`` collects pages
+  ``start..end`` into a ``BytesIO``, served as ``application/pdf`` bytes (+
+  ``nosniff``). No temp file. Whole-pdf path unchanged when no ``pages``.
+- The route stays sync ``def`` (FastAPI threadpool) — pypdf extraction + the
+  slice are blocking CPU/IO and must not run on the event loop.
+
+** Embed + full-page link (manage/web/threads.py)
+- ``_render_file_block`` passes the block's ``lines``/``pages`` into the embed.
+- ``_file_embed_html`` appends the range to BOTH the iframe/embed ``src`` AND the
+  caption link's href, so the inline embed AND the full-page link show the same
+  section. The caption link is the per-embed "view on its own page" affordance
+  (already present; now range-aware). UI-only — no agent/skill surface for it.
+
+* Dependency
+- **Add ``pypdf``** to pyproject (pure-Python; no system packages). Host currently
+  has no pypdf/qpdf/pdfseparate/pdftk. **Deploy needs ``make deploy-install``** (venv
+  rebuild), not just deploy-code.
+
+* Security / edge cases
+- Range parse: ints only, clamp to file bounds, malformed/reversed/out-of-range →
+  whole file (benign). No path/format change — traversal confinement, CSP, sandbox
+  iframe all unchanged and reused.
+- pypdf on a confined path; a corrupt/huge pdf → pypdf raises → caught → fall back
+  to whole file (or 404 if unreadable). Clamp pages to the reader's page count.
+- Line slice on org: a literal slice can cut a heading's subtree — accepted (user
+  asked "by line"); the org renderer degrades gracefully.
+
+* Validation
+- *Unit (CPU):* ``_parse_range`` (range/single/malformed/reversed/clamp); the route
+  for an org/md line slice (only those lines rendered) and a pdf page extraction
+  (served pdf has the right page count — build a multi-page fixture with pypdf);
+  the embed/caption carry the range; existing /show security tests still hold.
+- *Behavioral (light, fans-limited):* focal n=3 — "show me lines 10-40 of X" and
+  "show page 3 of report.pdf" → assert the render block carries ``lines:``/``pages:``.
+- Full N cadence deferred (GPU fans).
+
+* Critical files
+- Edit: ``manage/web/threads.py`` (``_parse_range``, route range params, slice +
+  pypdf extraction, embed/link range), ``assist/web_skills/render/SKILL.md`` (range
+  guidance), ``pyproject.toml`` (pypdf), ``tests/test_render.py`` (+range tests),
+  ``edd/eval/test_render_agent.py`` (+section emission).
+- Reused unchanged: ``_safe_workspace_file``, the md / pure-org renderers, CSP,
+  sandbox iframe, ``_RENDER_DISPATCH`` (still ``{"file": …}``).

--- a/docs/2026-06-28-render-section.org
+++ b/docs/2026-06-28-render-section.org
@@ -61,7 +61,9 @@ path: /workspace/notes.org
 lines: 10-40
 ```
 #+end_example
-- ``lines: N-M`` for org/md; ``pages: N-M`` for pdf. A bare ``N`` means ``N-N``.
+- ``lines: N-M`` for org/md; ``pages: N-M`` for pdf — always a range; for a
+  single line/page the skill repeats the number (e.g. ``pages: 3-3``). (A bare
+  ``N`` happens to parse as ``N-N`` but is not a relied-on contract.)
 - The wrong-mode key is ignored (``lines`` on a pdf / ``pages`` on org/md).
 - Range is untrusted model output → parsed defensively (ints only; malformed →
   ignored → whole file). No new injection surface (the path is still the only

--- a/edd/eval/test_render_agent.py
+++ b/edd/eval/test_render_agent.py
@@ -111,6 +111,24 @@ class TestRenderAgent(TestCase):
             f"expected a render block for log.org with a lines: range; blocks: {blocks}",
         )
 
+    def test_resolves_described_section_to_line_range(self):
+        """The common case: 'show me the section about X' (no explicit numbers) —
+        the agent must read the file, locate the section, and emit a lines: range
+        (description resolved to numbers, not left as prose)."""
+        fs = dict(_personal_workspace())
+        fs["config.org"] = (
+            "* Intro\nsome intro text\nmore intro\n"
+            "* Backups\nback up to the NAS nightly\nkeep three copies offsite\n"
+            "* Networking\nwifi is on channel 6\nrouter in the closet\n")
+        agent = self.create_agent(fs)
+        agent.message("Show me the section about backups in config.org")
+        blocks = self._render_block_paths(agent)
+        self.assertTrue(
+            any("config.org" in b and "lines:" in b.lower() for b in blocks),
+            f"expected a render block for config.org with a resolved lines: range; "
+            f"blocks: {blocks}",
+        )
+
     def test_emits_page_range(self):
         """Section by page: 'show page N of <pdf>' carries a pages: range."""
         from pypdf import PdfWriter

--- a/edd/eval/test_render_agent.py
+++ b/edd/eval/test_render_agent.py
@@ -67,9 +67,13 @@ class TestRenderAgent(TestCase):
                                          spec=AgentSpec(skill_sources=skills)))
 
     def _render_block_paths(self, agent) -> list:
-        """Bodies of render blocks the agent emitted in its message content."""
+        """Bodies of render blocks the AGENT emitted — only AIMessage content, so
+        the loaded skill's own example blocks (a ToolMessage) don't count."""
+        from langchain_core.messages import AIMessage
         bodies = []
         for m in agent.all_messages():
+            if not isinstance(m, AIMessage):
+                continue
             content = m.content if isinstance(m.content, str) else ""
             bodies.extend(b for b in _RENDER_BLOCK.findall(content) if "type:" in b.lower())
         return bodies
@@ -93,4 +97,39 @@ class TestRenderAgent(TestCase):
         self.assertTrue(
             any("recipes.org" in b for b in blocks),
             f"expected a render block for recipes.org; render blocks: {blocks}",
+        )
+
+    def test_emits_line_range(self):
+        """Section by line: 'show me lines X-Y of <file>' carries a lines: range."""
+        fs = dict(_personal_workspace())
+        fs["log.org"] = "* Log\n" + "".join(f"- entry {i}\n" for i in range(1, 60))
+        agent = self.create_agent(fs)
+        agent.message("Show me lines 10 to 20 of log.org")
+        blocks = self._render_block_paths(agent)
+        self.assertTrue(
+            any("log.org" in b and "lines:" in b.lower() for b in blocks),
+            f"expected a render block for log.org with a lines: range; blocks: {blocks}",
+        )
+
+    def test_emits_page_range(self):
+        """Section by page: 'show page N of <pdf>' carries a pages: range."""
+        import tempfile, os
+        from edd.eval.utils import create_filesystem
+        from pypdf import PdfWriter
+        root = tempfile.mkdtemp()
+        create_filesystem(root, _personal_workspace())
+        w = PdfWriter()
+        for _ in range(6):
+            w.add_blank_page(width=200, height=200)
+        with open(os.path.join(root, "report.pdf"), "wb") as f:
+            w.write(f)
+        skills = {"/render-skill/": FilesystemBackend(root_dir=_RENDER_SKILLS_DIR,
+                                                      virtual_mode=True)}
+        agent = AgentHarness(create_agent(self.model, root,
+                                          spec=AgentSpec(skill_sources=skills)))
+        agent.message("Show me page 3 of report.pdf")
+        blocks = self._render_block_paths(agent)
+        self.assertTrue(
+            any("report.pdf" in b and "pages:" in b.lower() for b in blocks),
+            f"expected a render block for report.pdf with a pages: range; blocks: {blocks}",
         )

--- a/edd/eval/test_render_agent.py
+++ b/edd/eval/test_render_agent.py
@@ -113,10 +113,8 @@ class TestRenderAgent(TestCase):
 
     def test_emits_page_range(self):
         """Section by page: 'show page N of <pdf>' carries a pages: range."""
-        import tempfile, os
-        from edd.eval.utils import create_filesystem
         from pypdf import PdfWriter
-        root = tempfile.mkdtemp()
+        root = tempfile.mkdtemp()  # throwaway, same as create_agent's pattern
         create_filesystem(root, _personal_workspace())
         w = PdfWriter()
         for _ in range(6):

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -8,6 +8,7 @@ Owns ``_process_message`` (the synchronous worker spawned as a
 from __future__ import annotations
 
 import html
+import io
 import json
 import logging
 import os
@@ -22,6 +23,7 @@ from fastapi.responses import (
     HTMLResponse,
     JSONResponse,
     RedirectResponse,
+    Response,
 )
 
 from assist.domain_manager import (
@@ -1030,10 +1032,25 @@ def _org_to_html(src: str) -> str:
     return "\n".join(parts)
 
 
-def _file_embed_html(tid: str, path: str) -> str:
+def _show_src(tid: str, path: str, lines: str = "", pages: str = "") -> str:
+    """The /show URL for a file, with an optional section range.  Built ONCE so
+    the inline embed and the caption full-page link can't diverge.  Only the
+    range key matching the file type is carried (.pdf → pages, else lines); the
+    range is the raw block value — the route parses it authoritatively."""
+    params = {"path": path}
+    is_pdf = os.path.splitext(path)[1].lower() == ".pdf"
+    rng = pages if is_pdf else lines
+    if rng:
+        params["pages" if is_pdf else "lines"] = rng
+    return f"/thread/{tid}/show?{urllib.parse.urlencode(params, quote_via=urllib.parse.quote)}"
+
+
+def _file_embed_html(tid: str, path: str, lines: str = "", pages: str = "") -> str:
     """Inline embed for a workspace file: pdf in the browser viewer, md/org as a
-    sandboxed iframe over the /show route, plus a caption link to open it."""
-    src = f"/thread/{tid}/show?path={urllib.parse.quote(path)}"
+    sandboxed iframe over the /show route, plus a caption link to open it on its
+    own page.  An optional line/page range is carried into BOTH the embed src and
+    the caption link, so inline and full-page show the same section."""
+    src = _show_src(tid, path, lines, pages)
     label = html.escape(path)
     if os.path.splitext(path)[1].lower() == ".pdf":
         viewer = f'<embed class="show-file" type="application/pdf" src="{src}" />'
@@ -1053,11 +1070,12 @@ def _file_embed_html(tid: str, path: str) -> str:
 def _render_file_block(tid: str, block: dict) -> str | None:
     """``type: file`` renderer.  Embeds a showable workspace file, or None when
     the path is missing / not a renderable extension (the block is then left to
-    show as a normal code block)."""
+    show as a normal code block).  An optional ``lines:``/``pages:`` range is
+    carried into the embed."""
     path = block.get("path", "")
     if not path or os.path.splitext(path)[1].lower() not in _SHOWABLE_EXTS:
         return None
-    return _file_embed_html(tid, path)
+    return _file_embed_html(tid, path, block.get("lines", ""), block.get("pages", ""))
 
 
 # type -> renderer(tid, block).  The SINGLE source of truth for the render-block
@@ -1109,14 +1127,69 @@ def _render_assistant_content(tid: str, raw: str) -> str:
     return "".join(out)
 
 
-@app.get("/thread/{tid}/show")
-def show_file_view(tid: str, path: str):
-    """Render a file from the thread's agent workspace for embedding: pdf as
-    bytes (browser viewer), md/org as a styled HTML page.
+# Bounds for PDF page extraction.  Extraction (pypdf PdfWriter) materializes the
+# selected pages in memory, and the source pdf is untrusted (agent/web-sourced),
+# so extraction runs ONLY within these coarse real bounds; outside them we serve
+# the whole file via the streamed FileResponse (the existing safe path).
+_MAX_PDF_EXTRACT_BYTES = 25 * 1024 * 1024  # don't load a giant pdf into memory
+_MAX_PAGE_SPAN = 25                          # a section, not a whole book
 
-    Declared SYNC (not ``async def``) on purpose: the file read and the
-    markdown/org conversion are blocking CPU/IO and a shown file can be large,
-    so FastAPI runs this in its threadpool, keeping the single-worker event
+
+def _parse_range(spec: str, hi: int) -> tuple[int, int] | None:
+    """Parse a 1-based inclusive ``N-M`` range (untrusted) against upper bound
+    ``hi`` (line or page count).  Returns clamped ``(start, end)``, or None for
+    empty / malformed / reversed / out-of-range — the caller then shows the whole
+    file.  (A bare ``N`` works as ``N-N``; not a relied-on contract.)"""
+    if not spec:
+        return None
+    a, _, b = spec.strip().partition("-")
+    b = b or a
+    try:
+        start, end = int(a), int(b)
+    except ValueError:
+        return None
+    if start < 1 or end < start or start > hi:
+        return None
+    return start, min(end, hi)
+
+
+def _extract_pdf_pages(fpath: str, pages: str) -> bytes | None:
+    """A page range from a workspace PDF as new PDF bytes, or None to fall back to
+    serving the whole file (oversize input, oversize span, bad range, or a
+    corrupt/encrypted pdf).  Bounded by construction so pypdf can't be driven to
+    materialize an unbounded amount of memory on the event-loop threadpool."""
+    try:
+        if os.path.getsize(fpath) > _MAX_PDF_EXTRACT_BYTES:
+            return None
+        from pypdf import PdfReader, PdfWriter
+        reader = PdfReader(fpath)
+        rng = _parse_range(pages, len(reader.pages))
+        if rng is None:
+            return None
+        start, end = rng
+        if end - start + 1 > _MAX_PAGE_SPAN:
+            return None
+        writer = PdfWriter()
+        for i in range(start - 1, end):
+            writer.add_page(reader.pages[i])
+        buf = io.BytesIO()
+        writer.write(buf)
+        return buf.getvalue()
+    except Exception as e:
+        logging.warning("pdf page extraction failed for %s: %s", fpath, e)
+        return None
+
+
+@app.get("/thread/{tid}/show")
+def show_file_view(tid: str, path: str, lines: str = "", pages: str = ""):
+    """Render a file from the thread's agent workspace for embedding: pdf as
+    bytes (browser viewer), md/org as a styled HTML page.  Optional section range
+    — ``lines=N-M`` (md/org) or ``pages=N-M`` (pdf, extracted); the key not
+    matching the file type is simply unread, a malformed range shows the whole file.
+
+    Declared SYNC (not ``async def``) on purpose: the file read, the markdown/org
+    conversion, and pdf extraction are blocking CPU/IO and a shown file can be
+    large, so FastAPI runs this in its threadpool, keeping the single-worker event
     loop free (the repo's event-loop-liveness rule)."""
     _existing_thread_dir(tid)  # 404 on a bad/missing tid (traversal-safe)
     fpath = _safe_workspace_file(tid, path)
@@ -1124,10 +1197,20 @@ def show_file_view(tid: str, path: str):
         raise HTTPException(status_code=404, detail="file not found")
     ext = os.path.splitext(fpath)[1].lower()
     if ext == ".pdf":
-        return FileResponse(fpath, media_type="application/pdf",
-                            headers={"X-Content-Type-Options": "nosniff"})
+        pdf_headers = {"X-Content-Type-Options": "nosniff"}
+        if pages:
+            extracted = _extract_pdf_pages(fpath, pages)
+            if extracted is not None:
+                return Response(content=extracted, media_type="application/pdf",
+                                headers=pdf_headers)
+        return FileResponse(fpath, media_type="application/pdf", headers=pdf_headers)
     with open(fpath, encoding="utf-8", errors="replace") as f:
         src = f.read()
+    if lines:
+        all_lines = src.splitlines()
+        rng = _parse_range(lines, len(all_lines))
+        if rng:
+            src = "\n".join(all_lines[rng[0] - 1:rng[1]])
     if ext == ".md":
         body = markdown.markdown(src, extensions=_MD_EXTENSIONS)
     elif ext == ".org":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ dependencies = [
     "Markdown",
     "openai",
     "pydantic",
+    # Host-side PDF page extraction for the render skill's `pages:` range
+    # (manage/web/threads.py `_extract_pdf_pages`). Pure-Python, no system deps.
+    "pypdf",
     "python-dotenv",
     "python-multipart",
     "requests",

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -15,9 +15,27 @@ from manage.web.threads import (
     _file_embed_html,
     _render_file_block,
     _render_assistant_content,
+    _parse_range,
+    _show_src,
+    _extract_pdf_pages,
     _RENDER_DISPATCH,
     _SHOWABLE_EXTS,
 )
+
+
+def _make_pdf(path, n_pages):
+    from pypdf import PdfWriter
+    w = PdfWriter()
+    for _ in range(n_pages):
+        w.add_blank_page(width=200, height=200)
+    with open(path, "wb") as f:
+        w.write(f)
+
+
+def _pdf_page_count(data: bytes) -> int:
+    import io
+    from pypdf import PdfReader
+    return len(PdfReader(io.BytesIO(data)).pages)
 
 
 @pytest.fixture
@@ -75,6 +93,13 @@ class TestFileEmbed:
     def test_render_file_block_renders_showable(self):
         assert "<iframe" in _render_file_block("t1", {"path": "/workspace/r.org"})
 
+    @pytest.mark.parametrize("name", ["a.org", "a.md", "a.pdf"])
+    def test_every_embed_has_a_fullpage_link(self, name):
+        # The full-page "view on its own page" affordance: every embed branch
+        # (md/org iframe + pdf embed) must carry a caption href to the /show page.
+        h = _file_embed_html("t1", name)
+        assert 'class="show-cap"' in h and "<a href=" in h
+
 
 class TestRenderAssistantContent:
     def test_render_block_becomes_embed(self):
@@ -108,6 +133,76 @@ class TestRenderAssistantContent:
 
     def test_dispatch_is_single_source_of_truth(self):
         assert set(_RENDER_DISPATCH) == {"file"}
+
+
+class TestParseRange:
+    @pytest.mark.parametrize("spec,hi,expected", [
+        ("10-40", 100, (10, 40)),
+        ("5", 100, (5, 5)),          # bare N -> N-N
+        ("5-100", 50, (5, 50)),      # end clamped to hi
+        ("40-10", 100, None),        # reversed
+        ("0-5", 100, None),          # start < 1
+        ("100-200", 50, None),       # start > hi (out of range)
+        ("abc", 100, None),          # malformed
+        ("", 100, None),             # empty
+    ])
+    def test_parse(self, spec, hi, expected):
+        assert _parse_range(spec, hi) == expected
+
+
+class TestShowSrc:
+    def test_carries_lines_for_text(self):
+        assert "lines=10-40" in _show_src("t1", "/workspace/n.md", lines="10-40")
+
+    def test_carries_pages_for_pdf(self):
+        assert "pages=2-5" in _show_src("t1", "/workspace/r.pdf", pages="2-5")
+
+    def test_ignores_wrong_mode_key(self):
+        # lines on a pdf / pages on org are unread by construction.
+        assert "lines" not in _show_src("t1", "/workspace/r.pdf", lines="10-40")
+        assert "pages" not in _show_src("t1", "/workspace/n.org", pages="2-5")
+
+    def test_embed_and_caption_share_the_range(self):
+        h = _file_embed_html("t1", "n.md", lines="10-40")
+        # the range appears in both the iframe src and the caption href
+        assert h.count("lines=10-40") == 2
+
+
+class TestSectionRender:
+    def test_md_line_slice(self, workspace):
+        (workspace / "n.md").write_text("# A\n# B\n# C\n# D\n# E\n")
+        r = TestClient(web.app).get("/thread/t1/show", params={"path": "n.md", "lines": "2-3"})
+        assert r.status_code == 200
+        assert "<h1>B</h1>" in r.text and "<h1>C</h1>" in r.text
+        assert "<h1>A</h1>" not in r.text and "<h1>E</h1>" not in r.text
+
+    def test_md_malformed_range_shows_whole(self, workspace):
+        (workspace / "n.md").write_text("# A\n# B\n# C\n")
+        r = TestClient(web.app).get("/thread/t1/show", params={"path": "n.md", "lines": "9-3"})
+        assert "<h1>A</h1>" in r.text and "<h1>C</h1>" in r.text  # whole file
+
+    def test_pdf_page_extraction(self, workspace):
+        _make_pdf(workspace / "r.pdf", 5)
+        r = TestClient(web.app).get("/thread/t1/show", params={"path": "r.pdf", "pages": "2-3"})
+        assert r.status_code == 200
+        assert r.headers["content-type"] == "application/pdf"
+        assert r.headers["x-content-type-options"] == "nosniff"   # nosniff on bytes path
+        assert _pdf_page_count(r.content) == 2
+
+    def test_pdf_no_pages_serves_whole(self, workspace):
+        _make_pdf(workspace / "r.pdf", 4)
+        r = TestClient(web.app).get("/thread/t1/show", params={"path": "r.pdf"})
+        assert r.status_code == 200 and _pdf_page_count(r.content) == 4
+
+    def test_pdf_oversize_span_falls_back_to_whole(self, workspace):
+        # span > _MAX_PAGE_SPAN -> extraction skipped -> whole file served.
+        _make_pdf(workspace / "big.pdf", 30)
+        out = _extract_pdf_pages(str(workspace / "big.pdf"), "1-30")
+        assert out is None
+
+    def test_pdf_corrupt_falls_back(self, workspace):
+        (workspace / "bad.pdf").write_bytes(b"%PDF-1.4 not really a pdf")
+        assert _extract_pdf_pages(str(workspace / "bad.pdf"), "1-2") is None
 
 
 class TestShowRoute:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -138,7 +138,6 @@ class TestRenderAssistantContent:
 class TestParseRange:
     @pytest.mark.parametrize("spec,hi,expected", [
         ("10-40", 100, (10, 40)),
-        ("5", 100, (5, 5)),          # bare N -> N-N
         ("5-100", 50, (5, 50)),      # end clamped to hi
         ("40-10", 100, None),        # reversed
         ("0-5", 100, None),          # start < 1


### PR DESCRIPTION
## Why
Extends the render skill (#146) to show a **section** of a file, per Pierre's request ("rendering a section of a local file — by line (org and md) or page (pdf)"). Plus: every embed's full-page link (UI-only) carries the section so it opens the same part on its own page.

## What
- **org / md → by line:** ` ```render ` + `lines: N-M` → the `/show` route slices those lines, renders the slice.
- **pdf → by page:** `pages: N-M` → **pypdf extracts only those pages** (Pierre's call: extract, not a `#page=N` jump), served as bytes.
- **Full-page link (UI-only, not agent-driven):** the existing per-embed caption link now carries the range (`_show_src` builds the URL once → both the embed `src` and the caption `href`, so they can't diverge). Every embed branch has the link (tested).
- Skill teaches the agent to add `lines:`/`pages:` for "lines 10-40 of X" / "page 3 of the report."

## Safety (by construction, from design review)
- PDF extraction runs **only** when input ≤ 25 MB **and** the clamped span ≤ 25 pages; otherwise serve the whole file via the streamed `FileResponse`. pypdf materializes selected pages in memory, so coarse real bounds make resource-exhaustion on an untrusted (web-sourced) PDF unreachable — not "catch and hope." Extracted bytes carry `X-Content-Type-Options: nosniff`. Corrupt/encrypted PDF → caught → whole file.
- Range is untrusted: `_parse_range` is ints-only, clamps to file bounds, and returns None (→ whole file) on reversed/malformed/out-of-range. It never reaches the filesystem (path still via the unchanged `_safe_workspace_file`).
- Route stays sync `def` (FastAPI threadpool) — slice + pypdf off the event loop.

## Dependency
- Adds **`pypdf`** to runtime `dependencies` (pure-Python). **Deploy needs `make deploy-install`** (venv rebuild), not just `deploy-code`.

## Validation
- **719 unit tests green** (CPU): `_parse_range`, line slice, pdf page extraction (served pdf has the right page count), nosniff on the bytes branch, oversize-span/corrupt → whole-file fallback, every embed carries a full-page link, range in embed src + caption href.
- **Section-emission eval (light, fans-limited): line-range 3/3, page-range 3/3** — the model emits `lines:`/`pages:` for section requests (validated AIMessage-only, so the skill's own examples don't false-pass).
- Design-review team (4 lenses) + code-review loop (security + simplicity/correctness/design) — both **ship**, 0 blocker/important.

## Design doc
`docs/2026-06-28-render-section.org` (decisions + design-review outcomes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)