### PR TITLE
time skill: answer date questions via the unix `date` command (+ local-TZ sandbox)

### DIFF
--- a/.deploy.env.example
+++ b/.deploy.env.example
@@ -58,6 +58,12 @@ ASSIST_ROUTING_URL=http://127.0.0.1:8088
 # so it stays commented by default.
 #ASSIST_GEOCODER_URL=http://127.0.0.1:8089
 
+# Sandbox timezone — the IANA zone the per-turn sandbox uses, so `date` and file
+# timestamps (and the `time` skill's answers) reflect LOCAL time, not UTC.  Unset
+# -> derived from the host (/etc/timezone or /etc/localtime) -> UTC.  Set it to
+# pin a zone explicitly (e.g. for a host whose clock differs from the user's).
+#ASSIST_TIMEZONE=America/Los_Angeles
+
 # Python version on remote server
 PYTHON=python3.14
 

--- a/.dev.env.example
+++ b/.dev.env.example
@@ -29,3 +29,7 @@ ASSIST_PORT=8000
 # geocoding, else travel falls back to MOTIS's built-in geocoder.
 # ASSIST_ROUTING_URL=http://127.0.0.1:8088
 # ASSIST_GEOCODER_URL=http://127.0.0.1:8089
+
+# Sandbox timezone for the `time` skill / `date` (IANA zone). Unset -> host zone
+# (/etc/timezone or /etc/localtime) -> UTC.
+# ASSIST_TIMEZONE=America/Los_Angeles

--- a/assist/sandbox_manager.py
+++ b/assist/sandbox_manager.py
@@ -23,7 +23,8 @@ def _sandbox_timezone() -> str:
     if tz:
         return tz
     try:  # Debian-likes: /etc/timezone is a plain zone name
-        name = open("/etc/timezone").read().strip()
+        with open("/etc/timezone") as f:
+            name = f.read().strip()
         if name:
             return name
     except OSError:

--- a/assist/sandbox_manager.py
+++ b/assist/sandbox_manager.py
@@ -14,11 +14,12 @@ def _rewrite_localhost(value: str) -> str:
 
 
 def _sandbox_timezone() -> str:
-    """IANA timezone for the sandbox so ``date`` / file timestamps reflect LOCAL
-    time, not the container's default UTC — without it the `time` skill answers
-    "what's today" in UTC (wrong for an evening PT user).  Order: ASSIST_TIMEZONE
-    override (operator config; the context-rider milestone will set per-user later),
-    else the host's zone, else UTC."""
+    """A timezone setting for the sandbox (an IANA zone name like
+    "America/Los_Angeles", or whatever ``TZ`` value is configured) so ``date`` /
+    file timestamps reflect LOCAL time, not the container's default UTC — without it
+    the `time` skill answers "what's today" in UTC (wrong for an evening PT user).
+    Order: ASSIST_TIMEZONE override (operator config; the context-rider milestone
+    will set per-user later), else ``TZ``, else the host's zone, else UTC."""
     tz = os.environ.get("ASSIST_TIMEZONE") or os.environ.get("TZ")
     if tz:
         return tz

--- a/assist/sandbox_manager.py
+++ b/assist/sandbox_manager.py
@@ -19,10 +19,16 @@ def _sandbox_timezone() -> str:
     "what's today" in UTC (wrong for an evening PT user).  Order: ASSIST_TIMEZONE
     override (operator config; the context-rider milestone will set per-user later),
     else the host's zone, else UTC."""
-    tz = os.environ.get("ASSIST_TIMEZONE")
+    tz = os.environ.get("ASSIST_TIMEZONE") or os.environ.get("TZ")
     if tz:
         return tz
-    try:
+    try:  # Debian-likes: /etc/timezone is a plain zone name
+        name = open("/etc/timezone").read().strip()
+        if name:
+            return name
+    except OSError:
+        pass
+    try:  # most distros: /etc/localtime symlinks into zoneinfo
         link = os.readlink("/etc/localtime")
         if "zoneinfo/" in link:
             return link.split("zoneinfo/", 1)[1]

