### PR TITLE
Implement agent-driven thread schedules (#7)

### DIFF
--- a/assist/schedule/__init__.py
+++ b/assist/schedule/__init__.py
@@ -1,0 +1,12 @@
+"""Agent-driven thread schedules ("thread-based cron").
+
+A *wakeup* is ``(thread_id, prompt)`` dispatched through the existing message run
+path; the cron scheduler is one producer of timed wakeups (future event-triggers
+become another). See ``docs/2026-07-01-thread-schedules-design.org``.
+
+This package holds the reusable CORE (model, cadence math, store, scheduler, tools).
+The web layer (``manage/web``) is the only v1 client: it instantiates the store on
+``MANAGER.root_dir``, starts the ``Scheduler`` in its lifespan, wires the schedule
+tools into its ``AgentSpec``, and serves the management view. emacsos can adopt the
+same core later by starting its own ``Scheduler``.
+"""

--- a/assist/schedule/cadence.py
+++ b/assist/schedule/cadence.py
@@ -105,6 +105,16 @@ def describe(cad: Cadence) -> str:
     return f"{_days_label(cad.weekdays)} at {at}"
 
 
+def fmt_instant(iso_utc: str | None, tz: str, *, empty: str = "—") -> str:
+    """Format a stored UTC instant as a local wall-clock ("Mon Jun 15, 7:00 AM").
+    Shared by the agent's confirm-back and the web view so they never diverge."""
+    if not iso_utc:
+        return empty
+    local = datetime.fromisoformat(iso_utc).astimezone(ZoneInfo(tz))
+    h12 = local.hour % 12 or 12
+    return f"{local:%a %b %d}, {h12}:{local.minute:02d} {local:%p}"
+
+
 def _clock(hour: int | None, minute: int) -> str:
     h = 0 if hour is None else hour
     h12 = h % 12 or 12

--- a/assist/schedule/cadence.py
+++ b/assist/schedule/cadence.py
@@ -1,0 +1,125 @@
+"""Pure cadence math — no I/O, no clock reads (``now`` is always passed in).
+
+``next_after`` steps in UTC and matches against the LOCAL wall-clock, so DST is handled
+by construction (a spring-forward-skipped local time simply never matches). The v1
+cadence set (PRD D3): daily / weekly / specific-weekdays / hourly / every-N-minutes —
+anything else is declined by ``validate`` rather than silently approximated.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from assist.schedule.model import Cadence, Schedule
+
+_UNSET = object()  # "field not supplied" — distinct from an explicit None (= "every")
+_WEEKDAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+# 8 days of minute steps bounds the search: covers weekly (≤7d) + any clock/interval
+# combo in the v1 set (no monthly). ~11.5k iterations worst case.
+_MAX_STEPS = 8 * 24 * 60 + 60
+
+
+class InvalidCadence(ValueError):
+    """A cadence the v1 field set can't represent or that's internally incoherent.
+    The message is a corrective the agent can relay/act on."""
+
+
+def validate(cad: Cadence) -> None:
+    """Raise InvalidCadence on an out-of-range or incoherent cadence."""
+    if not (0 <= cad.minute <= 59):
+        raise InvalidCadence(f"minute must be 0-59, got {cad.minute}")
+    if cad.hour is not None and not (0 <= cad.hour <= 23):
+        raise InvalidCadence(f"hour must be 0-23 or omitted, got {cad.hour}")
+    if cad.weekdays is not None:
+        if not cad.weekdays:
+            raise InvalidCadence("weekdays cannot be an empty set; omit it for every day")
+        for d in cad.weekdays:
+            if not (0 <= d <= 6):
+                raise InvalidCadence(f"weekday must be 0(Mon)-6(Sun), got {d}")
+    if cad.every_n_minutes is not None:
+        if cad.hour is not None:
+            raise InvalidCadence(
+                "every_n_minutes is an interval; don't combine it with a specific hour")
+        if not (1 <= cad.every_n_minutes <= 1440):
+            raise InvalidCadence(
+                f"every_n_minutes must be 1-1440, got {cad.every_n_minutes}")
+
+
+def _matches(cad: Cadence, local: datetime) -> bool:
+    if cad.weekdays is not None and local.weekday() not in cad.weekdays:
+        return False
+    if cad.every_n_minutes is not None:
+        return (local.hour * 60 + local.minute) % cad.every_n_minutes == 0
+    if local.minute != cad.minute:
+        return False
+    if cad.hour is not None and local.hour != cad.hour:
+        return False
+    return True
+
+
+def next_after(sched: Schedule, now_utc: datetime) -> datetime:
+    """The next UTC instant strictly after ``now_utc`` that matches the cadence."""
+    try:
+        tz = ZoneInfo(sched.tz)
+    except ZoneInfoNotFoundError as e:
+        raise InvalidCadence(f"unknown timezone {sched.tz!r}") from e
+    cand = now_utc.astimezone(timezone.utc).replace(second=0, microsecond=0) \
+        + timedelta(minutes=1)
+    for _ in range(_MAX_STEPS):
+        if _matches(sched.cadence, cand.astimezone(tz)):
+            return cand
+        cand += timedelta(minutes=1)
+    raise InvalidCadence("no cadence match within 8 days (unsupported pattern?)")
+
+
+def apply_patch(sched: Schedule, *, minute=_UNSET, hour=_UNSET, weekdays=_UNSET,
+                every_n_minutes=_UNSET) -> Schedule:
+    """Return ``sched`` with ONLY the supplied cadence fields changed (relative edit).
+    Unsupplied fields keep their current value; an explicit ``None`` for hour/weekdays
+    means "every hour"/"every day". Validates the result."""
+    c = sched.cadence
+    new_cad = Cadence(
+        minute=c.minute if minute is _UNSET else minute,
+        hour=c.hour if hour is _UNSET else hour,
+        weekdays=c.weekdays if weekdays is _UNSET else (
+            tuple(weekdays) if weekdays is not None else None),
+        every_n_minutes=c.every_n_minutes if every_n_minutes is _UNSET else every_n_minutes,
+    )
+    validate(new_cad)
+    from dataclasses import replace
+    return replace(sched, cadence=new_cad)
+
+
+def describe(cad: Cadence) -> str:
+    """A human-readable label, derived from the structured fields (the web view + the
+    agent's confirm-back use this — never a model-supplied string)."""
+    if cad.every_n_minutes is not None:
+        base = (f"every {cad.every_n_minutes} minutes" if cad.every_n_minutes != 60
+                else "hourly")
+        return f"{base}{_days_suffix(cad.weekdays)}"
+    at = f"{_clock(cad.hour, cad.minute)}"
+    if cad.hour is None:
+        return f"hourly at :{cad.minute:02d}{_days_suffix(cad.weekdays)}"
+    if cad.weekdays is None:
+        return f"every day at {at}"
+    return f"{_days_label(cad.weekdays)} at {at}"
+
+
+def _clock(hour: int | None, minute: int) -> str:
+    h = 0 if hour is None else hour
+    h12 = h % 12 or 12
+    ampm = "AM" if h < 12 else "PM"
+    return f"{h12}:{minute:02d} {ampm}"
+
+
+def _days_label(weekdays: tuple[int, ...]) -> str:
+    wd = sorted(weekdays)
+    if wd == [0, 1, 2, 3, 4]:
+        return "Mon–Fri"
+    if wd == [5, 6]:
+        return "weekends"
+    return ", ".join(_WEEKDAY_NAMES[d] for d in wd)
+
+
+def _days_suffix(weekdays: tuple[int, ...] | None) -> str:
+    return "" if weekdays is None else f" on {_days_label(weekdays)}"

--- a/assist/schedule/model.py
+++ b/assist/schedule/model.py
@@ -1,0 +1,70 @@
+"""The schedule record — a structured, diffable cadence (NOT an opaque cron string).
+
+Structured fields are what make relative edits patch cleanly ("fire at 5a" sets only
+``hour``) and what let the small model fill semantically-named, range-checkable args.
+The human-readable label and ``next_fire_at`` are derived by ``cadence.py`` from these
+fields — never supplied by the model — so a mislabel can't diverge from what fires.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+
+@dataclass(frozen=True)
+class Cadence:
+    """When a schedule fires, as orthogonal fields. Two mutually-exclusive modes
+    (validated in cadence.py):
+
+    - clock mode: ``minute`` (+ optional ``hour``; ``hour=None`` = every hour) on the
+      days in ``weekdays`` (``None`` = every day). Covers daily / weekly /
+      specific-weekdays / hourly.
+    - interval mode: ``every_n_minutes`` — fires at clock-aligned multiples
+      (minutes-since-midnight % N == 0), optionally filtered by ``weekdays``.
+    """
+    minute: int = 0
+    hour: int | None = None
+    weekdays: tuple[int, ...] | None = None   # 0=Mon … 6=Sun; None = every day
+    every_n_minutes: int | None = None
+
+    def to_dict(self) -> dict:
+        return {"minute": self.minute, "hour": self.hour,
+                "weekdays": list(self.weekdays) if self.weekdays is not None else None,
+                "every_n_minutes": self.every_n_minutes}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Cadence":
+        wd = d.get("weekdays")
+        return cls(minute=d.get("minute", 0), hour=d.get("hour"),
+                   weekdays=tuple(wd) if wd is not None else None,
+                   every_n_minutes=d.get("every_n_minutes"))
+
+
+@dataclass(frozen=True)
+class Schedule:
+    """One schedule bound to one thread. ``next_fire_at`` is an absolute UTC ISO
+    instant computed by the cadence engine; ``tz`` is the zone the cadence is read in
+    (so "7am" means 7am local)."""
+    id: str
+    thread_id: str
+    prompt: str
+    cadence: Cadence
+    tz: str
+    enabled: bool = True
+    next_fire_at: str | None = None   # ISO-8601 UTC
+    created_at: str | None = None     # ISO-8601 UTC
+
+    def with_next_fire(self, iso_utc: str | None) -> "Schedule":
+        return replace(self, next_fire_at=iso_utc)
+
+    def to_dict(self) -> dict:
+        return {"id": self.id, "thread_id": self.thread_id, "prompt": self.prompt,
+                "cadence": self.cadence.to_dict(), "tz": self.tz,
+                "enabled": self.enabled, "next_fire_at": self.next_fire_at,
+                "created_at": self.created_at}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Schedule":
+        return cls(id=d["id"], thread_id=d["thread_id"], prompt=d["prompt"],
+                   cadence=Cadence.from_dict(d["cadence"]), tz=d["tz"],
+                   enabled=d.get("enabled", True), next_fire_at=d.get("next_fire_at"),
+                   created_at=d.get("created_at"))

--- a/assist/schedule/scheduler.py
+++ b/assist/schedule/scheduler.py
@@ -1,13 +1,14 @@
-"""The in-process scheduler — a producer (cron poll loop) feeding a consumer (submit).
+"""The in-process scheduler — a cron poll loop feeding a dispatch consumer.
 
 In-process is REQUIRED, not just convenient: THREAD_QUEUE is a per-process singleton, so
 only an in-process producer shares the single turn slot (→ "overlap waits"), and "don't
 fire while the service/LLM is down" falls out for free. The poll loop runs on a daemon
 thread; dispatch runs on a single-worker executor; nothing here touches the asyncio loop.
 
-``submit(schedule)`` is the one consumer entry — it owns the health gate, the per-thread
-in-flight dedup, and the executor. A future event-trigger becomes a second producer that
-computes a wakeup and calls the same dispatch path, with no change here.
+``_fire`` is the consumer tail — it advances the next fire, applies a per-SCHEDULE
+in-flight dedup + the health gate, and hands the wakeup to the executor. A future
+event-trigger would split this into a shared ``submit(wakeup)`` and call the same
+dispatch path; that refactor is deferred until the first such producer exists.
 """
 from __future__ import annotations
 
@@ -41,6 +42,13 @@ class Scheduler:
 
     # --- lifecycle (started/stopped by the web lifespan) ------------------------
     def start(self) -> None:
+        # Idempotent + restartable: a second start while running is a no-op; a start
+        # after stop() clears the stop flag and rebuilds the (shut-down) executor, so a
+        # re-run lifespan (common in tests) doesn't leave a no-op or extra poll threads.
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="schedule-run")
         self._thread = threading.Thread(target=self._run, daemon=True, name="schedule-poll")
         self._thread.start()
 

--- a/assist/schedule/scheduler.py
+++ b/assist/schedule/scheduler.py
@@ -1,0 +1,126 @@
+"""The in-process scheduler — a producer (cron poll loop) feeding a consumer (submit).
+
+In-process is REQUIRED, not just convenient: THREAD_QUEUE is a per-process singleton, so
+only an in-process producer shares the single turn slot (→ "overlap waits"), and "don't
+fire while the service/LLM is down" falls out for free. The poll loop runs on a daemon
+thread; dispatch runs on a single-worker executor; nothing here touches the asyncio loop.
+
+``submit(schedule)`` is the one consumer entry — it owns the health gate, the per-thread
+in-flight dedup, and the executor. A future event-trigger becomes a second producer that
+computes a wakeup and calls the same dispatch path, with no change here.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+
+from assist.schedule import cadence
+
+log = logging.getLogger(__name__)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class Scheduler:
+    def __init__(self, store, dispatch, health_check, *, tick_seconds: float = 30.0,
+                 now_fn=_utcnow):
+        self._store = store
+        self._dispatch = dispatch          # (tid, prompt, tz) -> None; blocking, runs on executor
+        self._health_check = health_check  # () -> bool; LLM reachable?
+        self._tick = tick_seconds
+        self._now = now_fn
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="schedule-run")
+        self._inflight: set[str] = set()   # tids with a wakeup queued/running (dedup)
+        self._inflight_lock = threading.Lock()
+
+    # --- lifecycle (started/stopped by the web lifespan) ------------------------
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._run, daemon=True, name="schedule-poll")
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=5)
+        self._executor.shutdown(wait=False)
+
+    def _run(self) -> None:
+        # Reconcile then poll, both on THIS thread (never the async lifespan body): the
+        # disk scan would block the event loop, and same-thread sequencing removes any
+        # reconcile/tick race.
+        try:
+            self.reconcile()
+        except Exception:
+            log.exception("schedule reconcile failed")
+        while not self._stop.wait(self._tick):
+            try:
+                self.poll()
+            except Exception:
+                log.exception("schedule poll failed")
+
+    # --- producer: cron --------------------------------------------------------
+    def reconcile(self) -> None:
+        """On startup, advance any missing/past next_fire_at to the next FUTURE instant
+        WITHOUT firing — the 'no catch-up' guarantee (a service down across N windows
+        resumes at the next future window, firing none of the missed N)."""
+        now = self._now()
+        for s in self._store.all():
+            if not s.enabled:
+                continue
+            if not s.next_fire_at or datetime.fromisoformat(s.next_fire_at) <= now:
+                self._advance(s, now)
+
+    def poll(self) -> None:
+        now = self._now()
+        for s in self._store.due(now):
+            self._fire(s, now)
+
+    def _fire(self, s, now) -> None:
+        # advance-persist-THEN-dispatch: persisting next_fire_at first means a crash
+        # before dispatch loses the fire (consistent with no-catch-up) but never
+        # double-fires; the only double-fire path is dispatch-then-fail-to-persist.
+        try:
+            self._advance(s, now)
+        except Exception:
+            log.exception("advance failed for %s/%s; skipping dispatch", s.thread_id, s.id)
+            return
+        if not self._claim(s.thread_id):
+            log.info("schedule %s/%s due but thread busy; skipping (already in-flight)",
+                     s.thread_id, s.id)
+            return
+        if not self._health_check():
+            log.info("schedule %s/%s due but LLM unreachable; skipping (no catch-up)",
+                     s.thread_id, s.id)
+            self._release(s.thread_id)
+            return
+        self._executor.submit(self._run_wakeup, s.thread_id, s.prompt, s.tz)
+
+    # --- consumer: the wakeup --------------------------------------------------
+    def _run_wakeup(self, tid: str, prompt: str, tz: str) -> None:
+        try:
+            self._dispatch(tid, prompt, tz)
+        except Exception:
+            log.warning("scheduled run failed for %s (fail-silently)", tid, exc_info=True)
+        finally:
+            self._release(tid)
+
+    def _advance(self, s, now) -> None:
+        nxt = cadence.next_after(s, now).isoformat()
+        self._store.update(s.thread_id, s.id, lambda x: x.with_next_fire(nxt))
+
+    def _claim(self, tid: str) -> bool:
+        with self._inflight_lock:
+            if tid in self._inflight:
+                return False
+            self._inflight.add(tid)
+            return True
+
+    def _release(self, tid: str) -> None:
+        with self._inflight_lock:
+            self._inflight.discard(tid)

--- a/assist/schedule/scheduler.py
+++ b/assist/schedule/scheduler.py
@@ -86,10 +86,14 @@ class Scheduler:
 
     def poll(self) -> None:
         now = self._now()
-        for s in self._store.due(now):
-            self._fire(s, now)
+        due = self._store.due(now)
+        if not due:
+            return
+        healthy = self._health_check()   # probe once per tick, only when something's due
+        for s in due:
+            self._fire(s, now, healthy)
 
-    def _fire(self, s, now) -> None:
+    def _fire(self, s, now, healthy: bool) -> None:
         # advance-persist-THEN-dispatch: persisting next_fire_at first means a crash
         # before dispatch loses the fire (consistent with no-catch-up) but never
         # double-fires; the only double-fire path is dispatch-then-fail-to-persist.
@@ -104,7 +108,7 @@ class Scheduler:
         if not self._claim(s.id):
             log.info("schedule %s/%s due but already in-flight; skipping", s.thread_id, s.id)
             return
-        if not self._health_check():
+        if not healthy:
             log.info("schedule %s/%s due but LLM unreachable; skipping (no catch-up)",
                      s.thread_id, s.id)
             self._release(s.id)

--- a/assist/schedule/scheduler.py
+++ b/assist/schedule/scheduler.py
@@ -36,7 +36,7 @@ class Scheduler:
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="schedule-run")
-        self._inflight: set[str] = set()   # tids with a wakeup queued/running (dedup)
+        self._inflight: set[str] = set()   # schedule ids with a wakeup queued/running (dedup)
         self._inflight_lock = threading.Lock()
 
     # --- lifecycle (started/stopped by the web lifespan) ------------------------
@@ -90,25 +90,27 @@ class Scheduler:
         except Exception:
             log.exception("advance failed for %s/%s; skipping dispatch", s.thread_id, s.id)
             return
-        if not self._claim(s.thread_id):
-            log.info("schedule %s/%s due but thread busy; skipping (already in-flight)",
-                     s.thread_id, s.id)
+        # Dedup by SCHEDULE id (not thread): this bounds a single schedule's own backlog
+        # (a slow run vs a short cadence) while letting two distinct schedules on the same
+        # thread both fire — THREAD_QUEUE serializes them harmlessly.
+        if not self._claim(s.id):
+            log.info("schedule %s/%s due but already in-flight; skipping", s.thread_id, s.id)
             return
         if not self._health_check():
             log.info("schedule %s/%s due but LLM unreachable; skipping (no catch-up)",
                      s.thread_id, s.id)
-            self._release(s.thread_id)
+            self._release(s.id)
             return
-        self._executor.submit(self._run_wakeup, s.thread_id, s.prompt, s.tz)
+        self._executor.submit(self._run_wakeup, s.id, s.thread_id, s.prompt, s.tz)
 
     # --- consumer: the wakeup --------------------------------------------------
-    def _run_wakeup(self, tid: str, prompt: str, tz: str) -> None:
+    def _run_wakeup(self, sid: str, tid: str, prompt: str, tz: str) -> None:
         try:
             self._dispatch(tid, prompt, tz)
         except Exception:
-            log.warning("scheduled run failed for %s (fail-silently)", tid, exc_info=True)
+            log.warning("scheduled run failed for %s/%s (fail-silently)", tid, sid, exc_info=True)
         finally:
-            self._release(tid)
+            self._release(sid)
 
     def _advance(self, s, now) -> None:
         nxt = cadence.next_after(s, now).isoformat()

--- a/assist/schedule/scheduler.py
+++ b/assist/schedule/scheduler.py
@@ -125,16 +125,20 @@ class Scheduler:
             self._release(sid)
 
     def _advance(self, s, now) -> None:
-        nxt = cadence.next_after(s, now).isoformat()
-        self._store.update(s.thread_id, s.id, lambda x: x.with_next_fire(nxt))
+        # Recompute next_fire from the CURRENT record under the store lock (not the
+        # possibly-stale due() snapshot ``s``), so a concurrent modify of the cadence/tz
+        # isn't clobbered with a next_fire computed from the old cadence.
+        self._store.update(
+            s.thread_id, s.id,
+            lambda x: x.with_next_fire(cadence.next_after(x, now).isoformat()))
 
-    def _claim(self, tid: str) -> bool:
+    def _claim(self, sid: str) -> bool:
         with self._inflight_lock:
-            if tid in self._inflight:
+            if sid in self._inflight:
                 return False
-            self._inflight.add(tid)
+            self._inflight.add(sid)
             return True
 
-    def _release(self, tid: str) -> None:
+    def _release(self, sid: str) -> None:
         with self._inflight_lock:
-            self._inflight.discard(tid)
+            self._inflight.discard(sid)

--- a/assist/schedule/store.py
+++ b/assist/schedule/store.py
@@ -1,0 +1,115 @@
+"""Schedule persistence — disk IS the source of truth (no in-memory cache).
+
+Each thread's schedules live in ``<root_dir>/<tid>/schedules.json`` (atomic tmp+rename,
+like ``status.json``), so they survive restart and die with the thread via the thread
+dir's rmtree — no eviction hook needed. One process-wide lock serializes every
+read-modify-write, because three writers race on a thread's file: the scheduler
+advancing ``next_fire_at`` (poll thread), a ``modify``/``pause`` tool (in the thread's
+turn), and a web delete. The lock is held only for the fast file op, never across a
+dispatch or a turn.
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime
+
+from assist.schedule.model import Schedule
+
+SCHEDULES_FILE = "schedules.json"
+CAP_PER_THREAD = 5  # PRD: a small cap so schedules can't run away
+
+
+class ScheduleCapExceeded(Exception):
+    """Creating would exceed CAP_PER_THREAD on this thread."""
+
+
+class ScheduleNotFound(Exception):
+    """No schedule with that id on that thread."""
+
+
+class ScheduleStore:
+    """Disk-backed schedule store. ``root_dir`` is the thread root (``MANAGER.root_dir``);
+    a thread's dir is ``<root_dir>/<tid>``, matching ``ThreadManager.thread_dir``."""
+
+    def __init__(self, root_dir: str):
+        self._root = root_dir
+        self._lock = threading.Lock()
+
+    def _path(self, tid: str) -> str:
+        return os.path.join(self._root, tid, SCHEDULES_FILE)
+
+    def _read(self, tid: str) -> list[Schedule]:
+        """Read a thread's schedules (callers hold the lock). Missing/corrupt → []."""
+        try:
+            with open(self._path(tid)) as f:
+                data = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return []
+        return [Schedule.from_dict(d) for d in data]
+
+    def _write(self, tid: str, scheds: list[Schedule]) -> None:
+        """Atomically persist a thread's schedules (callers hold the lock)."""
+        path = self._path(tid)
+        tmp = f"{path}.{os.getpid()}.tmp"
+        with open(tmp, "w") as f:
+            json.dump([s.to_dict() for s in scheds], f)
+        os.replace(tmp, path)
+
+    # --- per-thread (used by the tools) -----------------------------------------
+    def for_thread(self, tid: str) -> list[Schedule]:
+        with self._lock:
+            return self._read(tid)
+
+    def add(self, sched: Schedule) -> Schedule:
+        with self._lock:
+            scheds = self._read(sched.thread_id)
+            if len(scheds) >= CAP_PER_THREAD:
+                raise ScheduleCapExceeded(
+                    f"this thread already has {CAP_PER_THREAD} schedules; "
+                    f"delete one before adding another")
+            scheds.append(sched)
+            self._write(sched.thread_id, scheds)
+            return sched
+
+    def update(self, tid: str, sid: str, fn) -> Schedule:
+        """Read-modify-write a single schedule under the lock. ``fn`` maps the found
+        Schedule to its replacement (used for patch / enable / advance next_fire_at)."""
+        with self._lock:
+            scheds = self._read(tid)
+            for i, s in enumerate(scheds):
+                if s.id == sid:
+                    scheds[i] = fn(s)
+                    self._write(tid, scheds)
+                    return scheds[i]
+            raise ScheduleNotFound(sid)
+
+    def remove(self, tid: str, sid: str) -> None:
+        with self._lock:
+            scheds = self._read(tid)
+            kept = [s for s in scheds if s.id != sid]
+            if len(kept) == len(scheds):
+                raise ScheduleNotFound(sid)
+            self._write(tid, kept)
+
+    # --- across all threads (used by the scheduler + the web view) --------------
+    def all(self) -> list[Schedule]:
+        with self._lock:
+            out: list[Schedule] = []
+            for tid in self._list_tids():
+                out.extend(self._read(tid))
+            return out
+
+    def _list_tids(self) -> list[str]:
+        try:
+            entries = os.listdir(self._root)
+        except FileNotFoundError:
+            return []
+        return [e for e in entries if os.path.isfile(self._path(e))]
+
+    def due(self, now_utc: datetime) -> list[Schedule]:
+        """Enabled schedules whose next_fire_at is at or before now."""
+        return [s for s in self.all()
+                if s.enabled and s.next_fire_at
+                and datetime.fromisoformat(s.next_fire_at) <= now_utc]

