### PR TITLE
geo context rider (#5): per-message location → model + "from here" routing

### DIFF
--- a/assist/skills/travel/SKILL.md
+++ b/assist/skills/travel/SKILL.md
@@ -42,7 +42,12 @@ If the user **names a mode**, pass it. If they **don't**, ask which mode they wa
 
 ## Place names (both tools)
 
-- The tool geocodes names itself — don't pass coordinates.
+- The tool geocodes names itself — pass place NAMES, not coordinates.
+- **"from here" / "near me" / "nearby":** when the user wants travel or directions
+  from their current location and gives no named origin, pass their coordinates from
+  the message context (the `[Message context: ... from ~<lat>, <lon>]` line) as the
+  origin, formatted exactly `"<lat>,<lon>"`. If there's no location in the context,
+  fall back to "home" or ask.
 - If the user gives only one place ("directions to the airport"), the other is
   usually "home" or the place from context; if unclear, ask.
 - For a short/ambiguous name, include the city/area from context (pass "Ferry

--- a/assist/skills/travel/SKILL.md
+++ b/assist/skills/travel/SKILL.md
@@ -24,8 +24,9 @@ or which line to take from your own knowledge** — call the tool.
 ## Calling `travel(origin, destination)`
 
 Pass plain place **names/addresses as the user said them** ("home", "the Ferry
-Building", "123 Main St"). Do NOT pass coordinates or a mode — it returns all four
-modes; you highlight the relevant one when you reply.
+Building", "123 Main St") — the one coordinate exception is the user's current
+location for "from here"/"near me" (see *Place names* below). Don't pass a mode — it
+returns all four modes; you highlight the relevant one when you reply.
 
 ## Calling `directions(origin, destination, mode)`
 

--- a/assist/skills/travel/SKILL.md
+++ b/assist/skills/travel/SKILL.md
@@ -46,8 +46,9 @@ If the user **names a mode**, pass it. If they **don't**, ask which mode they wa
 - **"from here" / "near me" / "nearby":** when the user wants travel or directions
   from their current location and gives no named origin, pass their coordinates from
   the message context (the `[Message context: ... from ~<lat>, <lon>]` line) as the
-  origin, formatted exactly `"<lat>,<lon>"`. If there's no location in the context,
-  fall back to "home" or ask.
+  origin — e.g. `"37.77,-122.42"` (the leading `~` and spaces from the context line
+  are fine to include). If there's no location in the context, fall back to "home"
+  or ask.
 - If the user gives only one place ("directions to the airport"), the other is
   usually "home" or the place from context; if unclear, ask.
 - For a short/ambiguous name, include the city/area from context (pass "Ferry

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -476,7 +476,8 @@ def travel(origin: str, destination: str) -> str:
     take the train" question.  It gives times + distances, NOT turn-by-turn
     directions.  Pass plain place
     NAMES/addresses as the user said them (e.g. "the Ferry Building", "123 Main
-    St") -- do NOT pass coordinates.  Returns a short per-mode summary computed by
+    St"); the one exception is the user's current location for "from here"/"near
+    me", which you pass as "<lat>,<lon>" from the message context.  Returns a short per-mode summary computed by
     the routing service -- time and distance for car/bike/walk, time for transit
     (transit distance isn't reported); relay those numbers, never invent your own.
     Covers the loaded metro area(s); a place outside them comes back as no route,
@@ -698,7 +699,9 @@ def directions(origin: str, destination: str, mode: str) -> str:
     Use this when the user wants DIRECTIONS / how to actually get somewhere -- "how
     do I get to X", "directions to Y", "which bus do I take", "walk me through it" --
     as opposed to "how long / how far" (use `travel` for that).  Pass plain place
-    NAMES (the geocoder resolves them) and a `mode`: "car", "bike", "walk", or
+    NAMES (the geocoder resolves them) -- except the user's current location for
+    "from here"/"near me", which you pass as "<lat>,<lon>" from the message context
+    -- and a `mode`: "car", "bike", "walk", or
     "transit".  Returns a numbered list -- turns + streets for car/bike/walk
     (street turns are approximate), or walk/board/transfer/alight for transit -- in
     US units (miles).  Relay it; never invent streets or lines.  A place outside the

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -378,14 +378,16 @@ def _nominatim_geocode(place: str) -> dict | None:
 
 def _parse_coord_string(place: str) -> dict | None:
     """A bare ``"lat,lon"`` (exactly two in-range numbers) → a geocode hit
-    {lat, lon, name}, so "from here" routes from the user's coordinates (from the
-    message context) without a forward-geocode. A real place name (anything that
+    {lat, lon, name}, so "from here" routes from the user's coordinates without a
+    forward-geocode. Tolerates the leading ``~`` the model sees in the context prose
+    (``~37.77, -122.42``) + surrounding whitespace. A real place name (anything that
     isn't two numbers) → None, falling through to geocoding."""
     parts = str(place).split(",")
     if len(parts) != 2:
         return None
     try:
-        lat, lon = float(parts[0].strip()), float(parts[1].strip())
+        lat = float(parts[0].strip().lstrip("~").strip())
+        lon = float(parts[1].strip().lstrip("~").strip())
     except (ValueError, TypeError):
         return None
     if -90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0:

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -376,12 +376,34 @@ def _nominatim_geocode(place: str) -> dict | None:
     return _first_usable_hit(hits, place)
 
 
+def _parse_coord_string(place: str) -> dict | None:
+    """A bare ``"lat,lon"`` (exactly two in-range numbers) → a geocode hit
+    {lat, lon, name}, so "from here" routes from the user's coordinates (from the
+    message context) without a forward-geocode. A real place name (anything that
+    isn't two numbers) → None, falling through to geocoding."""
+    parts = str(place).split(",")
+    if len(parts) != 2:
+        return None
+    try:
+        lat, lon = float(parts[0].strip()), float(parts[1].strip())
+    except (ValueError, TypeError):
+        return None
+    if -90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0:
+        return {"lat": lat, "lon": lon, "name": "your location"}
+    return None
+
+
 def _geocode(place: str) -> dict | None:
     """Resolve a place NAME to {lat, lon, name} (top match, with the resolved name
-    so the agent can say what it routed to), or None if nothing matched.  Uses the
-    self-hosted Nominatim geocoder when ASSIST_GEOCODER_URL is set (far better at
-    real addresses/POIs than MOTIS's built-in geocoder), else falls back to MOTIS
-    /api/v1/geocode.  Raises _TravelBackendError if the chosen backend is down."""
+    so the agent can say what it routed to), or None if nothing matched.  A bare
+    ``"lat,lon"`` is passed through directly (no geocode) so "from here" routes from
+    the user's coordinates.  Uses the self-hosted Nominatim geocoder when
+    ASSIST_GEOCODER_URL is set (far better at real addresses/POIs than MOTIS's
+    built-in geocoder), else falls back to MOTIS /api/v1/geocode.  Raises
+    _TravelBackendError if the chosen backend is down."""
+    coords = _parse_coord_string(place)
+    if coords:
+        return coords
     if os.getenv("ASSIST_GEOCODER_URL"):
         return _nominatim_geocode(place)
     return _first_usable_hit(_motis_get("/api/v1/geocode", {"text": place}), place)

--- a/docs/2026-06-29-geo-context-rider.org
+++ b/docs/2026-06-29-geo-context-rider.org
@@ -31,7 +31,7 @@ coarse geo, the middleware injects it (ephemeral, main-agent-only), and
 
 * Privacy (unchanged from #3, confirmed)
 Precise coords stay on ~configurable~ (per-invocation, NOT checkpointed); only the
-coarse ~~lat,lon~~ (2-decimal ≈ city block) reaches the model + the persisted prose;
+coarse ~lat,lon~ (2-decimal ≈ city block) reaches the model + the persisted prose;
 middleware is main-agent-only (no geo to the research sub-agent's egress). No raw
 coords logged. Browser permission grant = consent. "from here" routes from the
 coarse coords the model sees (v1).

--- a/docs/2026-06-29-geo-context-rider.org
+++ b/docs/2026-06-29-geo-context-rider.org
@@ -1,0 +1,52 @@
+#+title: Geo context rider (#5) — per-message location → model + "from here"
+#+date: 2026-06-29
+
+* Goal
+Extend the context rider (#3 shipped TIME only) to also carry the user's
+geo-location per message, so the agent knows *where* they are — enabling "find a
+restaurant nearby" / "directions from here". Pierre queued this as the geo half.
+
+* Most of the contract was already built (#3)
+~ContextRider~ already has ~lat/lon/place_label~ (validated), ~prose_line()~ renders
+coarse geo, the middleware injects it (ephemeral, main-agent-only), and
+~_process_message~ threads any rider onto ~configurable~. So #5 is three small deltas.
+
+* Deltas (as built)
+1. *Browser geo source* (~manage/web/threads.py~, message form). On message SEND
+   (not on thread-open, per Pierre), the form's ~assistSend()~ fetches
+   ~navigator.geolocation.getCurrentPosition~ (maxAge 1h, 5s timeout) and submits
+   with ~lat~/~lon~ hidden fields. The browser remembers the grant for
+   localhost:5050, so it prompts ONCE; later sends are instant/silent. Denied /
+   unsupported / timeout → submit without coords (rider stays time-only). Requires a
+   secure context — localhost qualifies (Pierre accesses via localhost:5050).
+2. *Backend* (~_build_rider~ + ~post_message~). Optional ~lat~/~lon~ Form fields →
+   ~_build_rider~ parses best-effort: both-or-neither, in-range; a bad/out-of-range
+   coord drops just geo, keeps the time; geo-only rider is valid. Pure-CPU on the
+   loop thread (event-loop safe).
+3. *"from here"* (~assist/tools.py~ + travel skill). ~_geocode~ gains a
+   ~_parse_coord_string~ passthrough: a bare ~"lat,lon"~ (two in-range numbers) →
+   those coords with name "your location", no forward-geocode; a real place name
+   falls through. The travel SKILL.md tells the model: for "from here"/"near me",
+   pass the message-context coords as the origin formatted ~"lat,lon"~.
+
+* Privacy (unchanged from #3, confirmed)
+Precise coords stay on ~configurable~ (per-invocation, NOT checkpointed); only the
+coarse ~~lat,lon~~ (2-decimal ≈ city block) reaches the model + the persisted prose;
+middleware is main-agent-only (no geo to the research sub-agent's egress). No raw
+coords logged. Browser permission grant = consent. "from here" routes from the
+coarse coords the model sees (v1).
+
+* Pierre's decisions
+- Web access: *localhost:5050* → geolocation works (secure context).
+- Consent: fetch on SEND (not open); browser prompts once + remembers; maxAge cache.
+- "from here" precision: coarse (recommended). Out-of-range coord: drop geo, keep time.
+
+* Validation
+Unit: ~_build_rider~ coords (valid / geo-only / bad-drops-geo-keeps-time);
+e2e (lat/lon flow to the rider on ~configurable~); ~_geocode~ coord passthrough +
+names still geocode; page renders with the geo JS. 767 unit green. A live "directions
+from here" smoke is APPROVAL-GATED (LLM + degraded fans).
+
+* emacsos (phone) — separate follow-up
+The phone has real GPS + already passes per-turn ~configurable~; it populates the same
+~ContextRider(lat=, lon=)~ — same mechanism, same privacy posture. Not wired here.

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -529,11 +529,29 @@ def render_thread(
           {"<div class='success-msg'>Pushed local main to origin/main.</div>" if pushed else ""}
           {conflict_banner_html}
           {f'<script>try {{ localStorage.removeItem("assist:review:" + {json.dumps(tid)}); }} catch (_) {{}}</script>' if reviewed else ""}
-          <form action="/thread/{tid}/message" method="post" onsubmit="try{{this.sent_at.value=new Date().toISOString();this.tz.value=Intl.DateTimeFormat().resolvedOptions().timeZone;}}catch(e){{}}">
+          <script>
+          // On send (not on thread-open): stamp time/tz, then fetch location.
+          // The browser remembers the permission grant for this origin, so it
+          // prompts once; maximumAge serves a cached fix instantly afterwards.
+          // Denied/unsupported/timeout → submit without coords (rider stays time-only).
+          function assistSend(form){{
+            try{{ form.sent_at.value=new Date().toISOString(); form.tz.value=Intl.DateTimeFormat().resolvedOptions().timeZone; }}catch(e){{}}
+            if(!navigator.geolocation){{ return true; }}
+            navigator.geolocation.getCurrentPosition(
+              function(p){{ form.lat.value=p.coords.latitude; form.lon.value=p.coords.longitude; form.submit(); }},
+              function(){{ form.submit(); }},
+              {{maximumAge:3600000, timeout:5000}}
+            );
+            return false;  // wait for the async fix, then submit programmatically
+          }}
+          </script>
+          <form action="/thread/{tid}/message" method="post" onsubmit="return assistSend(this);">
             <label for="text">Your message</label><br/>
             <textarea id="text" name="text" required placeholder="Type your message..." {form_disabled}></textarea><br/>
             <input type="hidden" name="sent_at"/>
             <input type="hidden" name="tz"/>
+            <input type="hidden" name="lat"/>
+            <input type="hidden" name="lon"/>
             <div class="button-group">
               <button class="btn" type="submit" {form_disabled}>Send</button>
               <button class="btn btn-secondary" type="button" onclick="showCaptureModal()" {form_disabled}>Capture Conversation</button>
@@ -850,12 +868,14 @@ def _mark_pending(tid: str, text: str) -> None:
     _set_status(tid, stage, pending_message=text)
 
 
-def _build_rider(sent_at: str | None, tz: str | None) -> ContextRider | None:
-    """Build the per-turn rider from the client's send-time + timezone. Event-loop
-    safe (no network/subprocess/lock; the only I/O is ZoneInfo's one-time cached
-    tzdata read); returns None on missing/bad data so a malformed rider never blocks
-    the message submit."""
-    if not sent_at and not tz:
+def _build_rider(sent_at: str | None, tz: str | None,
+                 lat: str | None = None, lon: str | None = None) -> ContextRider | None:
+    """Build the per-turn rider from the client's send-time + timezone + coords.
+    Event-loop safe (no network/subprocess/lock; the only I/O is ZoneInfo's one-time
+    cached tzdata read); each field is best-effort so a malformed one never blocks the
+    submit (a bad/out-of-range coord drops just geo, keeping the time), and an
+    all-absent rider is None."""
+    if not (sent_at or tz or lat or lon):
         return None
     dt = None
     if sent_at:
@@ -865,10 +885,18 @@ def _build_rider(sent_at: str | None, tz: str | None) -> ContextRider | None:
                 dt = None
         except ValueError:
             dt = None
-    if dt is None and not tz:
-        return None   # bad/naive sent_at with no tz → effectively no rider
+    coords = {}
+    if lat is not None and lon is not None:
+        try:  # both-or-neither; out-of-range/non-numeric → drop geo, keep the rest
+            la, lo = float(lat), float(lon)
+            if -90.0 <= la <= 90.0 and -180.0 <= lo <= 180.0:
+                coords = {"lat": la, "lon": lo}
+        except (ValueError, TypeError):
+            pass
+    if dt is None and not tz and not coords:
+        return None   # nothing usable
     try:
-        return ContextRider(sent_at=dt, tz=tz or None)
+        return ContextRider(sent_at=dt, tz=tz or None, **coords)
     except Exception:
         return None
 
@@ -876,10 +904,12 @@ def _build_rider(sent_at: str | None, tz: str | None) -> ContextRider | None:
 @app.post("/thread/{tid}/message")
 async def post_message(tid: str, background_tasks: BackgroundTasks,
                        text: str = Form(...),
-                       sent_at: str | None = Form(None), tz: str | None = Form(None)):
+                       sent_at: str | None = Form(None), tz: str | None = Form(None),
+                       lat: str | None = Form(None), lon: str | None = Form(None)):
     _existing_thread_dir(tid)  # validates tid (404 on traversal/NUL) + existence
     _mark_pending(tid, text)
-    background_tasks.add_task(_process_message, tid, text, _build_rider(sent_at, tz))
+    background_tasks.add_task(_process_message, tid, text,
+                             _build_rider(sent_at, tz, lat, lon))
     return RedirectResponse(url=f"/thread/{tid}", status_code=303)
 
 

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -535,7 +535,9 @@ def render_thread(
           // prompts once; maximumAge serves a cached fix instantly afterwards.
           // Denied/unsupported/timeout → submit without coords (rider stays time-only).
           function assistSend(form){{
+            if(form.__sending){{ return false; }}  // ignore repeat clicks while a send is in flight
             try{{ form.sent_at.value=new Date().toISOString(); form.tz.value=Intl.DateTimeFormat().resolvedOptions().timeZone; }}catch(e){{}}
+            form.__sending=true;
             if(!navigator.geolocation){{ return true; }}
             navigator.geolocation.getCurrentPosition(
               function(p){{ form.lat.value=p.coords.latitude; form.lon.value=p.coords.longitude; form.submit(); }},

--- a/tests/test_context_rider.py
+++ b/tests/test_context_rider.py
@@ -171,3 +171,26 @@ def test_build_rider_bad_sent_at_keeps_valid_tz():
     assert _build_rider("2026-06-29T21:05:00.000Z", "Not/AZone") is None
     # bad sent_at AND no tz → None, not an empty rider threaded through configurable
     assert _build_rider("not-a-date", None) is None
+
+
+def test_build_rider_with_coords():
+    from manage.web.threads import _build_rider
+    # valid lat/lon (browser strings) → coarse geo in the prose line
+    r = _build_rider("2026-06-29T21:05:00.000Z", "America/Los_Angeles",
+                     lat="37.7749", lon="-122.4194")
+    assert r is not None and r.lat == 37.7749 and r.lon == -122.4194
+    assert "~37.77, -122.42" in r.prose_line()
+    # geo-only rider (coords, no time) is valid
+    g = _build_rider(None, None, lat="40.0", lon="-70.0")
+    assert g is not None and g.lat == 40.0 and "from ~40.00, -70.00" in g.prose_line()
+
+
+def test_build_rider_bad_coords_drop_geo_keep_time():
+    from manage.web.threads import _build_rider
+    # out-of-range / non-numeric / half-a-pair → geo dropped, the rest survives
+    for lat, lon in [("91", "0"), ("abc", "1"), ("37.7", None)]:
+        r = _build_rider(None, "America/Los_Angeles", lat=lat, lon=lon)
+        assert r is not None and r.tz == "America/Los_Angeles"
+        assert r.lat is None and r.lon is None
+    # bad coords AND nothing else → None
+    assert _build_rider(None, None, lat="999", lon="999") is None

--- a/tests/test_travel.py
+++ b/tests/test_travel.py
@@ -191,3 +191,19 @@ class TestTravel:
         with patch.object(tools.requests, "get", no_transit):
             out = tools.travel("civic center", "ferry building")
         assert "- Transit: unavailable" in out and "- Car: 22 min" in out
+
+
+def test_geocode_passes_through_coord_string():
+    """A bare "lat,lon" (the "from here" origin) resolves to those coords WITHOUT a
+    geocode call; a real place name does not match and falls through to geocoding."""
+    # passthrough: exact coords + the synthetic "your location" name (so a real
+    # geocode — which would return a different name — provably didn't run)
+    assert tools._parse_coord_string("37.7749,-122.4194") == {
+        "lat": 37.7749, "lon": -122.4194, "name": "your location"}
+    assert tools._geocode("37.7749, -122.4194") == {
+        "lat": 37.7749, "lon": -122.4194, "name": "your location"}
+    # real names / non-coords → None (fall through to the geocoder)
+    for name in ["Ferry Building", "San Francisco, CA", "Building 7, suite 3", "", "1,2,3"]:
+        assert tools._parse_coord_string(name) is None
+    # out-of-range numbers are not coords
+    assert tools._parse_coord_string("200,200") is None

--- a/tests/test_travel.py
+++ b/tests/test_travel.py
@@ -202,6 +202,9 @@ def test_geocode_passes_through_coord_string():
         "lat": 37.7749, "lon": -122.4194, "name": "your location"}
     assert tools._geocode("37.7749, -122.4194") == {
         "lat": 37.7749, "lon": -122.4194, "name": "your location"}
+    # the model copies the context-prose form "~<lat>, <lon>" — must still parse
+    assert tools._parse_coord_string("~37.77, -122.42") == {
+        "lat": 37.77, "lon": -122.42, "name": "your location"}
     # real names / non-coords → None (fall through to the geocoder)
     for name in ["Ferry Building", "San Francisco, CA", "Building 7, suite 3", "", "1,2,3"]:
         assert tools._parse_coord_string(name) is None

--- a/tests/test_web_process_message_e2e.py
+++ b/tests/test_web_process_message_e2e.py
@@ -411,7 +411,8 @@ def test_rider_flows_to_sandbox_tz_and_configurable(client, monkeypatch):
         "/thread/thread-e2e/message",
         data={"text": "what's today?",
               "sent_at": "2026-06-29T21:05:00.000Z",  # real browser toISOString() format
-              "tz": "America/Los_Angeles"},
+              "tz": "America/Los_Angeles",
+              "lat": "37.7749", "lon": "-122.4194"},
         follow_redirects=False,
     )
     assert r.status_code == 303, r.text
@@ -420,3 +421,4 @@ def test_rider_flows_to_sandbox_tz_and_configurable(client, monkeypatch):
     assert captured.get("tz") == "America/Los_Angeles"
     rider = (captured.get("configurable") or {}).get(CONTEXT_RIDER_KEY)
     assert rider is not None and rider.tz == "America/Los_Angeles"
+    assert rider.lat == 37.7749 and rider.lon == -122.4194  # coords flow to the rider too


### PR DESCRIPTION
Roadmap #5 — the geo half of the context rider (#3 shipped time only). Design doc: `docs/2026-06-29-geo-context-rider.org`.

## Most of the contract was already built (#3)
`ContextRider` already carries `lat/lon/place_label`, renders coarse geo in the prose line, injects it ephemerally main-agent-only, and threads onto `configurable`. So three small deltas:

1. **Browser geo source** (`manage/web/threads.py`): on message **send** (not thread-open, per Pierre), `assistSend()` fetches `navigator.geolocation.getCurrentPosition` (maxAge 1h, 5s timeout) and submits `lat`/`lon` hidden fields. The browser remembers the grant for `localhost:5050`, so it **prompts once**; later sends are instant. Denied / unsupported / timeout → submit without coords (rider stays time-only — message never lost).
2. **Backend** (`_build_rider` + `post_message`): optional `lat`/`lon`, best-effort — both-or-neither, in-range; a bad coord drops *just* geo and keeps the time; geo-only rider is valid. Pure-CPU on the loop thread.
3. **"from here"** (`assist/tools.py` + travel skill): `_geocode` passes a bare `"lat,lon"` through (no forward-geocode); the skill + the `travel`/`directions` docstrings tell the model to pass the message-context coords as the origin for "from here"/"near me".

## Privacy (unchanged from #3, confirmed by review)
Precise coords ride `configurable` (per-invocation, **not** checkpointed); only the coarse 2-decimal `~lat,lon` (≈city block) reaches the model + persisted prose; main-agent-only (no geo to the research sub-agent's egress); **no raw coords logged**.

## Local review (folded in)
2 lenses. Event-loop/JS: clean — no submit loop (`form.submit()` doesn't re-fire `onsubmit`), message never lost, `required` holds, brace-escaping verified. Correctness/privacy: caught that the `travel`/`directions` docstrings still said "do NOT pass coordinates" (would fight the new contract on this docstring-obedient model) → fixed.

## Validation
**767 unit** (rider coords; e2e lat/lon → rider on `configurable`; `_geocode` coord passthrough + names still geocode; thread page renders with the geo JS). The live "directions/restaurant from here" behavior is **approval-gated** (LLM + degraded GPU fans) — Pierre's parallel testing covers it (the geolocation prompt appears once on the next send).

Deployed to the branch for parallel testing.