### PR TITLE
transit directions: real board + departure/arrival times (#6)

### DIFF
--- a/assist/skills/travel/SKILL.md
+++ b/assist/skills/travel/SKILL.md
@@ -64,8 +64,9 @@ If the user **names a mode**, pass it. If they **don't**, ask which mode they wa
 - **directions:** relay the numbered steps. For **street** routes (car/bike/walk)
   the turn directions are **approximate** — it's fine to hedge ("roughly"), and
   never invent a turn or street the tool didn't give. For **transit**, relay the
-  lines, stops, and transfers as listed. Mention the resolved place names if they
-  might differ from what the user meant.
+  lines, stops, transfers, **and the board/departure times** as listed (e.g. "catch
+  the 9R at 2:47 PM"). Mention the resolved place names if they might differ from
+  what the user meant.
 
 ## Surfacing problems (don't hide a degraded result)
 

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -321,8 +321,8 @@ def _fmt_clock(iso: str | None) -> str | None:
     never-raise-into-the-agent-loop contract."""
     if not isinstance(iso, str):
         return None
-    try:
-        dt = datetime.fromisoformat(iso).astimezone()
+    try:  # normalize a trailing 'Z' explicitly (works on any Python, not just 3.11+)
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00")).astimezone()
     except (ValueError, TypeError):
         return None
     hour12 = dt.hour % 12 or 12  # avoid the glibc-only %-I

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -26,6 +26,7 @@ import os
 import re
 import time
 import threading
+from datetime import datetime, timezone
 from html.parser import HTMLParser
 from urllib.parse import urlparse
 
@@ -310,6 +311,22 @@ def _fmt_duration(seconds: float) -> str:
     if m < 60:
         return f"{m} min"
     return f"{m // 60} h {m % 60:02d} min"
+
+
+def _fmt_clock(iso: str | None) -> str | None:
+    """A MOTIS leg/itinerary time (ISO-8601, UTC 'Z') → a local wall-clock like
+    "6:24 AM", or None if missing/unparseable. astimezone() (no arg) converts to the
+    system-local zone — the metro's tz on this single-region deploy — so the time
+    reads as it does on the platform. Returns None (not raises) on bad input, per the
+    never-raise-into-the-agent-loop contract."""
+    if not isinstance(iso, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(iso).astimezone()
+    except (ValueError, TypeError):
+        return None
+    hour12 = dt.hour % 12 or 12  # avoid the glibc-only %-I
+    return f"{hour12}:{dt.minute:02d} {dt:%p}"
 
 
 def _fmt_distance_m(meters: float) -> str:
@@ -665,7 +682,9 @@ def _transit_narrative(o: dict, d: dict):
     _TravelBackendError only if MOTIS is down."""
     data = _motis_get("/api/v1/plan", {
         "fromPlace": f"{o['lat']},{o['lon']}", "toPlace": f"{d['lat']},{d['lon']}",
-        "transitModes": "TRANSIT"})
+        "transitModes": "TRANSIT",
+        # Anchor to now so the itinerary's departures are the upcoming ones.
+        "time": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")})
     try:
         its = (data.get("itineraries") if isinstance(data, dict) else None) or []
         if not its:
@@ -676,8 +695,13 @@ def _transit_narrative(o: dict, d: dict):
                         (l.get("from") or {}).get("name") == (l.get("to") or {}).get("name"))]
         if not legs:
             return None
+        # Header: duration + the departs→arrives window (omit the window if times missing).
+        window = ""
+        depart, arrive = _fmt_clock(it.get("startTime")), _fmt_clock(it.get("endTime"))
+        if depart and arrive:
+            window = f", departs {depart} — arrives {arrive}"
         lines = [f'Transit directions from "{o["name"]}" to "{d["name"]}" '
-                 f'(~{_fmt_duration(it["duration"])}):']
+                 f'(~{_fmt_duration(it["duration"])}{window}):']
         for n, l in enumerate(legs, start=1):
             to_name = (l.get("to") or {}).get("name") or "your destination"
             if l.get("mode") == "WALK":