--- a/assist/sandbox_manager.py
+++ b/assist/sandbox_manager.py
@@ -12,6 +12,25 @@ def _rewrite_localhost(value: str) -> str:
     """Replace localhost/127.0.0.1 references with host.docker.internal."""
     return re.sub(r'localhost|127\.0\.0\.1', 'host.docker.internal', value)
 
+
+def _sandbox_timezone() -> str:
+    """IANA timezone for the sandbox so ``date`` / file timestamps reflect LOCAL
+    time, not the container's default UTC — without it the `time` skill answers
+    "what's today" in UTC (wrong for an evening PT user).  Order: ASSIST_TIMEZONE
+    override (operator config; the context-rider milestone will set per-user later),
+    else the host's zone, else UTC."""
+    tz = os.environ.get("ASSIST_TIMEZONE")
+    if tz:
+        return tz
+    try:
+        link = os.readlink("/etc/localtime")
+        if "zoneinfo/" in link:
+            return link.split("zoneinfo/", 1)[1]
+    except OSError:
+        pass
+    return "UTC"
+
+
 SANDBOX_IMAGE = "assist-sandbox"
 
 # Egress allowlist layer.  See docs/2026-05-08-sandbox-network-allowlist.org
@@ -291,6 +310,7 @@ class SandboxManager:
                 "HTTP_PROXY": proxy_url,
                 "https_proxy": proxy_url,
                 "http_proxy": proxy_url,