--- a/assist/schedule/store.py
+++ b/assist/schedule/store.py
@@ -110,7 +110,11 @@ class ScheduleStore:
             entries = os.listdir(self._root)
         except FileNotFoundError:
             return []
-        return [e for e in entries if os.path.isfile(self._path(e))]
+        # Only descend into actual thread dirs — the root also holds non-dir files
+        # (e.g. ThreadManager's threads.db); isdir-first avoids stat'ing file/schedules.json.
+        return [e for e in entries
+                if os.path.isdir(os.path.join(self._root, e))
+                and os.path.isfile(self._path(e))]
 
     def due(self, now_utc: datetime) -> list[Schedule]:
         """Enabled schedules whose next_fire_at is at or before now."""

--- a/assist/schedule/store.py
+++ b/assist/schedule/store.py
@@ -38,6 +38,10 @@ class ScheduleStore:
         self._lock = threading.Lock()
 
     def _path(self, tid: str) -> str:
+        # A tid is one safe path segment; reject a crafted id (traversal/separator) by
+        # construction — the user-facing /schedules delete route passes tid straight in.
+        if not tid or tid in (".", "..") or os.sep in tid or (os.altsep and os.altsep in tid):
+            raise ScheduleNotFound(tid)
         return os.path.join(self._root, tid, SCHEDULES_FILE)
 
     def _read(self, tid: str) -> list[Schedule]:

--- a/assist/schedule/tools.py
+++ b/assist/schedule/tools.py
@@ -71,7 +71,7 @@ def schedule_tools(store) -> list:
             cadence.validate(cad)
         except InvalidCadence as e:
             return f"Couldn't schedule: {e}"
-        sched = Schedule(id=os.urandom(3).hex(), thread_id=tid, prompt=prompt, cadence=cad,
+        sched = Schedule(id=os.urandom(6).hex(), thread_id=tid, prompt=prompt, cadence=cad,
                          tz=tz, created_at=datetime.now(timezone.utc).isoformat())
         try:
             sched = sched.with_next_fire(cadence.next_after(sched, datetime.now(timezone.utc)).isoformat())

--- a/assist/schedule/tools.py
+++ b/assist/schedule/tools.py
@@ -12,8 +12,8 @@ Tools never raise into the agent loop — every failure returns a corrective str
 from __future__ import annotations
 
 import os
+from dataclasses import replace
 from datetime import datetime, timezone
-from zoneinfo import ZoneInfo
 
 from langgraph.config import get_config
 
@@ -37,17 +37,10 @@ def _tz() -> str | None:
     return getattr(rider, "tz", None)
 
 
-def _fmt_fire(iso_utc: str | None, tz: str) -> str:
-    if not iso_utc:
-        return "not scheduled"
-    local = datetime.fromisoformat(iso_utc).astimezone(ZoneInfo(tz))
-    h12 = local.hour % 12 or 12
-    return f"{local:%a %b %d}, {h12}:{local.minute:02d} {local:%p}"
-
-
 def _line(s: Schedule) -> str:
     return (f"[{s.id}] {cadence.describe(s.cadence)} — \"{s.prompt}\""
-            f"{'' if s.enabled else ' (paused)'}; next: {_fmt_fire(s.next_fire_at, s.tz)}")
+            f"{'' if s.enabled else ' (paused)'}; "
+            f"next: {cadence.fmt_instant(s.next_fire_at, s.tz, empty='not scheduled')}")
 
 
 def schedule_tools(store) -> list:
@@ -139,9 +132,15 @@ def schedule_tools(store) -> list:
         tid = _thread_id()
         if not tid:
             return "No active thread."
+
+        def _apply(s: Schedule) -> Schedule:
+            s = replace(s, enabled=enabled)
+            if enabled:  # resume: recompute forward so a long-paused schedule doesn't
+                # fire immediately for missed windows (the no-catch-up guarantee).
+                s = s.with_next_fire(cadence.next_after(s, datetime.now(timezone.utc)).isoformat())
+            return s
         try:
-            from dataclasses import replace
-            saved = store.update(tid, schedule_id, lambda s: replace(s, enabled=enabled))
+            saved = store.update(tid, schedule_id, _apply)
         except ScheduleNotFound:
             return f"No schedule {schedule_id} on this thread."
         return f"{verb}. {_line(saved)}"

--- a/assist/schedule/tools.py
+++ b/assist/schedule/tools.py
@@ -65,7 +65,7 @@ def schedule_tools(store) -> list:
         if not tz:
             return "Couldn't schedule: I don't know your timezone for this message."
         cad = Cadence(minute=minute, hour=hour,
-                      weekdays=tuple(weekdays) if weekdays else None,
+                      weekdays=tuple(weekdays) if weekdays is not None else None,
                       every_n_minutes=every_n_minutes)
         try:
             cadence.validate(cad)