@@ -688,8 +712,11 @@ def _transit_narrative(o: dict, d: dict):
                 route = l.get("routeShortName") or l.get("tripShortName") or noun
                 toward = f" toward {l['headsign']}" if l.get("headsign") else ""
                 stops = len(l.get("intermediateStops") or []) + 1  # stops ridden to the alighting stop
+                # Board time (realtime startTime, else scheduled); omit if unparseable.
+                board = _fmt_clock(l.get("startTime") or l.get("scheduledStartTime"))
+                board_txt = f", board {board}" if board else ""
                 lines.append(f"{n}. Take the {route} {noun}{toward} to {to_name} "
-                             f"({stops} stop{'s' if stops != 1 else ''})")
+                             f"({stops} stop{'s' if stops != 1 else ''}{board_txt})")
         return "\n".join(lines)
     except (KeyError, TypeError, ValueError, AttributeError, IndexError):
         return None

--- a/tests/test_directions.py
+++ b/tests/test_directions.py
@@ -52,11 +52,15 @@ _STREET_PLAN = {"direct": [{"duration": 600, "legs": [{"distance": 1200.0, "step
     _step("A Street", _EAST, 600.0),
     _step("B Street", _NORTH, 600.0),
 ]}]}]}
-_TRANSIT_PLAN = {"itineraries": [{"duration": 1260, "legs": [
+# MOTIS leg/itinerary times are UTC 'Z' (verified against the live service). With
+# TZ=UTC pinned in the test (the utc_tz fixture), they render as the same wall-clock.
+_TRANSIT_PLAN = {"itineraries": [{"duration": 1260,
+    "startTime": "2026-06-30T14:45:00Z", "endTime": "2026-06-30T15:06:00Z", "legs": [
     {"mode": "WALK", "from": {"name": "Origin"}, "to": {"name": "Stop A"}, "duration": 180},
     {"mode": "BUS", "routeShortName": "9R", "headsign": "Downtown",
      "from": {"name": "Stop A"}, "to": {"name": "Stop B"},
-     "intermediateStops": [{}, {}], "duration": 720},
+     "intermediateStops": [{}, {}], "duration": 720,
+     "startTime": "2026-06-30T14:47:00Z"},
     {"mode": "WALK", "from": {"name": "Stop B"}, "to": {"name": "Dest"}, "duration": 360},
 ]}]}
 
@@ -74,6 +78,23 @@ def _fake_get(url, params=None, timeout=None, **kw):
 def routing_env(monkeypatch):
     monkeypatch.setenv("ASSIST_ROUTING_URL", "http://motis")
     monkeypatch.setenv("ASSIST_GEOCODER_URL", "http://nominatim")
+
+
+@pytest.fixture
+def utc_tz():
+    """Pin the process tz to UTC so _fmt_clock's astimezone() renders MOTIS's UTC 'Z'
+    leg times deterministically (the asserted clock is then tz-host-independent)."""
+    import os
+    import time
+    old = os.environ.get("TZ")
+    os.environ["TZ"] = "UTC"
+    time.tzset()
+    yield
+    if old is None:
+        os.environ.pop("TZ", None)
+    else:
+        os.environ["TZ"] = old
+    time.tzset()
 
 
 class TestHelpers:
@@ -117,13 +138,58 @@ class TestDirections:
             out = tools.directions("home", "the office", "bike")
         assert out.startswith("Biking directions")
 
-    def test_transit_directions_narrative(self, routing_env):
+    def test_transit_directions_narrative(self, routing_env, utc_tz):
         with patch.object(tools.requests, "get", _fake_get):
             out = tools.directions("home", "the office", "transit")
         assert out.startswith("Transit directions")
+        assert "departs 2:45 PM — arrives 3:06 PM" in out   # itinerary window (UTC-pinned)
         assert "1. Walk to Stop A (3 min)" in out
-        assert "2. Take the 9R bus toward Downtown to Stop B (3 stops)" in out
+        assert "2. Take the 9R bus toward Downtown to Stop B (3 stops, board 2:47 PM)" in out
         assert '3. Walk to "the office" (6 min)' in out      # last walk -> dest name
+
+    def test_transit_time_anchor_reaches_plan(self, routing_env):
+        seen = {}
+        def capture(url, params=None, timeout=None, **kw):
+            if "/api/v1/plan" in url and "transitModes" in (params or {}):
+                seen["params"] = params
+            return _fake_get(url, params=params, timeout=timeout, **kw)
+        with patch.object(tools.requests, "get", capture):
+            tools.directions("home", "the office", "transit")
+        from datetime import datetime
+        assert "time" in seen["params"]
+        datetime.fromisoformat(seen["params"]["time"].replace("Z", "+00:00"))  # ISO-parseable
+
+    def test_transit_missing_times_degrade(self, routing_env, utc_tz):
+        # No itinerary/leg times → no board suffix, no window, no raise (v1 narrative).
+        plan = {"itineraries": [{"duration": 1260, "legs": [
+            {"mode": "BUS", "routeShortName": "9R", "headsign": "Downtown",
+             "from": {"name": "A"}, "to": {"name": "B"},
+             "intermediateStops": [{}, {}], "duration": 720},
+        ]}]}
+        def no_times(url, params=None, **kw):
+            if "/api/v1/plan" in url:
+                return _Resp(plan)
+            return _fake_get(url, params=params, **kw)
+        with patch.object(tools.requests, "get", no_times):
+            out = tools.directions("home", "office", "transit")
+        assert "Take the 9R bus toward Downtown to B (3 stops)" in out  # no ", board ..."
+        assert "board" not in out and "departs" not in out
+
+    def test_transit_odd_typed_time_degrades(self, routing_env, utc_tz):
+        # A non-string time (epoch int) must omit the board time, not raise.
+        plan = {"itineraries": [{"duration": 720,
+            "startTime": 1234567890, "endTime": 1234568000, "legs": [
+            {"mode": "BUS", "routeShortName": "9R", "from": {"name": "A"},
+             "to": {"name": "B"}, "intermediateStops": [], "duration": 720,
+             "startTime": 1234567890},
+        ]}]}
+        def odd(url, params=None, **kw):
+            if "/api/v1/plan" in url:
+                return _Resp(plan)
+            return _fake_get(url, params=params, **kw)
+        with patch.object(tools.requests, "get", odd):
+            out = tools.directions("home", "office", "transit")  # must not raise
+        assert "Take the 9R bus to B" in out and "board" not in out
 
     def test_mode_synonyms_normalize(self):
         assert tools._normalize_mode("Driving")[1] == "CAR"


### PR DESCRIPTION
Roadmap #6 — the rider-unblocked directions follow-up. Transit directions showed no times ("take the 9R bus to X"); now they show **when to board** each leg and the **departs→arrives** window.

## What changed (`assist/tools.py` `_transit_narrative`)
- **Anchor MOTIS `/plan` to now** via the `time` param — verified live that this returns the *upcoming* departures (itinerary departs right after the query instant).
- **Per transit leg:** `, board 6:30 AM` (realtime `startTime` → `scheduledStartTime` fallback). Walk legs stay timeless.
- **Header:** `(~32 min, departs 6:28 AM — arrives 7:00 AM)`.
- `_fmt_clock` parses MOTIS's **UTC `Z`** leg times (verified format) and `astimezone()`s to local (the metro tz on this single-region deploy).

## Degrade-by-construction
A missing or odd-typed time omits that clock and never raises (kept inside the existing never-raise-into-the-agent-loop `try/except`); a no-times response renders exactly the v1 narrative.

## Validation
**Live-verified** (Potrero Hill → Ferry Building rendered correct PT board times). **771 unit**: board-time + window render (TZ-pinned for determinism), the time-anchor reaches `/plan`, and missing/odd-time degrade without raising. The "model relays the times well" eval is **deferred** (eval freeze — degraded GPU). Deployed for parallel testing.