### PR TITLE
travel: self-hosted Nominatim geocoder (real addresses/POIs), MOTIS keeps routing

### DIFF
--- a/.deploy.env.example
+++ b/.deploy.env.example
@@ -54,8 +54,9 @@ ASSIST_ROUTING_URL=http://127.0.0.1:8088
 # Travel geocoding — self-hosted Nominatim (name -> coords).  OPTIONAL: when set,
 # the travel tool geocodes place names through this (far better at real
 # addresses/POIs than MOTIS's built-in geocoder); unset -> falls back to MOTIS.
-# Set this only AFTER the Nominatim OSM import finishes (else geocode times out).
-ASSIST_GEOCODER_URL=http://127.0.0.1:8089
+# Set this only AFTER the Nominatim OSM import finishes (else geocode times out),
+# so it stays commented by default.
+#ASSIST_GEOCODER_URL=http://127.0.0.1:8089
 
 # Python version on remote server
 PYTHON=python3.14

--- a/.deploy.env.example
+++ b/.deploy.env.example
@@ -46,6 +46,17 @@ ASSIST_DOMAINS=user@host:/path/to/repo1.git,user@host:/path/to/repo2.git
 # container on 127.0.0.1:8890.
 ASSIST_SEARCH_URL=http://127.0.0.1:8890
 
+# Travel routing — self-hosted MOTIS (car/bike/walk/transit time+distance).
+# The `travel` tool reads this; if unset, travel returns "unavailable" (it never
+# guesses).  MOTIS also has a built-in geocoder, used only when
+# ASSIST_GEOCODER_URL (below) is unset.
+ASSIST_ROUTING_URL=http://127.0.0.1:8088
+# Travel geocoding — self-hosted Nominatim (name -> coords).  OPTIONAL: when set,
+# the travel tool geocodes place names through this (far better at real
+# addresses/POIs than MOTIS's built-in geocoder); unset -> falls back to MOTIS.
+# Set this only AFTER the Nominatim OSM import finishes (else geocode times out).
+ASSIST_GEOCODER_URL=http://127.0.0.1:8089
+
 # Python version on remote server
 PYTHON=python3.14
 

--- a/.dev.env.example
+++ b/.dev.env.example
@@ -22,3 +22,10 @@ ASSIST_PORT=8000
 # Run `make searxng-up`, then set this.  search_internet FAILS LOUDLY if it's
 # unset or unreachable (search is not silently degraded).
 # ASSIST_SEARCH_URL=http://127.0.0.1:8890
+
+# Travel: self-hosted MOTIS (routing) + optional Nominatim (geocoding).
+# `travel` reads ASSIST_ROUTING_URL (else returns "unavailable"); ASSIST_GEOCODER_URL
+# is optional — set it (after the Nominatim import finishes) for good address/POI
+# geocoding, else travel falls back to MOTIS's built-in geocoder.
+# ASSIST_ROUTING_URL=http://127.0.0.1:8088
+# ASSIST_GEOCODER_URL=http://127.0.0.1:8089

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ deploy-service:
 		ASSIST_DOMAINS='$(ASSIST_DOMAINS)' \
 		ASSIST_SEARCH_URL='$(ASSIST_SEARCH_URL)' \
 		ASSIST_ROUTING_URL='$(ASSIST_ROUTING_URL)' \