+                "TZ": _sandbox_timezone(),  # local time, not UTC (the `time` skill)
             }
             sandbox_env.update({
                 k: _rewrite_localhost(v)

--- a/assist/skills/time/SKILL.md
+++ b/assist/skills/time/SKILL.md
@@ -60,8 +60,11 @@ execute("date -d '7/5' '+%A'")
 
 ## Countdown — days until / since a date
 
+The `+ 43200` rounds to the nearest whole day, which absorbs the partial current
+day and any daylight-saving hour in the span (so the count isn't off by one):
+
 ```
-execute("echo $(( ($(date -d '2026-12-25' +%s) - $(date +%s)) / 86400 )) days")
+execute("echo $(( ($(date -d '2026-12-25' +%s) - $(date +%s) + 43200) / 86400 )) days")
 ```
 
 A positive number is days **until** the date; negative means it already passed.
@@ -76,7 +79,7 @@ A positive number is days **until** the date; negative means it already passed.
 - "What's the date a week from Friday... I mean, next Thursday?" →
   `execute("date -d 'next Thursday' '+%A, %B %-d, %Y'")` → respond with the date.
 - "How many days until Christmas?" →
-  `execute("echo $(( ($(date -d 'Dec 25' +%s) - $(date +%s)) / 86400 )) days")`.
+  `execute("echo $(( ($(date -d 'Dec 25' +%s) - $(date +%s) + 43200) / 86400 )) days")`.
 
 ## Anti-patterns
 

--- a/assist/skills/time/SKILL.md
+++ b/assist/skills/time/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: time
+description: Dates and times via the `date` command — what's today, the day of the week of a date, relative dates, and date countdowns. EXAMPLES — "what's today's date"; "what day of the week is 7/5"; "what's the date next Thursday"; "how many days until Christmas". MUST load before any question about the current date or time, a day of the week, a relative date, or how many days until/since a date.
+---
+
+# Time — run-then-answer guide for dates
+
+## The rule
+
+Every date/time answer must come from a `date` command you ran via `execute`.
+Never figure out today's date, a day of the week, or a future/past date in your
+head — you do **not** know what today is without running `date`, and calendar math
+("7/5 is a Saturday") is exactly what you get wrong. If you state a day or date you
+did not get from `date`, the answer is wrong even when it happens to be right.
+
+## How to run it
+
+Today:
+
+```
+execute("date '+%A, %B %-d, %Y'")
+```
+
+A specific or relative date (GNU `date -d` does the parsing):
+
+```
+execute("date -d 'next Thursday' '+%A, %B %-d, %Y'")
+```
+
+`date -d` understands a lot: `next Thursday`, `last friday`, `tomorrow`,
+`yesterday`, weekday names, `3 days`, `2 weeks ago`, `1 month`, and absolute dates
+like `7/5`, `July 5`, `2026-12-25`.
+
+## Translate the user's phrasing into a `date -d` expression
+
+The user's words aren't always what `date -d` wants — convert them:
+
+- "in 3 days" → `3 days`; "in two weeks" → `2 weeks`; "3 days ago" → `3 days ago`.
+- "what day is 7/5" → `date -d '7/5'` (US month/day — see below).
+
+`date -d` does NOT understand "X from <weekday>" ("two weeks from Friday"), "first
+Monday of July", or ordinal phrases. If you cannot express the request as a single
+`date -d` string, tell the user you can't compute that particular one — do **not**
+invent a date.
+
+## US dates and reading back
+
+`7/5` means **July 5** (month/day). Run it through `date` and **echo the full
+resolved date** so the user can catch a misread:
+
+```
+execute("date -d '7/5' '+%A (%B %-d, %Y)'")
+```
+
+## Day of the week
+
+```
+execute("date -d '7/5' '+%A'")
+```
+
+## Countdown — days until / since a date
+
+```
+execute("echo $(( ($(date -d '2026-12-25' +%s) - $(date +%s)) / 86400 )) days")
+```
+
+A positive number is days **until** the date; negative means it already passed.
+
+## Worked examples
+
+- "What's today's date?" → `execute("date '+%A, %B %-d, %Y'")` → output
+  `Monday, June 29, 2026` → respond with exactly that.
+- "What day of the week is 7/5?" →
+  `execute("date -d '7/5' '+%A (%B %-d, %Y)'")` → `Sunday (July 5, 2026)` →
+  respond "July 5 is a Sunday."
+- "What's the date a week from Friday... I mean, next Thursday?" →
+  `execute("date -d 'next Thursday' '+%A, %B %-d, %Y'")` → respond with the date.
+- "How many days until Christmas?" →
+  `execute("echo $(( ($(date -d 'Dec 25' +%s) - $(date +%s)) / 86400 )) days")`.
+
+## Anti-patterns
+
+- Stating a day of the week or a date you did **not** get from `date`.
+- Guessing today's date — you can't know it without running `date`.
+- Doing calendar math in your head (counting days, naming a weekday).
+- Inventing a date for a phrasing `date -d` can't parse — say you can't compute it.

--- a/edd/eval/test_time_agent.py
+++ b/edd/eval/test_time_agent.py
@@ -9,6 +9,7 @@ derived from `date` itself (not hard-coded) so the eval is year-independent.
 Prompts deliberately avoid the SKILL.md EXAMPLES verbatim (probe generalization).
 """
 import re
+import shlex
 import tempfile
 from unittest import TestCase
 
@@ -40,8 +41,9 @@ class TestTimeAgent(TestCase):
                                          sandbox_backend=self.sandbox))
 
     def _ran_date(self, agent) -> bool:
-        # `date` at command position — NOT `datetime.date` (the . is a \b, which the
-        # calculate-skill Python habit could otherwise sneak past this proxy).
+        # `date` at command position — NOT `datetime.date`: the prefix class
+        # [\s;&|()] excludes '.', so the `.date` in a Python `datetime.date` call
+        # (the calculate-skill habit) can't satisfy this unix-`date` proxy.
         return any(re.search(r"(?:^|[\s;&|()])date\b", cmd)
                    for cmd in executed_commands(agent))
 
@@ -49,7 +51,7 @@ class TestTimeAgent(TestCase):
         """(weekday, month, day) that `date -d <expr>` resolves to IN THE SANDBOX —
         same clock/TZ the agent uses. Fail fast on empty (an assertIn against an
         empty string would vacuously pass)."""
-        out = (self.sandbox.execute(f"date -d '{expr}' '+%A|%B|%-d'").output or "").strip()
+        out = (self.sandbox.execute(f"date -d {shlex.quote(expr)} '+%A|%B|%-d'").output or "").strip()
         self.assertIn("|", out, f"sandbox `date -d {expr}` produced no usable output")
         wk, mon, day = out.split("|")
         return wk.lower(), mon.lower(), day

--- a/edd/eval/test_time_agent.py
+++ b/edd/eval/test_time_agent.py
@@ -1,0 +1,81 @@
+"""Eval: the `time` skill makes the agent answer date questions with `date`.
+
+Real-LLM eval (small model), inside a Docker sandbox — the time skill's whole
+premise is that the agent runs the `date` command via `execute` instead of
+guessing the day/date from memory. Each test asserts: (a) the time skill loaded,
+(b) the agent actually ran `date`, (c) the answer is right. Correct answers are
+derived from `date` itself (not hard-coded) so the eval is year-independent.
+
+Prompts deliberately avoid the SKILL.md EXAMPLES verbatim (probe generalization).
+"""
+import re
+import subprocess
+import tempfile
+from unittest import TestCase
+
+from assist.agent import create_agent, AgentHarness
+from assist.model_manager import select_assistant_model
+from assist.sandbox_manager import SandboxManager
+
+from .utils import create_filesystem, skill_was_loaded, executed_commands, cleanup_workspace
+
+
+def _weekday(expr: str) -> str:
+    """The weekday `date -d <expr>` resolves to right now (e.g. 'Sunday')."""
+    return subprocess.run(["date", "-d", expr, "+%A"],
+                          capture_output=True, text=True).stdout.strip()
+
+
+class TestTimeAgent(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = select_assistant_model(0.1)
+
+    def setUp(self):
+        self.workspace = tempfile.mkdtemp(prefix="time_skill_eval_")
+        self.sandbox = SandboxManager.get_sandbox_backend(self.workspace)
+        if self.sandbox is None:
+            self.skipTest("Docker sandbox unavailable — is Docker running and "
+                          "assist-sandbox built?")
+
+    def tearDown(self):
+        SandboxManager.cleanup(self.workspace)
+        cleanup_workspace(self.workspace)
+
+    def _agent(self):
+        return AgentHarness(create_agent(self.model, self.workspace,
+                                         sandbox_backend=self.sandbox))
+
+    def _ran_date(self, agent) -> bool:
+        # `date` at command position — NOT `datetime.date` (the . is a \b, which the
+        # calculate-skill Python habit could otherwise sneak past this proxy).
+        return any(re.search(r"(?:^|[\s;&|()])date\b", cmd)
+                   for cmd in executed_commands(agent))
+
+    def test_weekday_of_a_date(self):
+        agent = self._agent()
+        reply = str(agent.message("What day of the week does the 5th of July land on?") or "").lower()
+        self.assertTrue(skill_was_loaded(agent, "time"), "time skill should load")
+        self.assertTrue(self._ran_date(agent), "agent should run the date command")
+        self.assertIn(_weekday("7/5").lower(), reply)
+
+    def test_relative_date(self):
+        agent = self._agent()
+        reply = str(agent.message("What's the date on the upcoming Thursday?") or "").lower()
+        self.assertTrue(skill_was_loaded(agent, "time"), "time skill should load")
+        self.assertTrue(self._ran_date(agent), "agent should run the date command")
+        self.assertIn("thursday", reply)   # next Thursday is a Thursday
+
+    def test_today(self):
+        agent = self._agent()
+        reply = str(agent.message("Remind me what the date is right now.") or "").lower()
+        self.assertTrue(skill_was_loaded(agent, "time"), "time skill should load")
+        self.assertTrue(self._ran_date(agent), "agent should run the date command")
+        self.assertIn(_weekday("today").lower(), reply)
+
+    def test_does_not_load_on_non_date_prompt(self):
+        # Anti-test: an off-topic prompt must not trip the time skill.
+        agent = self._agent()
+        agent.message("Write a haiku about the ocean.")
+        self.assertFalse(skill_was_loaded(agent, "time"),
+                         "time skill should NOT load for a non-date prompt")

--- a/edd/eval/test_time_agent.py
+++ b/edd/eval/test_time_agent.py
@@ -16,7 +16,7 @@ from assist.agent import create_agent, AgentHarness
 from assist.model_manager import select_assistant_model
 from assist.sandbox_manager import SandboxManager
 
-from .utils import create_filesystem, skill_was_loaded, executed_commands, cleanup_workspace
+from .utils import skill_was_loaded, executed_commands, cleanup_workspace
 
 
 class TestTimeAgent(TestCase):
@@ -45,34 +45,44 @@ class TestTimeAgent(TestCase):
         return any(re.search(r"(?:^|[\s;&|()])date\b", cmd)
                    for cmd in executed_commands(agent))
 
-    def _weekday(self, expr: str) -> str:
-        """The weekday `date -d <expr>` resolves to IN THE SANDBOX — same clock and
-        TZ the agent uses. Fail fast on empty output (else assertIn('', reply) would
-        vacuously pass and hide a broken `date`)."""
-        out = (self.sandbox.execute(f"date -d '{expr}' +%A").output or "").strip()
-        self.assertTrue(out, f"sandbox `date -d {expr}` produced no output")
-        return out
+    def _date_parts(self, expr: str):
+        """(weekday, month, day) that `date -d <expr>` resolves to IN THE SANDBOX —
+        same clock/TZ the agent uses. Fail fast on empty (an assertIn against an
+        empty string would vacuously pass)."""
+        out = (self.sandbox.execute(f"date -d '{expr}' '+%A|%B|%-d'").output or "").strip()
+        self.assertIn("|", out, f"sandbox `date -d {expr}` produced no usable output")
+        wk, mon, day = out.split("|")
+        return wk.lower(), mon.lower(), day
+
+    def _asserts_full_date(self, reply, expr):
+        """Reply names the resolved weekday AND month AND day — i.e. an actual
+        date, not just a weekday (the prompt asks for the date)."""
+        wk, mon, day = self._date_parts(expr)
+        self.assertIn(wk, reply)
+        self.assertIn(mon, reply)
+        self.assertRegex(reply, rf"\b{day}\b")   # day number, word-bounded (not '2' in '2026')
 
     def test_weekday_of_a_date(self):
         agent = self._agent()
         reply = str(agent.message("What day of the week does the 5th of July land on?") or "").lower()
         self.assertTrue(skill_was_loaded(agent, "time"), "time skill should load")
         self.assertTrue(self._ran_date(agent), "agent should run the date command")
-        self.assertIn(self._weekday("7/5").lower(), reply)
+        self.assertIn(self._date_parts("7/5")[0], reply)   # the prompt asks for the weekday
 
     def test_relative_date(self):
         agent = self._agent()
         reply = str(agent.message("What's the date on the upcoming Thursday?") or "").lower()
         self.assertTrue(skill_was_loaded(agent, "time"), "time skill should load")
         self.assertTrue(self._ran_date(agent), "agent should run the date command")
-        self.assertIn("thursday", reply)   # next Thursday is a Thursday
+        self.assertIn("thursday", reply)              # next Thursday is a Thursday
+        self._asserts_full_date(reply, "next Thursday")  # ...and the actual date
 
     def test_today(self):
         agent = self._agent()
         reply = str(agent.message("Remind me what the date is right now.") or "").lower()
         self.assertTrue(skill_was_loaded(agent, "time"), "time skill should load")
         self.assertTrue(self._ran_date(agent), "agent should run the date command")
-        self.assertIn(self._weekday("today").lower(), reply)
+        self._asserts_full_date(reply, "today")
 
     def test_does_not_load_on_non_date_prompt(self):
         # Anti-test: an off-topic prompt must not trip the time skill.

--- a/edd/eval/test_time_agent.py
+++ b/edd/eval/test_time_agent.py
@@ -9,7 +9,6 @@ derived from `date` itself (not hard-coded) so the eval is year-independent.
 Prompts deliberately avoid the SKILL.md EXAMPLES verbatim (probe generalization).
 """
 import re
-import subprocess
 import tempfile
 from unittest import TestCase
 
@@ -18,12 +17,6 @@ from assist.model_manager import select_assistant_model
 from assist.sandbox_manager import SandboxManager
 
 from .utils import create_filesystem, skill_was_loaded, executed_commands, cleanup_workspace
-
-
-def _weekday(expr: str) -> str:
-    """The weekday `date -d <expr>` resolves to right now (e.g. 'Sunday')."""
-    return subprocess.run(["date", "-d", expr, "+%A"],
-                          capture_output=True, text=True).stdout.strip()
 
 
 class TestTimeAgent(TestCase):
@@ -52,12 +45,20 @@ class TestTimeAgent(TestCase):
         return any(re.search(r"(?:^|[\s;&|()])date\b", cmd)
                    for cmd in executed_commands(agent))
 
+    def _weekday(self, expr: str) -> str:
+        """The weekday `date -d <expr>` resolves to IN THE SANDBOX — same clock and
+        TZ the agent uses. Fail fast on empty output (else assertIn('', reply) would
+        vacuously pass and hide a broken `date`)."""
+        out = (self.sandbox.execute(f"date -d '{expr}' +%A").output or "").strip()
+        self.assertTrue(out, f"sandbox `date -d {expr}` produced no output")
+        return out
+
     def test_weekday_of_a_date(self):
         agent = self._agent()
         reply = str(agent.message("What day of the week does the 5th of July land on?") or "").lower()
         self.assertTrue(skill_was_loaded(agent, "time"), "time skill should load")
         self.assertTrue(self._ran_date(agent), "agent should run the date command")
-        self.assertIn(_weekday("7/5").lower(), reply)
+        self.assertIn(self._weekday("7/5").lower(), reply)
 
     def test_relative_date(self):
         agent = self._agent()
@@ -71,7 +72,7 @@ class TestTimeAgent(TestCase):
         reply = str(agent.message("Remind me what the date is right now.") or "").lower()
         self.assertTrue(skill_was_loaded(agent, "time"), "time skill should load")
         self.assertTrue(self._ran_date(agent), "agent should run the date command")
-        self.assertIn(_weekday("today").lower(), reply)
+        self.assertIn(self._weekday("today").lower(), reply)
 
     def test_does_not_load_on_non_date_prompt(self):
         # Anti-test: an off-topic prompt must not trip the time skill.


### PR DESCRIPTION
A **skill-only** feature (per your call: start with unix commands, not a purpose-built tool — only escalate to a tool if `date` doesn't cover the tasks; it does).

## What
- `assist/skills/time/SKILL.md` guides the small model to answer date/time questions by running the unix **`date`** command via `execute` (the `calculate` "run-then-answer, never compute it yourself" pattern): today, day-of-week of a date, relative dates ("next Thursday"), countdowns. It translates user phrasings into `date -d` expressions ("in 3 days" → "3 days"), uses US month-first for "7/5", and is honest when a phrasing isn't parseable.
- No tool / no `tools.py` / no `agent.py` change (skills auto-discover).

## Real bug caught by local review — sandbox timezone
The Docker sandbox ran in **UTC**, so `date` answered in UTC — at 6pm PT it'd say "tomorrow," confidently wrong (and the skill tells the model to trust `date`). **Fixed**: `assist/sandbox_manager.py` now sets the sandbox `TZ` to the host zone (`_sandbox_timezone()`: `ASSIST_TIMEZONE` override → host `/etc/localtime` → UTC). Verified the sandbox now reports PDT. Fixes *all* sandbox time, not just this skill. Per-user TZ will come from the **context rider** milestone.

## Validation
- **Eval `edd/eval/test_time_agent.py` — 10/10**: 3 positive (today / day-of-week of a date / next Thursday) × 3 rounds + an anti-test (doesn't trip on a non-date prompt). The small model reliably runs `date`. Year-independent assertions (weekdays derived from `date`); the `_ran_date` proxy is anchored so `datetime.date` can't satisfy it.
- **745 unit tests** green (the sandbox-TZ change).

Deployed to prod for parallel testing (new cadence). Roadmap #2.