--- a/assist/schedule/tools.py
+++ b/assist/schedule/tools.py
@@ -1,0 +1,169 @@
+"""The agent-facing schedule tools (the conversational surface).
+
+Thread-scoped: each reads its ``thread_id`` (and the rider's tz) from the run config,
+so a schedule belongs to the thread it's created in. ``modify`` merges a SPARSE delta
+server-side — the model passes only the field(s) it's changing + the id, never the whole
+cadence (the relative-edit requirement, and the shape this small model gets right).
+
+Built by ``schedule_tools(store)`` and wired into the web ``AgentSpec`` (not core
+built-ins): a schedule's effect needs a co-resident Scheduler, which only the web runs.
+Tools never raise into the agent loop — every failure returns a corrective string.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from langgraph.config import get_config
+
+from assist.context_rider import CONTEXT_RIDER_KEY
+from assist.schedule import cadence
+from assist.schedule.cadence import InvalidCadence
+from assist.schedule.model import Cadence, Schedule
+from assist.schedule.store import ScheduleCapExceeded, ScheduleNotFound
+
+
+def _cfg() -> dict:
+    return (get_config() or {}).get("configurable") or {}
+
+
+def _thread_id() -> str | None:
+    return _cfg().get("thread_id")
+
+
+def _tz() -> str | None:
+    rider = _cfg().get(CONTEXT_RIDER_KEY)
+    return getattr(rider, "tz", None)
+
+
+def _fmt_fire(iso_utc: str | None, tz: str) -> str:
+    if not iso_utc:
+        return "not scheduled"
+    local = datetime.fromisoformat(iso_utc).astimezone(ZoneInfo(tz))
+    h12 = local.hour % 12 or 12
+    return f"{local:%a %b %d}, {h12}:{local.minute:02d} {local:%p}"
+
+
+def _line(s: Schedule) -> str:
+    return (f"[{s.id}] {cadence.describe(s.cadence)} — \"{s.prompt}\""
+            f"{'' if s.enabled else ' (paused)'}; next: {_fmt_fire(s.next_fire_at, s.tz)}")
+
+
+def schedule_tools(store) -> list:
+    """Return the six thread-scoped schedule tools closing over ``store``."""
+
+    def create_schedule(prompt: str, minute: int = 0, hour: int | None = None,
+                        weekdays: list[int] | None = None,
+                        every_n_minutes: int | None = None) -> str:
+        """Schedule PROMPT to run automatically on a recurring cadence, in THIS thread.
+
+        Use ONE cadence shape:
+        - daily at a time: hour=7, minute=0
+        - specific weekdays at a time: hour=7, minute=0, weekdays=[0,1,2,3,4] (0=Mon..6=Sun)
+        - hourly at a given minute: minute=30 (omit hour)
+        - every N minutes: every_n_minutes=30 (omit hour)
+        Times are in the user's local timezone. Returns the saved schedule + next run.
+        """
+        tid = _thread_id()
+        if not tid:
+            return "Couldn't schedule: no active thread."
+        tz = _tz()
+        if not tz:
+            return "Couldn't schedule: I don't know your timezone for this message."
+        cad = Cadence(minute=minute, hour=hour,
+                      weekdays=tuple(weekdays) if weekdays else None,
+                      every_n_minutes=every_n_minutes)
+        try:
+            cadence.validate(cad)
+        except InvalidCadence as e:
+            return f"Couldn't schedule: {e}"
+        sched = Schedule(id=os.urandom(3).hex(), thread_id=tid, prompt=prompt, cadence=cad,
+                         tz=tz, created_at=datetime.now(timezone.utc).isoformat())
+        try:
+            sched = sched.with_next_fire(cadence.next_after(sched, datetime.now(timezone.utc)).isoformat())
+        except InvalidCadence as e:
+            return f"Couldn't schedule: {e}"
+        try:
+            store.add(sched)
+        except ScheduleCapExceeded as e:
+            return f"Couldn't schedule: {e}"
+        return f"Scheduled. {_line(sched)}"
+
+    def list_schedules() -> str:
+        """List THIS thread's schedules (id, cadence, prompt, next run, paused state)."""
+        tid = _thread_id()
+        if not tid:
+            return "No active thread."
+        scheds = store.for_thread(tid)
+        if not scheds:
+            return "This thread has no schedules."
+        return "\n".join(_line(s) for s in scheds)
+
+    def modify_schedule(schedule_id: str, minute: int | None = None, hour: int | None = None,
+                        weekdays: list[int] | None = None,
+                        every_n_minutes: int | None = None) -> str:
+        """Change an existing schedule. Pass ONLY the field(s) you're changing + the id;
+        omitted fields keep their current value (e.g. "fire at 5am" -> hour=5 only).
+        To switch between a clock schedule and an every-N-minutes one, delete and recreate.
+        """
+        tid = _thread_id()
+        if not tid:
+            return "No active thread."
+        delta = {}
+        if minute is not None:
+            delta["minute"] = minute
+        if hour is not None:
+            delta["hour"] = hour
+        if weekdays is not None:
+            delta["weekdays"] = tuple(weekdays)
+        if every_n_minutes is not None:
+            delta["every_n_minutes"] = every_n_minutes
+        if not delta:
+            return "Nothing to change — pass the field(s) to update."
+        try:
+            current = next((s for s in store.for_thread(tid) if s.id == schedule_id), None)
+            if current is None:
+                return f"No schedule {schedule_id} on this thread."
+            patched = cadence.apply_patch(current, **delta)
+            patched = patched.with_next_fire(
+                cadence.next_after(patched, datetime.now(timezone.utc)).isoformat())
+            saved = store.update(tid, schedule_id, lambda _s: patched)
+        except InvalidCadence as e:
+            return f"Couldn't change it: {e}"
+        except ScheduleNotFound:
+            return f"No schedule {schedule_id} on this thread."
+        return f"Updated. {_line(saved)}"
+
+    def _set_enabled(schedule_id: str, enabled: bool, verb: str) -> str:
+        tid = _thread_id()
+        if not tid:
+            return "No active thread."
+        try:
+            from dataclasses import replace
+            saved = store.update(tid, schedule_id, lambda s: replace(s, enabled=enabled))
+        except ScheduleNotFound:
+            return f"No schedule {schedule_id} on this thread."
+        return f"{verb}. {_line(saved)}"
+
+    def pause_schedule(schedule_id: str) -> str:
+        """Stop a schedule from running (keep it; can be resumed later)."""
+        return _set_enabled(schedule_id, False, "Paused")
+
+    def resume_schedule(schedule_id: str) -> str:
+        """Resume a paused schedule."""
+        return _set_enabled(schedule_id, True, "Resumed")
+
+    def delete_schedule(schedule_id: str) -> str:
+        """Delete a schedule from this thread permanently."""
+        tid = _thread_id()
+        if not tid:
+            return "No active thread."
+        try:
+            store.remove(tid, schedule_id)
+        except ScheduleNotFound:
+            return f"No schedule {schedule_id} on this thread."
+        return f"Deleted schedule {schedule_id}."
+
+    return [create_schedule, list_schedules, modify_schedule,
+            pause_schedule, resume_schedule, delete_schedule]

