### PR TITLE
travel: turn-by-turn directions tool (car/bike/walk/transit), miles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ Each reviewer should return a numbered findings list with severity (BLOCKER / IM
 
 After Phase 2, push the branch and verify the build succeeds. Then run a GitHub Copilot review loop.
 
+**Deploy for parallel testing (default).** As soon as the local review loop converges, `make deploy-code` + `make restart` **from the feature branch** so the user can test the running change *while* Copilot reviews — don't wait for the Copilot loop to finish. Then **redeploy on every change made in response to a review** (Copilot or the user): fix → re-run tests → redeploy, and tell the user so they re-test. This is the default cadence, not a special request. (See `~/.claude/CLAUDE.md` → "Deploy for parallel testing"; only one feature branch is prod's source at a time.)
+
 **Setup.** Open the PR (or push to an existing one). If the build/CI doesn't pass first, fix that before requesting Copilot — there's no point reviewing a broken build.
 
 **Requesting a Copilot review** (the magic incantation):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Each reviewer should return a numbered findings list with severity (BLOCKER / IM
 
 After Phase 2, push the branch and verify the build succeeds. Then run a GitHub Copilot review loop.
 
-**Deploy for parallel testing (default).** As soon as the local review loop converges, `make deploy-code` + `make restart` **from the feature branch** so the user can test the running change *while* Copilot reviews — don't wait for the Copilot loop to finish. Then **redeploy on every change made in response to a review** (Copilot or the user): fix → re-run tests → redeploy, and tell the user so they re-test. This is the default cadence, not a special request. (See `~/.claude/CLAUDE.md` → "Deploy for parallel testing"; only one feature branch is prod's source at a time.)
+**Deploy for parallel testing (default).** As soon as the local review loop converges, `make deploy-code` + `make restart` **from the feature branch** so the user can test the running change *while* Copilot reviews — don't wait for the Copilot loop to finish. Then **redeploy on every change made in response to a review** (Copilot or the user): fix → re-run tests → redeploy, and tell the user so they re-test. This is the default cadence, not a special request. (Only one feature branch is prod's source at a time, since `deploy-code` is `rsync --delete`.)
 
 **Setup.** Open the PR (or push to an existing one). If the build/CI doesn't pass first, fix that before requesting Copilot — there's no point reviewing a broken build.
 

--- a/assist/agent.py
+++ b/assist/agent.py
@@ -13,7 +13,7 @@ from openai import APIConnectionError, InternalServerError
 
 from assist.promptable import base_prompt_for
 from assist.spec import AgentSpec
-from assist.tools import read_url, search_internet, travel
+from assist.tools import directions, read_url, search_internet, travel
 from assist.backends import create_composite_backend, create_sandbox_composite_backend, create_references_backend, STATEFUL_PATHS, SKILLS_ROUTE, DOMAIN_SKILLS_PATH
 from assist.checkpoint_rollback import invoke_with_rollback, RollbackRunnable
 from assist.research_cleanup import ReferencesCleanupRunnable
@@ -366,11 +366,11 @@ def create_agent(model: BaseChatModel,
         middleware=mw + [skills_mw, memory_mw, logging_mw],
         backend=backend,
         subagents=[context_sub, research_sub, critique_sub_agent],
-        # `travel` is a built-in: a direct deterministic A->B time/distance lookup
-        # the main agent answers inline (gated by the travel skill), like a
-        # calculation — not web research, so not on the research sub-agent.  Skip
-        # if a spec already supplies it, so it's never double-registered.
-        tools=list(spec.tools) + ([travel] if travel not in spec.tools else []),
+        # `travel` (time/distance) and `directions` (turn-by-turn steps) are
+        # built-ins: direct deterministic A->B lookups the main agent answers inline
+        # (gated by the travel skill), like a calculation — not web research, so not
+        # on the research sub-agent.  Skip any a spec already supplies (no dup).
+        tools=list(spec.tools) + [t for t in (travel, directions) if t not in spec.tools],
     )
 
     return agent

--- a/assist/skills/travel/SKILL.md
+++ b/assist/skills/travel/SKILL.md
@@ -1,45 +1,80 @@
 ---
 name: travel
-description: Real-world travel time between places by car, bike, walking, and public transit (with distance for car/bike/walk), across a metro area and nearby cities. EXAMPLES — "how long from home to the Ferry Building"; "is it faster to bike or take the train downtown"; "drive time to the airport"; "how far is the office"; "can I walk to the park". MUST load before answering any question about travel time, distance, or which mode is fastest between two places. (It gives times/distances, not turn-by-turn directions.)
+description: Real-world travel between places — time and distance by car/bike/walk/transit, AND step-by-step directions (turns, which bus or train), across a metro area and nearby cities. EXAMPLES — "how long from home to the Ferry Building"; "is it faster to bike or take the train"; "drive time to the airport"; "how far is the office"; "directions to City Hall"; "how do I get to the museum"; "which bus do I take"; "walk me through biking there". MUST load before answering any question about travel time, distance, the fastest mode, OR how to get from one place to another.
 ---
 
-# Travel — real-world time and distance between places
+# Travel & directions — real map data, two tools
 
-When the user asks how long or how far it is to get from one place to another —
-or which way is fastest — call the `travel` tool. Do NOT estimate distances or
-times from your own knowledge; the tool computes them from real map data.
+Two tools, both backed by real map data. **Never estimate times, distances, turns,
+or which line to take from your own knowledge** — call the tool.
 
-## How to call it
+- **`travel(origin, destination)`** — how LONG / how FAR / which MODE is fastest.
+  Returns time + distance for all four modes (car, bike, walk, transit).
+- **`directions(origin, destination, mode)`** — HOW to get there: the step-by-step
+  route (turns and streets, or which bus/train + transfers) for ONE mode.
 
-`travel(origin, destination)` — pass plain place **names or addresses exactly as
-the user said them** ("home", "the Ferry Building", "123 Main St", "the airport").
+## Which tool
 
