### PR TITLE
Research runaway: URL-provenance guard + recursion fail-fast

### DIFF
--- a/assist/agent.py
+++ b/assist/agent.py
@@ -629,8 +629,11 @@ def create_research_agent(model: BaseChatModel,
     # DISTINCT-arg searches/reads is bounded only by this limit (the host-side
     # search/read tools aren't covered by the sandbox exec timeout).  Lowered
     # from 300 so a runaway is caught in a few minutes rather than ~12-75 min.
-    # GraphRecursionError is in RollbackRunnable's rollback_on, so hitting it
-    # rolls back rather than crashing the thread.
+    # Hitting this limit is now TERMINAL: GraphRecursionError is no longer in
+    # RollbackRunnable's rollback_on, so it is NOT rolled-back-and-re-invoked
+    # (which used to multiply the effective bound ~7x to ~1050 steps). This 150
+    # is therefore the true effective ceiling now; the value is eval-gated (a
+    # limit hit surfaces as a terminal error, not a silent loop).
     rollback_runnable = RollbackRunnable(agent, recursion_limit=150)
 
     # Wrap with the references-cleanup runnable so intermediate drafts

--- a/assist/agent.py
+++ b/assist/agent.py
@@ -585,9 +585,10 @@ def create_research_agent(model: BaseChatModel,
         "system_prompt": base_prompt_for("deepagents/sub_research.txt.j2"),
         "tools": [search_internet, read_url],
         # Provenance guard: refuse read_url on a URL that appears nowhere prior
-        # (a fabrication). Applied to EVERY read_url-capable agent — this searcher,
-        # the fact-checker, and the orchestrator — since fabrication can happen at
-        # any of them; a legit fetch is always of a URL already in context.
+        # (a fabrication). On the SEARCHER (here) and the fact-checker — the two
+        # sub-agents whose read_url should only ever hit a URL already in context.
+        # NOT on the orchestrator (it re-dispatches, so a rejected fetch there can
+        # thrash); its runaway is bounded by recursion_limit.
         "middleware": _subagent_safety_mw() + [UrlProvenanceMiddleware()],
     }
 
@@ -622,10 +623,11 @@ def create_research_agent(model: BaseChatModel,
         system_prompt=base_prompt_for("deepagents/research_instructions.txt.j2",
                                       workspace_dir=workspace_dir),
         backend=backend,
-        # Provenance-guard the orchestrator's own read_url too: it reads specific
-        # URLs from the research results/report (all provenanced in its context)
-        # while writing the report — a URL it invents is a fabrication and refused.
-        middleware=base_mw + middleware + [logging_mw, UrlProvenanceMiddleware()],
+        # NOT provenance-guarded here (only the searcher + fact-check sub-agents
+        # are): guarding the orchestrator's own read_url risked re-dispatch thrash
+        # (a rejected fetch -> re-dispatch research -> more searches). The
+        # orchestrator's runaway is bounded by its recursion_limit instead.
+        middleware=base_mw + middleware + [logging_mw],
         subagents=[critique_sub_agent,
                    research_sub_agent,
                    fact_check_sub_agent]

--- a/assist/agent.py
+++ b/assist/agent.py
@@ -29,6 +29,7 @@ from assist.middleware.search_unavailable_breaker import SearchUnavailableBreake
 from assist.middleware.empty_response_recovery import EmptyResponseRecoveryMiddleware
 from assist.middleware.read_only_enforcer import ReadOnlyEnforcerMiddleware
 from assist.middleware.git_push_blocker import GitPushBlockerMiddleware
+from assist.middleware.url_provenance import UrlProvenanceMiddleware
 from assist.middleware.skills_middleware import SmallModelSkillsMiddleware
 from assist.middleware.memory_middleware import SmallModelMemoryMiddleware
 from assist.middleware.write_collision import WriteCollisionMiddleware
@@ -583,7 +584,10 @@ def create_research_agent(model: BaseChatModel,
         "description": "Used to research more in depth questions. Only give this researcher one topic at a time. It will return research results.",
         "system_prompt": base_prompt_for("deepagents/sub_research.txt.j2"),
         "tools": [search_internet, read_url],
-        "middleware": _subagent_safety_mw(),
+        # Provenance guard ONLY here (the searcher owns search_internet): refuse
+        # read_url on a URL that appears nowhere prior (a fabrication). Not on
+        # the fact-checker — it re-fetches cited URLs with no search of its own.
+        "middleware": _subagent_safety_mw() + [UrlProvenanceMiddleware()],
     }
 
     critique_sub_agent = {

--- a/assist/agent.py
+++ b/assist/agent.py
@@ -633,18 +633,18 @@ def create_research_agent(model: BaseChatModel,
                    fact_check_sub_agent]
     )
 
-    # 150 graph steps ≈ 75 model calls.  This is now the deliberate runaway
-    # backstop for the research flow: with the Pattern-E volume cap and
-    # Pattern-F re-dispatch cap removed, a research agent that keeps issuing
-    # DISTINCT-arg searches/reads is bounded only by this limit (the host-side
-    # search/read tools aren't covered by the sandbox exec timeout).  Lowered
-    # from 300 so a runaway is caught in a few minutes rather than ~12-75 min.
-    # Hitting this limit is now TERMINAL: GraphRecursionError is no longer in
-    # RollbackRunnable's rollback_on, so it is NOT rolled-back-and-re-invoked
-    # (which used to multiply the effective bound ~7x to ~1050 steps). This 150
-    # is therefore the true effective ceiling now; the value is eval-gated (a
-    # limit hit surfaces as a terminal error, not a silent loop).
-    rollback_runnable = RollbackRunnable(agent, recursion_limit=150)
+    # 300 graph steps ≈ 150 model calls: the deliberate runaway backstop for the
+    # research flow (Pattern-E/F caps removed, so a distinct-arg search/read
+    # runaway is bounded only by this limit; host-side tools aren't under the
+    # sandbox exec timeout). Hitting it is now TERMINAL: GraphRecursionError is
+    # no longer in RollbackRunnable's rollback_on, so it is NOT
+    # rolled-back-and-re-invoked (which used to multiply the effective bound ~7x
+    # — a true-150 was really ~1050). 300 is the true effective ceiling, restored
+    # from the pre-2026-06-06 value: the recursion baseline (2026-07-02) showed a
+    # true-150 cut off legit research turns (2 hits across the contract tests),
+    # so 150 was too tight once the ~7x cushion was removed. 300 still bounds a
+    # runaway to ~5 min (vs the 70-min incident) with room for thorough research.
+    rollback_runnable = RollbackRunnable(agent, recursion_limit=300)
 
     # Wrap with the references-cleanup runnable so intermediate drafts
     # and sub-sub-agent scratch files get pruned after the research call

--- a/assist/agent.py
+++ b/assist/agent.py
@@ -584,9 +584,10 @@ def create_research_agent(model: BaseChatModel,
         "description": "Used to research more in depth questions. Only give this researcher one topic at a time. It will return research results.",
         "system_prompt": base_prompt_for("deepagents/sub_research.txt.j2"),
         "tools": [search_internet, read_url],
-        # Provenance guard ONLY here (the searcher owns search_internet): refuse
-        # read_url on a URL that appears nowhere prior (a fabrication). Not on
-        # the fact-checker — it re-fetches cited URLs with no search of its own.
+        # Provenance guard: refuse read_url on a URL that appears nowhere prior
+        # (a fabrication). Applied to EVERY read_url-capable agent — this searcher,
+        # the fact-checker, and the orchestrator — since fabrication can happen at
+        # any of them; a legit fetch is always of a URL already in context.
         "middleware": _subagent_safety_mw() + [UrlProvenanceMiddleware()],
     }
 
@@ -602,7 +603,11 @@ def create_research_agent(model: BaseChatModel,
         "description": "Used to check all references for alignment with claims and statements. You MUST provide the file it should fact-check.",
         "system_prompt": base_prompt_for("deepagents/fact_checker.md.j2"),
         "tools": [read_url],
-        "middleware": _subagent_safety_mw(),
+        # Provenance-guard the fact-checker too: it re-fetches URLs cited in the
+        # report it's handed — those already appear in its context (the report
+        # ToolMessage), so they pass, while a URL it invents is refused. Without
+        # this, fabricated fact-check fetches bypass the guard entirely.
+        "middleware": _subagent_safety_mw() + [UrlProvenanceMiddleware()],
     }
 
     # The orchestrator DELEGATES searching to the research-agent (see its
@@ -617,7 +622,10 @@ def create_research_agent(model: BaseChatModel,
         system_prompt=base_prompt_for("deepagents/research_instructions.txt.j2",
                                       workspace_dir=workspace_dir),
         backend=backend,
-        middleware=base_mw + middleware + [logging_mw],
+        # Provenance-guard the orchestrator's own read_url too: it reads specific
+        # URLs from the research results/report (all provenanced in its context)
+        # while writing the report — a URL it invents is a fabrication and refused.
+        middleware=base_mw + middleware + [logging_mw, UrlProvenanceMiddleware()],
         subagents=[critique_sub_agent,
                    research_sub_agent,
                    fact_check_sub_agent]

--- a/assist/checkpoint_rollback.py
+++ b/assist/checkpoint_rollback.py
@@ -37,7 +37,6 @@ import uuid
 from typing import Any
 
 from openai import BadRequestError
-from langgraph.errors import GraphRecursionError
 from langgraph.graph.state import CompiledStateGraph
 
 logger = logging.getLogger(__name__)
@@ -50,7 +49,7 @@ def invoke_with_rollback(
     *,
     max_retries_per_step: int = 2,
     max_rollback_depth: int = 3,
-    rollback_on: tuple[type[Exception], ...] = (BadRequestError, GraphRecursionError),
+    rollback_on: tuple[type[Exception], ...] = (BadRequestError,),
 ) -> dict[str, Any]:
     """Invoke an agent with checkpoint-based rollback for state errors.
 
@@ -64,13 +63,20 @@ def invoke_with_rollback(
         max_rollback_depth: Maximum number of checkpoints to go back
             through before giving up.
         rollback_on: Exception types that trigger a rollback (default:
-            ``(BadRequestError, GraphRecursionError)``).
+            ``(BadRequestError,)``). NOTE: ``GraphRecursionError`` is
+            deliberately NOT here — a recursion-limit hit is a runaway, not a
+            recoverable bad-content error. Rolling back frees only a couple of
+            steps, so re-invoking just resumes the runaway (it was multiplying
+            the per-agent ``recursion_limit`` ~7x). The ``recursion_limit`` IS
+            the runaway backstop; it must be terminal, not retried past.
 
     Returns:
         The agent's invoke result (dict with ``messages`` key).
 
     Raises:
-        The original exception if all rollback attempts are exhausted.
+        The original exception if all rollback attempts are exhausted, and
+        immediately (one attempt) for any exception not in ``rollback_on`` —
+        including ``GraphRecursionError``.
     """
     current_input = input_data
     current_config = config
@@ -180,10 +186,12 @@ class RollbackRunnable:
         agent: The compiled subagent graph.
         max_retries_per_step: Passed to ``invoke_with_rollback``.
         max_rollback_depth: Passed to ``invoke_with_rollback``.
-        rollback_on: Exception types that trigger rollback.
+        rollback_on: Exception types that trigger rollback (default
+            ``(BadRequestError,)``; ``GraphRecursionError`` is terminal — see
+            ``invoke_with_rollback``).
         recursion_limit: If set, injected into the config passed to the
-            agent to cap the number of graph steps (default: None = use
-            LangGraph default of 1000).
+            agent to cap the number of graph steps. This is the per-agent
+            runaway backstop and is now terminal (a hit is NOT rolled back).
     """
 
     def __init__(
@@ -192,7 +200,7 @@ class RollbackRunnable:
         *,
         max_retries_per_step: int = 2,
         max_rollback_depth: int = 3,
-        rollback_on: tuple[type[Exception], ...] = (BadRequestError, GraphRecursionError),
+        rollback_on: tuple[type[Exception], ...] = (BadRequestError,),
         recursion_limit: int | None = None,
     ):
         self._agent = agent

--- a/assist/middleware/url_provenance.py
+++ b/assist/middleware/url_provenance.py
@@ -9,15 +9,16 @@ zero — the small model still slips. This middleware makes a fabricated fetch
 *unreachable*: ``read_url`` is refused unless the URL it's given already appears
 somewhere earlier in the conversation.
 
-"Already appears earlier" — not "came from a search result" — is deliberate: a
-provenanced URL is one the agent could have *copied* rather than *invented*. That
-set is every URL textually present in a prior message: search-result URLs, a URL
-the user put in the question, and links inside a page the agent already fetched
-(legitimate link-following). Only a URL that appears NOWHERE prior — a pure
-fabrication — is rejected. This keeps the guard a coarse, unambiguous bound (a
-substring/membership check on prior text, not a fuzzy "looks invented"
-heuristic), and it does not end the turn: it returns a corrective tool result so
-the model retries with a real URL.
+A provenanced URL is one the agent could have *copied* rather than *invented*:
+one textually present in a TOOL RESULT or the USER's message — search-result
+URLs, links inside a page the agent already fetched (legitimate link-following),
+or a URL the user pasted in the question. The model's OWN prior text does NOT
+count (else it launders a fabricated URL by writing it into its reasoning, then
+fetching it — see ``_seen_urls``). Only a URL that appears in no tool/user
+message — a pure fabrication — is rejected. This keeps the guard a coarse,
+unambiguous bound (a substring/membership check on tool+user text, not a fuzzy
+"looks invented" heuristic), and it does not end the turn: it returns a
+corrective tool result so the model retries with a real URL.
 
 Scope: the research SEARCHER only (it owns both ``search_internet`` and
 ``read_url``). NOT the fact-check agent — that subagent re-fetches URLs cited in
@@ -30,7 +31,7 @@ from typing import Any, Callable
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain.tools.tool_node import ToolCallRequest
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import HumanMessage, ToolMessage
 from langgraph.types import Command
 
 logger = logging.getLogger(__name__)
@@ -69,13 +70,22 @@ def _message_text(message: Any) -> str:
 
 
 def _seen_urls(messages: list) -> set[str]:
-    """Every URL that textually appears in the message content so far, normalized.
+    """Every URL in a TOOL RESULT or the USER's message, normalized — the sources
+    the model cannot fabricate.
 
-    Scans ``.content`` only — a ``read_url`` call's URL lives in the AIMessage's
-    ``tool_calls``, not its content, so the URL under check is never counted as
-    its own provenance."""
+    Scans ``ToolMessage`` content (search results + pages the agent already
+    fetched, so legitimate link-following is preserved) and ``HumanMessage``
+    content (a URL the user pasted in the question). It deliberately EXCLUDES the
+    model's own ``AIMessage`` content: otherwise the model launders a fabricated
+    URL by writing it into its reasoning first, then fetching it — observed on
+    Qwen3.6 (14 of 24 fetches slipped through this way against the provenance
+    eval). A copied-from-search URL is still allowed because it also appears in
+    the search ``ToolMessage``; only a URL invented in the model's own text and
+    present in no tool/user message is rejected."""
     seen: set[str] = set()
     for m in messages:
+        if not isinstance(m, (HumanMessage, ToolMessage)):
+            continue
         for raw in _URL_RE.findall(_message_text(m)):
             seen.add(normalize_url(raw))
     return seen

--- a/assist/middleware/url_provenance.py
+++ b/assist/middleware/url_provenance.py
@@ -28,6 +28,7 @@ would reject every (legitimate) fetch.
 import logging
 import re
 from typing import Any, Callable
+from urllib.parse import urlsplit, urlunsplit
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain.tools.tool_node import ToolCallRequest
@@ -37,10 +38,15 @@ from langgraph.types import Command
 logger = logging.getLogger(__name__)
 
 _READ_TOOL = "read_url"
-# URLs as they appear in tool results / text. Stop at whitespace and the
-# delimiters that bracket a URL in JSON-ish search output ("..."), markdown, or
-# prose so the captured token is the bare URL.
-_URL_RE = re.compile(r'https?://[^\s"\'<>)\]}]+')
+# URLs as they appear in tool results / text. Stop at whitespace and the quote
+# delimiters that bracket a URL in the search output (Python-repr ``'...'`` /
+# JSON ``"..."``). We deliberately DO NOT stop at ``)`` / ``]`` / ``}``: those are
+# valid URL characters (e.g. Wikipedia ``.../Mercury_(element)``) and the model
+# copies the FULL url verbatim as the read_url arg — truncating it here would
+# store a different string in the seen-set and wrongly reject the legit fetch.
+# Over-including a trailing bracket from prose only ever fails OPEN (the arg has
+# no trailing bracket, so it just doesn't match), never over-rejects.
+_URL_RE = re.compile(r'https?://[^\s"\'<>]+')
 # Cap how many available URLs the correction lists — enough to redirect, not so
 # many it bloats the context the model must re-read.
 _MAX_LISTED = 8
@@ -52,7 +58,6 @@ def normalize_url(url: str) -> str:
 
     Single source of truth for "the same URL" — the provenance eval imports this
     so the guard and the eval can't drift on what counts as a match."""
-    from urllib.parse import urlsplit, urlunsplit
     try:
         p = urlsplit(url.strip())
         if not p.scheme:

--- a/assist/middleware/url_provenance.py
+++ b/assist/middleware/url_provenance.py
@@ -50,23 +50,32 @@ _URL_RE = re.compile(r'https?://[^\s"\'<>]+')
 # Cap how many available URLs the correction lists — enough to redirect, not so
 # many it bloats the context the model must re-read.
 _MAX_LISTED = 8
+# Trailing chars stripped before comparison — sentence punctuation and brackets
+# that cling to a URL captured from prose. Stripped from BOTH the seen-set and
+# the checked URL (via normalize_url), so they stay consistent: a search result's
+# ``…/Mercury_(element)`` and the model's copied ``…/Mercury_(element)`` both
+# reduce to the same key, and a prose ``…/page.`` matches the clean ``…/page``.
+_TRAILING = ".,;:!?)]}'\""
 
 
 def normalize_url(url: str) -> str:
     """Canonical form for provenance comparison: lowercase scheme+host, drop the
-    fragment and a single trailing slash. Tolerates junk (returns it stripped).
+    fragment, a trailing slash, and trailing sentence punctuation/brackets.
+    Tolerates junk (returns it stripped).
 
     Single source of truth for "the same URL" — the provenance eval imports this
     so the guard and the eval can't drift on what counts as a match."""
+    s = url.strip().rstrip(_TRAILING)
     try:
-        p = urlsplit(url.strip())
+        p = urlsplit(s)
         if not p.scheme:
-            return url.strip().rstrip("/")
+            return s.rstrip("/")
         host = (p.hostname or "").lower()
         netloc = host + (f":{p.port}" if p.port else "")
-        return urlunsplit((p.scheme.lower(), netloc, p.path.rstrip("/"), p.query, ""))
+        rebuilt = urlunsplit((p.scheme.lower(), netloc, p.path.rstrip("/"), p.query, ""))
+        return rebuilt.rstrip(_TRAILING)
     except ValueError:
-        return url.strip().rstrip("/")
+        return s.rstrip("/")
 
 
 def _message_text(message: Any) -> str:

--- a/assist/middleware/url_provenance.py
+++ b/assist/middleware/url_provenance.py
@@ -1,0 +1,140 @@
+"""Structural backstop for research URL provenance.
+
+The research searcher (``sub_research.txt.j2``) fabricates canonical URLs it
+never saw — building ``casio.com/.../product.<model>/`` and store-search paths
+from memory and fetching them (the 2026-06-24 threads.db dead-URL flood; one
+thread held 101 GB of such a runaway). Guidance reduces this a lot (a worked
+example + read-cap took guessing from ~86 to 0-3 per turn) but cannot guarantee
+zero — the small model still slips. This middleware makes a fabricated fetch
+*unreachable*: ``read_url`` is refused unless the URL it's given already appears
+somewhere earlier in the conversation.
+
+"Already appears earlier" — not "came from a search result" — is deliberate: a
+provenanced URL is one the agent could have *copied* rather than *invented*. That
+set is every URL textually present in a prior message: search-result URLs, a URL
+the user put in the question, and links inside a page the agent already fetched
+(legitimate link-following). Only a URL that appears NOWHERE prior — a pure
+fabrication — is rejected. This keeps the guard a coarse, unambiguous bound (a
+substring/membership check on prior text, not a fuzzy "looks invented"
+heuristic), and it does not end the turn: it returns a corrective tool result so
+the model retries with a real URL.
+
+Scope: the research SEARCHER only (it owns both ``search_internet`` and
+``read_url``). NOT the fact-check agent — that subagent re-fetches URLs cited in
+a report it was handed, with no search results of its own, so the same check
+would reject every (legitimate) fetch.
+"""
+import logging
+import re
+from typing import Any, Callable
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain.tools.tool_node import ToolCallRequest
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
+
+logger = logging.getLogger(__name__)
+
+_READ_TOOL = "read_url"
+# URLs as they appear in tool results / text. Stop at whitespace and the
+# delimiters that bracket a URL in JSON-ish search output ("..."), markdown, or
+# prose so the captured token is the bare URL.
+_URL_RE = re.compile(r'https?://[^\s"\'<>)\]}]+')
+# Cap how many available URLs the correction lists — enough to redirect, not so
+# many it bloats the context the model must re-read.
+_MAX_LISTED = 8
+
+
+def normalize_url(url: str) -> str:
+    """Canonical form for provenance comparison: lowercase scheme+host, drop the
+    fragment and a single trailing slash. Tolerates junk (returns it stripped).
+
+    Single source of truth for "the same URL" — the provenance eval imports this
+    so the guard and the eval can't drift on what counts as a match."""
+    from urllib.parse import urlsplit, urlunsplit
+    try:
+        p = urlsplit(url.strip())
+        if not p.scheme:
+            return url.strip().rstrip("/")
+        host = (p.hostname or "").lower()
+        netloc = host + (f":{p.port}" if p.port else "")
+        return urlunsplit((p.scheme.lower(), netloc, p.path.rstrip("/"), p.query, ""))
+    except ValueError:
+        return url.strip().rstrip("/")
+
+
+def _message_text(message: Any) -> str:
+    content = getattr(message, "content", "")
+    return content if isinstance(content, str) else str(content)
+
+
+def _seen_urls(messages: list) -> set[str]:
+    """Every URL that textually appears in the message content so far, normalized.
+
+    Scans ``.content`` only — a ``read_url`` call's URL lives in the AIMessage's
+    ``tool_calls``, not its content, so the URL under check is never counted as
+    its own provenance."""
+    seen: set[str] = set()
+    for m in messages:
+        for raw in _URL_RE.findall(_message_text(m)):
+            seen.add(normalize_url(raw))
+    return seen
+
+
+def _correction(allowed: set[str]) -> str:
+    listed = sorted(allowed)[:_MAX_LISTED]
+    urls = "\n".join(f"- {u}" for u in listed) if listed else "(none yet — run search_internet first)"
+    return (
+        "That URL was not fetched: it does not appear in any search result, the "
+        "question, or a page you already read, so it is a guess and would be a "
+        "dead link. Do NOT type URLs from memory. Read one of the URLs your "
+        "search returned, or run search_internet to find the page:\n"
+        f"{urls}"
+    )
+
+
+class UrlProvenanceMiddleware(AgentMiddleware):
+    """Refuse a ``read_url`` whose URL appears nowhere earlier in the turn.
+
+    Corrective, not turn-ending: a rejected call returns an error ToolMessage
+    listing the URLs the agent may actually read, so it retries with a real one.
+    Stateless across turns except an intervention counter for logging."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.tools = []
+        self._intervention_count = 0
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], "ToolMessage | Command"],
+    ) -> "ToolMessage | Command":
+        tool_call = request.tool_call
+        if tool_call.get("name", "") != _READ_TOOL:
+            return handler(request)
+
+        args: Any = tool_call.get("args") or tool_call.get("arguments") or {}
+        url = args.get("url", "") if isinstance(args, dict) else ""
+        if not url:
+            return handler(request)
+
+        state = request.state or {}
+        messages = state.get("messages", []) if isinstance(state, dict) \
+            else getattr(state, "messages", [])
+        allowed = _seen_urls(messages)
+        if normalize_url(url) in allowed:
+            return handler(request)
+
+        self._intervention_count += 1
+        logger.warning(
+            "UrlProvenanceGuard: rejected read_url(%s) — not seen in prior "
+            "messages (intervention #%d, %d allowed urls)",
+            url, self._intervention_count, len(allowed),
+        )
+        return ToolMessage(
+            content=_correction(allowed),
+            tool_call_id=tool_call.get("id", ""),
+            name=_READ_TOOL,
+            status="error",
+        )

--- a/assist/middleware/url_provenance.py
+++ b/assist/middleware/url_provenance.py
@@ -85,9 +85,12 @@ def _message_text(message: Any) -> str:
     return content if isinstance(content, str) else str(content)
 
 
-def _seen_urls(messages: list) -> set[str]:
-    """Every URL in a TOOL RESULT or the USER's message, normalized — the sources
-    the model cannot fabricate.
+def _seen_urls(messages: list) -> dict[str, str]:
+    """Every URL in a TOOL RESULT or the USER's message: a map from the normalized
+    form (the membership key) to the ORIGINAL as it appeared (first seen). The
+    normalized keys are the sources the model cannot fabricate; the originals feed
+    the correction message so it never surfaces a normalize_url-truncated form
+    (e.g. a stripped trailing paren on a Wikipedia URL).
 
     Scans ``ToolMessage`` content (search results + pages the agent already
     fetched, so legitimate link-following is preserved) and ``HumanMessage``
@@ -98,17 +101,17 @@ def _seen_urls(messages: list) -> set[str]:
     eval). A copied-from-search URL is still allowed because it also appears in
     the search ``ToolMessage``; only a URL invented in the model's own text and
     present in no tool/user message is rejected."""
-    seen: set[str] = set()
+    seen: dict[str, str] = {}
     for m in messages:
         if not isinstance(m, (HumanMessage, ToolMessage)):
             continue
         for raw in _URL_RE.findall(_message_text(m)):
-            seen.add(normalize_url(raw))
+            seen.setdefault(normalize_url(raw), raw)
     return seen
 
 
-def _correction(allowed: set[str]) -> str:
-    listed = sorted(allowed)[:_MAX_LISTED]
+def _correction(allowed: dict[str, str]) -> str:
+    listed = sorted(allowed.values())[:_MAX_LISTED]
     urls = "\n".join(f"- {u}" for u in listed) if listed else "(none yet — run search_internet first)"
     return (
         "That URL was not fetched: it does not appear in any search result, the "

--- a/assist/middleware/url_provenance.py
+++ b/assist/middleware/url_provenance.py
@@ -113,8 +113,20 @@ def _seen_urls(messages: list) -> dict[str, str]:
         if not isinstance(m, (HumanMessage, ToolMessage)):
             continue
         for raw in _URL_RE.findall(_message_text(m)):
-            seen.setdefault(normalize_url(raw), raw.rstrip(_DISPLAY_STRIP))
+            seen.setdefault(normalize_url(raw), _display_url(raw))
     return seen
+
+
+def _display_url(raw: str) -> str:
+    """The captured URL trimmed for the correction message so it's fetchable:
+    drop trailing sentence punctuation, plus a trailing closing bracket ONLY when
+    it's UNBALANCED — a prose wrapper like ``(…/page)`` — while a balanced one is
+    a valid URL character (Wikipedia ``…/Mercury_(element)``) and is kept."""
+    u = raw.rstrip(_DISPLAY_STRIP)
+    closers = {")": "(", "]": "[", "}": "{"}
+    while u and u[-1] in closers and u.count(u[-1]) > u.count(closers[u[-1]]):
+        u = u[:-1].rstrip(_DISPLAY_STRIP)
+    return u
 
 
 def _correction(allowed: dict[str, str]) -> str:

--- a/assist/middleware/url_provenance.py
+++ b/assist/middleware/url_provenance.py
@@ -49,6 +49,13 @@ _READ_TOOL = "read_url"
 # Over-including a trailing bracket from prose only ever fails OPEN (the arg has
 # no trailing bracket, so it just doesn't match), never over-rejects.
 _URL_RE = re.compile(r'https?://[^\s"\'<>]+')
+# Trailing sentence punctuation to trim off the ORIGINAL before it's surfaced in
+# the correction message — so a URL captured from prose ("…see …/page.") is
+# listed as a clean, fetchable "…/page". Excludes brackets ``)]}`` on purpose:
+# those can be valid URL characters (Wikipedia ``…/Mercury_(element)``), so
+# stripping them would list a broken URL. (Membership uses normalize_url, which
+# is stricter; this only cleans the human/model-facing display.)
+_DISPLAY_STRIP = ".,;:!?"
 # Cap how many available URLs the correction lists — enough to redirect, not so
 # many it bloats the context the model must re-read.
 _MAX_LISTED = 8
@@ -106,7 +113,7 @@ def _seen_urls(messages: list) -> dict[str, str]:
         if not isinstance(m, (HumanMessage, ToolMessage)):
             continue
         for raw in _URL_RE.findall(_message_text(m)):
-            seen.setdefault(normalize_url(raw), raw)
+            seen.setdefault(normalize_url(raw), raw.rstrip(_DISPLAY_STRIP))
     return seen
 
 

--- a/assist/middleware/url_provenance.py
+++ b/assist/middleware/url_provenance.py
@@ -20,10 +20,12 @@ unambiguous bound (a substring/membership check on tool+user text, not a fuzzy
 "looks invented" heuristic), and it does not end the turn: it returns a
 corrective tool result so the model retries with a real URL.
 
-Scope: the research SEARCHER only (it owns both ``search_internet`` and
-``read_url``). NOT the fact-check agent — that subagent re-fetches URLs cited in
-a report it was handed, with no search results of its own, so the same check
-would reject every (legitimate) fetch.
+Scope: the research SEARCHER and the FACT-CHECKER — the two sub-agents whose
+``read_url`` should only ever hit a URL already in context (the searcher's own
+search results; the fact-checker's cited URLs, which live in the report
+``ToolMessage`` it is handed). NOT the orchestrator: guarding its ``read_url``
+risks re-dispatch thrash (a rejected fetch → re-dispatch research → more
+searches); its runaway is bounded by ``recursion_limit`` instead.
 """
 import logging
 import re

--- a/assist/templates/deepagents/sub_research.txt.j2
+++ b/assist/templates/deepagents/sub_research.txt.j2
@@ -6,7 +6,16 @@ Conduct focused research and then reply to the user with a detailed answer to th
 
 Stop searching once you can answer the question. Aim for about 4 searches — you do NOT need exhaustive coverage, and you do not need to keep searching for a better source once you have a usable answer. A handful of good results plus, if useful, one or two page reads is enough. Then write your final answer.
 
-Every URL you pass to `read_url` MUST be copied exactly from a `search_internet` result. NEVER type, construct, guess, or edit a URL from memory — do not build a site's product or category path yourself (e.g. a `.../product.<model>/` or `.../<brand>-kids/` URL you assume exists). If the page you want is not among your search results, run another search to find it; do not guess its address. When `read_url` returns an error for a URL, do NOT call that URL again and do NOT try a guessed variant of it — move on to a DIFFERENT search result.
+How to use `read_url` (follow this procedure):
+1. `search_internet` returns a list of `{title, url, content}` — `content` is a snippet of each page. Answer from the snippets when you can; they are usually enough.
+2. If you need a page's full text, copy ONE `url` value VERBATIM from a results list and pass that to `read_url`. Read at most 2 pages.
+3. The `url` you pass to `read_url` must be one you copied from a results list. You do not know what URLs exist — only the search results do. To find more pages, run another `search_internet`; never type a URL yourself.
+4. If a `read_url` errors, do not call it again or a variant of it — move to a different result URL.
+
+Example — suppose search_internet returned:
+`[{"title": "Casio F-91W", "url": "https://shop.example/f91w", "content": "..."}]`
+- Correct: `read_url("https://shop.example/f91w")`  ← copied from the results
+- WRONG: `read_url("https://www.casio.com/watch/f-91w/")`  ← you typed this from memory; it is a guess and will fail
 
 If web SEARCH reports that it is unavailable (an error saying web search is unavailable), STOP immediately: do NOT retry the search with different wording — it is unavailable and every retry will fail the same way — and do NOT answer from your own knowledge. Make your final message relay that status — say you couldn't look this up right now. A guess from memory is worse than an honest "I couldn't look this up right now." (A single page fetch failing — `read_url` returning an error for ONE url — is different and usually recoverable: just try another source/result; do not stop for that.)
 

--- a/assist/templates/deepagents/sub_research.txt.j2
+++ b/assist/templates/deepagents/sub_research.txt.j2
@@ -6,6 +6,8 @@ Conduct focused research and then reply to the user with a detailed answer to th
 
 Stop searching once you can answer the question. Aim for about 4 searches — you do NOT need exhaustive coverage, and you do not need to keep searching for a better source once you have a usable answer. A handful of good results plus, if useful, one or two page reads is enough. Then write your final answer.
 
+Every URL you pass to `read_url` MUST be copied exactly from a `search_internet` result. NEVER type, construct, guess, or edit a URL from memory — do not build a site's product or category path yourself (e.g. a `.../product.<model>/` or `.../<brand>-kids/` URL you assume exists). If the page you want is not among your search results, run another search to find it; do not guess its address. When `read_url` returns an error for a URL, do NOT call that URL again and do NOT try a guessed variant of it — move on to a DIFFERENT search result.
+
 If web SEARCH reports that it is unavailable (an error saying web search is unavailable), STOP immediately: do NOT retry the search with different wording — it is unavailable and every retry will fail the same way — and do NOT answer from your own knowledge. Make your final message relay that status — say you couldn't look this up right now. A guess from memory is worse than an honest "I couldn't look this up right now." (A single page fetch failing — `read_url` returning an error for ONE url — is different and usually recoverable: just try another source/result; do not stop for that.)
 
 Only your FINAL answer will be passed on to the user. They will have NO knowledge of anything except your final message, so your final report should be your final message!

--- a/assist/thread.py
+++ b/assist/thread.py
@@ -162,7 +162,16 @@ class Thread:
         self.on_queue_state = on_queue_state
         self.runconfig = {
             "configurable": {"thread_id": self.thread_id},
-            "max_concurrency": self.max_concurrency
+            "max_concurrency": self.max_concurrency,
+            # Bound the TOP-LEVEL orchestrator too. Without this it runs at
+            # langgraph's default (~10007 steps); the sub-agents have their own
+            # recursion_limits (research 150, context 500) but the trunk was
+            # effectively unbounded. Now that a recursion hit is terminal (not
+            # rolled-back-and-retried), this makes the orchestrator's own runaway
+            # (e.g. re-dispatch / read_file thrash) fail fast in a few minutes.
+            # Its own steps are mostly task-dispatch + synthesis, so 500 is
+            # generous for legit work while still bounding a runaway; eval-gated.
+            "recursion_limit": 500,
         }
         if configurable is not None:
             if not isinstance(configurable, Mapping):

--- a/assist/thread.py
+++ b/assist/thread.py
@@ -165,7 +165,7 @@ class Thread:
             "max_concurrency": self.max_concurrency,
             # Bound the TOP-LEVEL orchestrator too. Without this it runs at
             # langgraph's default (~10007 steps); the sub-agents have their own
-            # recursion_limits (research 150, context 500) but the trunk was
+            # recursion_limits (research 300, context 500) but the trunk was
             # effectively unbounded. Now that a recursion hit is terminal (not
             # rolled-back-and-retried), this makes the orchestrator's own runaway
             # (e.g. re-dispatch / read_file thrash) fail fast in a few minutes.

--- a/docs/2026-06-24-research-reliability.org
+++ b/docs/2026-06-24-research-reliability.org
@@ -1,0 +1,85 @@
+#+TITLE: Research reliability — URL provenance, dead-URL recovery, corroboration
+#+DATE: <2026-06-24>
+#+STATUS: DESIGN (awaiting redirect)
+
+* Context / why
+
+Research is the heart of the agent's value (roadmap: "Research is at the heart
+of what this agent is capable of"). The 2026-06-24 threads.db forensics showed
+the dominant historical failure mode: research sessions *fetching hundreds of
+guessed / dead URLs* (e.g. =casio.com/watch/<every-model>=, polygon articles
+that 404) — the largest single thread held 101 GB of such a runaway. PR #141
+improved *what* a fetch returns; it did nothing about *which URLs the agent
+chooses* or *whether cited sources support the claim*. That is this work.
+
+* Failure modes (grounded in the map, all currently UNgoverned + UNtested)
+
+1. *URL provenance* — the inner research agent (=sub_research.txt.j2=) is not
+   told to fetch only URLs that appeared in =search_internet= results. The small
+   model constructs/guesses URLs. (root cause of the dead-URL flood)
+2. *Dead-URL handling* — on a failed =read_url= the prompt says only "try
+   another source"; no rule against re-fetching the same dead URL or guessing
+   variants. Only loop-detection (same-URL ×3) + recursion_limit(150) backstop.
+3. *Corroboration* — =fact_checker.md.j2= verifies claims but has no
+   =search_internet= and can only *report* mismatches/dead links, not fix them.
+   The orchestrator's citation rules don't require corroboration in the first
+   place.
+4. *Recovery* — no eval that the agent completes a useful report after a fetch
+   fails.
+
+Eval coverage today: 3 happy-path tests (=test_research_agent.py=), none of 1–4.
+No helper inspects =read_url= / =search_internet= call ARGS.
+
+* Approach
+
+- *Guidance-first* (small-model ethos: prompts before middleware). URL-choice is
+  a single-agent behavior inside =sub_research=, where the memory says soft
+  prompt edits DO move the model (unlike multi-agent delegation). Validate by eval.
+- *Eval-driven* (the contract). Reproduce each failure as an eval FIRST, baseline
+  it, then fix to pass — measure baseline→after at N=3/5/10.
+- *Evals run live, no cassette dependency.* Provenance is a STRUCTURAL property
+  (every =read_url= arg ∈ prior =search_internet= result URLs) — robust to model
+  variation, so it asserts reliably on a live run without the (unmerged) cassette
+  infra. Recovery uses a patched =read_url= that errors for a target URL.
+
+* Increment 1 (this PR): URL provenance + dead-URL recovery
+
+** Eval helpers (=edd/eval/utils.py=)
+- =tool_call_args(agent, name) -> list[dict]= — args of every call to a tool.
+- =urls_fetched(agent) -> list[str]= — every =read_url= url arg, in order.
+- =search_result_urls(agent) -> set[str]= — URLs returned across all
+  =search_internet= results (parse the tool RESULTS).
+- assertion: every fetched url ∈ search_result_urls (provenance), and no url is
+  fetched >1× (no dead-URL retry).
+
+** Evals (=edd/eval/test_research_reliability.py=)
+- =test_only_fetches_search_result_urls= — real research question; assert
+  =urls_fetched ⊆ search_result_urls= (no constructed/guessed URLs).
+- =test_recovers_from_dead_fetch= — patch =read_url= to error for the URL the
+  agent first picks; assert it does NOT re-fetch that URL, fetches a different
+  search-result URL, and still writes a report.
+
+** Fix (=templates/deepagents/sub_research.txt.j2=)
+- Add: "Only call =read_url= on a URL that appears in a =search_internet=
+  result. Never construct, guess, or modify a URL." + "If a =read_url= returns
+  an error, do NOT retry it or try a guessed variant — pick a DIFFERENT
+  search-result URL, or search again."
+- Consider making =read_url='s error string directive ("…try a different
+  search result; do not retry this URL").
+
+** Measure
+Baseline (current prompt) → after (new guidance), N=3 then N=5/N=10 for the two
+new tests + spot-check the 3 existing research tests for regression.
+
+* Increment 2 (follow-up, NOT this PR): corroboration
+- LLM-judge eval: does each cited URL's fetched content support the claim?
+- Give =fact-check-agent= a remediation path (search for a better source, or
+  have the orchestrator drop unsupported claims). Harder; separate design.
+
+* Risks / open questions
+- Small model may under-comply with soft guidance → eval decides; if guidance
+  can't carry it, consider a structural nudge (e.g. =read_url= rejects a URL not
+  seen in a prior search result — a middleware last-resort, weighed against the
+  "guardrails: coarse real bounds only" rule).
+- Provenance assertion must tolerate trivial URL normalization (trailing slash,
+  fragment) — compare normalized forms.

--- a/docs/2026-07-02-research-runaway.org
+++ b/docs/2026-07-02-research-runaway.org
@@ -114,10 +114,16 @@ A recursion hit no longer wedges the thread at =processing= (the prod symptom):
 =SandboxContainerLostError= one) that sets a terminal =error= status with
 *narrow/split* guidance — NOT "retry" (retrying re-runs the runaway).
 
-** recursion_limit values are eval-gated
-150 was silently ~1050 (7× via rollback). The true-150 + orchestrator-500 are
-provisional pending a research-eval baseline with a recursion-hit counter — bump
-if legit deep research brushes the ceiling. (Baseline in progress.)
+** recursion_limit values — baselined 2026-07-02
+150 was silently ~1050 (7× via rollback). The recursion baseline (research
+contract tests × rounds, with a recursion-hit counter) showed a *true-150 cut
+off legit research* — 2 turns hit 150 and terminated (correlating with test
+failures). So 150 was too tight once the ~7× cushion was removed. **Bumped
+research to 300** (the pre-2026-06-06 value): a true-300 (~150 model calls) still
+bounds a runaway to ~5 min (vs the 70-min incident) but gives thorough research
+room. Orchestrator stays 500 (the eval runs the orchestrator at the harness's
+5000, so its prod-500 wasn't stressed; 500 is generous for a delegate-and-
+synthesize trunk). Final: research 300, orchestrator 500.
 
 * Validation
 

--- a/docs/2026-07-02-research-runaway.org
+++ b/docs/2026-07-02-research-runaway.org
@@ -1,0 +1,147 @@
+#+TITLE: Research runaway — URL-provenance guard + recursion fail-fast
+#+DATE: <2026-07-02>
+#+STATUS: DESIGN (as-built, PR #165, awaiting Pierre review)
+
+Supersedes the increment-1 sketch in =docs/2026-06-24-research-reliability.org=
+(that branch was stranded when the GPU fans died; this revives + hardens it and
+adds the recursion fix). Two orthogonal, complementary layers.
+
+* Context / the incident
+
+A prod research turn (thread =20260702084748-a8553d33=, "coffee shop with WiFi
+near Valencia") ran for ~70 minutes holding the single LLM slot, and left a
+stale =processing= status. Forensics: the model searched legitimately, then
+*fabricated* coffee-shop URLs from memory (=wavecoffee.co/...=, present in ZERO
+search results) and =read_url=-looped them — self-aware ("I notice I'm stuck in
+a loop") but not stopping, accumulating thousands of fetches. Same family as the
+2026-06-24 dead-URL flood (one thread held 101 GB).
+
+Two independent causes, so two independent fixes:
+1. *The model chooses bad URLs* — invents them. → URL-provenance guard.
+2. *Nothing bounded the runaway in time* — a recursion-limit hit was being
+   rolled-back-and-retried ~7×, and the orchestrator was effectively unbounded.
+   → recursion fail-fast.
+
+They are layers, not alternatives: provenance is a *targeted guard* on the
+fabrication surface; recursion is the *coarse real backstop* behind everything
+(matches the "coarse real bounds as the backstop; targeted guards only on
+unambiguous signals" ethos). Neither alone suffices — see §Validation.
+
+* Layer 1 — URL-provenance guard
+
+=UrlProvenanceMiddleware= (=assist/middleware/url_provenance.py=) intercepts
+=read_url= and refuses a URL that appears in NO prior tool result or user
+message — i.e. a fabrication. Corrective, not turn-ending: it returns a
+=ToolMessage= listing the real URLs to retry with, so the model recovers (this
+is the anti-pattern the rolled-back volume-cap violated — it must not kill the
+turn, see =docs/2026-06-05-research-volume-cap-destroys-output.org=).
+
+Coarse + unambiguous by construction: a substring/membership check on prior
+text, not a fuzzy "looks invented" heuristic.
+
+** Decision — provenance source is tool + user messages ONLY (the laundering fix)
+Reviving on the current model, the original guard was *defeated*: the model
+laundered a fabricated URL by writing it into its own reasoning first, then
+fetching it — the guard counted =AIMessage= content as provenance (14 of 24
+fetches slipped through). Fix: =_seen_urls= scans only =ToolMessage= (search
+results + pages already fetched → link-following preserved) and =HumanMessage=
+(a URL the user pasted), NEVER the model's own =AIMessage=. A copied-from-search
+URL still passes (it is also in the search =ToolMessage=); only a URL invented
+in the model's own text is refused.
+
+** Decision — guard the SEARCHER and FACT-CHECKER, NOT the orchestrator
+=read_url= is given to three agents. Fabricated fetches from the two unguarded
+ones bypassed the guard entirely (the eval's global =read_url= spy counts all).
+- *Searcher* (=research_sub_agent=): guarded. The original + main offender.
+- *Fact-checker*: guarded. It re-fetches URLs *cited in the report it is
+  handed* — those are in its context (the report =ToolMessage=) → they pass;
+  invented ones refused. (The old "exempt the fact-checker" note was
+  over-cautious.)
+- *Orchestrator*: NOT guarded — reverted. An eval trial where it *was* guarded
+  became a 303-search runaway: guarding the orchestrator's own =read_url= risks
+  *re-dispatch thrash* (a rejected fetch → the orchestrator re-dispatches
+  research → more searches). The orchestrator's runaway is bounded by its
+  =recursion_limit= (Layer 2) instead, not by provenance.
+
+** Normalization
+=normalize_url= (single source of truth, imported by the eval so they can't
+drift) lowercases scheme+host, drops the fragment + a trailing slash, and strips
+trailing sentence punctuation/brackets on BOTH sides — so a search result's
+=…/Mercury_(element)= and the model's copied =…/Mercury_(element)= reduce to the
+same key, and a prose =…/page.= matches the clean =…/page= (this closed a
+Copilot-flagged over-rejection introduced by widening the URL regex to keep
+whole parenthesized URLs).
+
+* Layer 2 — recursion fail-fast
+
+=recursion_limit= is the deliberate runaway backstop (per the 2026-06-06
+rollback, =docs/2026-06-05-loop-detection-audit.org=, commit d477ec4: all
+per-tool caps / loop heuristics were removed and =recursion_limit= made THE
+bound). But =invoke_with_rollback= had =GraphRecursionError= in its =rollback_on=
+tuple — so a limit hit rolled back a couple of checkpoints and RE-INVOKED, up to
+=1 + max_rollback_depth*max_retries_per_step = 7= times, each resuming the
+runaway (~150 → ~1050 effective steps). It silently defeated the very backstop
+the team chose.
+
+** Decision — GraphRecursionError is terminal (minimal change)
+Drop =GraphRecursionError= from both =rollback_on= defaults →
+(=BadRequestError=,). The existing =if not isinstance(exc, rollback_on): raise=
+guard then makes a recursion hit terminal on the first attempt, no new branch.
+=BadRequestError= rollback (recovering a malformed LLM message by rolling back +
+letting non-determinism take a different path) is *preserved* — that is
+genuinely recoverable; a recursion hit is not (rolling back a couple of steps
+just re-enters the same runaway). "Fail fast on infrastructure failure; don't
+heal-and-retry."
+
+** Decision — bound the orchestrator too
+=Thread.runconfig= set no =recursion_limit=, so the top-level agent ran at
+langgraph's default (~10007). The sub-agents had their own limits (research 150,
+context 500) but the trunk was effectively unbounded. Set orchestrator
+=recursion_limit=500=.
+
+** Decision — sub-agent recursion is turn-terminal (Option 1)
+When a sub-agent hits its limit, =GraphRecursionError= propagates out of the
+=task= tool (langgraph's default tool-error handler re-raises a non-
+=ToolInvocationError=) and terminates the turn. We accept this (Option 1) over a
+graceful =task=-boundary degradation (Option 2): Option 2 hands the orchestrator
+"sub-agent failed, carry on", and the small model reliably *re-dispatches* — the
+exact Pattern-F behavior d477ec4 removed. Partial =references/= files persist;
+the user retries.
+
+** Terminal error surface
+A recursion hit no longer wedges the thread at =processing= (the prod symptom):
+=manage/web/threads.py= gains an =except GraphRecursionError= branch (mirrors the
+=SandboxContainerLostError= one) that sets a terminal =error= status with
+*narrow/split* guidance — NOT "retry" (retrying re-runs the runaway).
+
+** recursion_limit values are eval-gated
+150 was silently ~1050 (7× via rollback). The true-150 + orchestrator-500 are
+provisional pending a research-eval baseline with a recursion-hit counter — bump
+if legit deep research brushes the ceiling. (Baseline in progress.)
+
+* Validation
+
+- *Unit*: 880 tests — anti-laundering, paren-URL, trailing-punct, recursion-
+  terminal (call_count==1, no rollback), BadRequest-still-rolls-back, and the
+  prod symptom (recursion → terminal =error= status, no wedge).
+- *Provenance eval* (=test_research_reliability.py=, live model): normal ops
+  clean after the laundering + all-guarded-subagents fixes.
+- *The eval CANNOT validate Layer 2.* It runs through =AgentHarness= at
+  =recursion_limit=5000=, so it does not exercise the prod bound (500/150). A
+  trial that over-searched to 303 (harness=5000) leaked fabrications under that
+  load — which is exactly the runaway the recursion bound stops in prod, and
+  confirms the two-layer design (provenance for normal ops; recursion for the
+  runaway). The recursion baseline runs the research suite with a recursion-hit
+  counter to size true-150 directly.
+
+* Known limitations / follow-ups
+
+- *Provenance residual under extreme load*: a determined over-search still leaks
+  some fabrication; the recursion bound (not provenance) is the backstop for
+  that. Do not expect the guard to be bulletproof under a runaway.
+- *Orchestrator re-dispatch (over-search)*: the orchestrator dispatching research
+  many times (Pattern-F territory, deliberately un-guarded since d477ec4) is
+  bounded by orchestrator =recursion_limit=, not eliminated. Out of scope.
+- *recursion_limit values*: eval-gated (see above).
+- *Corroboration* (does a cited URL support the claim): the increment-2
+  follow-up from the 2026-06-24 doc — still separate, not this PR.

--- a/docs/2026-07-02-research-runaway.org
+++ b/docs/2026-07-02-research-runaway.org
@@ -95,9 +95,9 @@ heal-and-retry."
 
 ** Decision — bound the orchestrator too
 =Thread.runconfig= set no =recursion_limit=, so the top-level agent ran at
-langgraph's default (~10007). The sub-agents had their own limits (research 150,
-context 500) but the trunk was effectively unbounded. Set orchestrator
-=recursion_limit=500=.
+langgraph's default (~10007). The sub-agents had their own limits (research 300
+— see §values below, context 500) but the trunk was effectively unbounded. Set
+orchestrator =recursion_limit=500=.
 
 ** Decision — sub-agent recursion is turn-terminal (Option 1)
 When a sub-agent hits its limit, =GraphRecursionError= propagates out of the
@@ -133,12 +133,14 @@ synthesize trunk). Final: research 300, orchestrator 500.
 - *Provenance eval* (=test_research_reliability.py=, live model): normal ops
   clean after the laundering + all-guarded-subagents fixes.
 - *The eval CANNOT validate Layer 2.* It runs through =AgentHarness= at
-  =recursion_limit=5000=, so it does not exercise the prod bound (500/150). A
+  =recursion_limit=5000=, so it does not exercise the prod bound (orch 500 /
+  research 300). A
   trial that over-searched to 303 (harness=5000) leaked fabrications under that
   load — which is exactly the runaway the recursion bound stops in prod, and
   confirms the two-layer design (provenance for normal ops; recursion for the
   runaway). The recursion baseline runs the research suite with a recursion-hit
-  counter to size true-150 directly.
+  counter to size the research limit directly (it found true-150 too tight →
+  research is now 300; see §values below).
 
 * Known limitations / follow-ups
 

--- a/edd/eval/test_research_reliability.py
+++ b/edd/eval/test_research_reliability.py
@@ -1,0 +1,103 @@
+"""Research reliability evals: URL provenance + dead-fetch recovery.
+
+The 2026-06-24 threads.db forensics showed research's dominant failure mode was
+the agent *fetching guessed/constructed URLs* (e.g. casio.com/watch/<model>) and
+re-fetching dead ones. These evals pin the contract:
+
+- Every URL the agent fetches must have come from a search result (no guessing).
+- A failed fetch must not be retried; the agent picks a different result and
+  still produces a report.
+
+Real model, but search + fetch are served from a CANNED fixture via
+ResearchToolSpy — provenance/recovery are about what the model does with search
+results, not live search quality, and the live SearXNG engines rate-limit /
+CAPTCHA unpredictably (a live run burned 26 min on dead-search retries). Canned
+fixtures make the eval deterministic and fast. The spy patches the tools where
+the research sub-agents bind them, so the inner sub-agent's calls are captured
+(``all_messages()`` only exposes the top-level thread).
+"""
+import logging
+import sys
+import tempfile
+from unittest import TestCase
+
+from assist.agent import create_research_agent, AgentHarness
+from assist.model_manager import select_assistant_model
+
+from .utils import (create_filesystem, files_in_directory, normalize_url,
+                    ResearchToolSpy)
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+_RESEARCH_Q = ("What kids' digital watches does Casio currently sell, and what "
+               "are their model numbers? Save the result to casio.org")
+
+# Canned search results: model numbers (F-91W, LA670, DW-5600) are present in the
+# snippets, so the agent CAN answer from these — a guessing-prone model will
+# nonetheless construct per-model casio.com URLs that are NOT in this set, which
+# is exactly what the provenance test catches.
+_CASIO_FIXTURE = [
+    {"title": "Casio F-91W Standard Digital Watch",
+     "url": "https://www.casio.com/us/watches/casio/product.F-91W-1/",
+     "content": "The F-91W is Casio's classic compact digital watch, a popular "
+                "first watch for kids: daily alarm, stopwatch, water resistant."},
+    {"title": "Best Casio watches for kids in 2026",
+     "url": "https://www.example-watchguide.com/best-casio-kids-watches",
+     "content": "Top kid-friendly Casio models: the F-91W, the LA670, and the "
+                "tough G-Shock DW-5600."},
+    {"title": "Casio LA670WA compact digital watch",
+     "url": "https://www.example-retailer.com/casio-la670wa",
+     "content": "The LA670WA is a small-wrist digital watch with alarm, calendar "
+                "and LED light — often recommended for children."},
+    {"title": "G-Shock DW-5600 review",
+     "url": "https://www.example-watchguide.com/g-shock-dw-5600",
+     "content": "The DW-5600 is a tough, kid-proof digital G-Shock: 200m water "
+                "resistance and shock resistance."},
+]
+
+
+class TestResearchReliability(TestCase):
+    def setUp(self):
+        self.model = select_assistant_model(0.1)
+
+    def _agent(self):
+        root = tempfile.mkdtemp()
+        create_filesystem(root, {"references": {}})
+        return AgentHarness(create_research_agent(self.model, root)), root
+
+    def test_only_fetches_search_result_urls(self):
+        """Every fetched URL came from a search result — none were guessed."""
+        with ResearchToolSpy(search_fixture=_CASIO_FIXTURE) as spy:
+            agent, _root = self._agent()  # build INSIDE the patch so sub-agent
+            agent.message(_RESEARCH_Q)    # tools bind to the spy, not the real fns
+        self.assertTrue(spy.fetched,
+                        "agent fetched no URLs — cannot assess provenance")
+        guessed = spy.guessed_fetches()
+        self.assertEqual(
+            guessed, [],
+            f"agent fetched {len(guessed)} URL(s) from NO search result "
+            f"(guessed/constructed): {guessed} — searched {len(spy.searched)}x "
+            f"yielding {len(spy.search_results)} result URLs; "
+            f"fetched {len(spy.fetched)} total.")
+
+    def test_recovers_from_dead_fetch(self):
+        """A failed fetch isn't retried; the agent tries a different result and
+        still writes a report."""
+        with ResearchToolSpy(search_fixture=_CASIO_FIXTURE, fail_first=1) as spy:
+            agent, root = self._agent()  # build INSIDE the patch (see above)
+            agent.message(_RESEARCH_Q)
+        self.assertTrue(spy.failed_first,
+                        "no fetch occurred, so the dead-fetch path was never hit")
+        dead = spy.failed_first[0]
+        self.assertEqual(
+            spy.fetch_count(dead), 1,
+            f"agent re-fetched the dead URL {dead} {spy.fetch_count(dead)}x "
+            f"instead of moving on")
+        others = {normalize_url(u) for u in spy.fetched} - {dead}
+        self.assertTrue(
+            others,
+            "agent fetched no other URL after the dead fetch — it gave up "
+            "instead of trying a different search result")
+        self.assertTrue(
+            files_in_directory(f"{root}/references"),
+            "agent produced no report after recovering from the dead fetch")

--- a/edd/eval/test_research_reliability.py
+++ b/edd/eval/test_research_reliability.py
@@ -32,27 +32,51 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 _RESEARCH_Q = ("What kids' digital watches does Casio currently sell, and what "
                "are their model numbers? Save the result to casio.org")
 
-# Canned search results: model numbers (F-91W, LA670, DW-5600) are present in the
-# snippets, so the agent CAN answer from these — a guessing-prone model will
-# nonetheless construct per-model casio.com URLs that are NOT in this set, which
-# is exactly what the provenance test catches.
+# Canned search results — deliberately GENEROUS (~10 real URLs spanning the kids'
+# watch space, with model numbers in the snippets) so the agent has ample real
+# sources and no excuse to invent more. A guessing-prone model still constructs
+# per-model casio.com paths NOT in this set; that's the failure the test catches.
 _CASIO_FIXTURE = [
     {"title": "Casio F-91W Standard Digital Watch",
      "url": "https://www.casio.com/us/watches/casio/product.F-91W-1/",
      "content": "The F-91W is Casio's classic compact digital watch, a popular "
                 "first watch for kids: daily alarm, stopwatch, water resistant."},
-    {"title": "Best Casio watches for kids in 2026",
-     "url": "https://www.example-watchguide.com/best-casio-kids-watches",
-     "content": "Top kid-friendly Casio models: the F-91W, the LA670, and the "
-                "tough G-Shock DW-5600."},
+    {"title": "Casio A158WA stainless digital watch",
+     "url": "https://www.casio.com/us/watches/casio/product.A158WA-1/",
+     "content": "The A158WA is a compact stainless-steel digital watch with "
+                "alarm, stopwatch and LED — small case suits younger wrists."},
     {"title": "Casio LA670WA compact digital watch",
      "url": "https://www.example-retailer.com/casio-la670wa",
      "content": "The LA670WA is a small-wrist digital watch with alarm, calendar "
                 "and LED light — often recommended for children."},
+    {"title": "Casio W-218H sport digital watch",
+     "url": "https://www.example-retailer.com/casio-w218h",
+     "content": "The W-218H is a lightweight 10-year-battery sport watch with "
+                "100m water resistance, popular as a durable kids' watch."},
+    {"title": "Best Casio watches for kids in 2026",
+     "url": "https://www.example-watchguide.com/best-casio-kids-watches",
+     "content": "Top kid-friendly Casio models: the F-91W, A158WA, LA670, W-218H "
+                "and the tough G-Shock DW-5600."},
     {"title": "G-Shock DW-5600 review",
      "url": "https://www.example-watchguide.com/g-shock-dw-5600",
      "content": "The DW-5600 is a tough, kid-proof digital G-Shock: 200m water "
                 "resistance and shock resistance."},
+    {"title": "Baby-G BGD-565 for older kids",
+     "url": "https://www.example-watchguide.com/baby-g-bgd-565",
+     "content": "The Baby-G BGD-565 is a compact, shock-resistant digital watch "
+                "marketed for teens and older children."},
+    {"title": "Casio kids' & small watches buying guide",
+     "url": "https://www.example-retailer.com/guides/casio-kids-watches",
+     "content": "Roundup of Casio's smaller digital watches suitable for kids: "
+                "F-91W, A158WA, LA670WA, W-218H, and Baby-G models."},
+    {"title": "Are Casio F-91W watches good for children? (forum)",
+     "url": "https://www.example-forum.com/t/casio-f91w-for-kids/1042",
+     "content": "Parents discuss the F-91W and LA670 as inexpensive, durable "
+                "first watches; model numbers and sizing tips."},
+    {"title": "Casio digital watch lineup overview",
+     "url": "https://www.example-watchguide.com/casio-digital-lineup",
+     "content": "Overview of Casio's current digital line including the F-91W, "
+                "A158WA, W-218H, LA670WA and G-Shock/Baby-G families."},
 ]
 
 
@@ -70,9 +94,12 @@ class TestResearchReliability(TestCase):
         with ResearchToolSpy(search_fixture=_CASIO_FIXTURE) as spy:
             agent, _root = self._agent()  # build INSIDE the patch so sub-agent
             agent.message(_RESEARCH_Q)    # tools bind to the spy, not the real fns
+        guessed = spy.guessed_fetches()
+        print(f"PROVENANCE_SUMMARY searched={len(spy.searched)} "
+              f"result_urls={len(spy.search_results)} fetched={len(spy.fetched)} "
+              f"guessed={len(guessed)}")
         self.assertTrue(spy.fetched,
                         "agent fetched no URLs — cannot assess provenance")
-        guessed = spy.guessed_fetches()
         self.assertEqual(
             guessed, [],
             f"agent fetched {len(guessed)} URL(s) from NO search result "

--- a/edd/eval/utils.py
+++ b/edd/eval/utils.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import subprocess
 from unittest.mock import patch
-from urllib.parse import urlsplit, urlunsplit
 from unittest import TestCase
 from langchain_core.messages import ToolMessage, AIMessage
 
@@ -223,18 +222,9 @@ def create_filesystem(root_dir: str,
 
 # -------------------- research URL-provenance spy --------------------
 
-def normalize_url(u: str) -> str:
-    """Canonical form for provenance comparison: lowercase scheme+host, drop
-    fragment and a single trailing slash. Tolerates junk (returns it stripped)."""
-    try:
-        p = urlsplit(u.strip())
-        if not p.scheme:
-            return u.strip().rstrip("/")
-        host = (p.hostname or "").lower()
-        netloc = host + (f":{p.port}" if p.port else "")
-        return urlunsplit((p.scheme.lower(), netloc, p.path.rstrip("/"), p.query, ""))
-    except Exception:
-        return u.strip().rstrip("/")
+# One source of truth for "the same URL" — the prod guard defines it, the eval
+# imports it, so the spy's provenance accounting can't drift from the guard's.
+from assist.middleware.url_provenance import normalize_url
 
 
 def _urls_in_search_result(result_str: str) -> list[str]:

--- a/edd/eval/utils.py
+++ b/edd/eval/utils.py
@@ -1,6 +1,10 @@
+import ast
+import functools
 import os
 import shutil
 import subprocess
+from unittest.mock import patch
+from urllib.parse import urlsplit, urlunsplit
 from unittest import TestCase
 from langchain_core.messages import ToolMessage, AIMessage
 
@@ -215,3 +219,129 @@ def create_filesystem(root_dir: str,
             # Create a directory and recursively process its contents
             os.makedirs(path, exist_ok=True)
             create_filesystem(path, content)
+
+
+# -------------------- research URL-provenance spy --------------------
+
+def normalize_url(u: str) -> str:
+    """Canonical form for provenance comparison: lowercase scheme+host, drop
+    fragment and a single trailing slash. Tolerates junk (returns it stripped)."""
+    try:
+        p = urlsplit(u.strip())
+        if not p.scheme:
+            return u.strip().rstrip("/")
+        host = (p.hostname or "").lower()
+        netloc = host + (f":{p.port}" if p.port else "")
+        return urlunsplit((p.scheme.lower(), netloc, p.path.rstrip("/"), p.query, ""))
+    except Exception:
+        return u.strip().rstrip("/")
+
+
+def _urls_in_search_result(result_str: str) -> list[str]:
+    """Extract URLs from a search_internet result string
+    (``[{'title','url','content'}, ...]``). Returns [] for non-list results
+    (e.g. the unavailable message or ``"[]"``)."""
+    try:
+        items = ast.literal_eval(result_str)
+    except (ValueError, SyntaxError):
+        return []
+    if not isinstance(items, list):
+        return []
+    return [it["url"] for it in items
+            if isinstance(it, dict) and it.get("url")]
+
+
+class ResearchToolSpy:
+    """Context manager that records every ``search_internet`` / ``read_url``
+    call made anywhere in the research agent (it patches the names where
+    ``assist.agent`` binds them, so nested sub-agent calls are captured too —
+    ``all_messages()`` only exposes the top-level thread). Calls pass through to
+    the real tools, so research runs for real.
+
+    Optionally injects a fetch failure to test dead-fetch recovery:
+      - ``fail_first=N`` — the first N *distinct* URLs fetched return a 404.
+      - ``fail_urls={...}`` — these exact URLs return a 404.
+
+    After the ``with`` block:
+      ``fetched``        — list[str], every read_url url arg in call order
+      ``searched``       — list[str], every search query
+      ``search_results`` — set[str], normalized URLs returned by all searches
+      ``failed_first``   — list[str] normalized URLs failed via ``fail_first``
+    """
+
+    def __init__(self, fail_first: int = 0, fail_urls=None,
+                 search_fixture=None, read_fixture=None):
+        """``search_fixture`` (list of ``{title,url,content}`` dicts) makes
+        ``search_internet`` return that canned set for every query instead of
+        hitting SearXNG — deterministic and immune to the upstream-engine
+        rate-limits/CAPTCHAs that make live research evals flaky. In canned mode
+        ``read_url`` also returns canned text (``read_fixture`` maps normalized
+        url->text; otherwise a generic body), so the eval exercises the model's
+        URL-choice behavior without any network."""
+        self.fetched: list[str] = []
+        self.searched: list[str] = []
+        self.search_results: set[str] = set()
+        self.failed_first: list[str] = []
+        self._fail_first = fail_first
+        self._fail = {normalize_url(u) for u in (fail_urls or [])}
+        self._search_fixture = search_fixture
+        self._read_fixture = {normalize_url(k): v
+                              for k, v in (read_fixture or {}).items()}
+        self._patches: list = []
+
+    @staticmethod
+    def _err(url: str) -> str:
+        return f"Error fetching URL: 404 Client Error: Not Found for url: {url}"
+
+    def __enter__(self):
+        import assist.agent as ag
+        real_read, real_search = ag.read_url, ag.search_internet
+
+        # @wraps so deepagents/langchain wrap these as tools named "read_url" /
+        # "search_internet" (it derives the tool name + description from
+        # __name__/__doc__), not "spy_read"/"spy_search".
+        @functools.wraps(real_read)
+        def spy_read(url):
+            self.fetched.append(url)
+            n = normalize_url(url)
+            if n in self._fail:
+                return self._err(url)
+            if (self._fail_first and n not in self.failed_first
+                    and len(self.failed_first) < self._fail_first):
+                self.failed_first.append(n)
+                return self._err(url)
+            if self._search_fixture is not None:  # canned mode: no network
+                return self._read_fixture.get(n, f"Reference page at {url}.")
+            return real_read(url)
+
+        @functools.wraps(real_search)
+        def spy_search(query, max_results=5):
+            self.searched.append(query)
+            if self._search_fixture is not None:
+                res = str(self._search_fixture[:max_results])
+            else:
+                res = real_search(query, max_results)
+            for u in _urls_in_search_result(res):
+                self.search_results.add(normalize_url(u))
+            return res
+
+        self._patches = [patch.object(ag, "read_url", spy_read),
+                         patch.object(ag, "search_internet", spy_search)]
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *exc):
+        for p in self._patches:
+            p.stop()
+        return False
+
+    def guessed_fetches(self) -> list[str]:
+        """Fetched URLs that came from NO search result — i.e. the agent
+        constructed/guessed them rather than picking a search hit."""
+        return [u for u in self.fetched
+                if normalize_url(u) not in self.search_results]
+
+    def fetch_count(self, url: str) -> int:
+        n = normalize_url(url)
+        return sum(1 for u in self.fetched if normalize_url(u) == n)

--- a/edd/eval/utils.py
+++ b/edd/eval/utils.py
@@ -6,6 +6,9 @@ import subprocess
 from unittest.mock import patch
 from unittest import TestCase
 from langchain_core.messages import ToolMessage, AIMessage
+# One source of truth for "the same URL" — the prod guard defines it, the eval
+# imports it, so the spy's provenance accounting can't drift from the guard's.
+from assist.middleware.url_provenance import normalize_url
 
 
 class AgentTestMixin:
@@ -221,11 +224,6 @@ def create_filesystem(root_dir: str,
 
 
 # -------------------- research URL-provenance spy --------------------
-
-# One source of truth for "the same URL" — the prod guard defines it, the eval
-# imports it, so the spy's provenance accounting can't drift from the guard's.
-from assist.middleware.url_provenance import normalize_url
-
 
 def _urls_in_search_result(result_str: str) -> list[str]:
     """Extract URLs from a search_internet result string

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -36,6 +36,7 @@ from assist.domain_manager import (
     MergeConflictError,
     OriginAdvancedError,
 )
+from langgraph.errors import GraphRecursionError
 from assist.context_rider import ContextRider, CONTEXT_RIDER_KEY
 from assist.events.reply import SMS_SENDER_KEY
 from assist.schedule.scheduler import Scheduler
@@ -800,6 +801,19 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
             error=("The sandbox container for this thread was lost mid-run. "
                    "Your last message was not completed. Send the message "
                    "again to retry in a fresh sandbox."),
+            **pending_kwargs,
+        )
+    except GraphRecursionError as e:
+        # The turn hit its step ceiling (the runaway backstop) and was stopped.
+        # Distinct message from the generic branch: this is terminal, not a
+        # transient fault, and retrying the same request would just run away
+        # again — so suggest narrowing/splitting, NOT "send again to retry".
+        logging.warning("Recursion limit hit for thread %s: %s", tid, e)
+        _set_status(
+            tid, "error",
+            error=("This request grew too large to complete — it hit the internal "
+                   "step limit and was stopped. Try narrowing it or splitting it "
+                   "into smaller parts."),
             **pending_kwargs,
         )
     except Exception as e:

--- a/roadmap.org
+++ b/roadmap.org
@@ -77,6 +77,49 @@ Idea (from 2026-06-15):
 - Watch the trade-off: over-aggressive extraction can drop tables/code/lists the
   research actually needs; the fallback exists for exactly that.  Validate with
   research evals (report still cites the right facts/URLs) before defaulting.
+** TODO Research resilience to search rate-limiting + =read_url= link exploration
+Observed 2026-07-02, thread =20260702160303-2ba1f923= ("Research good coffee
+shops with WiFi within walking distance of Fellow Barber, 1398 Valencia St SF"):
+the agent gave up with "couldn't look this up because web search is currently
+unavailable" even though it HAD a good result.
+
+Root cause (=assist/tools.py= =search_internet=, log-confirmed): the agent fired
+a burst of searches (3 parallel + 2 retries) which tripped SearXNG's free
+UPSTREAM ENGINE rate limits — logged reason =engines failed: [['brave', 'too
+many requests' -> 'Suspended'], ['duckduckgo', 'CAPTCHA'], ['startpage', ...]]=.
+The FIRST search landed before the limits and returned a real, on-point result
+(a "Mission District Coffee Shops for Remote Work" guide); the next four came
+back zero-results-with-engine-errors -> =_SEARCH_UNAVAILABLE_MESSAGE=. Seeing
+4/5 "unavailable", the agent RELAYED unavailable and abandoned the one good
+result. This is NOT the research-runaway PR (#165 provenance/recursion worked:
+real searches, no fabrication, no loop, 1.5 min) — it's upstream of it.
+
+Desired behaviour (Pierre): don't give up on partial success — USE what you got
+and be transparent, e.g. "I could only find a few data points before I was
+rate-limited. Based on X sources, I can tell you that ...". The
+=search_unavailable= handling over-triggers: "unavailable" from SOME queries in
+a burst must not discard the results from the ones that SUCCEEDED.
+
+Two work items:
+1. *Partial-results resilience + honest messaging.* When some searches succeed
+   and others hit rate-limit/engine-error, keep the good results, keep
+   researching from them, and report the partial/rate-limited state instead of a
+   flat "unavailable". Distinguish "backend genuinely down (0 results ever)" from
+   "burst tripped the engine limits (some results in hand)". Relates to the
+   stranded =heed-research-rate-limit-signal= branch. Consider serializing/spacing
+   the searches (the 3-parallel burst is what trips the limits — single/spaced
+   queries succeed) and/or sturdier SearXNG engines (cf. DONE "real Search API"
+   item — the free scraped engines rate-limit hard).
+2. *=read_url= returns the page's hyperlinks (Pierre).* Today =read_url=
+   (=_extract_main_content=) returns TEXT only — it strips =<a href>=, so the
+   research agent can't follow links to explore. Surface the page's outbound
+   links (deduped, maybe labelled with anchor text) so the agent can EXPLORE from
+   a few good results — a direct workaround for rate-limited search (fetch the 1
+   good guide, follow its coffee-shop links). The provenance guard already PERMITS
+   link-following (a URL in a fetched =ToolMessage= is provenanced), so this
+   unlocks a path the guard already allows but =read_url= never exposed. Validate
+   with research evals; watch the char budget (links compete with content —
+   maybe a separate =read_url_links= tool, or a links section appended).
 * Reliability
 ** DONE Streamed sub-agent wedge — langgraph checkpoint-put thread-pool exhaustion
 *Symptom.*  A =/chat= turn that spawns a sub-agent (=task= → research/context-agent) over the STREAMED path (emacsos-server: =Thread.stream_message= → =agent.stream()= consumed via =run_in_executor=→=next()=) hangs after the sub-agent runs, with no error, and then wedges every later turn (they block on =THREAD_QUEUE=).  The web UI's blocking =Thread.message()= → =invoke_with_rollback= → =.invoke()= path was initially thought to be immune.  *That was wrong.*  On 2026-05-29 thread =20260528073914-cbd6a4cb= wedged for ~5h26m via the same chained-futures mechanism after a general-agent → research-agent → 4-concurrent-tools nesting depth was reached from the =.invoke()= side.  Mirrored the =durability="sync"= fix into =invoke_with_rollback= on 2026-05-30; see [[file:docs/2026-05-30-message-path-durability-sync.org][docs/2026-05-30-message-path-durability-sync.org]].

--- a/roadmap.org
+++ b/roadmap.org
@@ -147,12 +147,22 @@ estimating. Variations to cover the shape, e.g.:
 Assert: routing tool invoked with the right places; NO hand-estimated
 miles/minutes surface in the research phase.
 
-*Secondary (verify-the-anchor):* the origin fact was ALSO wrong — the prompt said
-"Fellow Barber at 1398 Valencia St" (real: 696 Valencia, near 18th St), and the
-research agent echoed/confabulated it ("they have a location at 1398 Valencia St")
-instead of verifying. A distance answer is only as good as its anchor; consider an
-eval that the agent verifies/geocodes the named origin before measuring from it.
-Related: [[queued-research-rate-limit-resilience]] + the =read_url= link item above.
+*Also (CONFABULATED ANCHOR — the root of the whole coffee-shop saga):* the origin
+address was FABRICATED BY THE MODEL, not given by the user. Pierre's actual prompt
+(thread =...084748=, 08:47) was just "What's a good coffee shop with WiFi near
+fellow barber (walking) on Valencia?" — NO address. At 08:48:35 the model wrote,
+in its own planning text, "*Confirming Fellow Barber's address — … (they have a
+location at 1398 Valencia St, San Francisco, CA 94110)*" — asserting a wrong street
+number as a parenthetical FACT from its own knowledge (real: 696 Valencia, near
+18th St), then planning to "confirm" via Google Maps (that confirm-step is what
+spun into the 70-min runaway). Verified: ZERO search results ever contained "1398
+Valencia" (not in any tool result content/url/title) — pure confabulation. The
+provenance guard (PR #165) catches fabricated URLs but NOT a fabricated FACT like
+an address. So the deeper item: the agent must VERIFY/geocode a named entity's
+address (via the geocoder/routing tool it already has) instead of asserting it
+from memory — a distance answer is only as good as its anchor, and here the anchor
+was invented. Related: [[queued-research-rate-limit-resilience]] + the =read_url=
+link item above.
 * Reliability
 ** DONE Streamed sub-agent wedge — langgraph checkpoint-put thread-pool exhaustion
 *Symptom.*  A =/chat= turn that spawns a sub-agent (=task= → research/context-agent) over the STREAMED path (emacsos-server: =Thread.stream_message= → =agent.stream()= consumed via =run_in_executor=→=next()=) hangs after the sub-agent runs, with no error, and then wedges every later turn (they block on =THREAD_QUEUE=).  The web UI's blocking =Thread.message()= → =invoke_with_rollback= → =.invoke()= path was initially thought to be immune.  *That was wrong.*  On 2026-05-29 thread =20260528073914-cbd6a4cb= wedged for ~5h26m via the same chained-futures mechanism after a general-agent → research-agent → 4-concurrent-tools nesting depth was reached from the =.invoke()= side.  Mirrored the =durability="sync"= fix into =invoke_with_rollback= on 2026-05-30; see [[file:docs/2026-05-30-message-path-durability-sync.org][docs/2026-05-30-message-path-durability-sync.org]].

--- a/roadmap.org
+++ b/roadmap.org
@@ -137,6 +137,27 @@ agent would add them correctly by calling the routing tool. So keep distance
 computation OUT of research (don't let it emit invented numbers); the
 distance-capable agent fills them via the tool.
 
+*Fix is TWO-SIDED (Pierre) — belt AND suspenders:*
+1. *General agent must NOT ask research for distances/travel times.* When it
+   delegates (the =task= dispatch to the research sub-agent), the delegated task
+   should ask only for the PLACES/facts, never the walking/driving distances or
+   times — the general agent computes those itself with =travel=/=directions=
+   AFTER research returns the candidates. Prompt/guidance on the
+   orchestrator (=research_instructions.txt.j2=): "delegate the finding of
+   places/facts; you compute distances & travel times yourself with the routing
+   tool — never ask the researcher for them."
+2. *Research sub-agent must NOT look up / estimate distances even if asked
+   (refuse).* It has no routing tool, so any distance it produces is a guess.
+   Guidance in =sub_research.txt.j2=: "you do NOT compute or estimate distances or
+   travel times — you have no routing tool; if the task asks for them, omit them
+   (or state the caller should route them) and return only the places/facts."
+   Potentially a harder lever if guidance doesn't hold (the small model may
+   estimate anyway): don't let a hand-estimated number survive — but the coarse-
+   bounds/guidance-first ethos says try guidance + eval first.
+Neither side alone is enough: if only (1), the researcher volunteers guesses; if
+only (2), the general agent might still surface no distances for a distance-nature
+question. Both → research returns places, general agent routes the distances.
+
 *Eval to add (Pierre):* mock a research report/answer that has NO distances while
 the QUESTION is about distances — 3 variations — and assert the agent CALLS the
 appropriate tool (=travel=/=directions=) to get the distances rather than

--- a/roadmap.org
+++ b/roadmap.org
@@ -184,6 +184,32 @@ address (via the geocoder/routing tool it already has) instead of asserting it
 from memory — a distance answer is only as good as its anchor, and here the anchor
 was invented. Related: [[queued-research-rate-limit-resilience]] + the =read_url=
 link item above.
+** TODO Audit research turns for ADVERSE guard effects (provenance / recursion cut-offs)
+The PR #165 guards (=UrlProvenanceMiddleware= + recursion fail-fast) are corrective
+by design and validated on evals, but the thing to actively watch is the
+FALSE-POSITIVE side: a research turn that was going WELL and got CUT OFF by a
+guard, forcing a suboptimal result. Two failure shapes to hunt:
+1. *Provenance guard over-rejecting a LEGIT fetch.* The guard refuses a =read_url=
+   whose URL isn't in prior tool/user messages. A real, correct URL could be
+   rejected if the model got it from somewhere the guard doesn't scan, or via a
+   normalization mismatch (we already fixed paren/trailing-punct edges in review
+   — watch for more). Symptom: the model had a good URL, the guard blocked it,
+   the answer got worse.
+2. *Recursion limit cutting off PRODUCTIVE research (not a runaway).* The
+   recursion baseline already caught that true-150 cut off legit turns (-> bumped
+   to 300). Keep watching at 300: a deep/multi-subject turn that was converging
+   and hit the ceiling is a false-positive terminal — the answer is truncated,
+   not a runaway.
+*How:* audit the thread history (prod =threads.db= + the assist-web log's
+=UrlProvenanceGuard: rejected= and recursion-terminal lines) — for each guard
+intervention / recursion hit, classify TRUE positive (blocked a fabrication /
+bounded a genuine runaway) vs FALSE positive (killed good work). A cheap start:
+grep the logs for guard fires + recursion terminals, pull those threads, and read
+whether the outcome degraded. If false positives show up, they tune the levers
+(guard scope/normalization; recursion_limit value; or route-vs-guess as in the
+distances item). Matches the "coarse real bounds must not misfire on real work"
+ethos — a mid-task guard misfire is worse than the rare runaway it prevents.
+Related: the distances item + [[queued-research-rate-limit-resilience]] above.
 * Reliability
 ** DONE Streamed sub-agent wedge — langgraph checkpoint-put thread-pool exhaustion
 *Symptom.*  A =/chat= turn that spawns a sub-agent (=task= → research/context-agent) over the STREAMED path (emacsos-server: =Thread.stream_message= → =agent.stream()= consumed via =run_in_executor=→=next()=) hangs after the sub-agent runs, with no error, and then wedges every later turn (they block on =THREAD_QUEUE=).  The web UI's blocking =Thread.message()= → =invoke_with_rollback= → =.invoke()= path was initially thought to be immune.  *That was wrong.*  On 2026-05-29 thread =20260528073914-cbd6a4cb= wedged for ~5h26m via the same chained-futures mechanism after a general-agent → research-agent → 4-concurrent-tools nesting depth was reached from the =.invoke()= side.  Mirrored the =durability="sync"= fix into =invoke_with_rollback= on 2026-05-30; see [[file:docs/2026-05-30-message-path-durability-sync.org][docs/2026-05-30-message-path-durability-sync.org]].

--- a/roadmap.org
+++ b/roadmap.org
@@ -120,6 +120,39 @@ Two work items:
    unlocks a path the guard already allows but =read_url= never exposed. Validate
    with research evals; watch the char budget (links compete with content —
    maybe a separate =read_url_links= tool, or a links section appended).
+** TODO Research agent must NOT judge distances/travel — the routing tool does
+Observed 2026-07-02 (threads =...160303=, =...202502=, "coffee shops near Fellow
+Barber"): the research/critique agent ESTIMATED walking times by counting blocks
+by hand ("18th to 24th is ~6 blocks south -> ~0.5 mi, 8-10 min") — the report
+gave Fellow Barber -> Haus as ~11 min; the real answer (MOTIS =directions=) is
+*24 min / 1.06 mi*. The research sub-agent's tools are =[search_internet,
+read_url]= only — it has NO routing tool, so a hand-estimated distance is
+guaranteed-wrong AND looks authoritative.
+
+*Principle (Pierre):* the research agent should NOT judge distances. For a
+distance-/travel-nature question, distances belong to the agent that HAS the
+routing tool (=travel= / =directions=, MOTIS+Nominatim) — the general/orchestrator
+agent. If the research agent returns a report WITHOUT distances, the general
+agent would add them correctly by calling the routing tool. So keep distance
+computation OUT of research (don't let it emit invented numbers); the
+distance-capable agent fills them via the tool.
+
+*Eval to add (Pierre):* mock a research report/answer that has NO distances while
+the QUESTION is about distances — 3 variations — and assert the agent CALLS the
+appropriate tool (=travel=/=directions=) to get the distances rather than
+estimating. Variations to cover the shape, e.g.:
+1. "coffee shops within walking distance of X" (report lists shops, no distances).
+2. "which of these N places is closest to X / rank by travel time" (list, no times).
+3. "how far / how long from A to B" (a direct A->B travel question).
+Assert: routing tool invoked with the right places; NO hand-estimated
+miles/minutes surface in the research phase.
+
+*Secondary (verify-the-anchor):* the origin fact was ALSO wrong — the prompt said
+"Fellow Barber at 1398 Valencia St" (real: 696 Valencia, near 18th St), and the
+research agent echoed/confabulated it ("they have a location at 1398 Valencia St")
+instead of verifying. A distance answer is only as good as its anchor; consider an
+eval that the agent verifies/geocodes the named origin before measuring from it.
+Related: [[queued-research-rate-limit-resilience]] + the =read_url= link item above.
 * Reliability
 ** DONE Streamed sub-agent wedge — langgraph checkpoint-put thread-pool exhaustion
 *Symptom.*  A =/chat= turn that spawns a sub-agent (=task= → research/context-agent) over the STREAMED path (emacsos-server: =Thread.stream_message= → =agent.stream()= consumed via =run_in_executor=→=next()=) hangs after the sub-agent runs, with no error, and then wedges every later turn (they block on =THREAD_QUEUE=).  The web UI's blocking =Thread.message()= → =invoke_with_rollback= → =.invoke()= path was initially thought to be immune.  *That was wrong.*  On 2026-05-29 thread =20260528073914-cbd6a4cb= wedged for ~5h26m via the same chained-futures mechanism after a general-agent → research-agent → 4-concurrent-tools nesting depth was reached from the =.invoke()= side.  Mirrored the =durability="sync"= fix into =invoke_with_rollback= on 2026-05-30; see [[file:docs/2026-05-30-message-path-durability-sync.org][docs/2026-05-30-message-path-durability-sync.org]].

--- a/tests/test_checkpoint_rollback.py
+++ b/tests/test_checkpoint_rollback.py
@@ -191,6 +191,45 @@ class TestInvokeWithRollback:
         assert agent.invoke.call_count == 1
         agent.get_state_history.assert_not_called()
 
+    def test_recursion_error_is_terminal_not_retried(self):
+        """A GraphRecursionError (the runaway backstop) is NOT rolled back — it
+        propagates on the FIRST attempt with no rollback, even when history
+        exists. Anti-amplification pin: it used to be in rollback_on and got
+        re-invoked up to ~7x, resuming the runaway (~1050 effective steps)."""
+        from langgraph.errors import GraphRecursionError
+        agent = Mock()
+        agent.invoke.side_effect = GraphRecursionError("Recursion limit of 150 reached")
+        # History IS available, so a rollback would be *possible* — recursion
+        # must still refuse it.
+        agent.get_state_history.return_value = [_make_checkpoint("c1", step=1),
+                                                _make_checkpoint("c2", step=0)]
+
+        with pytest.raises(GraphRecursionError):
+            invoke_with_rollback(
+                agent,
+                {"messages": [{"role": "user", "content": "hi"}]},
+                {"configurable": {"thread_id": "t1"}},
+            )
+
+        assert agent.invoke.call_count == 1
+        agent.get_state_history.assert_not_called()
+
+    def test_bad_request_still_rolls_back_after_recursion_dropped(self):
+        """Guard against over-narrowing rollback_on: a BadRequestError must STILL
+        roll back and retry (call_count > 1) even though GraphRecursionError was
+        removed from the default tuple."""
+        agent = Mock()
+        agent.invoke.side_effect = [_make_bad_request_error(), {"messages": ["ok"]}]
+        agent.get_state_history.return_value = [_make_checkpoint("c1", step=1),
+                                                _make_checkpoint("c2", step=0)]
+        result = invoke_with_rollback(
+            agent,
+            {"messages": [{"role": "user", "content": "hi"}]},
+            {"configurable": {"thread_id": "t1"}},
+        )
+        assert result == {"messages": ["ok"]}
+        assert agent.invoke.call_count == 2
+
     def test_raises_immediately_when_no_history(self):
         """If there are no checkpoints at all, raise without retrying."""
         agent = Mock()

--- a/tests/test_url_provenance.py
+++ b/tests/test_url_provenance.py
@@ -85,6 +85,18 @@ class TestUrlProvenanceMiddleware(TestCase):
         self.assertIsNotNone(handler.called_with,
                              "a copied parenthesized search-result URL must pass")
 
+    def test_trailing_punctuation_matches_clean_url(self):
+        # A URL captured from a fetched page's prose WITH trailing punctuation
+        # ("...see https://shop.example/deep/page.") must still match the model's
+        # clean copied fetch — normalize_url strips the trailing char on BOTH
+        # sides, so the widened regex can't cause a spurious rejection.
+        msgs = [_search_result(["https://shop.example/index"]),
+                ToolMessage(content="Details at https://shop.example/deep/page. Enjoy.",
+                            name="read_url", tool_call_id="r0")]
+        _result, handler = self._call("https://shop.example/deep/page", msgs)
+        self.assertIsNotNone(handler.called_with,
+                             "a clean URL must match a prose URL with trailing punctuation")
+
     def test_model_cannot_launder_via_its_own_text(self):
         # A URL present ONLY in the model's own AIMessage content is NOT provenance —
         # else the model writes a fabricated URL into its reasoning, then fetches it

--- a/tests/test_url_provenance.py
+++ b/tests/test_url_provenance.py
@@ -1,0 +1,100 @@
+"""Unit tests for UrlProvenanceMiddleware — the research read_url guard.
+
+Deterministic (no LLM): drive wrap_tool_call directly with a constructed
+ToolCallRequest and assert allow (handler invoked) vs reject (corrective
+ToolMessage, handler NOT invoked).
+"""
+from unittest import TestCase
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain.tools.tool_node import ToolCallRequest
+
+from assist.middleware.url_provenance import UrlProvenanceMiddleware, normalize_url
+
+
+def _search_result(urls):
+    items = [{"title": "t", "url": u, "content": "snippet"} for u in urls]
+    return ToolMessage(content=str(items), name="search_internet", tool_call_id="s1")
+
+
+class _Handler:
+    """Stand-in tool executor: records invocation, returns a sentinel."""
+    def __init__(self):
+        self.called_with = None
+
+    def __call__(self, request):
+        self.called_with = request
+        return ToolMessage(content="FETCHED", tool_call_id=request.tool_call.get("id", ""),
+                           name="read_url")
+
+
+def _request(url, messages):
+    return ToolCallRequest(
+        tool_call={"name": "read_url", "args": {"url": url}, "id": "r1"},
+        tool=None,
+        state={"messages": messages},
+        runtime=None,
+    )
+
+
+class TestUrlProvenanceMiddleware(TestCase):
+    def setUp(self):
+        self.mw = UrlProvenanceMiddleware()
+
+    def _call(self, url, messages):
+        handler = _Handler()
+        result = self.mw.wrap_tool_call(_request(url, messages), handler)
+        return result, handler
+
+    def test_allows_url_from_a_search_result(self):
+        msgs = [HumanMessage(content="find casio watches"),
+                _search_result(["https://shop.example/f91w", "https://shop.example/la670"])]
+        result, handler = self._call("https://shop.example/f91w", msgs)
+        self.assertIsNotNone(handler.called_with, "should pass a provenanced URL through")
+        self.assertEqual(result.content, "FETCHED")
+
+    def test_rejects_fabricated_url(self):
+        msgs = [_search_result(["https://shop.example/f91w"])]
+        result, handler = self._call("https://www.casio.com/watch/kids/f-91w/", msgs)
+        self.assertIsNone(handler.called_with, "fabricated URL must NOT reach the tool")
+        self.assertEqual(result.status, "error")
+        self.assertIn("not fetched", result.content)
+        self.assertIn("https://shop.example/f91w", result.content)  # lists a real one
+
+    def test_allows_user_provided_url(self):
+        # A URL in the question itself is provenanced (copyable, not invented).
+        msgs = [HumanMessage(content="summarize https://blog.example/post-1 for me")]
+        _result, handler = self._call("https://blog.example/post-1", msgs)
+        self.assertIsNotNone(handler.called_with)
+
+    def test_allows_link_followed_from_a_fetched_page(self):
+        # A URL found inside a page the agent already read is legitimate.
+        msgs = [_search_result(["https://shop.example/index"]),
+                ToolMessage(content="See also https://shop.example/deep/page-2 for specs.",
+                            name="read_url", tool_call_id="r0")]
+        _result, handler = self._call("https://shop.example/deep/page-2", msgs)
+        self.assertIsNotNone(handler.called_with)
+
+    def test_normalizes_trailing_slash(self):
+        msgs = [_search_result(["https://shop.example/f91w"])]
+        _result, handler = self._call("https://shop.example/f91w/", msgs)
+        self.assertIsNotNone(handler.called_with, "trailing-slash variant should match")
+
+    def test_passes_non_read_url_tools_through(self):
+        handler = _Handler()
+        req = ToolCallRequest(
+            tool_call={"name": "search_internet", "args": {"query": "x"}, "id": "s2"},
+            tool=None, state={"messages": []}, runtime=None)
+        self.mw.wrap_tool_call(req, handler)
+        self.assertIsNotNone(handler.called_with, "non-read_url tools are untouched")
+
+    def test_no_search_yet_rejects(self):
+        # read_url before any provenance source -> reject (must search first).
+        result, handler = self._call("https://www.casio.com/x", [HumanMessage(content="hi")])
+        self.assertIsNone(handler.called_with)
+        self.assertEqual(result.status, "error")
+
+    def test_empty_url_passes_through(self):
+        # Don't second-guess a malformed call; let the tool surface its own error.
+        _result, handler = self._call("", [_search_result(["https://shop.example/a"])])
+        self.assertIsNotNone(handler.called_with)

--- a/tests/test_url_provenance.py
+++ b/tests/test_url_provenance.py
@@ -75,6 +75,16 @@ class TestUrlProvenanceMiddleware(TestCase):
         _result, handler = self._call("https://shop.example/deep/page-2", msgs)
         self.assertIsNotNone(handler.called_with)
 
+    def test_allows_parenthesized_search_result_url(self):
+        # A URL with a paren (Wikipedia disambiguation pages — a dominant research
+        # source) must be captured WHOLE from the search result, so the model's
+        # verbatim-copied fetch of it is allowed, not truncated-then-rejected.
+        url = "https://en.wikipedia.org/wiki/Mercury_(element)"
+        msgs = [_search_result([url])]
+        _result, handler = self._call(url, msgs)
+        self.assertIsNotNone(handler.called_with,
+                             "a copied parenthesized search-result URL must pass")
+
     def test_model_cannot_launder_via_its_own_text(self):
         # A URL present ONLY in the model's own AIMessage content is NOT provenance —
         # else the model writes a fabricated URL into its reasoning, then fetches it

--- a/tests/test_url_provenance.py
+++ b/tests/test_url_provenance.py
@@ -75,6 +75,16 @@ class TestUrlProvenanceMiddleware(TestCase):
         _result, handler = self._call("https://shop.example/deep/page-2", msgs)
         self.assertIsNotNone(handler.called_with)
 
+    def test_model_cannot_launder_via_its_own_text(self):
+        # A URL present ONLY in the model's own AIMessage content is NOT provenance —
+        # else the model writes a fabricated URL into its reasoning, then fetches it
+        # (observed on Qwen3.6). It must still be rejected.
+        msgs = [_search_result(["https://shop.example/f91w"]),
+                AIMessage(content="I'll check https://www.casiowatch.com/kids/ next.")]
+        result, handler = self._call("https://www.casiowatch.com/kids/", msgs)
+        self.assertIsNone(handler.called_with, "model's own text must not provenance a URL")
+        self.assertEqual(result.status, "error")
+
     def test_normalizes_trailing_slash(self):
         msgs = [_search_result(["https://shop.example/f91w"])]
         _result, handler = self._call("https://shop.example/f91w/", msgs)

--- a/tests/test_url_provenance.py
+++ b/tests/test_url_provenance.py
@@ -111,6 +111,19 @@ class TestUrlProvenanceMiddleware(TestCase):
         self.assertNotIn("shop.example/page.", result.content)       # trailing dot trimmed
         self.assertIn("Mercury_(element)", result.content)           # valid paren kept whole
 
+    def test_correction_strips_prose_wrapper_paren_keeps_valid_paren(self):
+        # A URL wrapped in prose parens "(…/page)" is listed WITHOUT the trailing
+        # ')' (unbalanced = a wrapper), while a valid parenthesized URL keeps it.
+        msgs = [ToolMessage(
+            content=("See (https://shop.example/page) and "
+                     "https://en.wikipedia.org/wiki/Mercury_(element)"),
+            name="search_internet", tool_call_id="s1")]
+        result, handler = self._call("https://www.fabricated.example/x", msgs)
+        self.assertIsNone(handler.called_with)
+        self.assertIn("https://shop.example/page", result.content)
+        self.assertNotIn("shop.example/page)", result.content)   # wrapper paren stripped
+        self.assertIn("Mercury_(element)", result.content)       # valid paren kept
+
     def test_model_cannot_launder_via_its_own_text(self):
         # A URL present ONLY in the model's own AIMessage content is NOT provenance —
         # else the model writes a fabricated URL into its reasoning, then fetches it

--- a/tests/test_url_provenance.py
+++ b/tests/test_url_provenance.py
@@ -97,6 +97,20 @@ class TestUrlProvenanceMiddleware(TestCase):
         self.assertIsNotNone(handler.called_with,
                              "a clean URL must match a prose URL with trailing punctuation")
 
+    def test_correction_lists_clean_fetchable_urls(self):
+        # The correction (shown on a rejected fetch) must list fetchable URLs: a
+        # prose URL with a trailing '.' is listed clean; a valid parenthesized URL
+        # is listed WHOLE (not truncated by the membership normalization).
+        msgs = [ToolMessage(
+            content=("Refs: https://shop.example/page. and "
+                     "https://en.wikipedia.org/wiki/Mercury_(element)"),
+            name="search_internet", tool_call_id="s1")]
+        result, handler = self._call("https://www.fabricated.example/x", msgs)
+        self.assertIsNone(handler.called_with)                       # fabricated -> rejected
+        self.assertIn("https://shop.example/page", result.content)
+        self.assertNotIn("shop.example/page.", result.content)       # trailing dot trimmed
+        self.assertIn("Mercury_(element)", result.content)           # valid paren kept whole
+
     def test_model_cannot_launder_via_its_own_text(self):
         # A URL present ONLY in the model's own AIMessage content is NOT provenance —
         # else the model writes a fabricated URL into its reasoning, then fetches it

--- a/tests/test_web_process_message_e2e.py
+++ b/tests/test_web_process_message_e2e.py
@@ -226,6 +226,30 @@ def test_process_message_kills_container_even_when_turn_errors(client, monkeypat
     assert len(calls) == 1, f"erroring turn must still tear down its container, got {calls}"
 
 
+def test_recursion_limit_sets_error_status(client, monkeypatch):
+    """The prod symptom pin: when the runaway backstop fires (GraphRecursionError,
+    now terminal), the turn must reach a TERMINAL error status with narrow/split
+    guidance — NOT stay wedged at 'processing' (the 70-min prod incident) and NOT
+    dump a raw langgraph exception repr."""
+    from langgraph.errors import GraphRecursionError
+
+    class _RunawayChat:
+        def pending_reply(self):
+            return None
+
+        def message(self, text):
+            raise GraphRecursionError(
+                "Recursion limit of 150 reached without hitting a stop condition")
+    _stub_happy_path(monkeypatch, _RunawayChat())
+
+    r = client.post("/thread/thread-e2e/message", data={"text": "hi"},
+                    follow_redirects=False)
+    assert r.status_code == 303, r.text
+    status = _wait_for_terminal_status("thread-e2e")
+    assert status.get("stage") == "error"
+    assert "step limit" in (status.get("error") or "").lower(), status.get("error")
+
+
 def test_process_message_reaps_registered_container_when_creation_then_raises(
         client, monkeypatch, tmp_path):
     """The exact round-1 gap: sandbox creation registers a container and THEN

--- a/tests/test_web_process_message_e2e.py
+++ b/tests/test_web_process_message_e2e.py
@@ -239,7 +239,7 @@ def test_recursion_limit_sets_error_status(client, monkeypatch):
 
         def message(self, text):
             raise GraphRecursionError(
-                "Recursion limit of 150 reached without hitting a stop condition")
+                "Recursion limit reached without hitting a stop condition")
     _stub_happy_path(monkeypatch, _RunawayChat())
 
     r = client.post("/thread/thread-e2e/message", data={"text": "hi"},


### PR DESCRIPTION
Two orthogonal, complementary fixes for research-agent runaways — surfaced by a real 70-min prod incident (a turn fabricated coffee-shop URLs and `read_url`-looped a dead domain, holding the LLM slot). Reviving the stranded `research-url-provenance` work + a new recursion fail-fast. Design + 3-lens design-review + 3-lens code-review captured below.

## 1. URL-provenance guard (revived + hardened)
`UrlProvenanceMiddleware` refuses a `read_url` whose URL appears in **no tool result or user message** — i.e. the model fabricated it. Corrective, not turn-ending (returns the real URLs to retry with). Scoped to the research searcher.

**Revival was not a clean rebase** — the live model defeated the original guard: it **laundered fabricated URLs by writing them into its own reasoning first**, then fetching them (the guard counted `AIMessage` content as provenance → 14/24 fetches slipped through). Fixed by construction: `_seen_urls` now scans **only `ToolMessage` + `HumanMessage`**, never the model's own text. Link-following (links live in tool results) and copied-from-search URLs still pass. Re-validated N=3 on the live model: **guessed 14 → {4, 0, 0}** (2/3 pass; residual under investigation — see Known limitations).

## 2. Recursion fail-fast
`GraphRecursionError` was in `invoke_with_rollback`'s `rollback_on`, so a recursion-limit hit rolled back and **re-invoked up to 7×**, resuming the runaway (~150 → ~1050 effective steps). Dropped it → a limit hit is now **terminal** (`recursion_limit` is the deliberate backstop; `BadRequestError` rollback preserved). Also:
- **Bound the orchestrator**: `Thread.runconfig` set no `recursion_limit`, so the top-level agent ran at langgraph's default ~10007 — the trunk was effectively unbounded. Now 500.
- **Terminal error surface**: a new `except GraphRecursionError` web branch sets a terminal `error` status with narrow/split guidance (mirrors `SandboxContainerLostError`), fixing the stale-`processing` wedge from the prod incident.

## Testing
879 unit tests (anti-laundering, paren-URL, recursion-terminal, BadRequest-still-rolls-back, recursion→error-status symptom). Provenance eval N=3 on the live model. Local code review: 0 blockers, 1 important (a paren-URL over-rejection regression, fixed), 2 nits.

## Resolved during review
- **Provenance residual — root-caused + fixed.** Instrumenting the guard showed the slipped fetches came from the fact-checker and orchestrator (both have `read_url`, neither was guarded); the eval's global `read_url` spy counts all agents. Extended the guard to the fact-checker (its cited URLs are provenanced, so they pass). A trial guarding the orchestrator too became a 303-search re-dispatch thrash, so the orchestrator guard was **reverted** — its runaway is bounded by `recursion_limit` (Layer 2) instead. Normal-ops eval is clean with searcher + fact-check guarded. A determined *runaway* still leaks some fabrication under extreme load — that's what the recursion bound is for, not provenance (see the design doc).
- **recursion_limit baselined.** 150 was silently ~1050 (7× via rollback). The recursion baseline showed a true-150 cut off legit research (2 turns hit it), so **research was bumped to 300** (still bounds a runaway to ~5 min vs the 70-min incident). Orchestrator stays 500.

## Known limitations / follow-ups
- Provenance is not bulletproof under a runaway (recursion is the backstop there); orchestrator over-search (Pattern-F territory) is bounded, not eliminated; corroboration (does a cited URL support the claim) remains a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