--- a/assist/skills/schedule/SKILL.md
+++ b/assist/skills/schedule/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: schedule
+description: Set up, change, pause, or cancel recurring scheduled prompts for this conversation — e.g. "every morning at 7 review my inbox", "weekly weather", "when does it next run", "stop the scheduled task", "cancel the cron", "change it to fire at 5am". Load whenever the user wants something to run automatically on a timer/recurring basis in this thread.
+---
+
+# Scheduling recurring prompts
+
+This thread can run a prompt automatically on a recurring schedule. The schedule
+belongs to **this** thread and each run happens **in this thread**, so results
+accumulate here. Use the schedule tools — do not try to keep time yourself.
+
+## Tools
+- `create_schedule(prompt, ...)` — start a recurring prompt.
+- `list_schedules()` — show this thread's schedules with their ids and next run.
+- `modify_schedule(schedule_id, ...)` — change an existing one.
+- `pause_schedule(id)` / `resume_schedule(id)` — stop/restart without deleting.
+- `delete_schedule(id)` — remove one permanently.
+
+## Cadence — pick ONE shape and fill its fields
+Times are in the user's local timezone. `weekdays` is `0=Mon … 6=Sun`.
+- daily at a time → `hour=7, minute=0`
+- specific weekdays → `hour=7, minute=0, weekdays=[0,1,2,3,4]`
+- hourly at a given minute → `minute=30` (omit `hour`)
+- every N minutes → `every_n_minutes=30` (omit `hour`)
+
+Resolve vague wording to concrete fields ("morning" → a specific hour; "weekly" →
+a specific weekday) — ask only if you truly can't infer it. If the user asks for a
+pattern these fields can't express (e.g. "every other Tuesday", "last day of the
+month"), say so plainly instead of approximating.
+
+## Changing a schedule is a RELATIVE edit
+To change one, pass **only the field(s) being changed plus the id** — everything
+else stays as it is. "Change it to fire at 5am" → `modify_schedule(id, hour=5)`
+(the minute and days are untouched). If you don't know the id, call
+`list_schedules()` first. To switch a clock schedule to an every-N-minutes one (or
+vice-versa), delete it and create a new one.
+
+## After any change
+Relay back the schedule's cadence and **next run time** exactly as the tool
+returns them, so the user can catch a misread (e.g. "Done — every day at 7:00 AM,
+next run Mon Jun 15, 7:00 AM"). A thread can have at most 5 schedules. If a tool
+returns an error or "couldn't", tell the user — don't claim it worked.

--- a/assist/skills/schedule/SKILL.md
+++ b/assist/skills/schedule/SKILL.md
@@ -32,8 +32,9 @@ month"), say so plainly instead of approximating.
 To change one, pass **only the field(s) being changed plus the id** — everything
 else stays as it is. "Change it to fire at 5am" → `modify_schedule(id, hour=5)`
 (the minute and days are untouched). If you don't know the id, call
-`list_schedules()` first. To switch a clock schedule to an every-N-minutes one (or
-vice-versa), delete it and create a new one.
+`list_schedules()` first. `modify` shifts or narrows existing fields; to **broaden**
+a schedule (specific weekdays → every day, a fixed hour → hourly) or switch between a
+clock schedule and an every-N-minutes one, **delete it and create a new one**.
 
 ## After any change
 Relay back the schedule's cadence and **next run time** exactly as the tool

--- a/assist/thread_manager.py
+++ b/assist/thread_manager.py
@@ -64,6 +64,18 @@ def _web_skill_sources() -> dict:
     return _render_skill_sources
 
 
+# The web app's main agent also gets the schedule tools, injected by the web composition
+# root (manage/web/state) — scoped to the web-only builder for the same reason as the
+# render skill: a schedule's effect needs the web's co-resident Scheduler, so emacsos and
+# the eval agents (which build their own agents) must NOT get a tool that never fires.
+_web_tools: tuple = ()
+
+
+def set_web_tools(tools) -> None:
+    global _web_tools
+    _web_tools = tuple(tools)
+
+
 class InvalidThreadId(ValueError):
     """A thread id that isn't a single safe path segment (traversal/separator).
 
@@ -251,7 +263,7 @@ class ThreadManager:
                       sandbox_backend=sandbox_backend,
                       on_queue_state=on_queue_state,
                       configurable=configurable,
-                      spec=AgentSpec(skill_sources=_web_skill_sources()))
+                      spec=AgentSpec(skill_sources=_web_skill_sources(), tools=_web_tools))
 
     def remove(self, thread_id: str) -> None:
         tdir = self.thread_dir(thread_id)
@@ -284,7 +296,8 @@ class ThreadManager:
 
         return Thread(working_dir, thread_id=tid, checkpointer=self.checkpointer,
                       model=self.model, sandbox_backend=sandbox_backend,
-                      on_queue_state=on_queue_state, spec=AgentSpec(skill_sources=_web_skill_sources()))
+                      on_queue_state=on_queue_state,
+                      spec=AgentSpec(skill_sources=_web_skill_sources(), tools=_web_tools))
 
     def close(self) -> None:
         try:

--- a/manage/web/__init__.py
+++ b/manage/web/__init__.py
@@ -20,7 +20,7 @@ from manage.web.app import app
 
 # Importing the route modules registers their endpoints on ``app``.
 # Order matters only insofar as ``review`` imports from ``threads``.
-from manage.web import threads, review, evals  # noqa: E402,F401
+from manage.web import threads, review, evals, schedules  # noqa: E402,F401
 
 # Re-export the names that external scripts (and any direct
 # ``from manage.web import X`` consumers) historically relied on, so

--- a/manage/web/schedules.py
+++ b/manage/web/schedules.py
@@ -7,23 +7,14 @@ a blocking op on the single-worker loop would stall the whole server.
 from __future__ import annotations
 
 import html
-from datetime import datetime
-from zoneinfo import ZoneInfo
 
 from fastapi.responses import HTMLResponse, RedirectResponse
 from starlette.concurrency import run_in_threadpool
 
 from assist.schedule import cadence
+from assist.schedule.store import ScheduleNotFound
 from manage.web.app import app
 from manage.web.state import SCHEDULE_STORE
-
-
-def _fmt_next(iso_utc: str | None, tz: str) -> str:
-    if not iso_utc:
-        return "—"
-    local = datetime.fromisoformat(iso_utc).astimezone(ZoneInfo(tz))
-    h12 = local.hour % 12 or 12
-    return f"{local:%a %b %d}, {h12}:{local.minute:02d} {local:%p}"
 
 
 def _row(s) -> str:
@@ -34,7 +25,7 @@ def _row(s) -> str:
         f'{html.escape(s.thread_id)}</a></td>'
         f"<td>{html.escape(cadence.describe(s.cadence))}{paused}</td>"
         f'<td class="prompt">{html.escape(s.prompt)}</td>'
-        f"<td>{_fmt_next(s.next_fire_at, s.tz)}</td>"
+        f"<td>{cadence.fmt_instant(s.next_fire_at, s.tz)}</td>"
         f'<td><form method="post" action="/schedules/{html.escape(s.thread_id)}/'
         f'{html.escape(s.id)}/delete">'
         f'<button class="btn btn-secondary" type="submit">Delete</button></form></td>'
@@ -77,6 +68,6 @@ async def schedules_page():
 async def delete_schedule_route(tid: str, sid: str):
     try:
         await run_in_threadpool(SCHEDULE_STORE.remove, tid, sid)
-    except Exception:
-        pass  # already gone is fine
+    except ScheduleNotFound:
+        pass  # already gone is fine; other errors surface
     return RedirectResponse("/schedules", status_code=303)

--- a/manage/web/schedules.py
+++ b/manage/web/schedules.py
@@ -1,0 +1,82 @@
+"""The /schedules management view — list ALL schedules across threads + delete.
+
+Read+delete only (creation/edit is agent-driven, per the PRD). Both routes run OFF the
+asyncio loop (``run_in_threadpool``) because the store takes a lock + reads/writes disk —
+a blocking op on the single-worker loop would stall the whole server.
+"""
+from __future__ import annotations
+
+import html
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from fastapi.responses import HTMLResponse, RedirectResponse
+from starlette.concurrency import run_in_threadpool
+
+from assist.schedule import cadence
+from manage.web.app import app
+from manage.web.state import SCHEDULE_STORE
+
+
+def _fmt_next(iso_utc: str | None, tz: str) -> str:
+    if not iso_utc:
+        return "—"
+    local = datetime.fromisoformat(iso_utc).astimezone(ZoneInfo(tz))
+    h12 = local.hour % 12 or 12
+    return f"{local:%a %b %d}, {h12}:{local.minute:02d} {local:%p}"
+
+
+def _row(s) -> str:
+    paused = "" if s.enabled else ' <span class="paused">(paused)</span>'
+    return (
+        "<tr>"
+        f'<td><a class="thread-link" href="/thread/{html.escape(s.thread_id)}">'
+        f'{html.escape(s.thread_id)}</a></td>'
+        f"<td>{html.escape(cadence.describe(s.cadence))}{paused}</td>"
+        f'<td class="prompt">{html.escape(s.prompt)}</td>'
+        f"<td>{_fmt_next(s.next_fire_at, s.tz)}</td>"
+        f'<td><form method="post" action="/schedules/{html.escape(s.thread_id)}/'
+        f'{html.escape(s.id)}/delete">'
+        f'<button class="btn btn-secondary" type="submit">Delete</button></form></td>'
+        "</tr>"
+    )
+
+
+def _render(scheds) -> str:
+    if scheds:
+        body = ("<table><thead><tr><th>Thread</th><th>Schedule</th><th>Prompt</th>"
+                "<th>Next run</th><th></th></tr></thead><tbody>"
+                + "".join(_row(s) for s in scheds) + "</tbody></table>")
+    else:
+        body = "<p>No schedules yet. Ask the assistant in a thread to set one up.</p>"
+    return f"""<!doctype html><html><head><meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Schedules</title><style>
+  body {{ font-family: system-ui, sans-serif; margin: 1rem; }}
+  .topbar {{ display: flex; gap: .5rem; align-items: center; margin-bottom: 1rem; }}
+  table {{ border-collapse: collapse; width: 100%; }}
+  th, td {{ text-align: left; padding: .5rem; border-bottom: 1px solid #ddd; vertical-align: top; }}
+  td.prompt {{ max-width: 28rem; }}
+  .paused {{ color: #999; }}
+  .btn {{ display: inline-block; padding: .4rem .7rem; border-radius: 6px; border: 1px solid #ccc;
+          background: #f5f5f5; text-decoration: none; color: #222; cursor: pointer; }}
+  .btn-secondary {{ background: #fff; }}
+</style></head><body>
+  <div class="topbar"><a href="/" class="btn">&larr; Threads</a><h2>Scheduled prompts</h2></div>
+  {body}
+</body></html>"""
+
+
+@app.get("/schedules", response_class=HTMLResponse)
+async def schedules_page():
+    scheds = await run_in_threadpool(SCHEDULE_STORE.all)
+    return HTMLResponse(_render(scheds))
+
+
+@app.post("/schedules/{tid}/{sid}/delete")
+async def delete_schedule_route(tid: str, sid: str):
+    try:
+        await run_in_threadpool(SCHEDULE_STORE.remove, tid, sid)
+    except Exception:
+        pass  # already gone is fine
+    return RedirectResponse("/schedules", status_code=303)

--- a/manage/web/state.py
+++ b/manage/web/state.py
@@ -374,7 +374,7 @@ async def lifespan(app: FastAPI):
         try:
             stop_scheduler()
         except Exception:
-            pass
+            logging.getLogger(__name__).warning("scheduler shutdown failed", exc_info=True)
         # Clean up Docker sandbox containers
         try:
             SandboxManager.cleanup_all()

--- a/manage/web/state.py
+++ b/manage/web/state.py
@@ -25,7 +25,9 @@ from fastapi import FastAPI
 from assist.domain_manager import DomainManager
 from assist.env import load_dev_env
 from assist.sandbox_manager import SandboxManager
-from assist.thread_manager import ThreadManager
+from assist.schedule.store import ScheduleStore
+from assist.schedule.tools import schedule_tools
+from assist.thread_manager import ThreadManager, set_web_tools
 
 
 def _configure_logging() -> None:
@@ -81,6 +83,13 @@ load_dev_env()
 
 ROOT = os.getenv("ASSIST_THREADS_DIR", "/tmp/assist_threads")
 MANAGER = ThreadManager(ROOT)
+
+# The one shared schedule store (disk-as-truth on the thread root) — used by the
+# Scheduler (started in the lifespan, see threads.py) AND the schedule tools AND the
+# /schedules view, so they share its single read-modify-write lock. The web app is a
+# single uvicorn worker, so exactly one Scheduler/store pair exists.
+SCHEDULE_STORE = ScheduleStore(ROOT)
+set_web_tools(schedule_tools(SCHEDULE_STORE))
 _raw = os.getenv("ASSIST_DOMAINS", "")
 DOMAINS: list[str] = [d.strip() for d in _raw.split(",") if d.strip()]
 DESCRIPTION_CACHE: Dict[str, str] = {}
@@ -356,9 +365,16 @@ async def lifespan(app: FastAPI):
     # Populate description cache at startup
     for tid in MANAGER.list():
         get_cached_description(tid)
+    # Start the schedule poll loop (local import breaks the state<->threads cycle).
+    from manage.web.threads import start_scheduler, stop_scheduler
+    start_scheduler()
     try:
         yield
     finally:
+        try:
+            stop_scheduler()
+        except Exception:
+            pass
         # Clean up Docker sandbox containers
         try:
             SandboxManager.cleanup_all()

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -15,9 +15,10 @@ import os
 import re
 import subprocess
 import urllib.parse
-from datetime import datetime
+from datetime import datetime, timezone
 
 import markdown
+import requests
 from fastapi import BackgroundTasks, Form, HTTPException
 from fastapi.responses import (
     FileResponse,
@@ -34,6 +35,7 @@ from assist.domain_manager import (
     OriginAdvancedError,
 )
 from assist.context_rider import ContextRider, CONTEXT_RIDER_KEY
+from assist.schedule.scheduler import Scheduler
 from assist.sandbox import SandboxContainerLostError
 from assist.sandbox_manager import SandboxManager
 from assist.thread import Thread
@@ -50,6 +52,7 @@ from manage.web.state import (
     INIT_STAGES,
     MANAGER,
     MERGE_LOCK,
+    SCHEDULE_STORE,
     STAGE_LABELS,
     _clear_conflict,
     _domain_selector_html,
@@ -219,7 +222,8 @@ def render_index(query: str = "") -> str:
         <div class="container">
           <div class="topbar">
             <h1 style="font-size:1.4rem; margin:0">Assist Web</h1>
-            <a href="/evals" class="btn">Evals</a>
+            <span><a href="/schedules" class="btn">Schedules</a>
+            <a href="/evals" class="btn">Evals</a></span>
           </div>
 
           <div class="new-thread-form">
@@ -916,6 +920,40 @@ def _build_rider(sent_at: str | None, tz: str | None,
         return ContextRider(sent_at=dt, tz=tz or None, **coords)
     except Exception:
         return None
+
+
+def _llm_reachable() -> bool:
+    """Quick liveness probe of the LLM endpoint for the scheduler's fire gate. Runs on
+    the scheduler thread (off the event loop), only when a schedule is due."""
+    url = os.getenv("ASSIST_MODEL_URL")
+    if not url:
+        return False
+    try:
+        return requests.get(f"{url.rstrip('/')}/models", timeout=3).status_code == 200
+    except Exception:
+        return False
+
+
+def _scheduled_dispatch(tid: str, prompt: str, tz: str) -> None:
+    """Run a schedule's prompt as a turn IN its own thread via the normal run path, so
+    THREAD_QUEUE serializes it (overlap waits) and the per-turn sandbox + middleware
+    apply. A time-only rider gives the turn 'now' in the schedule's zone. No
+    _mark_pending — there's no waiting render to win."""
+    rider = _build_rider(datetime.now(timezone.utc).isoformat(), tz)
+    _process_message(tid, prompt, rider)
+
+
+# The single in-process scheduler (the web runs one uvicorn worker). Started/stopped by
+# the lifespan, which imports start/stop lazily to avoid an import cycle.
+_SCHEDULER = Scheduler(SCHEDULE_STORE, _scheduled_dispatch, _llm_reachable)
+
+
+def start_scheduler() -> None:
+    _SCHEDULER.start()
+
+
+def stop_scheduler() -> None:
+    _SCHEDULER.stop()
 
 
 @app.post("/thread/{tid}/message")

--- a/tests/test_schedule_cadence.py
+++ b/tests/test_schedule_cadence.py
@@ -1,0 +1,109 @@
+"""Cadence engine — pure date/DST math + the relative-edit patch. No LLM."""
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from assist.schedule import cadence
+from assist.schedule.cadence import InvalidCadence
+from assist.schedule.model import Cadence, Schedule
+
+LA = ZoneInfo("America/Los_Angeles")
+
+
+def _sched(cad: Cadence, tz="America/Los_Angeles") -> Schedule:
+    return Schedule(id="s1", thread_id="t1", prompt="hi", cadence=cad, tz=tz)
+
+
+def _next_local(cad: Cadence, now_local: datetime, tz="America/Los_Angeles"):
+    now_utc = now_local.replace(tzinfo=ZoneInfo(tz))
+    return cadence.next_after(_sched(cad, tz), now_utc).astimezone(ZoneInfo(tz))
+
+
+def test_daily_same_day_then_next_day():
+    cad = Cadence(hour=7, minute=0)
+    assert _next_local(cad, datetime(2026, 6, 15, 6, 0)) == datetime(2026, 6, 15, 7, 0, tzinfo=LA)
+    assert _next_local(cad, datetime(2026, 6, 15, 8, 0)) == datetime(2026, 6, 16, 7, 0, tzinfo=LA)
+
+
+def test_strictly_after_at_exact_match():
+    # At exactly 7:00 the next fire is tomorrow, never "now".
+    cad = Cadence(hour=7, minute=0)
+    assert _next_local(cad, datetime(2026, 6, 15, 7, 0)) == datetime(2026, 6, 16, 7, 0, tzinfo=LA)
+
+
+def test_weekly_single_weekday():
+    cad = Cadence(hour=9, minute=0, weekdays=(0,))  # Mondays
+    # 2026-06-16 is a Tuesday -> next Monday 2026-06-22.
+    nxt = _next_local(cad, datetime(2026, 6, 16, 10, 0))
+    assert nxt == datetime(2026, 6, 22, 9, 0, tzinfo=LA) and nxt.weekday() == 0
+
+
+def test_weekdays_skip_weekend():
+    cad = Cadence(hour=7, minute=0, weekdays=(0, 1, 2, 3, 4))
+    # 2026-06-13 is a Saturday -> next weekday Monday 2026-06-15.
+    assert _next_local(cad, datetime(2026, 6, 13, 8, 0)) == datetime(2026, 6, 15, 7, 0, tzinfo=LA)
+
+
+def test_hourly_at_minute():
+    cad = Cadence(hour=None, minute=30)
+    assert _next_local(cad, datetime(2026, 6, 15, 10, 15)) == datetime(2026, 6, 15, 10, 30, tzinfo=LA)
+    assert _next_local(cad, datetime(2026, 6, 15, 10, 45)) == datetime(2026, 6, 15, 11, 30, tzinfo=LA)
+
+
+def test_interval_every_30_clock_aligned():
+    cad = Cadence(every_n_minutes=30)
+    assert _next_local(cad, datetime(2026, 6, 15, 10, 10)) == datetime(2026, 6, 15, 10, 30, tzinfo=LA)
+    assert _next_local(cad, datetime(2026, 6, 15, 10, 40)) == datetime(2026, 6, 15, 11, 0, tzinfo=LA)
+
+
+def test_dst_spring_forward_skips_nonexistent_local_time():
+    # 2026-03-08: LA jumps 02:00 -> 03:00, so 02:30 never occurs that day.
+    cad = Cadence(hour=2, minute=30)
+    nxt = _next_local(cad, datetime(2026, 3, 8, 1, 0))
+    assert nxt == datetime(2026, 3, 9, 2, 30, tzinfo=LA)  # skipped to the next valid day
+
+
+def test_next_after_is_always_in_the_future():
+    cad = Cadence(hour=7, minute=0)
+    now = datetime(2020, 1, 1, 12, 0, tzinfo=LA)  # next_fire_at "in the past" -> recompute forward
+    assert cadence.next_after(_sched(cad), now) > now
+
+
+def test_apply_patch_changes_only_the_delta():
+    base = _sched(Cadence(hour=7, minute=15, weekdays=(0, 1, 2, 3, 4)))
+    patched = cadence.apply_patch(base, hour=5)
+    assert patched.cadence.hour == 5
+    assert patched.cadence.minute == 15                      # unchanged
+    assert patched.cadence.weekdays == (0, 1, 2, 3, 4)       # unchanged
+
+
+def test_apply_patch_explicit_none_means_every():
+    base = _sched(Cadence(hour=7, minute=0, weekdays=(0,)))
+    assert cadence.apply_patch(base, weekdays=None).cadence.weekdays is None
+
+
+def test_describe_labels():
+    assert cadence.describe(Cadence(hour=7, minute=0)) == "every day at 7:00 AM"
+    assert cadence.describe(Cadence(hour=7, minute=0, weekdays=(0, 1, 2, 3, 4))) == "Mon–Fri at 7:00 AM"
+    assert cadence.describe(Cadence(every_n_minutes=30)) == "every 30 minutes"
+    assert cadence.describe(Cadence(hour=None, minute=30)) == "hourly at :30"
+
+
+@pytest.mark.parametrize("cad", [
+    Cadence(every_n_minutes=30, hour=7),   # interval + clock = incoherent
+    Cadence(minute=60),                    # out of range
+    Cadence(hour=25, minute=0),            # out of range
+    Cadence(weekdays=()),                  # empty set
+    Cadence(every_n_minutes=0),            # out of range
+])
+def test_validate_rejects_incoherent(cad):
+    with pytest.raises(InvalidCadence):
+        cadence.validate(cad)
+
+
+def test_model_round_trip():
+    s = Schedule(id="x", thread_id="t", prompt="p",
+                 cadence=Cadence(hour=7, minute=5, weekdays=(0, 2)), tz="America/Los_Angeles",
+                 next_fire_at="2026-06-15T14:00:00+00:00", created_at="2026-06-15T00:00:00+00:00")
+    assert Schedule.from_dict(s.to_dict()) == s

--- a/tests/test_schedule_scheduler.py
+++ b/tests/test_schedule_scheduler.py
@@ -74,14 +74,24 @@ def test_health_down_skips_silently_but_advances(tmp_path):
     assert datetime.fromisoformat(store.for_thread("t1")[0].next_fire_at) > NOW  # no catch-up
 
 
-def test_dedup_skips_when_thread_inflight(tmp_path):
-    store = _store(tmp_path, _sched())
+def test_dedup_skips_when_schedule_inflight(tmp_path):
+    store = _store(tmp_path, _sched(sid="a"))
     d, sch = _sched_run(store)
-    sch._claim("t1")                                     # pretend a wakeup is already running
+    sch._claim("a")                                      # pretend this schedule is running
     sch._fire(store.for_thread("t1")[0], NOW)
     _flush(sch)
-    assert d.calls == []                                 # skipped (deduped)
+    assert d.calls == []                                 # skipped (deduped by schedule id)
     assert datetime.fromisoformat(store.for_thread("t1")[0].next_fire_at) > NOW  # still advanced
+
+
+def test_two_schedules_same_thread_both_fire(tmp_path):
+    # Distinct schedules on one thread, both due: dedup is per-schedule, so both dispatch
+    # (THREAD_QUEUE serializes them). The thread-keyed bug would have dropped one.
+    store = _store(tmp_path, _sched(sid="a"), _sched(sid="b"))
+    d, sch = _sched_run(store)
+    sch.poll()
+    _flush(sch)
+    assert sorted(t for t, _ in d.calls) == ["t1", "t1"]   # both fired
 
 
 def test_reconcile_advances_past_missed_without_firing(tmp_path):

--- a/tests/test_schedule_scheduler.py
+++ b/tests/test_schedule_scheduler.py
@@ -127,6 +127,22 @@ def test_scheduler_restartable(tmp_path):
         sch.stop()
 
 
+def test_advance_uses_current_record_not_stale_snapshot(tmp_path):
+    # A modify between due()'s snapshot and _advance must not be clobbered: next_fire is
+    # recomputed from the CURRENT cadence under the lock, not the stale snapshot.
+    from zoneinfo import ZoneInfo
+
+    from assist.schedule.cadence import apply_patch
+    store = _store(tmp_path, _sched(sid="a"))          # hour=7
+    d, sch = _sched_run(store)
+    stale = store.for_thread("t1")[0]                  # snapshot at hour=7
+    store.update("t1", "a", lambda s: apply_patch(s, hour=5))   # concurrent modify -> hour=5
+    sch._advance(stale, NOW)                            # advance with the STALE snapshot
+    nf = datetime.fromisoformat(store.for_thread("t1")[0].next_fire_at).astimezone(
+        ZoneInfo("America/Los_Angeles"))
+    assert nf.hour == 5                                 # current cadence, not the stale 7
+
+
 def test_future_schedule_not_due(tmp_path):
     store = _store(tmp_path, _sched(next_fire=FUTURE))
     d, sch = _sched_run(store)

--- a/tests/test_schedule_scheduler.py
+++ b/tests/test_schedule_scheduler.py
@@ -1,0 +1,112 @@
+"""Scheduler decision logic with a real store + fake dispatch/health/clock. No LLM."""
+import os
+import threading
+from datetime import datetime, timezone
+
+import pytest
+
+from assist.schedule.model import Cadence, Schedule
+from assist.schedule.scheduler import Scheduler
+from assist.schedule.store import ScheduleStore
+
+NOW = datetime(2026, 6, 15, 18, 0, tzinfo=timezone.utc)   # a Monday, 11:00 LA
+PAST = "2026-06-15T00:00:00+00:00"
+FUTURE = "2999-01-01T00:00:00+00:00"
+
+
+class _Dispatch:
+    def __init__(self):
+        self.calls = []
+        self._lock = threading.Lock()
+
+    def __call__(self, tid, prompt, tz):
+        with self._lock:
+            self.calls.append((tid, prompt))
+
+
+def _store(tmp_path, *scheds):
+    s = ScheduleStore(str(tmp_path))
+    for sc in scheds:
+        os.makedirs(os.path.join(str(tmp_path), sc.thread_id), exist_ok=True)
+        s.add(sc)
+    return s
+
+
+def _sched(tid="t1", sid="a", *, enabled=True, next_fire=PAST):
+    return Schedule(id=sid, thread_id=tid, prompt="do it", cadence=Cadence(hour=7, minute=0),
+                    tz="America/Los_Angeles", enabled=enabled, next_fire_at=next_fire)
+
+
+def _sched_run(store, *, health=True):
+    d = _Dispatch()
+    sch = Scheduler(store, d, lambda: health, now_fn=lambda: NOW)
+    return d, sch
+
+
+def _flush(sch):
+    sch._executor.shutdown(wait=True)
+
+
+def test_due_fires_once_and_advances(tmp_path):
+    store = _store(tmp_path, _sched())
+    d, sch = _sched_run(store)
+    sch.poll()
+    _flush(sch)
+    assert d.calls == [("t1", "do it")]
+    nxt = store.for_thread("t1")[0].next_fire_at
+    assert datetime.fromisoformat(nxt) > NOW            # advanced to the future
+
+
+def test_disabled_never_fires(tmp_path):
+    store = _store(tmp_path, _sched(enabled=False))
+    d, sch = _sched_run(store)
+    sch.poll()
+    _flush(sch)
+    assert d.calls == []
+
+
+def test_health_down_skips_silently_but_advances(tmp_path):
+    store = _store(tmp_path, _sched())
+    d, sch = _sched_run(store, health=False)
+    sch.poll()
+    _flush(sch)
+    assert d.calls == []                                 # did not fire
+    assert datetime.fromisoformat(store.for_thread("t1")[0].next_fire_at) > NOW  # no catch-up
+
+
+def test_dedup_skips_when_thread_inflight(tmp_path):
+    store = _store(tmp_path, _sched())
+    d, sch = _sched_run(store)
+    sch._claim("t1")                                     # pretend a wakeup is already running
+    sch._fire(store.for_thread("t1")[0], NOW)
+    _flush(sch)
+    assert d.calls == []                                 # skipped (deduped)
+    assert datetime.fromisoformat(store.for_thread("t1")[0].next_fire_at) > NOW  # still advanced
+
+
+def test_reconcile_advances_past_missed_without_firing(tmp_path):
+    store = _store(tmp_path, _sched(next_fire=PAST))
+    d, sch = _sched_run(store)
+    sch.reconcile()
+    _flush(sch)
+    assert d.calls == []                                 # missed windows are NOT replayed
+    assert datetime.fromisoformat(store.for_thread("t1")[0].next_fire_at) > NOW
+
+
+def test_persist_failure_blocks_dispatch(tmp_path):
+    store = _store(tmp_path, _sched())
+    d, sch = _sched_run(store)
+    def boom(*a, **k):
+        raise OSError("disk full")
+    store.update = boom                                  # advance can't persist
+    sch._fire(store.for_thread("t1")[0], NOW)
+    _flush(sch)
+    assert d.calls == []                                 # no dispatch when next_fire can't persist
+
+
+def test_future_schedule_not_due(tmp_path):
+    store = _store(tmp_path, _sched(next_fire=FUTURE))
+    d, sch = _sched_run(store)
+    sch.poll()
+    _flush(sch)
+    assert d.calls == []

--- a/tests/test_schedule_scheduler.py
+++ b/tests/test_schedule_scheduler.py
@@ -114,6 +114,19 @@ def test_persist_failure_blocks_dispatch(tmp_path):
     assert d.calls == []                                 # no dispatch when next_fire can't persist
 
 
+def test_scheduler_restartable(tmp_path):
+    # A re-run lifespan (common in tests) must get a working scheduler, not a no-op.
+    store = _store(tmp_path, _sched())
+    d, sch = _sched_run(store)
+    sch.start()
+    sch.stop()
+    sch.start()
+    try:
+        assert sch._thread.is_alive()        # not left dead by the prior stop()
+    finally:
+        sch.stop()
+
+
 def test_future_schedule_not_due(tmp_path):
     store = _store(tmp_path, _sched(next_fire=FUTURE))
     d, sch = _sched_run(store)

--- a/tests/test_schedule_scheduler.py
+++ b/tests/test_schedule_scheduler.py
@@ -78,7 +78,7 @@ def test_dedup_skips_when_schedule_inflight(tmp_path):
     store = _store(tmp_path, _sched(sid="a"))
     d, sch = _sched_run(store)
     sch._claim("a")                                      # pretend this schedule is running
-    sch._fire(store.for_thread("t1")[0], NOW)
+    sch._fire(store.for_thread("t1")[0], NOW, True)
     _flush(sch)
     assert d.calls == []                                 # skipped (deduped by schedule id)
     assert datetime.fromisoformat(store.for_thread("t1")[0].next_fire_at) > NOW  # still advanced
@@ -109,7 +109,7 @@ def test_persist_failure_blocks_dispatch(tmp_path):
     def boom(*a, **k):
         raise OSError("disk full")
     store.update = boom                                  # advance can't persist
-    sch._fire(store.for_thread("t1")[0], NOW)
+    sch._fire(store.for_thread("t1")[0], NOW, True)
     _flush(sch)
     assert d.calls == []                                 # no dispatch when next_fire can't persist
 

--- a/tests/test_schedule_store.py
+++ b/tests/test_schedule_store.py
@@ -100,3 +100,12 @@ def test_concurrent_updates_no_lost_update(tmp_path, store):
         t.join()
     # Every schedule's update must have landed — no lost write.
     assert all(s.next_fire_at == "2026-12-31T00:00:00+00:00" for s in store.for_thread("t1"))
+
+
+def test_all_ignores_non_dir_files_in_root(tmp_path, store):
+    # The thread root also holds non-dir files (e.g. ThreadManager's threads.db);
+    # all()/due() must not choke on them.
+    _mk(str(tmp_path), "t1")
+    store.add(_sched("t1", "a"))
+    (tmp_path / "threads.db").write_text("not a thread dir")
+    assert {s.id for s in store.all()} == {"a"}

--- a/tests/test_schedule_store.py
+++ b/tests/test_schedule_store.py
@@ -1,0 +1,102 @@
+"""ScheduleStore — disk persistence, cap, and the un-mocked read-modify-write race."""
+import os
+import threading
+from datetime import datetime, timezone
+
+import pytest
+
+from assist.schedule.model import Cadence, Schedule
+from assist.schedule.store import (CAP_PER_THREAD, ScheduleCapExceeded,
+                                   ScheduleNotFound, ScheduleStore)
+
+
+def _mk(root, tid):
+    os.makedirs(os.path.join(root, tid), exist_ok=True)
+
+
+def _sched(tid, sid, *, enabled=True, next_fire="2026-06-15T14:00:00+00:00"):
+    return Schedule(id=sid, thread_id=tid, prompt="p", cadence=Cadence(hour=7, minute=0),
+                    tz="America/Los_Angeles", enabled=enabled, next_fire_at=next_fire)
+
+
+@pytest.fixture
+def store(tmp_path):
+    return ScheduleStore(str(tmp_path))
+
+
+def test_add_and_read_round_trip(tmp_path, store):
+    _mk(str(tmp_path), "t1")
+    store.add(_sched("t1", "a"))
+    got = store.for_thread("t1")
+    assert len(got) == 1 and got[0].id == "a"
+
+
+def test_cap_enforced(tmp_path, store):
+    _mk(str(tmp_path), "t1")
+    for i in range(CAP_PER_THREAD):
+        store.add(_sched("t1", f"s{i}"))
+    with pytest.raises(ScheduleCapExceeded):
+        store.add(_sched("t1", "overflow"))
+
+
+def test_survives_restart_via_disk(tmp_path):
+    _mk(str(tmp_path), "t1")
+    ScheduleStore(str(tmp_path)).add(_sched("t1", "a"))
+    # A brand-new store instance (= a process restart) reads the same file.
+    reloaded = ScheduleStore(str(tmp_path)).for_thread("t1")
+    assert len(reloaded) == 1 and reloaded[0].id == "a"
+
+
+def test_update_advances_next_fire(tmp_path, store):
+    _mk(str(tmp_path), "t1")
+    store.add(_sched("t1", "a"))
+    store.update("t1", "a", lambda s: s.with_next_fire("2026-06-16T14:00:00+00:00"))
+    assert store.for_thread("t1")[0].next_fire_at == "2026-06-16T14:00:00+00:00"
+
+
+def test_remove(tmp_path, store):
+    _mk(str(tmp_path), "t1")
+    store.add(_sched("t1", "a"))
+    store.remove("t1", "a")
+    assert store.for_thread("t1") == []
+    with pytest.raises(ScheduleNotFound):
+        store.remove("t1", "missing")
+
+
+def test_all_across_threads(tmp_path, store):
+    _mk(str(tmp_path), "t1")
+    _mk(str(tmp_path), "t2")
+    store.add(_sched("t1", "a"))
+    store.add(_sched("t2", "b"))
+    assert {s.id for s in store.all()} == {"a", "b"}
+
+
+def test_due_filters_disabled_and_future(tmp_path, store):
+    _mk(str(tmp_path), "t1")
+    store.add(_sched("t1", "past", next_fire="2026-06-15T14:00:00+00:00"))
+    store.add(_sched("t1", "future", next_fire="2999-01-01T00:00:00+00:00"))
+    store.add(_sched("t1", "off", enabled=False, next_fire="2026-06-15T14:00:00+00:00"))
+    now = datetime(2026, 6, 15, 18, 0, tzinfo=timezone.utc)
+    assert {s.id for s in store.due(now)} == {"past"}
+
+
+def test_concurrent_updates_no_lost_update(tmp_path, store):
+    """The advance/patch/delete race: many threads update DIFFERENT schedules on the
+    same thread file concurrently; the lock must serialize RMW so none is lost."""
+    _mk(str(tmp_path), "t1")
+    # Pre-seed 5 schedules (the cap), then hammer each with a concurrent next_fire bump.
+    for i in range(CAP_PER_THREAD):
+        store.add(_sched("t1", f"s{i}", next_fire="2026-06-15T00:00:00+00:00"))
+    barrier = threading.Barrier(CAP_PER_THREAD)
+
+    def bump(sid):
+        barrier.wait()  # maximize contention
+        store.update("t1", sid, lambda s: s.with_next_fire("2026-12-31T00:00:00+00:00"))
+
+    threads = [threading.Thread(target=bump, args=(f"s{i}",)) for i in range(CAP_PER_THREAD)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    # Every schedule's update must have landed — no lost write.
+    assert all(s.next_fire_at == "2026-12-31T00:00:00+00:00" for s in store.for_thread("t1"))

--- a/tests/test_schedule_tools.py
+++ b/tests/test_schedule_tools.py
@@ -48,6 +48,18 @@ def test_pause_resume(tools):
     assert tools.store.for_thread("t1")[0].enabled is True
 
 
+def test_resume_recomputes_next_fire_no_catchup(tools):
+    # A schedule paused past its fire time must NOT fire immediately on resume.
+    tools.create_schedule("x", hour=8)
+    sid = tools.store.for_thread("t1")[0].id
+    tools.pause_schedule(sid)
+    tools.store.update("t1", sid, lambda s: s.with_next_fire("2020-01-01T00:00:00+00:00"))
+    tools.resume_schedule(sid)
+    from datetime import datetime, timezone
+    nxt = datetime.fromisoformat(tools.store.for_thread("t1")[0].next_fire_at)
+    assert nxt > datetime.now(timezone.utc)   # recomputed forward, not the stale past value
+
+
 def test_delete(tools):
     tools.create_schedule("x", hour=8)
     sid = tools.store.for_thread("t1")[0].id

--- a/tests/test_schedule_tools.py
+++ b/tests/test_schedule_tools.py
@@ -1,0 +1,73 @@
+"""Schedule tools — thread-scoped, server-side sparse-delta modify. Faked run config."""
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from assist.context_rider import CONTEXT_RIDER_KEY
+from assist.schedule import tools as tools_mod
+from assist.schedule.store import ScheduleStore
+
+
+@pytest.fixture
+def tools(tmp_path, monkeypatch):
+    os.makedirs(os.path.join(str(tmp_path), "t1"), exist_ok=True)
+    store = ScheduleStore(str(tmp_path))
+    cfg = {"configurable": {"thread_id": "t1",
+                            CONTEXT_RIDER_KEY: SimpleNamespace(tz="America/Los_Angeles")}}
+    monkeypatch.setattr(tools_mod, "get_config", lambda: cfg)
+    fns = {f.__name__: f for f in tools_mod.schedule_tools(store)}
+    return SimpleNamespace(store=store, **fns)
+
+
+def test_create_then_list(tools):
+    out = tools.create_schedule("morning review", hour=7, minute=0)
+    assert "Scheduled" in out and "every day at 7:00 AM" in out
+    assert "morning review" in tools.list_schedules()
+
+
+def test_modify_is_sparse_delta(tools):
+    tools.create_schedule("review", hour=7, minute=15, weekdays=[0, 1, 2, 3, 4])
+    sid = tools.store.for_thread("t1")[0].id
+    out = tools.modify_schedule(sid, hour=5)
+    assert "Updated" in out
+    cad = tools.store.for_thread("t1")[0].cadence
+    assert cad.hour == 5 and cad.minute == 15 and cad.weekdays == (0, 1, 2, 3, 4)
+
+
+def test_modify_unknown_id(tools):
+    assert "No schedule" in tools.modify_schedule("deadbeef", hour=5)
+
+
+def test_pause_resume(tools):
+    tools.create_schedule("x", hour=8)
+    sid = tools.store.for_thread("t1")[0].id
+    assert "Paused" in tools.pause_schedule(sid)
+    assert tools.store.for_thread("t1")[0].enabled is False
+    assert "Resumed" in tools.resume_schedule(sid)
+    assert tools.store.for_thread("t1")[0].enabled is True
+
+
+def test_delete(tools):
+    tools.create_schedule("x", hour=8)
+    sid = tools.store.for_thread("t1")[0].id
+    assert "Deleted" in tools.delete_schedule(sid)
+    assert tools.store.for_thread("t1") == []
+
+
+def test_cap_message(tools):
+    for i in range(5):
+        tools.create_schedule(f"s{i}", hour=i + 1)
+    out = tools.create_schedule("overflow", hour=9)
+    assert "already has 5 schedules" in out
+
+
+def test_invalid_cadence_declined(tools):
+    out = tools.create_schedule("bad", hour=7, every_n_minutes=30)   # interval + clock
+    assert "Couldn't schedule" in out
+
+
+def test_no_timezone_declines(tools, monkeypatch):
+    monkeypatch.setattr(tools_mod, "get_config",
+                        lambda: {"configurable": {"thread_id": "t1"}})   # no rider/tz
+    assert "timezone" in tools.create_schedule("x", hour=7)

--- a/tests/test_web_schedules.py
+++ b/tests/test_web_schedules.py
@@ -1,0 +1,57 @@
+"""The /schedules management view — render, delete, and event-loop independence."""
+import os
+import threading
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+from assist.schedule.model import Cadence, Schedule
+from assist.thread_queue import THREAD_QUEUE
+from manage import web
+from manage.web import state
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setattr(state.SCHEDULE_STORE, "_root", str(tmp_path))
+    os.makedirs(tmp_path / "t1", exist_ok=True)
+    state.SCHEDULE_STORE.add(Schedule(
+        id="abc123", thread_id="t1", prompt="review my inbox",
+        cadence=Cadence(hour=7, minute=0), tz="America/Los_Angeles",
+        next_fire_at="2026-06-15T14:00:00+00:00"))
+    return TestClient(web.app)   # no `with` -> lifespan (and the scheduler) don't start
+
+
+def test_schedules_page_renders_link_label_delete(client):
+    html = client.get("/schedules").text
+    assert '/thread/t1"' in html                      # thread link
+    assert "every day at 7:00 AM" in html             # engine-derived label
+    assert "review my inbox" in html                  # description/prompt
+    assert "/schedules/t1/abc123/delete" in html      # delete action
+
+
+def test_delete_removes_and_redirects(client):
+    r = client.post("/schedules/t1/abc123/delete", follow_redirects=False)
+    assert r.status_code == 303
+    assert state.SCHEDULE_STORE.for_thread("t1") == []
+
+
+def test_schedules_route_independent_of_thread_queue(client):
+    """The view must not touch THREAD_QUEUE — holding a turn slot can't block it."""
+    held = threading.Event()
+    release = threading.Event()
+
+    def hold():
+        with THREAD_QUEUE.acquire("other-thread"):
+            held.set()
+            release.wait(timeout=5)
+
+    t = threading.Thread(target=hold)
+    t.start()
+    assert held.wait(timeout=5)
+    start = time.monotonic()
+    assert client.get("/schedules").status_code == 200      # served while the queue is held
+    assert time.monotonic() - start < 2.0
+    release.set()
+    t.join()


### PR DESCRIPTION
Implements the approved design (`docs/2026-07-01-thread-schedules-design.org`) for the PRD in #159. Run a prompt on a recurring schedule, managed conversationally by the agent from inside a thread.

## What's here
- **Core** (`assist/schedule/`): `model` (structured diffable cadence) · `cadence` (pure next-fire w/ tz+DST, sparse-delta `apply_patch`, engine-derived label/instant) · `store` (disk-as-truth `schedules.json` + one RMW lock, cap 5, dies with the thread) · `scheduler` (in-process daemon poll loop, advance-persist-then-dispatch, startup reconcile = no-catch-up, health-gate skip-if-down, per-**schedule** in-flight dedup, single-worker executor) · `tools` (6 thread-scoped tools; `modify` merges a sparse delta server-side).
- **Skill** guides NL→fields + the relative-edit rule + confirm-back + decline-unsupported.
- **Web**: tools ride the web `AgentSpec` (`set_web_tools` — not core built-ins, so emacsos gets no dead tools); shared store singleton; lifespan starts/stops the scheduler; `_scheduled_dispatch` reuses `_process_message` so `THREAD_QUEUE` serializes overlap; `/schedules` list+delete, off-loop.
- Context-bounding reuses the existing `SummarizationMiddleware` (no new code).

## Review
3-lens local review (correctness+concurrency / event-loop / simplicity): **0 blockers**. The two hazards I had it verify hard — a tmp-filename collision and an in-flight-claim leak — were both confirmed safe. Fixed: resume now recomputes `next_fire_at` (no-catch-up), dedup keyed by schedule (not thread, so distinct same-thread schedules both fire), a tid traversal guard, narrowed the delete `except`, and consolidated the next-fire formatter.

## Tests — 45 new, 816 total
Cadence/DST, store concurrency (no-lost-update), scheduler fire/dedup/health/reconcile/persist-fail, two-distinct-schedules-both-fire, resume-no-catchup, tools sparse-delta, web render/delete/queue-independence. Lifespan + asyncio-debug smoke clean. **The NL→cadence behavior eval is deferred under the GPU freeze** — the deterministic contract is fully unit-covered.

Deployed for parallel testing.