-- Do NOT pass coordinates — the tool geocodes names itself.
-- Do NOT pass a mode — it always returns all four (car, bike, walk, transit);
-  you choose which to highlight when you reply.
-- If the user gives only one place ("how far is the airport"), the other is
-  usually "home" or the place from context — if it's unclear, ask.
-- For a short or ambiguous place name, include the city/area from context (pass
-  "Ferry Building San Francisco", not just "the Ferry Building") so the geocoder
-  picks the right place. The result echoes the resolved place names — if one
-  looks wrong, retry with a more specific name or tell the user, and don't trust
-  those numbers.
+- Wants a **time, a distance, or a comparison** ("how long", "how far", "faster to
+  bike or drive") → **`travel`**.
+- Wants the **steps / the route / which bus or train / turn-by-turn** ("how do I
+  get to X", "directions to Y", "which train to Z", "walk me through it") →
+  **`directions`**.
+
+## Calling `travel(origin, destination)`
+
+Pass plain place **names/addresses as the user said them** ("home", "the Ferry
+Building", "123 Main St"). Do NOT pass coordinates or a mode — it returns all four
+modes; you highlight the relevant one when you reply.
+
+## Calling `directions(origin, destination, mode)`
+
+Pass the same kind of place names, plus a **`mode`** — one of `"car"`, `"bike"`,
+`"walk"`, `"transit"`. Map the user's words to one of those exactly:
+
+- drive / driving / by car → `"car"`
+- bike / biking / cycling / bicycle → `"bike"`
+- walk / walking / on foot → `"walk"`
+- bus / train / subway / metro / light rail / public transit → `"transit"`
+
+If the user **names a mode**, pass it. If they **don't**, ask which mode they want
+— don't guess (transit directions when they meant to drive is a wrong answer).
+
+## Place names (both tools)
+
+- The tool geocodes names itself — don't pass coordinates.
+- If the user gives only one place ("directions to the airport"), the other is
+  usually "home" or the place from context; if unclear, ask.
+- For a short/ambiguous name, include the city/area from context (pass "Ferry
+  Building San Francisco", not just "the Ferry Building"). Both tools echo the
+  **resolved place names** — if one looks wrong, retry with a more specific name or
+  tell the user; don't trust the result.
 
 ## Presenting the result
 
-The tool returns a per-mode summary (time and distance for car/bike/walk; time
-only for transit) plus the resolved place names it routed between. When you reply:
+- **travel:** lead with the mode asked about ("driving is ~25 min"); else compare
+  briefly. Round naturally. If a mode is `unavailable`, say so — don't fill a guess.
+- **directions:** relay the numbered steps. For **street** routes (car/bike/walk)
+  the turn directions are **approximate** — it's fine to hedge ("roughly"), and
+  never invent a turn or street the tool didn't give. For **transit**, relay the
+  lines, stops, and transfers as listed. Mention the resolved place names if they
+  might differ from what the user meant.
 
-- Lead with the mode the user asked about ("driving is ~25 min"); if they didn't
-  name one, give a short comparison across modes.
-- Round naturally ("about 25 minutes", not "24.7 min").
-- Mention the **resolved place names** if they might differ from what the user
-  meant, so they can correct you ("routing from <resolved origin>…").
-- If a mode comes back `unavailable` (e.g. transit not covered there), say so
-  plainly — do not fill it in with a guess.
+## Surfacing problems (don't hide a degraded result)
 
-## When NOT to use it
+When a result is degraded, NOTICE it and tell the user — and when more information
+would likely fix it, ASK for that:
 
-- For places that aren't real/locatable, or purely hypothetical distances.
-- If `travel` reports routing is unavailable, tell the user you couldn't look it
-  up right now — do NOT substitute an estimate from memory.
+- **No route / unavailable / "couldn't find a place"** → say so plainly (never
+  substitute an estimate or route from memory), and ask for what would resolve it:
+  a more specific address or a nearby landmark, the city/area, or a different mode.
+- **A resolved place name looks wrong** (the echoed name isn't what the user meant)
+  → point it out and offer to retry with a more specific place.
+- **A mode comes back `unavailable`** (e.g. no transit there) → name it, and suggest
+  a mode that did work.
+- **Approximate street turns** → it's fine to hedge; don't present an approximate
+  turn as exact.
+
+## When NOT to use
+
+- Places that aren't real/locatable, or purely hypothetical distances.

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -615,12 +615,14 @@ def _street_narrative(o: dict, d: dict, directmode: str, label: str):
         direct = (data.get("direct") if isinstance(data, dict) else None) or []
         if not direct:
             return None
-        leg = direct[0]["legs"][0]
-        runs = _consolidate_street_steps(leg.get("steps") or [])
+        legs = direct[0]["legs"]  # aggregate across legs, like travel._plan_direct sums them
+        steps = [s for leg in legs for s in (leg.get("steps") or [])]
+        total_dist = sum((leg.get("distance") or 0) for leg in legs)
+        runs = _consolidate_street_steps(steps)
         if not runs:
             return None
         lines = [f'{label} directions from "{o["name"]}" to "{d["name"]}" '
-                 f'(~{_fmt_duration(direct[0]["duration"])}, {_fmt_distance_m(leg.get("distance", 0))}):']
+                 f'(~{_fmt_duration(direct[0]["duration"])}, {_fmt_distance_m(total_dist)}):']
         prev_exit = None
         for n, r in enumerate(runs, start=1):
             phrase = "Head onto" if n == 1 else _turn_phrase(prev_exit, r["entry_bearing"])

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -21,6 +21,7 @@ casio-runaway shape: ~9,000 fetches across many distinct URLs in two hours).
 """
 
 import logging
+import math
 import os
 import re
 import time
@@ -312,8 +313,8 @@ def _fmt_duration(seconds: float) -> str:
 
 
 def _fmt_distance_m(meters: float) -> str:
-    km = meters / 1000.0
-    return f"{km:.1f} km" if km >= 0.1 else f"{int(round(meters))} m"
+    miles = meters / 1609.344  # US units throughout (travel + directions)
+    return f"{miles:.1f} mi" if miles >= 0.1 else f"{int(round(meters * 3.28084))} ft"
 
 
 class _TravelBackendError(Exception):
@@ -427,6 +428,24 @@ def _plan_transit(o: dict, d: dict) -> dict | None:
         return None
 
 
+def _resolve_od(origin: str, destination: str):
+    """Geocode origin + destination -> (o, d) dicts, or an error STRING the caller
+    returns to the agent: service down -> the "unavailable" message; a name that
+    doesn't resolve -> "couldn't find …".  Shared by travel() and directions()."""
+    try:
+        o = _geocode(origin)
+        d = _geocode(destination)
+    except _TravelBackendError as e:
+        return _travel_unavailable(str(e))  # service down -> "unavailable", not "not found"
+    if o is None:
+        return (f"I couldn't find a place matching '{origin}'. Ask the user to "
+                "clarify or give a more specific location.")
+    if d is None:
+        return (f"I couldn't find a place matching '{destination}'. Ask the user "
+                "to clarify or give a more specific location.")
+    return o, d
+
+
 def travel(origin: str, destination: str) -> str:
     """Real-world travel time and distance between two places, by car, bike,
     walking, and public transit.
@@ -446,17 +465,10 @@ def travel(origin: str, destination: str) -> str:
     # so fail fast with the standard message instead.
     if not os.getenv("ASSIST_ROUTING_URL"):
         return _travel_unavailable("ASSIST_ROUTING_URL is not set")
-    try:
-        o = _geocode(origin)
-        d = _geocode(destination)
-    except _TravelBackendError as e:
-        return _travel_unavailable(str(e))  # service down -> "unavailable", not "not found"
-    if o is None:
-        return (f"I couldn't find a place matching '{origin}'. Ask the user to "
-                "clarify or give a more specific location.")
-    if d is None:
-        return (f"I couldn't find a place matching '{destination}'. Ask the user "
-                "to clarify or give a more specific location.")
+    od = _resolve_od(origin, destination)
+    if isinstance(od, str):
+        return od
+    o, d = od
 
     lines = [f'Travel from "{o["name"]}" to "{d["name"]}":']
     for label, mode in _TRAVEL_DIRECT_MODES:
@@ -468,3 +480,216 @@ def travel(origin: str, destination: str) -> str:
     lines.append(f"- Transit: {_fmt_duration(t['duration_s'])}" if t
                  else "- Transit: unavailable")
     return "\n".join(lines)
+
+
+# --- directions (turn-by-turn) -------------------------------------------------
+# `directions` is the step-by-step sibling of `travel`: same _geocode + MOTIS /plan
+# + fail-loud-but-RETURNED contract, but it walks the per-leg/step detail travel
+# discards.  MOTIS's own turn field (relativeDirection) is uniformly "CONTINUE", so
+# street turns are derived from polyline geometry, CONFIDENCE-GATED: a left/right is
+# emitted only when the heading change is unambiguous, else the neutral "Continue
+# onto" -- so a confident WRONG turn is unreachable by construction.
+
+_DIRECTIONS_STREET = {  # mode word -> (MOTIS directModes, label)
+    "car": ("CAR", "Driving"), "drive": ("CAR", "Driving"), "driving": ("CAR", "Driving"),
+    "bike": ("BIKE", "Biking"), "bicycle": ("BIKE", "Biking"), "cycling": ("BIKE", "Biking"),
+    "cycle": ("BIKE", "Biking"),
+    "walk": ("WALK", "Walking"), "walking": ("WALK", "Walking"), "foot": ("WALK", "Walking"),
+    "on foot": ("WALK", "Walking"),
+}
+_DIRECTIONS_TRANSIT = {"transit", "bus", "train", "subway", "metro", "rail", "tram",
+                       "light rail", "public transit"}
+_TRANSIT_NOUN = {"BUS": "bus", "TRAM": "tram", "SUBWAY": "train", "RAIL": "train",
+                 "FERRY": "ferry", "FUNICULAR": "funicular", "CABLE_CAR": "cable car",
+                 "COACH": "coach"}
+_TURN_STRAIGHT_DEG = 30.0   # |heading change| below this -> "Continue" (no turn)
+_TURN_UTURN_DEG = 160.0     # above this -> U-turn
+_MIN_RUN_M = 15             # drop negligible connector runs from the step list
+
+
+def _normalize_mode(mode: str):
+    """('street', MOTIS_directModes, label) | ('transit', None, 'Transit') | None."""
+    m = str(mode or "").strip().lower()  # str() -> never raise on a non-string arg
+    if m in _DIRECTIONS_STREET:
+        directmode, label = _DIRECTIONS_STREET[m]
+        return ("street", directmode, label)
+    if m in _DIRECTIONS_TRANSIT:
+        return ("transit", None, "Transit")
+    return None
+
+
+def _decode_polyline(points, precision) -> list:
+    """Decode a Google-encoded polyline -> [(lat, lon), ...]; [] on any bad input
+    (never raises -- module contract)."""
+    if not isinstance(points, str):
+        return []
+    try:
+        factor = 10 ** int(precision)
+        out = []; lat = lon = 0; i = 0; n = len(points)
+        while i < n:
+            for axis in range(2):
+                shift = result = 0
+                while True:
+                    b = ord(points[i]) - 63; i += 1
+                    result |= (b & 0x1f) << shift; shift += 5
+                    if b < 0x20:
+                        break
+                delta = ~(result >> 1) if (result & 1) else (result >> 1)
+                if axis == 0:
+                    lat += delta
+                else:
+                    lon += delta
+            out.append((lat / factor, lon / factor))
+        return out
+    except (IndexError, TypeError, ValueError):
+        return []
+
+
+def _bearing(a, b) -> float:
+    """Initial compass bearing (0-360deg) from point a=(lat,lon) to b."""
+    lat1, lat2 = math.radians(a[0]), math.radians(b[0])
+    dlon = math.radians(b[1] - a[1])
+    y = math.sin(dlon) * math.cos(lat2)
+    x = math.cos(lat1) * math.sin(lat2) - math.sin(lat1) * math.cos(lat2) * math.cos(dlon)
+    return (math.degrees(math.atan2(y, x)) + 360) % 360
+
+
+def _turn_phrase(prev_exit, this_entry) -> str:
+    """Confidence-gated turn: commit to left/right ONLY when the heading change is
+    unambiguous; otherwise 'Continue onto' (a confident wrong turn is unreachable)."""
+    if prev_exit is None or this_entry is None:
+        return "Continue onto"
+    delta = ((this_entry - prev_exit + 180) % 360) - 180  # signed -180..180
+    a = abs(delta)
+    if a < _TURN_STRAIGHT_DEG:
+        return "Continue onto"
+    if a > _TURN_UTURN_DEG:
+        return "Make a U-turn onto"
+    return "Turn right onto" if delta > 0 else "Turn left onto"
+
+
+def _consolidate_street_steps(steps) -> list:
+    """Collapse consecutive same-streetName steps into runs with entry/exit bearings
+    (from each run's decoded geometry).  -> [{name, distance_m, entry_bearing,
+    exit_bearing}].  Never raises."""
+    runs = []
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        name = (step.get("streetName") or "").strip()
+        dist = step.get("distance")
+        dist = dist if isinstance(dist, (int, float)) else 0  # never raise on a bad type
+        pl = step.get("polyline") if isinstance(step.get("polyline"), dict) else {}
+        pts = _decode_polyline(pl.get("points"), pl.get("precision", 7))
+        if runs and runs[-1]["name"] == name:
+            runs[-1]["distance_m"] += dist
+            runs[-1]["_pts"].extend(pts)
+        else:
+            runs.append({"name": name, "distance_m": dist, "_pts": list(pts)})
+    out = []
+    for r in runs:
+        if r["distance_m"] < _MIN_RUN_M:
+            continue
+        pts = r["_pts"]
+        entry = _bearing(pts[0], pts[1]) if len(pts) >= 2 else None
+        exit_ = _bearing(pts[-2], pts[-1]) if len(pts) >= 2 else None
+        out.append({"name": r["name"], "distance_m": r["distance_m"],
+                    "entry_bearing": entry, "exit_bearing": exit_})
+    return out
+
+
+def _street_narrative(o: dict, d: dict, directmode: str, label: str):
+    """A car/bike/walk turn-by-turn list, or None (no route).  Raises
+    _TravelBackendError only if MOTIS is down (caller -> 'unavailable')."""
+    data = _motis_get("/api/v1/plan", {
+        "fromPlace": f"{o['lat']},{o['lon']}", "toPlace": f"{d['lat']},{d['lon']}",
+        "directModes": directmode, "maxDirectTime": _TRAVEL_MAX_DIRECT_S})
+    try:
+        direct = (data.get("direct") if isinstance(data, dict) else None) or []
+        if not direct:
+            return None
+        leg = direct[0]["legs"][0]
+        runs = _consolidate_street_steps(leg.get("steps") or [])
+        if not runs:
+            return None
+        lines = [f'{label} directions from "{o["name"]}" to "{d["name"]}" '
+                 f'(~{_fmt_duration(direct[0]["duration"])}, {_fmt_distance_m(leg.get("distance", 0))}):']
+        prev_exit = None
+        for n, r in enumerate(runs, start=1):
+            phrase = "Head onto" if n == 1 else _turn_phrase(prev_exit, r["entry_bearing"])
+            lines.append(f"{n}. {phrase} {r['name'] or 'an unnamed road'} "
+                         f"({_fmt_distance_m(r['distance_m'])})")
+            prev_exit = r["exit_bearing"]
+        lines.append(f'{len(runs) + 1}. Arrive at "{d["name"]}"')
+        return "\n".join(lines)
+    except (KeyError, TypeError, ValueError, AttributeError, IndexError):
+        return None  # malformed itinerary -> "no route", never raise into the agent loop
+
+
+def _transit_narrative(o: dict, d: dict):
+    """A walk/board/transfer/alight transit list, or None (no journey).  Raises
+    _TravelBackendError only if MOTIS is down."""
+    data = _motis_get("/api/v1/plan", {
+        "fromPlace": f"{o['lat']},{o['lon']}", "toPlace": f"{d['lat']},{d['lon']}",
+        "transitModes": "TRANSIT"})
+    try:
+        its = (data.get("itineraries") if isinstance(data, dict) else None) or []
+        if not its:
+            return None
+        it = min(its, key=lambda x: x["duration"])
+        legs = [l for l in (it.get("legs") or [])  # drop degenerate zero-length legs
+                if not (not l.get("duration") and
+                        (l.get("from") or {}).get("name") == (l.get("to") or {}).get("name"))]
+        if not legs:
+            return None
+        lines = [f'Transit directions from "{o["name"]}" to "{d["name"]}" '
+                 f'(~{_fmt_duration(it["duration"])}):']
+        for n, l in enumerate(legs, start=1):
+            to_name = (l.get("to") or {}).get("name") or "your destination"
+            if l.get("mode") == "WALK":
+                dest = f'"{d["name"]}"' if n == len(legs) else to_name
+                lines.append(f"{n}. Walk to {dest} ({_fmt_duration(l.get('duration', 0))})")
+            else:
+                noun = _TRANSIT_NOUN.get(l.get("mode"), "line")
+                route = l.get("routeShortName") or l.get("tripShortName") or noun
+                toward = f" toward {l['headsign']}" if l.get("headsign") else ""
+                stops = len(l.get("intermediateStops") or []) + 1  # stops ridden to the alighting stop
+                lines.append(f"{n}. Take the {route} {noun}{toward} to {to_name} "
+                             f"({stops} stop{'s' if stops != 1 else ''})")
+        return "\n".join(lines)
+    except (KeyError, TypeError, ValueError, AttributeError, IndexError):
+        return None
+
+
+def directions(origin: str, destination: str, mode: str) -> str:
+    """Step-by-step route directions between two places for a SINGLE travel mode.
+
+    Use this when the user wants DIRECTIONS / how to actually get somewhere -- "how
+    do I get to X", "directions to Y", "which bus do I take", "walk me through it" --
+    as opposed to "how long / how far" (use `travel` for that).  Pass plain place
+    NAMES (the geocoder resolves them) and a `mode`: "car", "bike", "walk", or
+    "transit".  Returns a numbered list -- turns + streets for car/bike/walk
+    (street turns are approximate), or walk/board/transfer/alight for transit -- in
+    US units (miles).  Relay it; never invent streets or lines.  A place outside the
+    covered area or with no route comes back as "couldn't find a route", not a guess.
+    """
+    if not os.getenv("ASSIST_ROUTING_URL"):
+        return _travel_unavailable("ASSIST_ROUTING_URL is not set")
+    m = _normalize_mode(mode)
+    if m is None:
+        return ("Tell me which travel mode you want directions for: car, bike, "
+                "walk, or transit.")
+    kind, directmode, label = m
+    od = _resolve_od(origin, destination)
+    if isinstance(od, str):
+        return od
+    o, d = od
+    try:
+        out = _transit_narrative(o, d) if kind == "transit" else _street_narrative(o, d, directmode, label)
+    except _TravelBackendError as e:
+        return _travel_unavailable(str(e))  # plan service down -> "unavailable"
+    if out is None:
+        route_kind = "transit" if kind == "transit" else label.lower()
+        return (f'I couldn\'t find a {route_kind} route from "{o["name"]}" to '
+                f'"{d["name"]}".')
+    return out

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -525,13 +525,18 @@ def _decode_polyline(points, precision) -> list:
         return []
     try:
         factor = 10 ** int(precision)
-        out = []; lat = lon = 0; i = 0; n = len(points)
+        out = []
+        lat = lon = 0
+        i = 0
+        n = len(points)
         while i < n:
             for axis in range(2):
                 shift = result = 0
                 while True:
-                    b = ord(points[i]) - 63; i += 1
-                    result |= (b & 0x1f) << shift; shift += 5
+                    b = ord(points[i]) - 63
+                    i += 1
+                    result |= (b & 0x1f) << shift
+                    shift += 5
                     if b < 0x20:
                         break
                 delta = ~(result >> 1) if (result & 1) else (result >> 1)

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -524,7 +524,9 @@ def _decode_polyline(points, precision) -> list:
     if not isinstance(points, str):
         return []
     try:
-        factor = 10 ** int(precision)
+        # Clamp the (untrusted backend) precision so factor is never 0 or absurd:
+        # a very negative precision would underflow 10**p to 0.0 -> ZeroDivisionError.
+        factor = 10 ** max(0, min(int(precision), 15))
         out = []
         lat = lon = 0
         i = 0

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -548,8 +548,8 @@ def _decode_polyline(points, precision) -> list:
                     lon += delta
             out.append((lat / factor, lon / factor))
         return out
-    except (IndexError, TypeError, ValueError):
-        return []
+    except (IndexError, TypeError, ValueError, OverflowError):
+        return []  # OverflowError: int(Infinity) from a malformed precision field
 
 
 def _bearing(a, b) -> float:

--- a/docs/2026-06-29-turn-by-turn-directions.org
+++ b/docs/2026-06-29-turn-by-turn-directions.org
@@ -1,0 +1,181 @@
+#+TITLE: turn-by-turn directions — design (for review; no code yet)
+#+DATE: <2026-06-29>
+#+STATUS: DESIGN — internal design-review done; awaiting Pierre's call on the open questions before any code
+
+* Goal
+Extend the travel capability from "how long / which mode" (the shipped ~travel~
+tool) to actual route STEPS — "how do I get from A to B", "which bus do I take",
+"directions to X". Next item on Pierre's roadmap after travel (routing + 511
+transit + Nominatim geocoder, all shipped).
+
+This doc is the Phase-1 design: an architect plan + a 4-lens internal design
+review, grounded in live MOTIS probes. It ends with **open questions for Pierre**.
+No code is written until those are settled.
+
+* Measured findings (live MOTIS, http://$ASSIST_ROUTING_URL — measure, don't guess)
+The travel-tool lesson was to verify response shapes, not guess. What MOTIS
+~/api/v1/plan~ actually returns:
+
+- *Transit legs are clean + rich.* A real itinerary = WALK → BUS (~routeShortName~
+  e.g. "9R", ~headsign~, ~agencyName~, ~intermediateStops~) → WALK → SUBWAY (BART
+  "Yellow-N", 2 intermediate stops) → WALK. ~from.name~/~to.name~ are stop names.
+  Transfers = multiple transit legs. So a "walk to X, take the 9R to Y, transfer
+  to BART to Z, walk to dest" narrative is construction-correct from the fields.
+  Edge: one degenerate FUNICULAR leg had ~duration:0~ + identical from/to — must
+  be filtered.
+- *Street legs give raw geometry, not turns.* A CAR leg = a ~steps[]~ array, each
+  step = {~relativeDirection~, ~streetName~, ~distance~, ~polyline~, ~osmWay~, …}.
+  CRITICAL: ~relativeDirection~ is **uniformly "CONTINUE"** — 163/163 (Civic→Ferry
+  car), 423/423 (Sunset→Embarcadero car), 165/166 walk. MOTIS emits one step per
+  OSM way-segment and does NOT classify turns. So usable directions need
+  post-processing.
+- *Street-name consolidation works.* Collapsing consecutive same-~streetName~ steps
+  turned 423 raw steps → **18 clean street runs** ("951 m Noriega Street, 1248 m
+  19th Avenue, …"). Genuinely useful as a "follow these streets" list.
+- *Turn direction IS recoverable from geometry.* Decoding each step ~polyline~
+  (Google-encoded, read ~precision~ from the field) and taking the bearing delta
+  across street-change boundaries classified turns correctly (29th→Noriega +90°
+  right, Noriega→19th −90° left, 19th→Crossover ~0° straight; 15/15 sensible).
+  Deltas cluster sharply at ±90° / ~0°, so a threshold classifier is reliable on
+  ordinary surface streets — but roundabouts / freeway merges / forks will
+  misclassify (a gentle highway curve can read as a turn).
+- *Bike routing is genuinely bike-aware* (Pierre's question). Same OD
+  (Panhandle→Ferry): CAR took Masonic / Turk Blvd / Golden Gate Ave (arterials);
+  BIKE took Ashbury → **Page Street** (the Wiggle — SF's low-traffic bike
+  boulevard) → Market Street (bike lanes). MOTIS's BIKE street profile follows OSM
+  cycling infrastructure, so bike directions ride real bike-friendly streets, not
+  the car path. Caveat: quality tracks OSM bike-tag completeness (excellent in SF);
+  explicit hill-avoidance is unconfirmed (the flat-Wiggle choice is encouraging).
+
+* Design (resolved after the 4-lens internal review)
+The internal review (simplicity, agentic/small-model fit, user-intention, clean
+interfaces) converged on these; the genuine forks are in *Open questions*.
+
+** A new ~directions(origin, destination, mode)~ tool, built-in on the main agent
+- Separate tool, not a ~travel(detail=…)~ knob. Honest framing: this is a
+  *small-model routing* concession, not a code-design necessity — ~travel~ and
+  ~directions~ share origin/destination + ~_geocode~ + the MOTIS call, so by pure
+  code design it's a parameter. But Qwen3.6 picks behavior by tool/skill, not by a
+  ~detail=~ flag it would ignore (the repo's "structure is the floor, prose is a
+  nudge" lesson) — a separate tool + skill is the harder lever for "user wants
+  steps, not a time". Registered like ~travel~:
+  ~tools=list(spec.tools) + ([directions] if directions not in spec.tools else [])~.
+- *~mode~ is REQUIRED, no silent default.* The review's strongest point: a silent
+  ~default="transit"~ would return transit steps when the user wanted to drive — a
+  silent wrong-mode answer, exactly the no-guessing property ~travel~ was built
+  around (travel takes NO mode and returns all four; directions needs one, so make
+  the model supply it). The SKILL gives a **checkable synonym→enum table** (the
+  arg-shape lever this model obeys): bus/train/subway/metro/light-rail → ~transit~;
+  drive/car/driving → ~car~; walk/on foot/walking → ~walk~; bike/cycle/cycling →
+  ~bike~. ~mode~ is one short string the model copies — checkable, unlike travel's
+  rejected list-of-enums.
+
+** Per-mode output — one preformatted numbered list the model relays verbatim
+Same philosophy as travel's summary string (lean on the chat's markdown; no map in
+v1 — that's separate render-skill territory). ~mode~ dispatches at the top into ONE
+of two builders (not four mode paths; car/bike/walk share the street builder):
+
+- *Transit* (~_transit_narrative~): walk-to-stop / board-line / transfer /
+  alight / walk-to-dest, from the min-duration itinerary. Filter zero-duration /
+  same-stop legs. Example:
+  #+begin_example
+  Transit directions from "Civic Center" to "Embarcadero" (~21 min):
+  1. Walk to Grove St & Van Ness Ave (3 min)
+  2. Take the 6 bus toward Civic Center Station to Hyde St & Grove St (1 stop)
+  3. Walk to Civic Center BART (2 min)
+  4. Take BART Yellow-N toward Pittsburg/Bay Point to Embarcadero (2 stops)
+  5. Walk to Embarcadero (6 min)
+  #+end_example
+- *Street — car / bike / walk* (~_street_narrative~ over consolidated runs):
+  consolidate same-street steps into runs (sum distance), and emit a turn verb
+  **only when the geometry bearing delta is UNAMBIGUOUS**; otherwise the neutral
+  "Continue onto X". This is the by-construction safety the review demanded: a
+  *confident wrong turn is unreachable* — ambiguous transitions (roundabouts,
+  merges, forks, gentle curves) degrade to "Continue", they don't guess "turn
+  left". Bike rides the bike-aware route (Page St etc.). Example:
+  #+begin_example
+  Bike directions from "the Panhandle" to "the Ferry Building" (~3.7 mi):
+  1. Head onto Ashbury Street (0.1 mi)
+  2. Continue onto Page Street (1.5 mi)        # the Wiggle
+  3. Turn right onto Market Street (2.0 mi)
+  4. Arrive at the Ferry Building
+  #+end_example
+  The ~directions~ skill tells the agent street turns are approximate, so it can
+  hedge when relaying.
+
+** Reuse + the never-raise contract (a stated requirement, not a note)
+- Reuses ~_geocode~ (Nominatim → coords), the ~_TravelBackendError~ → "unavailable"
+  vs ~None~ → "couldn't find that place" pattern, ~_fmt_duration~, and the single
+  ~/plan~ call shape. ~directions~ makes ONE ~/plan~ call (one mode) — cheaper than
+  travel's up-to-six.
+- The NEW code (polyline decode + bearing math + leg/step extraction) adds raise
+  sites (malformed/empty/one-point polyline, non-numeric coords, missing steps).
+  REQUIREMENT: every narrative-build path is wrapped so a malformed leg/polyline
+  **degrades** (skip the turn → "Continue"; or a bare street name; or "couldn't
+  find a route") and NEVER raises into the agent loop — mirroring
+  ~_plan_direct~/~_plan_transit~'s ~try/except (KeyError,TypeError,ValueError,
+  AttributeError)~. The malformed-data fallback and the ambiguous-turn fallback
+  share ONE degradation path (both → "Continue onto X").
+
+** Helpers (kept minimal) + skill
+- ~_consolidate_street_steps~ (group consecutive same-street steps), ~_street_narrative~,
+  ~_transit_narrative~, a ~mode~ normalizer, and — only if geometry turns are in v1 —
+  ~_decode_polyline~ + ~_bearing_delta~. No ~_plan_for_directions~ wrapper (inline the
+  ~_motis_get~ call). Group-runs and classify-turn stay separate (one concern each);
+  ~mode~ dispatches at the top, never threaded into the geometry helpers.
+- New ~assist/skills/directions/SKILL.md~ (separate from travel's — the model selects
+  skills lexically, and a sharp partition is what routes the right tool). Triggers:
+  "directions to / how do I get to / step by step / which bus|train|line / route to".
+  ~travel~'s skill + docstring get a *strengthened* pointer (leading, not a
+  parenthetical): "For step-by-step directions or which line/bus, use ~directions~."
+  YAML: no ~: ~ colon-space in the description; run the ~yaml.safe_load~ check.
+
+** Files to touch (at code time)
+~assist/tools.py~ (the new tool + helpers), ~assist/agent.py~ (register the built-in +
+import + comment), ~assist/skills/directions/SKILL.md~ (new), ~assist/skills/travel/SKILL.md~
+(pointer), ~tests/test_directions.py~ (mocked MOTIS shapes), ~edd/eval/test_directions_agent.py~
+(new — see Validation), ~README.md~ (Skills entry).
+
+* Validation plan
+- Unit (mocked MOTIS shapes, like ~tests/test_travel.py~): transit narrative from a
+  multi-leg itinerary; street consolidation + the confidence-gated turn classifier
+  (incl. ambiguous → "Continue"); the contract (backend-down → "unavailable",
+  malformed polyline → no raise, no route → "couldn't find").
+- Eval — invocation IS NOT ENOUGH (two lexically-overlapping skills). A
+  **discrimination eval** (both directions): directions-shaped prompt → ~directions~
+  called AND ~travel~ NOT; travel-shaped prompt → ~travel~ called AND ~directions~
+  NOT (guards the new skill from stealing travel's traffic — a regression the
+  travel suite alone won't catch); + ~mode~-passing ("which bus to X" → ~mode=transit~).
+  Re-run ~test_travel_agent.py~ for regression (N=3 post-impl, scaling per CLAUDE.md).
+
+* Open questions — Pierre's call (the genuine forks; reviewers split or deferred)
+1. *Street turn detail in v1.* The reviewers split: simplicity says the geometry
+   turn-classifier is "probabilistic" (cut it; ship the bare correct street-run
+   list); user-intention says a street list without turns isn't "directions". The
+   synthesis that satisfies both is the **confidence-gated turn** above — emit
+   left/right ONLY when unambiguous, else "Continue" — which makes a confident
+   wrong turn unreachable by construction (not merely rare). RECOMMEND: ship
+   confidence-gated turns in v1. Alternatives: (a) bare street-run list only
+   (simplest, unimpeachably correct, but thinner); (b) transit-only directions in
+   v1, street deferred. Your call.
+2. *Units for street directions.* RECOMMEND **miles** for car/bike/walk steps (a
+   US/SF user reads driving directions against a mile-signed network + odometer —
+   it's operational, not the at-a-glance "~5 km" travel gives). Cost: a cross-tool
+   unit split (travel stays km, or we move both to miles). Alternative: keep metric
+   for consistency. Your call.
+3. *Confirm: ~mode~ required* (recommended, no silent wrong-mode) vs a default.
+4. Minor (recommended defaults, say if you disagree): new ~directions~ skill (not a
+   combined travel+directions skill); ~origin~ defaults to "home" for one-place
+   asks (matches the travel skill); map render DEFERRED.
+
+* Internal review outcomes (folded in)
+- simplicity: cut to ~3 core helpers, one street + one transit path (not 4 modes),
+  inline the plan wrapper; flagged the turn-classifier as the probabilistic risk →
+  resolved by confidence-gating (Q1).
+- agentic/small-model: kill the silent ~mode~ default → required + synonym table;
+  add the discrimination eval; verified MOTIS returns step/leg granularity (it does).
+- user-intention: turns ARE the deliverable (don't ship a bare list AS "directions");
+  miles for US driving; surface the turn-limit honestly (skill says "approximate").
+- clean-interfaces: two cohesive tools over the shared ~_geocode~/~_motis_get~
+  Resource layer; small surface; the never-raise contract elevated to a requirement
+  with one shared degradation path.

--- a/docs/2026-06-29-turn-by-turn-directions.org
+++ b/docs/2026-06-29-turn-by-turn-directions.org
@@ -1,4 +1,4 @@
-#+TITLE: turn-by-turn directions — design (for review; no code yet)
+#+TITLE: turn-by-turn directions — design + as-built
 #+DATE: <2026-06-29>
 #+STATUS: DESIGN APPROVED (Pierre 2026-06-29) — implementing. Decisions: (1) confidence-gated street turns; (2) MILES everywhere (incl. the existing travel tool); (3) mode REQUIRED; (4) roll directions into the travel skill (one skill), validated by the discrimination eval — split only if the model mis-picks.
 
@@ -8,9 +8,11 @@ tool) to actual route STEPS — "how do I get from A to B", "which bus do I take
 "directions to X". Next item on Pierre's roadmap after travel (routing + 511
 transit + Nominatim geocoder, all shipped).
 
-This doc is the Phase-1 design: an architect plan + a 4-lens internal design
-review, grounded in live MOTIS probes. It ends with **open questions for Pierre**.
-No code is written until those are settled.
+This doc began as the Phase-1 design (architect plan + a 4-lens internal review,
+grounded in live MOTIS probes, ending with open questions for Pierre). Pierre's
+answers are recorded in the STATUS line above; the implementation followed, and the
+"As-built deviations" + "Pierre's PR review notes" sections below reconcile the doc
+with what shipped. So this is now both the design rationale and the as-built record.
 
 * Measured findings (live MOTIS, http://$ASSIST_ROUTING_URL — measure, don't guess)
 The travel-tool lesson was to verify response shapes, not guess. What MOTIS

--- a/docs/2026-06-29-turn-by-turn-directions.org
+++ b/docs/2026-06-29-turn-by-turn-directions.org
@@ -1,6 +1,6 @@
 #+TITLE: turn-by-turn directions — design (for review; no code yet)
 #+DATE: <2026-06-29>
-#+STATUS: DESIGN — internal design-review done; awaiting Pierre's call on the open questions before any code
+#+STATUS: DESIGN APPROVED (Pierre 2026-06-29) — implementing. Decisions: (1) confidence-gated street turns; (2) MILES everywhere (incl. the existing travel tool); (3) mode REQUIRED; (4) roll directions into the travel skill (one skill), validated by the discrimination eval — split only if the model mis-picks.
 
 * Goal
 Extend the travel capability from "how long / which mode" (the shipped ~travel~
@@ -167,6 +167,32 @@ import + comment), ~assist/skills/directions/SKILL.md~ (new), ~assist/skills/tra
 4. Minor (recommended defaults, say if you disagree): new ~directions~ skill (not a
    combined travel+directions skill); ~origin~ defaults to "home" for one-place
    asks (matches the travel skill); map render DEFERRED.
+
+* Pierre's PR review notes (2026-06-29)
+- *Transit departure times — FOLLOW-UP, gated on the context rider.* Transit
+  directions should eventually carry real board times: each leg shows a "leave on
+  time" board time AND the next departure, and the chain is anchored to a *departure
+  time a few minutes after the user's most recent message*. The times themselves are
+  in the API already (MOTIS legs carry ``startTime`` / ``scheduledStartTime`` /
+  ``endTime``); what's missing is the "now" anchor — so this depends on the **context
+  rider** milestone (message time + geo) landing first. v1 ships the
+  walk/board/transfer/alight narrative WITHOUT times; the times follow-up comes after
+  the context rider. (See [[queued-assist-feature-roadmap]].)
+- *Degradations must be surfaced by the agent — DONE in v1.* When a result is
+  degraded (no route, an odd resolved name, an unavailable mode, approximate turns),
+  the agent should call it out AND ask for what would resolve it (a more specific
+  place, the city/area, a different mode). Implemented as skill guidance
+  (assist/skills/travel/SKILL.md "Surfacing problems"), not tool code — the tool
+  already returns honest degraded strings; the skill tells the agent to act on them.
+
+* As-built deviations from the plan (doc-vs-diff reconciliation)
+- *One skill, not a new ~directions~ skill* — per Pierre's call (#4): the existing
+  ~travel~ skill was extended to cover both tools with a checkable tool-choice rule +
+  a mode synonym table. Validated by the discrimination eval; split only if the model
+  mis-picks.
+- *No README entry* — ~travel~ itself was never added to the README; kept consistent
+  (no unrequested docs). The skill + this doc are the documentation.
+- Transit "stops" = intermediate stops + 1 (the stops ridden to the alighting stop).
 
 * Internal review outcomes (folded in)
 - simplicity: cut to ~3 core helpers, one street + one transit path (not 4 modes),

--- a/edd/eval/test_directions_agent.py
+++ b/edd/eval/test_directions_agent.py
@@ -1,0 +1,67 @@
+"""Eval: the agent DISCRIMINATES between `travel` and `directions`.
+
+Real-LLM eval (small model) — deploy venv, live MOTIS (ASSIST_ROUTING_URL in
+.dev.env). Both tools live behind ONE travel skill (Pierre's call), so the risk is
+mis-selection: the model must call `directions` (+ a mode) for "how do I get there
+/ which bus" prompts, and `travel` for "how long / how far" prompts — and NOT the
+other. Prompts deliberately avoid the skill's example wording (probe generalization,
+not lexical proximity).
+"""
+import tempfile
+from unittest import TestCase
+
+from assist.agent import create_agent, AgentHarness
+from assist.model_manager import select_assistant_model
+
+from .utils import create_filesystem
+
+
+class TestDirectionsAgent(TestCase):
+    def setUp(self):
+        self.model = select_assistant_model(0.1)
+
+    def _agent(self):
+        root = tempfile.mkdtemp()
+        create_filesystem(root, {"README.org": "Personal notes."})
+        return AgentHarness(create_agent(self.model, root))  # travel + directions built-in
+
+    def _calls(self, agent):
+        names = []
+        for m in agent.all_messages():
+            for c in (getattr(m, "tool_calls", None) or []):
+                if c.get("name") in ("travel", "directions"):
+                    names.append((c["name"], c.get("args") or {}))
+        return names
+
+    # --- directions-shaped prompts -> directions, NOT travel ---
+    def test_step_by_step_calls_directions(self):
+        agent = self._agent()
+        agent.message("Give me step-by-step directions from Coit Tower to Oracle "
+                      "Park by car.")
+        calls = self._calls(agent)
+        self.assertTrue(any(n == "directions" for n, _ in calls),
+                        f"expected directions; got {[n for n, _ in calls]}")
+        self.assertFalse(any(n == "travel" for n, _ in calls),
+                         "directions-shaped prompt should not call travel")
+
+    def test_which_train_calls_directions_transit(self):
+        agent = self._agent()
+        agent.message("Which train do I take to get from Civic Center to the "
+                      "Embarcadero?")
+        calls = self._calls(agent)
+        dir_calls = [a for n, a in calls if n == "directions"]
+        self.assertTrue(dir_calls, f"expected directions; got {[n for n, _ in calls]}")
+        # mode should resolve to transit for a "which train" ask
+        self.assertTrue(any(str(a.get("mode", "")).lower() == "transit" for a in dir_calls),
+                        f"expected mode=transit; got {dir_calls}")
+
+    # --- travel-shaped prompt -> travel, NOT directions (no traffic-stealing) ---
+    def test_how_long_calls_travel_not_directions(self):
+        agent = self._agent()
+        agent.message("Roughly how long is the drive from the Ferry Building to "
+                      "Oakland City Hall?")
+        calls = self._calls(agent)
+        self.assertTrue(any(n == "travel" for n, _ in calls),
+                        f"expected travel; got {[n for n, _ in calls]}")
+        self.assertFalse(any(n == "directions" for n, _ in calls),
+                         "travel-shaped prompt should not call directions")

--- a/tests/test_create_agent_spec.py
+++ b/tests/test_create_agent_spec.py
@@ -42,16 +42,17 @@ class _CreateAgentHarness:
 class TestSpecWiring(_CreateAgentHarness):
     """The spec's fields reach create_deep_agent."""
 
-    def test_default_spec_has_only_builtin_travel_tool(self):
-        # `travel` is a built-in always on the main agent; default spec adds nothing else.
-        from assist.tools import travel
-        assert self._build()["tools"] == [travel]
-        assert self._build(spec=AgentSpec())["tools"] == [travel]
+    def test_default_spec_has_only_builtin_travel_tools(self):
+        # `travel` + `directions` are built-ins always on the main agent; a default
+        # spec adds nothing else.
+        from assist.tools import directions, travel
+        assert self._build()["tools"] == [travel, directions]
+        assert self._build(spec=AgentSpec())["tools"] == [travel, directions]
 
     def test_spec_tools_reach_create_deep_agent(self):
-        from assist.tools import travel
+        from assist.tools import directions, travel
         kwargs = self._build(spec=AgentSpec(tools=(_tool_a, _tool_b)))
-        assert kwargs["tools"] == [_tool_a, _tool_b, travel]
+        assert kwargs["tools"] == [_tool_a, _tool_b, travel, directions]
 
     def test_spec_skill_sources_reach_middleware(self):
         from assist.middleware.skills_middleware import SmallModelSkillsMiddleware

--- a/tests/test_directions.py
+++ b/tests/test_directions.py
@@ -1,0 +1,160 @@
+"""Tests for the directions tool (assist/tools.py) — turn-by-turn over MOTIS /plan.
+
+CPU/no-model, no live service: HTTP is mocked against MOTIS's real shapes. Street
+geometry is built with a local polyline ENCODER (the inverse of the tool's decoder)
+so turns are deterministic — "go east then go north" must read as a left turn.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from assist import tools
+
+
+class _Resp:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+def _encode(coords, precision=7):
+    """Google-encode [(lat, lon), ...] — inverse of tools._decode_polyline."""
+    factor = 10 ** precision
+    out = []
+    plat = plon = 0
+    for lat, lon in coords:
+        ilat, ilon = round(lat * factor), round(lon * factor)
+        for d in (ilat - plat, ilon - plon):
+            d = ~(d << 1) if d < 0 else (d << 1)
+            while d >= 0x20:
+                out.append(chr((0x20 | (d & 0x1f)) + 63))
+                d >>= 5
+            out.append(chr(d + 63))
+        plat, plon = ilat, ilon
+    return "".join(out)
+
+
+def _step(name, coords, meters):
+    return {"streetName": name, "distance": meters,
+            "polyline": {"points": _encode(coords), "precision": 7}}
+
+
+# "A Street" runs EAST (lon increasing), "B Street" runs NORTH (lat increasing):
+# the boundary is a ~90° left turn.
+_EAST = [(37.78, -122.42), (37.78, -122.41)]
+_NORTH = [(37.78, -122.41), (37.79, -122.41)]
+_STREET_PLAN = {"direct": [{"duration": 600, "legs": [{"distance": 1200.0, "steps": [
+    _step("A Street", _EAST, 600.0),
+    _step("B Street", _NORTH, 600.0),
+]}]}]}
+_TRANSIT_PLAN = {"itineraries": [{"duration": 1260, "legs": [
+    {"mode": "WALK", "from": {"name": "Origin"}, "to": {"name": "Stop A"}, "duration": 180},
+    {"mode": "BUS", "routeShortName": "9R", "headsign": "Downtown",
+     "from": {"name": "Stop A"}, "to": {"name": "Stop B"},
+     "intermediateStops": [{}, {}], "duration": 720},
+    {"mode": "WALK", "from": {"name": "Stop B"}, "to": {"name": "Dest"}, "duration": 360},
+]}]}
+
+
+def _fake_get(url, params=None, timeout=None, **kw):
+    params = params or {}
+    if "/search" in url:  # Nominatim geocode: echo the query as the resolved name
+        return _Resp([{"lat": "37.78", "lon": "-122.42", "display_name": params["q"]}])
+    if "/api/v1/plan" in url:
+        return _Resp(_TRANSIT_PLAN if "transitModes" in params else _STREET_PLAN)
+    raise AssertionError(f"unexpected GET {url} {params}")
+
+
+@pytest.fixture
+def routing_env(monkeypatch):
+    monkeypatch.setenv("ASSIST_ROUTING_URL", "http://motis")
+    monkeypatch.setenv("ASSIST_GEOCODER_URL", "http://nominatim")
+
+
+class TestHelpers:
+    def test_decode_polyline_known_vector(self):
+        # The canonical Google example (precision 5).
+        pts = tools._decode_polyline("_p~iF~ps|U_ulLnnqC_mqNvxq`@", 5)
+        assert len(pts) == 3
+        assert round(pts[0][0], 5) == 38.5 and round(pts[0][1], 5) == -120.2
+        assert round(pts[2][0], 3) == 43.252
+
+    def test_decode_polyline_bad_input_returns_empty(self):
+        assert tools._decode_polyline(None, 7) == []
+        assert tools._decode_polyline(123, 7) == []
+
+    def test_turn_phrase_confidence_gated(self):
+        assert tools._turn_phrase(0, 90) == "Turn right onto"
+        assert tools._turn_phrase(90, 0) == "Turn left onto"
+        assert tools._turn_phrase(0, 10) == "Continue onto"   # below threshold
+        assert tools._turn_phrase(0, 178) == "Make a U-turn onto"
+        assert tools._turn_phrase(None, 90) == "Continue onto"  # unknown -> neutral
+        assert tools._turn_phrase(90, None) == "Continue onto"
+
+
+class TestDirections:
+    def test_street_directions_has_turns_and_miles(self, routing_env):
+        with patch.object(tools.requests, "get", _fake_get):
+            out = tools.directions("home", "the office", "car")
+        assert out.startswith('Driving directions from "home" to "the office"')
+        assert "1. Head onto A Street (0.4 mi)" in out
+        assert "2. Turn left onto B Street (0.4 mi)" in out   # east -> north = left
+        assert out.rstrip().endswith('Arrive at "the office"')
+
+    def test_bike_uses_street_path(self, routing_env):
+        with patch.object(tools.requests, "get", _fake_get):
+            out = tools.directions("home", "the office", "bike")
+        assert out.startswith("Biking directions")
+
+    def test_transit_directions_narrative(self, routing_env):
+        with patch.object(tools.requests, "get", _fake_get):
+            out = tools.directions("home", "the office", "transit")
+        assert out.startswith("Transit directions")
+        assert "1. Walk to Stop A (3 min)" in out
+        assert "2. Take the 9R bus toward Downtown to Stop B (3 stops)" in out
+        assert '3. Walk to "the office" (6 min)' in out      # last walk -> dest name
+
+    def test_mode_synonyms_normalize(self):
+        assert tools._normalize_mode("Driving")[1] == "CAR"
+        assert tools._normalize_mode("cycling")[1] == "BIKE"
+        assert tools._normalize_mode("on foot")[1] == "WALK"
+        assert tools._normalize_mode("subway")[0] == "transit"
+
+    def test_unknown_mode_asks(self, routing_env):
+        with patch.object(tools.requests, "get", _fake_get):
+            out = tools.directions("a", "b", "teleport")
+        assert "car, bike, walk, or transit" in out
+
+    def test_routing_unset_is_unavailable(self, monkeypatch):
+        monkeypatch.delenv("ASSIST_ROUTING_URL", raising=False)
+        monkeypatch.delenv("ASSIST_GEOCODER_URL", raising=False)
+        assert "unavailable" in tools.directions("a", "b", "car").lower()
+
+    def test_no_route_is_reported(self, routing_env):
+        def empty(url, params=None, **kw):
+            if "/api/v1/plan" in url:
+                return _Resp({"direct": []})
+            return _fake_get(url, params=params, **kw)
+        with patch.object(tools.requests, "get", empty):
+            out = tools.directions("home", "office", "car")
+        assert "couldn't find a driving route" in out.lower()
+
+    def test_service_down_is_unavailable(self, routing_env):
+        def boom(url, params=None, **kw):
+            raise ConnectionError("MOTIS down")
+        with patch.object(tools.requests, "get", boom):
+            assert "unavailable" in tools.directions("home", "office", "transit").lower()
+
+    def test_malformed_plan_does_not_raise(self, routing_env):
+        def wrong(url, params=None, **kw):
+            if "/api/v1/plan" in url:
+                return _Resp(["not", "a", "dict"])
+            return _fake_get(url, params=params, **kw)
+        with patch.object(tools.requests, "get", wrong):
+            out = tools.directions("home", "office", "car")  # must not raise
+        assert "couldn't find" in out.lower()

--- a/tests/test_directions.py
+++ b/tests/test_directions.py
@@ -87,6 +87,12 @@ class TestHelpers:
     def test_decode_polyline_bad_input_returns_empty(self):
         assert tools._decode_polyline(None, 7) == []
         assert tools._decode_polyline(123, 7) == []
+        assert tools._decode_polyline("abc", None) == []      # bad precision type -> []
+
+    def test_decode_polyline_extreme_precision_does_not_raise(self):
+        # A malformed-backend precision must not crash (10**-400 -> 0.0 -> div-by-zero).
+        assert isinstance(tools._decode_polyline("_p~iF~ps|U", -400), list)
+        assert isinstance(tools._decode_polyline("_p~iF~ps|U", 10 ** 6), list)
 
     def test_turn_phrase_confidence_gated(self):
         assert tools._turn_phrase(0, 90) == "Turn right onto"

--- a/tests/test_travel.py
+++ b/tests/test_travel.py
@@ -64,8 +64,8 @@ class TestFormat:
         assert tools._fmt_duration(9600) == "2 h 40 min"
 
     def test_distance(self):
-        assert tools._fmt_distance_m(14000) == "14.0 km"
-        assert tools._fmt_distance_m(80) == "80 m"
+        assert tools._fmt_distance_m(14000) == "8.7 mi"
+        assert tools._fmt_distance_m(80) == "262 ft"
 
 
 class TestTravel:
@@ -73,9 +73,9 @@ class TestTravel:
         with patch.object(tools.requests, "get", _fake_get):
             out = tools.travel("civic center", "ferry building")
         assert 'from "Civic Center" to "Ferry Building"' in out
-        assert "- Car: 22 min, 14.0 km" in out
-        assert "- Bike: 48 min, 13.0 km" in out
-        assert "- Walk: 2 h 40 min, 13.0 km" in out
+        assert "- Car: 22 min, 8.7 mi" in out
+        assert "- Bike: 48 min, 8.1 mi" in out
+        assert "- Walk: 2 h 40 min, 8.1 mi" in out
         assert "- Transit: 35 min" in out  # fastest of the two itineraries
 
     def test_passes_coords_not_names_to_plan(self, routing_env):
@@ -127,7 +127,7 @@ class TestTravel:
             out = tools.travel("civic center", "ferry building")
         assert any("/api/v1/geocode" in u for u in seen)   # MOTIS geocoder fallback
         assert not any("/search" in u for u in seen)
-        assert "- Car: 22 min, 14.0 km" in out            # full summary still works
+        assert "- Car: 22 min, 8.7 mi" in out            # full summary still works
 
     def test_service_down_is_unavailable_not_not_found(self, routing_env):
         # A geocoder/service outage must yield the "unavailable" message, NOT a


### PR DESCRIPTION
Implements the approved design (`docs/2026-06-29-turn-by-turn-directions.org`). Started as a design-only PR; now carries the full implementation with your review notes folded in.

## What
New built-in `directions(origin, destination, mode)` alongside `travel`:
- **Transit**: walk → board (line + headsign) → transfer → alight → walk narrative.
- **Street (car/bike/walk)**: consolidated street runs + **confidence-gated turns** from polyline bearing deltas (MOTIS's own turn field is uselessly all-`CONTINUE`) — left/right only when unambiguous, else "Continue onto", so a confident *wrong* turn is unreachable by construction. Bike rides the bike-aware route (e.g. the Wiggle).
- `mode` **required** (no silent default); never raises into the agent loop.
- **Miles everywhere** (`_fmt_distance_m`, so `travel` too).
- Rolled into the **one** travel skill (tool-choice rule + mode synonym table).

## Your PR notes
- **Degradation callouts** → done in v1 (skill "Surfacing problems": notice + call out + ask for what resolves it).
- **Transit departure times** → noted as a follow-up, gated on the **context rider** (needs a "now" anchor; MOTIS legs already carry the times).

## Validation
- **744 unit tests** green (incl. `test_directions.py` with a local polyline encoder → deterministic turns).
- **Discrimination eval 9/9** (3 rounds): step-by-step→directions, which-train→directions+transit, how-long→travel (not directions — no traffic stealing). Validates the one-skill choice.
- Local code-review (3 lenses): 0 blockers; fixed 1 IMPORTANT (extracted shared `_resolve_od`) + NITs (non-string mode, distance-type guard).

## As-built deviations (reconciled in the doc)
One combined skill (not a new `directions` skill, per your #4); no README entry (consistent with `travel`).