### PR TITLE
'new' unread-AI-response badge on the thread list (v1)

### DIFF
--- a/docs/2026-07-03-unread-badge.org
+++ b/docs/2026-07-03-unread-badge.org
@@ -1,0 +1,137 @@
+#+TITLE: "New" (unread AI response) badge on the web thread list
+#+DATE: <2026-07-03>
+#+STATUS: DESIGN (Phase 1) — architect + 2-lens design-review folded in; awaiting Pierre
+
+* What Pierre asked for (v1 scope = BADGE-ONLY)
+A *"new" badge* on the web thread LIST next to any thread that has an AI response
+the user hasn't seen yet, taking *PRECEDENCE over the existing "unmerged" badge*.
+Motivation: threads now get AI responses WITHOUT the user actively chatting —
+scheduled turns (thread-schedules) and inbound-SMS triage / approvals — so an
+unread indicator matters.
+
+*Explicitly OUT of v1* (Pierre, 2026-07-03 — deferred follow-ups, not this change):
+- the agent =notify= tool (flagging urgent/time-sensitive items),
+- the iOS / PWA home-screen icon badge,
+- unread COUNTS, per-session/per-device tracking, live push to an open list page.
+
+* The contract
+Per thread, know one bit: *is there an AI response the user hasn't seen?*
+- becomes true when a turn produces a user-visible response/draft,
+- becomes false when the user opens that thread's page,
+- drives a "new" badge on the thread list.
+
+* Data model — a single MARKER FILE (existence = unseen)
+A per-thread sidecar file =unseen_response= in the thread dir. Its *existence* is
+the whole signal — no contents, no timestamp. Symmetric with the existing
+per-thread sidecars (=merge_conflict.json=, =description.txt=).
+
+*Why a flag, not the architect's two timestamps:* the badge is BINARY, so a
+present/absent marker is the minimal representation — fix-by-construction (the
+state can't encode an invalid value) — and it *removes the clock-skew edge case
+entirely* (no time comparison). No smaller correct option: =status.json= is out
+(=_set_status= full-REPLACES it every stage transition → would clobber the flag);
+reusing checkpoint/message mtime would force the O(threads×checkpoint) read the
+list must avoid.
+
+New helpers in =manage/web/state.py= (beside =_get_status=/=_status_path=), named
+for symmetry with the =_set_conflict=/=_clear_conflict= sidecar pair:
+- =_unseen_path(tid)= → =os.path.join(thread_dir(tid), "unseen_response")= (constant
+  filename; =thread_dir= validates tid — rejects =..=/=/=/NUL — so no traversal).
+- =_mark_unseen_response(tid)= — *command*, idempotent create (=Path.touch()= /
+  =open(path,"w")=; NEVER =open(...,"x")= — a 2nd/3rd response must tolerate exists).
+- =_clear_unseen_response(tid)= — *command*, *bare* =os.remove= with missing-ok
+  (=Path(path).unlink(missing_ok=True)=). NOT =_atomic_write=, NO lock (see
+  Event-loop).
+- =_has_unseen_response(tid)= — *query*, =os.path.exists(path)=.
+
+* Write path — mark (single choke point)
+Create the marker at ONE seam: inside =_set_status= (=state.py=), when
+=stage in ("ready", "awaiting_approval")=. Audited: those two stages are set ONLY
+at =_process_message='s THREE response-success exits and NOWHERE else —
+=threads.py:757= (supersede-couldn't-clear early =return= → awaiting_approval),
+=:792= (terminal awaiting_approval), =:795= (terminal ready). So the choke point
+covers all three by construction — including the early =return= at :757 that a
+"stamp once before the pending branch" seam would MISS (both design reviewers'
+top finding). Error stages (=SandboxContainerLostError=, =GraphRecursionError=,
+generic) do NOT mark — an error is not an answer to read, and the "error" badge
+(above "new" in precedence) already covers it.
+
+Minor layering note: =_set_status= (a status writer) gaining a marker side-effect
+for exactly 2 of its stages is justified because those 2 stages *are* precisely
+"a response/draft is now waiting" — and it's the only seam that can't miss an exit.
+
+* Clear path — seen
+=get_thread= (=threads.py:892=, the async route) calls =_clear_unseen_response(tid)=
+once per page render (after the =os.path.isdir= 404 guard). Opening the thread page
+= "seen". Merely LISTING threads does not clear it — only opening the thread does.
+
+* Read path — the badge
+In =render_index= (=threads.py:137-167=, the =for tid in MANAGER.list()= loop),
+insert ONE branch BETWEEN the =error= arm (=:153=) and the =_has_unmerged_changes=
+arm (=:159=):
+: elif _has_unseen_response(tid):
+:     badge = '<span ...>new</span>'    # distinct color (blue/green pill)
+Precedence (all mutually-exclusive =elif= arms → one badge per row):
+- *below* live process-state (queued / busy / error) — those are actionable NOW;
+  a running/errored thread shouldn't also cry "new".
+- *above* "unmerged" — per Pierre; "there's something the AI said" is more
+  time-sensitive than a housekeeping reminder.
+Pin the insertion SLOT (don't append — appending would invert the vs-unmerged
+precedence).
+
+* Event-loop liveness (single-worker uvicorn — blocker-level)
+- *Read (on the loop):* one =os.path.exists= (a bare =stat=) per row — strictly
+  CHEAPER than what =render_index= already does per row (=_get_status= open+json.load,
+  =_has_unmerged_changes= git I/O). No checkpoint deserialization. No new blocking.
+- *Create (off the loop):* =_process_message= is a sync =BackgroundTask=; a file
+  create there is fine.
+- *Clear (on the loop):* a single bare =unlink= in =get_thread= — one bounded,
+  lock-free syscall, same class as the =os.path.isdir= already there. MUST stay a
+  raw missing-ok =unlink= — do NOT route through =_atomic_write= (tempfile) or add
+  a lock (Phase-2 must not "harden" it into something blocking).
+
+* Known residuals (accepted for v1 — named, not "fixed")
+1. *Sticky-badge race.* If =get_thread='s clear runs just BEFORE =_process_message='s
+   create (user opens as the turn finishes), the marker is left present → badge
+   stays until the NEXT open. Worst case is a spuriously-sticky badge, never a lost
+   message. The badge's honest meaning is "a response landed since your last
+   page-load." A by-construction fix (marker records a response/seen COUNT; badge
+   only when marker-count > seen-count) is a *v2 option, deliberately not built* —
+   it reintroduces a per-row read the flag avoids.
+2. *open==seen is a proxy; no live poll.* The thread page renders once (no
+   client-side polling). A response arriving while a tab sits open won't auto-appear
+   there; the LIST badge is the signal. Acceptable for v1.
+3. *Multi-tab/device:* one global "seen" per thread — opening anywhere clears it.
+   Fine for a single-user local assistant (matches the "unmerged" model).
+
+* Coverage / correctness (swept)
+- Every response producer funnels through =_process_message= (message POST,
+  =_initialize_thread=, =_scheduled_dispatch=, =_dispatch_event=/SMS-triage, and the
+  approve/edit/reject resume). No out-of-band producer. So the =_set_status= choke
+  point catches them all — the scheduled/SMS-on-a-never-opened-thread case (the
+  whole point) works: create fires, no =get_thread= ran → badge shows.
+- Brand-new thread: create → 303 redirect → =get_thread= clears a not-yet-existing
+  marker (missing-ok no-op) → the init turn creates it → badge on the list after.
+- tid is server-generated + =thread_dir=-validated; the marker filename is a
+  constant → no path-injection surface.
+
+* Files to touch
+- =manage/web/state.py= — the 4 helpers (=_unseen_path=, =_mark_unseen_response=,
+  =_clear_unseen_response=, =_has_unseen_response=); the =_set_status= choke-point
+  create on =ready=/=awaiting_approval=.
+- =manage/web/threads.py= — =_clear_unseen_response= in =get_thread=; the =elif=
+  badge branch in =render_index= (+ the "new" pill styling, inline like the others).
+- Tests (symptom-level — this is the manage/web hot path):
+  1. badge APPEARS — mark unseen, =render_index("")=, assert =>new<= in the row.
+  2. badge CLEARS on view — mark unseen, drive =get_thread= (TestClient) to clear,
+     =render_index=, assert "new" gone (exercises the real =_clear= path, not a proxy).
+  3. precedence: "new" beats "unmerged" (monkeypatch =_has_unmerged_changes=→True +
+     unseen → row shows "new").
+  4. precedence: process-state beats "new" (=_set_status(tid,"processing")= /
+     "error" + unseen → shows busy/error, not "new").
+  5. the choke point stamps on =ready= AND =awaiting_approval= (e2e via
+     =_process_message= to each terminal, incl. the draft/pending case).
+
+* Estimate
+~4 state.py helpers + 1 =_set_status= line + 1 =get_thread= line + 1 =render_index=
+=elif= + a pill string + ~5 tests. Small, additive, no new infra, no locks.

--- a/docs/2026-07-03-unread-badge.org
+++ b/docs/2026-07-03-unread-badge.org
@@ -20,29 +20,48 @@ Per thread, know one bit: *is there an AI response the user hasn't seen?*
 - becomes false when the user opens that thread's page,
 - drives a "new" badge on the thread list.
 
-* Data model — a single MARKER FILE (existence = unseen)
-A per-thread sidecar file =unseen_response= in the thread dir. Its *existence* is
-the whole signal — no contents, no timestamp. Symmetric with the existing
-per-thread sidecars (=merge_conflict.json=, =description.txt=).
+* Data model — a MARKER FILE (durable) + an in-memory SET (fast read) (Pierre)
+Two representations of the same one bit, kept in sync:
+- *On disk (source of truth, survives restart):* a per-thread sidecar file
+  =unseen_response= in the thread dir. Its *existence* is the signal — no contents,
+  no timestamp. Symmetric with the existing =merge_conflict.json= sidecar. (Pierre:
+  "It's important to persist on disk.")
+- *In memory (the READ path):* a process-singleton =set[tid]= =_UNSEEN= in
+  =state.py= (alongside =MANAGER=/=THREAD_QUEUE=). =render_index= tests membership —
+  O(1), NO filesystem hit per row. *Populated ONCE at startup* by scanning the
+  thread dirs for the marker (Pierre: "populated at startup in a very efficient
+  manner → page loads are very quick"). This is the answer to Pierre's load-time
+  worry: the per-row read is a Python set lookup, never a =stat=.
 
-*Why a flag, not the architect's two timestamps:* the badge is BINARY, so a
-present/absent marker is the minimal representation — fix-by-construction (the
-state can't encode an invalid value) — and it *removes the clock-skew edge case
-entirely* (no time comparison). No smaller correct option: =status.json= is out
-(=_set_status= full-REPLACES it every stage transition → would clobber the flag);
-reusing checkpoint/message mtime would force the O(threads×checkpoint) read the
-list must avoid.
+*Why a flag (present/absent), not the architect's two timestamps:* the badge is
+BINARY, so a present/absent bit is the minimal representation — fix-by-construction
+(can't encode an invalid value) — and it *removes the clock-skew edge case
+entirely* (no time comparison). =status.json= is out (=_set_status= full-REPLACES
+it every stage transition → would clobber the flag).
 
-New helpers in =manage/web/state.py= (beside =_get_status=/=_status_path=), named
-for symmetry with the =_set_conflict=/=_clear_conflict= sidecar pair:
+*Why BOTH a file and a set* (not just one): the set alone wouldn't survive a
+restart (a scheduled/SMS response's badge would vanish on redeploy); the file alone
+would =stat= per row on every list render (Pierre's load-time worry). File = durable
+backing; set = fast runtime read; startup reconciles set ← files.
+
+New in =manage/web/state.py=, named for symmetry with =_set_conflict=/=_clear_conflict=:
+- =_UNSEEN: set[str]= — process singleton; the badge read path.
 - =_unseen_path(tid)= → =os.path.join(thread_dir(tid), "unseen_response")= (constant
   filename; =thread_dir= validates tid — rejects =..=/=/=/NUL — so no traversal).
-- =_mark_unseen_response(tid)= — *command*, idempotent create (=Path.touch()= /
-  =open(path,"w")=; NEVER =open(...,"x")= — a 2nd/3rd response must tolerate exists).
-- =_clear_unseen_response(tid)= — *command*, *bare* =os.remove= with missing-ok
-  (=Path(path).unlink(missing_ok=True)=). NOT =_atomic_write=, NO lock (see
-  Event-loop).
-- =_has_unseen_response(tid)= — *query*, =os.path.exists(path)=.
+- =_mark_unseen_response(tid)= — *command*: =_UNSEEN.add(tid)= AND idempotent file
+  create (=Path.touch()=; NEVER =open(...,"x")= — a 2nd/3rd response must tolerate
+  exists). Both, so the badge is live AND survives restart.
+- =_clear_unseen_response(tid)= — *command*: =_UNSEEN.discard(tid)= AND *bare*
+  =Path(path).unlink(missing_ok=True)=. NOT =_atomic_write=, NO lock (see Event-loop).
+- =_has_unseen_response(tid)= — *query*: =tid in _UNSEEN= (in-memory; no FS).
+- =load_unseen_cache()= — *startup*: for each =MANAGER.list()= tid, =_UNSEEN.add(tid)=
+  iff its marker file exists. O(threads) =stat=s ONCE at startup (not per page load).
+
+*Concurrency (no lock needed):* =set.add=/=discard=/=in= are each atomic under the
+GIL (CPython) — single ops, no compound read-modify-write — so the set is safe
+across the loop (=render_index= read, =get_thread= clear) and the bg
+=_process_message= thread (mark) without a lock. This preserves event-loop liveness
+(no lock acquired on the loop thread — cf. the =peek_holder()= lock-free rule).
 
 * Write path — mark (single choke point)
 Create the marker at ONE seam: inside =_set_status= (=state.py=), when
@@ -79,16 +98,25 @@ Precedence (all mutually-exclusive =elif= arms → one badge per row):
 Pin the insertion SLOT (don't append — appending would invert the vs-unmerged
 precedence).
 
+* Startup wiring
+=load_unseen_cache()= runs at web-app startup (the FastAPI lifespan in
+=manage/web/__main__.py= / =app.py=, where the schedules scheduler is already
+started), AFTER =MANAGER= is ready. One =stat= per thread, once — rebuilds =_UNSEEN=
+from the on-disk markers so scheduled/SMS badges survive a restart.
+
 * Event-loop liveness (single-worker uvicorn — blocker-level)
-- *Read (on the loop):* one =os.path.exists= (a bare =stat=) per row — strictly
-  CHEAPER than what =render_index= already does per row (=_get_status= open+json.load,
-  =_has_unmerged_changes= git I/O). No checkpoint deserialization. No new blocking.
-- *Create (off the loop):* =_process_message= is a sync =BackgroundTask=; a file
-  create there is fine.
-- *Clear (on the loop):* a single bare =unlink= in =get_thread= — one bounded,
-  lock-free syscall, same class as the =os.path.isdir= already there. MUST stay a
-  raw missing-ok =unlink= — do NOT route through =_atomic_write= (tempfile) or add
-  a lock (Phase-2 must not "harden" it into something blocking).
+- *Read (on the loop):* =tid in _UNSEEN= — a Python set membership test, NO
+  filesystem hit per row (this is the point of Pierre's cache). Was already going to
+  be cheaper than the per-row =_get_status=/=_has_unmerged_changes= the list does;
+  now it's a pure in-memory lookup.
+- *Create (off the loop):* =_process_message= is a sync =BackgroundTask=; =set.add=
+  + a file create there is fine.
+- *Clear (on the loop):* =set.discard= + a single bare =unlink= in =get_thread= —
+  bounded, lock-free, same class as the =os.path.isdir= already there. The unlink
+  MUST stay a raw missing-ok =unlink= — do NOT route through =_atomic_write=
+  (tempfile) or add a lock (Phase-2 must not "harden" it into something blocking).
+- *No lock on the set* — single atomic add/discard/=in= under the GIL (see
+  Concurrency above).
 
 * Known residuals (accepted for v1 — named, not "fixed")
 1. *Sticky-badge race.* If =get_thread='s clear runs just BEFORE =_process_message='s
@@ -116,9 +144,12 @@ precedence).
   constant → no path-injection surface.
 
 * Files to touch
-- =manage/web/state.py= — the 4 helpers (=_unseen_path=, =_mark_unseen_response=,
-  =_clear_unseen_response=, =_has_unseen_response=); the =_set_status= choke-point
-  create on =ready=/=awaiting_approval=.
+- =manage/web/state.py= — =_UNSEEN= set + the helpers (=_unseen_path=,
+  =_mark_unseen_response=, =_clear_unseen_response=, =_has_unseen_response=,
+  =load_unseen_cache=); the =_set_status= choke-point =_mark_unseen_response= on
+  =ready=/=awaiting_approval=.
+- =manage/web/__main__.py= / =app.py= — call =load_unseen_cache()= in the startup
+  lifespan (beside the schedules scheduler start).
 - =manage/web/threads.py= — =_clear_unseen_response= in =get_thread=; the =elif=
   badge branch in =render_index= (+ the "new" pill styling, inline like the others).
 - Tests (symptom-level — this is the manage/web hot path):
@@ -131,6 +162,10 @@ precedence).
      "error" + unseen → shows busy/error, not "new").
   5. the choke point stamps on =ready= AND =awaiting_approval= (e2e via
      =_process_message= to each terminal, incl. the draft/pending case).
+  6. =load_unseen_cache()= rebuilds =_UNSEEN= from on-disk markers (write a marker
+     file, clear the set, run load, assert the tid is back in =_UNSEEN= → badge
+     survives restart); and =_clear_unseen_response= removes BOTH the set entry and
+     the file (so a later reload doesn't resurrect it).
 
 * Estimate
 ~4 state.py helpers + 1 =_set_status= line + 1 =get_thread= line + 1 =render_index=

--- a/manage/web/state.py
+++ b/manage/web/state.py
@@ -289,6 +289,7 @@ def _evict_caches(tid: str) -> None:
     """
     DOMAIN_MANAGERS.pop(tid, None)
     DESCRIPTION_CACHE.pop(tid, None)
+    _UNSEEN.discard(tid)  # the marker file went with the dir; drop the set entry too
 
 
 # --- Thread status tracking ----------------------------------------------
@@ -359,9 +360,9 @@ def _mark_unseen_response(tid: str) -> None:
     """Record an AI response the user hasn't seen: the live set + an idempotent
     marker file (existence is the whole signal — touch, tolerate exists)."""
     _UNSEEN.add(tid)
-    path = _unseen_path(tid)
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    open(path, "w").close()
+    # The thread dir already exists (status.json was just written to it); existence
+    # is the whole signal, so a plain idempotent touch — tolerate already-exists.
+    open(_unseen_path(tid), "w").close()
 
 
 def _clear_unseen_response(tid: str) -> None:

--- a/manage/web/state.py
+++ b/manage/web/state.py
@@ -360,18 +360,27 @@ def _mark_unseen_response(tid: str) -> None:
     """Record an AI response the user hasn't seen: the live set + an idempotent
     marker file (existence is the whole signal — touch, tolerate exists)."""
     _UNSEEN.add(tid)
-    # The thread dir already exists (status.json was just written to it); existence
-    # is the whole signal, so a plain idempotent touch — tolerate already-exists.
-    open(_unseen_path(tid), "w").close()
+    # The durable marker is BEST-EFFORT: this runs in the terminal path (via
+    # _set_status on ready/awaiting_approval), so a file-write OSError must NEVER
+    # propagate and flip an otherwise-successful turn to error. The in-memory set
+    # carries the badge this session; on write failure we just lose restart-survival.
+    try:
+        open(_unseen_path(tid), "w").close()
+    except OSError:
+        pass
 
 
 def _clear_unseen_response(tid: str) -> None:
     """Mark ``tid`` seen (its page was opened): drop the set entry + the marker.
     Bare, missing-ok unlink — no _atomic_write, no lock (runs on the event loop)."""
     _UNSEEN.discard(tid)
-    path = _unseen_path(tid)
-    if os.path.isfile(path):
-        os.remove(path)
+    # Truly missing-ok AND never-raise: this runs on the event loop (get_thread), so
+    # neither a missing file nor any OSError may 500 the thread page. A try/remove
+    # (not isfile→remove) also avoids the TOCTOU race with the marker's writer.
+    try:
+        os.remove(_unseen_path(tid))
+    except OSError:
+        pass
 
 
 def _has_unseen_response(tid: str) -> bool:
@@ -380,12 +389,15 @@ def _has_unseen_response(tid: str) -> bool:
 
 def load_unseen_cache() -> None:
     """Rebuild _UNSEEN from the on-disk markers at startup, so a scheduled/SMS
-    response's badge survives a restart.  One stat per thread, once."""
+    response's badge survives a restart.  One stat per thread, once.  A true
+    REBUILD — clears first, so it's idempotent and drops stale entries if ever
+    re-invoked with a non-empty set."""
+    _UNSEEN.clear()
     for tid in MANAGER.list():
         try:
             if os.path.isfile(_unseen_path(tid)):
                 _UNSEEN.add(tid)
-        except Exception:
+        except OSError:
             pass  # a per-thread dir hiccup must not abort startup
 
 

--- a/manage/web/state.py
+++ b/manage/web/state.py
@@ -329,6 +329,63 @@ def _get_status(tid: str) -> dict:
 
 def _set_status(tid: str, stage: str, **kwargs) -> None:
     _atomic_write(_status_path(tid), json.dumps({"stage": stage, **kwargs}))
+    # Single choke point for the "unseen AI response" badge: `ready` and
+    # `awaiting_approval` are set ONLY at _process_message's three response-success
+    # exits (incl. the supersede early-return), and nowhere else — so marking here
+    # catches every response/draft the user should see, and can't miss an exit.
+    # Errors don't mark (the "error" badge, above "new" in precedence, covers them).
+    if stage in ("ready", "awaiting_approval"):
+        _mark_unseen_response(tid)
+
+
+# --- "unseen AI response" badge state -------------------------------------
+# A thread carries an "unseen" AI response from when a turn produces a
+# response/draft until the user OPENS that thread's page.  Two representations of
+# the one bit, kept in sync (see docs/2026-07-03-unread-badge.org):
+#   - a marker file per thread (durable — survives restart),
+#   - the _UNSEEN set (the badge READ PATH — render_index tests membership per row,
+#     O(1), no FS stat; Pierre's cache to keep list page-loads fast).
+# set add/discard/`in` are each atomic under the GIL, so no lock is needed across
+# the event loop (render_index read, get_thread clear) and the bg _process_message
+# thread (mark) — preserving event-loop liveness.
+_UNSEEN: set[str] = set()
+
+
+def _unseen_path(tid: str) -> str:
+    return os.path.join(MANAGER.thread_dir(tid), "unseen_response")
+
+
+def _mark_unseen_response(tid: str) -> None:
+    """Record an AI response the user hasn't seen: the live set + an idempotent
+    marker file (existence is the whole signal — touch, tolerate exists)."""
+    _UNSEEN.add(tid)
+    path = _unseen_path(tid)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    open(path, "w").close()
+
+
+def _clear_unseen_response(tid: str) -> None:
+    """Mark ``tid`` seen (its page was opened): drop the set entry + the marker.
+    Bare, missing-ok unlink — no _atomic_write, no lock (runs on the event loop)."""
+    _UNSEEN.discard(tid)
+    path = _unseen_path(tid)
+    if os.path.isfile(path):
+        os.remove(path)
+
+
+def _has_unseen_response(tid: str) -> bool:
+    return tid in _UNSEEN
+
+
+def load_unseen_cache() -> None:
+    """Rebuild _UNSEEN from the on-disk markers at startup, so a scheduled/SMS
+    response's badge survives a restart.  One stat per thread, once."""
+    for tid in MANAGER.list():
+        try:
+            if os.path.isfile(_unseen_path(tid)):
+                _UNSEEN.add(tid)
+        except Exception:
+            pass  # a per-thread dir hiccup must not abort startup
 
 
 def _thread_title(tid: str) -> str:
@@ -392,6 +449,9 @@ async def lifespan(app: FastAPI):
     # Populate description cache at startup
     for tid in MANAGER.list():
         get_cached_description(tid)
+    # Rebuild the "unseen AI response" badge cache from on-disk markers, so a
+    # scheduled/SMS response's badge survives a restart.
+    load_unseen_cache()
     # Start the schedule poll loop (local import breaks the state<->threads cycle).
     from manage.web.threads import start_scheduler, stop_scheduler
     start_scheduler()

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -69,6 +69,8 @@ from manage.web.state import (
     _get_sandbox_backend,
     _get_status,
     _has_unmerged_changes,
+    _has_unseen_response,
+    _clear_unseen_response,
     _set_conflict,
     _set_status,
     _thread_domain_html,
@@ -155,6 +157,17 @@ def render_index(query: str = "") -> str:
                 '<span style="font-size:.7rem; color:#721c24; background:#f8d7da;'
                 ' border:1px solid #f5c6cb; padding:.1rem .4rem; border-radius:10px;'
                 ' margin-right:.4rem;">error</span>'
+            )
+        elif _has_unseen_response(tid):
+            # "new": an AI response the user hasn't opened yet (scheduled turn,
+            # SMS-triage draft, or a reply that landed since their last view).
+            # Below the live process-state badges (a running/errored thread isn't
+            # "new" yet), ABOVE "unmerged" (a response to read beats a housekeeping
+            # reminder) — per Pierre.  Blue/green, distinct from the others.
+            badge = (
+                '<span style="font-size:.7rem; color:#0b5c2e; background:#d7f3e3;'
+                ' border:1px solid #9fdcbb; padding:.1rem .4rem; border-radius:10px;'
+                ' margin-right:.4rem;">new</span>'
             )
         elif _has_unmerged_changes(tid):
             # Soft amber, distinct from yellow (busy) and red (error).
@@ -900,6 +913,10 @@ async def get_thread(
     tdir = MANAGER.thread_dir(tid)
     if not os.path.isdir(tdir):
         raise HTTPException(status_code=404, detail="Thread not found")
+
+    # Opening the thread page = the user has seen its responses -> clear the "new"
+    # badge (bare missing-ok unlink + set discard; lock-free on the event loop).
+    _clear_unseen_response(tid)
 
     stage = _get_status(tid).get("stage", "ready")
     # During the initial setup stages there is no point constructing a Thread

--- a/tests/test_web_unseen_badge.py
+++ b/tests/test_web_unseen_badge.py
@@ -31,12 +31,6 @@ def _make_thread(root, tid, title="A thread"):
     state.DESCRIPTION_CACHE[tid] = title
 
 
-def _row(html, title):
-    """The badge text (if any) shown for the row with `title` — just check the row
-    contains/omits a badge label; rows are distinct by their unique titles."""
-    return html
-
-
 class TestBadgeAppearsAndClears:
     def test_badge_appears_when_unseen(self, threads_root):
         _make_thread(threads_root, "t1", "Coffee thread")
@@ -70,6 +64,14 @@ class TestBadgeAppearsAndClears:
         state._UNSEEN.clear()
         state.load_unseen_cache()
         assert ">new<" not in render_index("")
+
+    def test_evict_caches_drops_unseen(self, threads_root):
+        # hard-deleting a never-opened unseen thread must not leak its tid in _UNSEEN.
+        _make_thread(threads_root, "t1")
+        state._mark_unseen_response("t1")
+        assert state._has_unseen_response("t1")
+        state._evict_caches("t1")              # the hard_delete on_delete callback
+        assert not state._has_unseen_response("t1")
 
 
 class TestChokePoint:

--- a/tests/test_web_unseen_badge.py
+++ b/tests/test_web_unseen_badge.py
@@ -65,6 +65,13 @@ class TestBadgeAppearsAndClears:
         state.load_unseen_cache()
         assert ">new<" not in render_index("")
 
+    def test_load_cache_is_true_rebuild_drops_stale(self, threads_root):
+        # a stale in-memory entry with no marker file must be dropped on reload.
+        _make_thread(threads_root, "t1")
+        state._UNSEEN.add("ghost")   # no marker file backs this
+        state.load_unseen_cache()
+        assert "ghost" not in state._UNSEEN
+
     def test_evict_caches_drops_unseen(self, threads_root):
         # hard-deleting a never-opened unseen thread must not leak its tid in _UNSEEN.
         _make_thread(threads_root, "t1")

--- a/tests/test_web_unseen_badge.py
+++ b/tests/test_web_unseen_badge.py
@@ -1,0 +1,128 @@
+"""Tests for the "new" (unread AI response) badge on the web thread list.
+
+No model/GPU: titles seeded into DESCRIPTION_CACHE; the unseen state is driven via
+the state helpers / a status write; the route-clears test opens a thread parked in
+an INIT stage so get_thread skips constructing a Thread.
+See docs/2026-07-03-unread-badge.org.
+"""
+import asyncio
+import os
+
+import pytest
+
+from manage import web
+from manage.web import state
+from manage.web.threads import render_index, get_thread
+
+
+@pytest.fixture
+def threads_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(web.MANAGER, "root_dir", str(tmp_path))
+    monkeypatch.setattr("manage.web.threads._has_unmerged_changes", lambda tid: False)
+    state.DESCRIPTION_CACHE.clear()
+    state._UNSEEN.clear()
+    yield tmp_path
+    state.DESCRIPTION_CACHE.clear()
+    state._UNSEEN.clear()
+
+
+def _make_thread(root, tid, title="A thread"):
+    os.makedirs(root / tid, exist_ok=True)
+    state.DESCRIPTION_CACHE[tid] = title
+
+
+def _row(html, title):
+    """The badge text (if any) shown for the row with `title` — just check the row
+    contains/omits a badge label; rows are distinct by their unique titles."""
+    return html
+
+
+class TestBadgeAppearsAndClears:
+    def test_badge_appears_when_unseen(self, threads_root):
+        _make_thread(threads_root, "t1", "Coffee thread")
+        state._mark_unseen_response("t1")
+        assert ">new<" in render_index("")
+
+    def test_no_badge_when_seen(self, threads_root):
+        _make_thread(threads_root, "t1", "Coffee thread")
+        # never marked unseen -> no "new"
+        assert ">new<" not in render_index("")
+
+    def test_badge_clears_after_clear(self, threads_root):
+        _make_thread(threads_root, "t1", "Coffee thread")
+        state._mark_unseen_response("t1")
+        assert ">new<" in render_index("")
+        state._clear_unseen_response("t1")
+        assert ">new<" not in render_index("")
+
+    def test_marker_survives_restart_via_load_cache(self, threads_root):
+        _make_thread(threads_root, "t1", "Coffee thread")
+        state._mark_unseen_response("t1")     # writes the marker FILE
+        state._UNSEEN.clear()                 # simulate a restart (cache lost)
+        assert ">new<" not in render_index("")
+        state.load_unseen_cache()             # rebuild from disk
+        assert ">new<" in render_index("")
+
+    def test_clear_removes_file_so_reload_doesnt_resurrect(self, threads_root):
+        _make_thread(threads_root, "t1", "Coffee thread")
+        state._mark_unseen_response("t1")
+        state._clear_unseen_response("t1")     # removes set entry AND file
+        state._UNSEEN.clear()
+        state.load_unseen_cache()
+        assert ">new<" not in render_index("")
+
+
+class TestChokePoint:
+    def test_set_status_ready_marks_unseen(self, threads_root):
+        _make_thread(threads_root, "t1")
+        state._set_status("t1", "ready")
+        assert state._has_unseen_response("t1")
+
+    def test_set_status_awaiting_approval_marks_unseen(self, threads_root):
+        _make_thread(threads_root, "t1")
+        state._set_status("t1", "awaiting_approval")
+        assert state._has_unseen_response("t1")
+
+    def test_set_status_error_does_not_mark(self, threads_root):
+        _make_thread(threads_root, "t1")
+        state._set_status("t1", "error", error="boom")
+        assert not state._has_unseen_response("t1")
+
+
+class TestPrecedence:
+    def test_new_beats_unmerged(self, threads_root, monkeypatch):
+        monkeypatch.setattr("manage.web.threads._has_unmerged_changes", lambda tid: True)
+        _make_thread(threads_root, "t1", "Coffee thread")
+        state._mark_unseen_response("t1")
+        html = render_index("")
+        assert ">new<" in html
+        assert ">unmerged<" not in html
+
+    def test_error_beats_new(self, threads_root):
+        _make_thread(threads_root, "t1", "Coffee thread")
+        state._set_status("t1", "error", error="boom")   # does not mark
+        state._mark_unseen_response("t1")                # mark separately
+        html = render_index("")
+        assert ">error<" in html
+        assert ">new<" not in html
+
+    def test_busy_beats_new(self, threads_root):
+        _make_thread(threads_root, "t1", "Coffee thread")
+        state._set_status("t1", "processing")
+        state._mark_unseen_response("t1")
+        html = render_index("")
+        assert ">new<" not in html   # a busy/process-state badge wins
+
+
+class TestRouteClears:
+    def test_opening_thread_clears_marker(self, threads_root):
+        # Park the thread in an INIT stage so get_thread skips constructing a Thread
+        # (no model); the _clear runs before the stage check regardless. Call the
+        # handler directly (not TestClient) to avoid the app lifespan/scheduler.
+        _make_thread(threads_root, "t1", "Coffee thread")
+        state._set_status("t1", "initializing")
+        state._mark_unseen_response("t1")
+        assert state._has_unseen_response("t1")
+        html = asyncio.run(get_thread("t1"))
+        assert isinstance(html, str)
+        assert not state._has_unseen_response("t1")   # route cleared it


### PR DESCRIPTION
A **"new" badge** on the web thread list for any thread with an AI response you haven't seen, taking **precedence over "unmerged."** Motivation: threads now get responses without you actively chatting — scheduled turns + SMS triage — so an unread signal matters. Design doc: `docs/2026-07-03-unread-badge.org`. (v1 = badge only; the agent `notify` tool + iOS PWA badge are follow-ups.)

## How it works
- **Data model:** a per-thread marker file (`unseen_response`, **durable** — survives restart) mirrored in a process-singleton **in-memory `_UNSEEN` set** (added on your review) that is the badge **read path** — `render_index` does an O(1) set-membership test per row, **no per-row FS stat**. `load_unseen_cache()` rebuilds the set from markers once at startup. Lock-free (atomic set add/discard/`in` under the GIL).
- **Mark (unseen):** a single choke point — `_set_status` when the stage is `ready`/`awaiting_approval`, which are set *only* at `_process_message`'s three response-success exits (including a supersede early-return a naive seam would miss). Errors don't mark (the error badge covers them, above "new").
- **Clear (seen):** `get_thread` deletes the marker (bare missing-ok unlink + set discard — lock-free on the event loop) when you open the thread.
- **Badge:** slotted below the live process-state badges (busy/error), above "unmerged." Blue/green pill.

## Review (architect + Phase-1 design review + Phase-2 code review)
- **Phase-1 design review** (simplicity/interfaces + event-loop/correctness) fixed the write seam (single choke point so the early-return isn't missed), the bare-unlink clear, and named two residuals.
- **Phase-2 code review** (correctness/event-loop + simplicity/adherence): 1 IMPORTANT — `_evict_caches` now drops `_UNSEEN` on hard-delete (was leaking a tid) — + 2 nits (redundant `makedirs`, dead test helper), all fixed. Verified the no-lock claim sound and the choke point exact/exclusive.

## Named residuals (accepted, not built)
- A delete-before-create race can leave a **sticky** badge until the next open (never a lost message — badge means "a response landed since your last page-load"; clears on next open). A by-construction fix (marker records a seen-count) is a v2 option.
- No live poll: a response landing in an already-open tab won't auto-appear there — the list badge is the signal.

**921 unit tests green. Deployed + live for testing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)