+		ASSIST_GEOCODER_URL='$(ASSIST_GEOCODER_URL)' \
 		'bash -s' < scripts/install-service.sh
 	@echo "✓ Service installed"
 

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -1,6 +1,7 @@
 """Tools the agent exposes: a self-hosted SearXNG metasearch, a per-host
 throttled URL fetch, and a self-hosted MOTIS-backed ``travel`` tool (real-world
-time/distance by car/bike/walk/transit — see the travel() section below).
+time/distance by car/bike/walk/transit — see the travel() section below;
+geocoding goes through an optional self-hosted Nominatim via ``ASSIST_GEOCODER_URL``).
 
 Search goes through a self-hosted SearXNG instance (``ASSIST_SEARCH_URL``) —
 private, on hardware we control, multi-engine, no API key.  There is NO
@@ -338,21 +339,48 @@ def _motis_get(path: str, params: dict) -> dict | list:
         raise _TravelBackendError(f"MOTIS {path} failed: {e}") from e
 
 
-def _geocode(place: str) -> dict | None:
-    """Resolve a place NAME to coords via MOTIS geocoding (self-hosted).  Returns
-    {lat, lon, name} (top match, with the resolved name so the agent can say what
-    it routed to), or None if nothing matched.  Raises _TravelBackendError if the
-    service is down (so the caller distinguishes that from a genuine no-match)."""
-    hits = _motis_get("/api/v1/geocode", {"text": place})
-    if not isinstance(hits, list):  # wrong shape = a backend problem, not "no match"
-        raise _TravelBackendError(f"unexpected geocode response: {type(hits).__name__}")
-    for h in hits:  # take the first USABLE hit; skip a malformed one (no false not-found)
+def _first_usable_hit(hits, place: str) -> dict | None:
+    """First geocoder hit with parseable coords -> {lat, lon, name}; skip a
+    malformed one (no false not-found); None if none usable.  A non-list `hits`
+    is a wrong-shape 200 = backend problem, so raise _TravelBackendError (the
+    caller turns that into "unavailable", not "couldn't find").  Works for both
+    backends: MOTIS hits carry `name`; Nominatim carries `name`/`display_name`."""
+    if not isinstance(hits, list):
+        raise _TravelBackendError(f"unexpected geocoder response: {type(hits).__name__}")
+    for h in hits:
         try:
             return {"lat": float(h["lat"]), "lon": float(h["lon"]),
-                    "name": h.get("name") or place}  # never propagate a blank name
+                    "name": h.get("name") or h.get("display_name") or place}
         except (KeyError, TypeError, ValueError, AttributeError):
             continue
     return None
+
+
+def _nominatim_geocode(place: str) -> dict | None:
+    """Geocode a place NAME via the self-hosted Nominatim search API.  The loaded
+    OSM extract IS the region, so no country/viewbox filter is needed.  Raises
+    _TravelBackendError if Nominatim is unreachable/errors (callers -> unavailable)."""
+    base = os.getenv("ASSIST_GEOCODER_URL")
+    try:
+        resp = requests.get(base.rstrip("/") + "/search",
+                            params={"q": place, "format": "jsonv2", "limit": 5},
+                            timeout=_TRAVEL_TIMEOUT_S)
+        resp.raise_for_status()
+        hits = resp.json()
+    except Exception as e:
+        raise _TravelBackendError(f"Nominatim /search failed: {e}") from e
+    return _first_usable_hit(hits, place)
+
+
+def _geocode(place: str) -> dict | None:
+    """Resolve a place NAME to {lat, lon, name} (top match, with the resolved name
+    so the agent can say what it routed to), or None if nothing matched.  Uses the
+    self-hosted Nominatim geocoder when ASSIST_GEOCODER_URL is set (far better at
+    real addresses/POIs than MOTIS's built-in geocoder), else falls back to MOTIS
+    /api/v1/geocode.  Raises _TravelBackendError if the chosen backend is down."""
+    if os.getenv("ASSIST_GEOCODER_URL"):
+        return _nominatim_geocode(place)
+    return _first_usable_hit(_motis_get("/api/v1/geocode", {"text": place}), place)
 
 
 def _plan_direct(o: dict, d: dict, mode: str) -> dict | None:

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -349,10 +349,13 @@ def _first_usable_hit(hits, place: str) -> dict | None:
         raise _TravelBackendError(f"unexpected geocoder response: {type(hits).__name__}")
     for h in hits:
         try:
-            return {"lat": float(h["lat"]), "lon": float(h["lon"]),
-                    "name": h.get("name") or h.get("display_name") or place}
+            lat, lon = float(h["lat"]), float(h["lon"])
+            name = h.get("name") or h.get("display_name") or place
         except (KeyError, TypeError, ValueError, AttributeError):
             continue
+        if -90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0:  # also rejects NaN/inf
+            return {"lat": lat, "lon": lon, "name": name}
+        # out-of-range/NaN/inf coords would poison /plan as "nan,nan" -> skip the hit
     return None
 
 
@@ -438,6 +441,11 @@ def travel(origin: str, destination: str) -> str:
     Covers the loaded metro area(s); a place outside them comes back as no route,
     not a guess.
     """
+    # Routing is required for the whole tool; without it, geocoding (now possibly
+    # via Nominatim) would succeed and every mode would come back "unavailable" --
+    # so fail fast with the standard message instead.
+    if not os.getenv("ASSIST_ROUTING_URL"):
+        return _travel_unavailable("ASSIST_ROUTING_URL is not set")
     try:
         o = _geocode(origin)
         d = _geocode(destination)

--- a/docs/2026-06-29-nominatim-geocoder.org
+++ b/docs/2026-06-29-nominatim-geocoder.org
@@ -1,6 +1,6 @@
 #+TITLE: travel geocoder — self-hosted Nominatim (name → coords)
 #+DATE: <2026-06-29>
-#+STATUS: built; Nominatim NorCal import running; pending live-verify + review/PR + deploy
+#+STATUS: built + LIVE-VERIFIED (Nominatim NorCal up; "222 2nd St"/Ferry Building/Coit Tower/Oracle Park resolve; OSM gaps like "Connecticut Yankee" honestly reported); in review (PR #149); pending merge+deploy
 
 * Why
 MOTIS's built-in geocoder is too weak for real addresses/POIs — Pierre's first

--- a/docs/2026-06-29-nominatim-geocoder.org
+++ b/docs/2026-06-29-nominatim-geocoder.org
@@ -1,0 +1,60 @@
+#+TITLE: travel geocoder — self-hosted Nominatim (name → coords)
+#+DATE: <2026-06-29>
+#+STATUS: built; Nominatim NorCal import running; pending live-verify + review/PR + deploy
+
+* Why
+MOTIS's built-in geocoder is too weak for real addresses/POIs — Pierre's first
+real query mis-resolved BOTH endpoints ("Connecticut Yankee" → "Connecticut
+Street"; "222 2nd St" → "Francisco Street"). Routing is fine; geocoding is the
+weak link. Fix: a proper self-hosted geocoder (Nominatim) for name→coords; MOTIS
+keeps doing the routing (coords→all-modes). Follow-up to the travel skill
+(docs/2026-06-28-local-travel-skill.org).
+
+* Decisions
+- *Engine = Nominatim* (``mediagis/nominatim:4.5``, self-hosted), not Photon —
+  Nominatim handles both structured addresses AND POIs in one service; Photon
+  would add Elasticsearch + a build-from-Nominatim step. Simplicity wins.
+- *New env ``ASSIST_GEOCODER_URL``*. Set → ``_geocode`` uses Nominatim ``/search``;
+  unset → falls back to MOTIS ``/api/v1/geocode`` (so dev/tests/un-provisioned
+  deploys still work, and the code can ship before the slow import finishes).
+- *The OSM extract IS the region* — Nominatim loads only the NorCal extract, so
+  every result is already regional; NO ``countrycodes``/``viewbox`` filter needed
+  (dropped from the initial plan). Expanding regions = load a bigger extract +
+  re-import, NO code change (same knob as MOTIS).
+- *Shared hit-parsing* — ``_first_usable_hit(hits, place)`` is used by both the
+  Nominatim and MOTIS paths: first hit with parseable coords → ``{lat, lon,
+  name}``, skip malformed, non-list → ``_TravelBackendError``, blank name →
+  ``display_name`` → ``place``. Same FAIL-LOUD-BUT-RETURNED contract for both.
+- *Same units/contract* — ``travel()`` and the ``_plan_*`` calls are unchanged
+  (they take coords); only the geocode source changes.
+
+* Code (branch nominatim-geocoder)
+- ``assist/tools.py``: ``_first_usable_hit`` (shared), ``_nominatim_geocode``
+  (``GET {ASSIST_GEOCODER_URL}/search?q=&format=jsonv2&limit=5``), ``_geocode``
+  dispatches on ``ASSIST_GEOCODER_URL``.
+- ``tests/test_travel.py``: ``routing_env`` now sets both URLs (Nominatim is the
+  default path); ``_fake_get`` learns the ``/search`` shape; new tests pin the
+  Nominatim-vs-MOTIS dispatch + the fallback; all prior contract tests preserved.
+- Deploy wiring (mirror ``ASSIST_ROUTING_URL``): ``scripts/install-service.sh`` +
+  ``Makefile`` deploy-service + ``.deploy.env.example`` / ``.dev.env.example``.
+
+* Infra
+``mediagis/nominatim:4.5`` container ``nominatim-geocoder`` on ``127.0.0.1:8089``,
+NorCal extract (``~/motis-travel/input/norcal.osm.pbf``), PG data in named volume
+``nominatim-geocoder-data``, ``--restart unless-stopped``. The PBF is mounted at
+``/data`` (OUTSIDE ``/nominatim``) because the entrypoint does ``chown -R
+/nominatim`` under ``set -e`` and a read-only mount under it crash-loops the import.
+
+* Verify live (after the import finishes)
+1. ``curl 127.0.0.1:8089/status`` → DB loaded.
+2. ``/search?q=Connecticut Yankee San Francisco`` → the Potrero Hill bar (~37.76,
+   -122.40), and ``222 2nd St San Francisco`` → the SoMa address — i.e. the two
+   queries that MOTIS's geocoder got wrong.
+3. Real ``travel("Connecticut Yankee San Francisco","222 2nd St San Francisco")``
+   → correct resolved names + plausible times (incl. Muni transit).
+4. Then set ``ASSIST_GEOCODER_URL`` in prod ``.deploy.env`` + redeploy-service +
+   restart; confirm prod ``travel`` geocodes via Nominatim.
+
+* Follow-ups
+- A ``deploy-nominatim`` / refresh target (like ``searxng.sh``) for reproducible
+  provisioning + periodic OSM re-import (paired with the 511 GTFS refresh cron).

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -36,6 +36,7 @@ ENV_VARS=""
 [ -n "$ASSIST_DOMAINS" ] && ENV_VARS="${ENV_VARS}Environment=\"ASSIST_DOMAINS=$ASSIST_DOMAINS\"\n"
 [ -n "$ASSIST_SEARCH_URL" ] && ENV_VARS="${ENV_VARS}Environment=\"ASSIST_SEARCH_URL=$ASSIST_SEARCH_URL\"\n"
 [ -n "$ASSIST_ROUTING_URL" ] && ENV_VARS="${ENV_VARS}Environment=\"ASSIST_ROUTING_URL=$ASSIST_ROUTING_URL\"\n"
+[ -n "$ASSIST_GEOCODER_URL" ] && ENV_VARS="${ENV_VARS}Environment=\"ASSIST_GEOCODER_URL=$ASSIST_GEOCODER_URL\"\n"
 
 # Generate service file from template and install it
 cat "$DEPLOY_PATH/scripts/assist-web.service.template" | \

--- a/tests/test_travel.py
+++ b/tests/test_travel.py
@@ -34,7 +34,10 @@ def _fake_get(url, params=None, timeout=None, **kw):
     if "/search" in url:  # Nominatim geocoder (the default path)
         q = params["q"].lower()
         key = "civic" if "civic" in q else ("ferry" if "ferry" in q else None)
-        return _Resp([_GEO[key]] if key else [])
+        if not key:
+            return _Resp([])
+        g = _GEO[key]  # Nominatim shape: display_name, no `name` -> exercises the fallback
+        return _Resp([{"display_name": g["name"], "lat": g["lat"], "lon": g["lon"]}])
     if "/api/v1/geocode" in url:  # MOTIS built-in geocoder (fallback path)
         t = params["text"].lower()
         key = "civic" if "civic" in t else ("ferry" if "ferry" in t else None)
@@ -90,6 +93,18 @@ class TestTravel:
         monkeypatch.delenv("ASSIST_ROUTING_URL", raising=False)
         monkeypatch.delenv("ASSIST_GEOCODER_URL", raising=False)
         assert "unavailable" in tools.travel("a", "b").lower()
+
+    def test_geocoder_set_but_routing_unset_is_unavailable(self, monkeypatch):
+        # Routing is required; with Nominatim, geocode would otherwise succeed and
+        # every mode show "unavailable". Fail fast with the standard message, no HTTP.
+        monkeypatch.setenv("ASSIST_GEOCODER_URL", "http://nominatim")
+        monkeypatch.delenv("ASSIST_ROUTING_URL", raising=False)
+        called = []
+        with patch.object(tools.requests, "get",
+                          lambda *a, **k: called.append(1) or _Resp([])):
+            out = tools.travel("civic center", "ferry building")
+        assert "unavailable" in out.lower()
+        assert not called  # bailed before any HTTP
 
     def test_geocode_uses_nominatim_when_set(self, routing_env):
         seen = []

--- a/tests/test_travel.py
+++ b/tests/test_travel.py
@@ -31,7 +31,11 @@ _DIRECT = {"CAR": (1320, 14000.0), "BIKE": (2880, 13000.0), "WALK": (9600, 13000
 
 def _fake_get(url, params=None, timeout=None, **kw):
     params = params or {}
-    if "/api/v1/geocode" in url:
+    if "/search" in url:  # Nominatim geocoder (the default path)
+        q = params["q"].lower()
+        key = "civic" if "civic" in q else ("ferry" if "ferry" in q else None)
+        return _Resp([_GEO[key]] if key else [])
+    if "/api/v1/geocode" in url:  # MOTIS built-in geocoder (fallback path)
         t = params["text"].lower()
         key = "civic" if "civic" in t else ("ferry" if "ferry" in t else None)
         return _Resp([_GEO[key]] if key else [])
@@ -46,7 +50,9 @@ def _fake_get(url, params=None, timeout=None, **kw):
 
 @pytest.fixture
 def routing_env(monkeypatch):
+    # Production default: Nominatim geocodes, MOTIS routes.
     monkeypatch.setenv("ASSIST_ROUTING_URL", "http://motis")
+    monkeypatch.setenv("ASSIST_GEOCODER_URL", "http://nominatim")
 
 
 class TestFormat:
@@ -82,7 +88,31 @@ class TestTravel:
 
     def test_routing_unset_is_unavailable(self, monkeypatch):
         monkeypatch.delenv("ASSIST_ROUTING_URL", raising=False)
+        monkeypatch.delenv("ASSIST_GEOCODER_URL", raising=False)
         assert "unavailable" in tools.travel("a", "b").lower()
+
+    def test_geocode_uses_nominatim_when_set(self, routing_env):
+        seen = []
+        def cap(url, params=None, **kw):
+            seen.append(url)
+            return _fake_get(url, params=params, **kw)
+        with patch.object(tools.requests, "get", cap):
+            tools.travel("civic center", "ferry building")
+        assert any("/search" in u for u in seen)          # geocoded via Nominatim
+        assert not any("/api/v1/geocode" in u for u in seen)  # not MOTIS's geocoder
+
+    def test_geocode_falls_back_to_motis_when_unset(self, monkeypatch):
+        monkeypatch.setenv("ASSIST_ROUTING_URL", "http://motis")
+        monkeypatch.delenv("ASSIST_GEOCODER_URL", raising=False)
+        seen = []
+        def cap(url, params=None, **kw):
+            seen.append(url)
+            return _fake_get(url, params=params, **kw)
+        with patch.object(tools.requests, "get", cap):
+            out = tools.travel("civic center", "ferry building")
+        assert any("/api/v1/geocode" in u for u in seen)   # MOTIS geocoder fallback
+        assert not any("/search" in u for u in seen)
+        assert "- Car: 22 min, 14.0 km" in out            # full summary still works
 
     def test_service_down_is_unavailable_not_not_found(self, routing_env):
         # A geocoder/service outage must yield the "unavailable" message, NOT a


### PR DESCRIPTION
## What
MOTIS's built-in geocoder is too weak for real addresses/POIs — Pierre's first real query mis-resolved BOTH endpoints ("Connecticut Yankee" → "Connecticut Street"; "222 2nd St" → "Francisco Street"). This adds a self-hosted **Nominatim** geocoder for name→coords; **MOTIS keeps doing the routing** (coords→all-modes).

## Design (docs/2026-06-29-nominatim-geocoder.org)
- `_geocode` dispatches on **`ASSIST_GEOCODER_URL`**: set → Nominatim `GET /search?q=&format=jsonv2&limit=5`; unset → MOTIS `/api/v1/geocode` **fallback** (dev/tests/un-provisioned deploys keep working, and the code ships before the slow OSM import finishes; a Nominatim outage when set is an outage, not a silent fallback).
- Shared **`_first_usable_hit(hits, place)`** for both backends — first hit with parseable coords, skip malformed, non-list → `_TravelBackendError`, blank name → `display_name` → `place`. Same **fail-loud-but-returned** contract (never raises into the agent loop).
- **The OSM extract IS the region** — Nominatim loads only the NorCal extract, so every result is already regional; no `countrycodes`/`viewbox` filter (keeps "region = config, not code"). Expanding regions = bigger extract + re-import, no code change.
- `travel()` and the `_plan_*` calls are unchanged (they take coords).

## Validation
- **731 unit tests green** (new dispatch + fallback tests; `routing_env` now exercises the Nominatim path; all prior contract tests preserved).
- Local code-review (2 lenses: correctness/contract, simplicity/security): **0 blockers / 0 important** — contract verified on every path, `place` URL-encoded via `params=` (no injection/SSRF), `_first_usable_hit` is genuine de-dup.
- **Live-verified** against a self-hosted Nominatim (NorCal extract): "222 2nd St San Francisco", Ferry Building, Coit Tower, Oracle Park, Tartine, Zuni Café all resolve correctly (MOTIS got these wrong); full pipeline routes all four modes incl. Muni transit (Coit Tower→Oracle Park transit 32 min).

## Known limitations
- **OSM data gaps**: a place not tagged in OpenStreetMap (e.g. the bar "Connecticut Yankee") returns no match → the tool honestly says "couldn't find" (the resolved name is echoed so the user can catch a wrong/absent match). Not a geocoder bug — well-known POIs resolve fine.
- Nominatim infra (the OSM import) lives outside the repo, like MOTIS/SearXNG; deploy sets `ASSIST_GEOCODER_URL` only after the import finishes. A reproducible `deploy-nominatim` + periodic re-import target is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)