### PR TITLE
Research evals: mock the research subagent except the crucial few

### DIFF
--- a/edd/eval/test_location_research.py
+++ b/edd/eval/test_location_research.py
@@ -15,6 +15,7 @@ with/without metrics so the EFFECT is visible, not just pass/fail.
 """
 import os
 import re
+import shutil
 import tempfile
 from unittest import TestCase
 
@@ -60,6 +61,7 @@ class TestLocationResearch(TestCase):
 
     def _run(self, question: str, with_render: bool) -> dict:
         root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
         create_filesystem(root, {"README.org": "Personal assistant workspace."})
         skills = ({"/render-skill/": FilesystemBackend(root_dir=_RENDER_SKILLS_DIR,
                                                         virtual_mode=True)}

--- a/edd/eval/test_location_research.py
+++ b/edd/eval/test_location_research.py
@@ -25,7 +25,7 @@ from assist.agent import create_agent, AgentHarness
 from assist.model_manager import select_assistant_model
 from assist.spec import AgentSpec
 
-from .utils import create_filesystem
+from .utils import create_filesystem, stub_research_subagent
 
 _RENDER_SKILLS_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "assist", "web_skills")
@@ -64,9 +64,14 @@ class TestLocationResearch(TestCase):
         skills = ({"/render-skill/": FilesystemBackend(root_dir=_RENDER_SKILLS_DIR,
                                                         virtual_mode=True)}
                   if with_render else {})
-        agent = AgentHarness(create_agent(self.model, root,
-                                          spec=AgentSpec(skill_sources=skills)))
-        agent.message(question)
+        # Stub the research subagent: this eval tests whether the render/map skill
+        # SUPPRESSES research DISPATCH (it counts `task` calls) — not the research
+        # results — so we don't need real search.  The orchestrator still issues the
+        # dispatch; the stub just returns fast (rate-limit-free + deterministic).
+        with stub_research_subagent("Found several highly-rated options near the area."):
+            agent = AgentHarness(create_agent(self.model, root,
+                                              spec=AgentSpec(skill_sources=skills)))
+            agent.message(question)
         return _metrics(agent)
 
     def test_map_skill_does_not_suppress_research(self):

--- a/edd/eval/test_research_multi_turn_token_regression.py
+++ b/edd/eval/test_research_multi_turn_token_regression.py
@@ -56,6 +56,20 @@ from unittest import TestCase
 from openai import BadRequestError
 
 from assist.thread_manager import ThreadManager
+from edd.eval.utils import stub_research_subagent
+
+# A substantial canned research report (~a few KB) so the stubbed subagent still
+# drives the orchestrator's context/summarization path across the 3 turns without
+# hitting SearXNG.  Repeated realistic sentences, not lorem, so token counting is
+# representative.
+_CANNED_REPORT = (
+    "The San Francisco Giants finished the 2024 season with a competitive record, "
+    "anchored by strong starting pitching and a resurgent bullpen. Key contributors "
+    "posted career-best numbers at the plate, and the team remained in the divisional "
+    "race deep into September. Notable series included a home sweep and several "
+    "walk-off wins that kept the wildcard hopes alive. Season-ticket packages, mini "
+    "plans, and single-game options were compared for value across the schedule. "
+) * 60
 
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
@@ -121,12 +135,18 @@ class TestGiantsThreadTokenRegression(TestCase):
             )
 
     def test_three_turns_no_token_overflow(self):
-        r1 = self._send("turn 1", TURN_1)
-        logger.info("turn 1 response (first 300 chars): %s", str(r1)[:300])
-        r2 = self._send("turn 2", TURN_2)
-        logger.info("turn 2 response (first 300 chars): %s", str(r2)[:300])
-        r3 = self._send("turn 3", TURN_3)
-        logger.info("turn 3 response (first 300 chars): %s", str(r3)[:300])
+        # Mock the research subagent (no SearXNG → rate-limit-free + deterministic).
+        # This eval tests the CALLER-facing overflow guard (no BadRequestError leaks
+        # past retry/rollback across 3 turns), not search behavior — so a large canned
+        # research report per turn drives the orchestrator's context/summarization path
+        # without real search, and turns the ~40-min real-search run into minutes.
+        with stub_research_subagent(_CANNED_REPORT):
+            r1 = self._send("turn 1", TURN_1)
+            logger.info("turn 1 response (first 300 chars): %s", str(r1)[:300])
+            r2 = self._send("turn 2", TURN_2)
+            logger.info("turn 2 response (first 300 chars): %s", str(r2)[:300])
+            r3 = self._send("turn 3", TURN_3)
+            logger.info("turn 3 response (first 300 chars): %s", str(r3)[:300])
 
         # Sanity: the thread actually progressed.  Empty replies on every
         # turn would suggest the agent is silently bailing rather than

--- a/edd/eval/test_research_multi_turn_token_regression.py
+++ b/edd/eval/test_research_multi_turn_token_regression.py
@@ -46,12 +46,14 @@ The research subagent is MOCKED (a large canned report per turn via
 real search rate-limits SearXNG, and this eval tests the caller-facing
 overflow guard, not search behavior.  The canned report drives the
 orchestrator's context/summarization path across the three turns
-without SearXNG, turning the ~40-min real-search run into ~14 min and
-removing rate-limit false-negatives.  (Historical note: the original
-``BadRequestError`` was a 53k-context older model; on the current 131k
-model this run passes without forcing overflow — it is a plumbing
-regression guard for the summarizer/retry wiring, which the mocked
-context still exercises.)
+without SearXNG, so the run is rate-limit-free and deterministic (and
+much faster than the real-search version).  The mock is entered BEFORE
+the ``Thread`` is constructed (``Thread.__init__`` eagerly builds the
+agent — see ``stub_research_subagent``'s usage constraint).  (Historical
+note: the original ``BadRequestError`` was a 53k-context older model; on
+the current 131k model this run passes without forcing overflow — it is
+a plumbing regression guard for the summarizer/retry wiring, which the
+mocked context still exercises.)
 """
 import logging
 import os

--- a/edd/eval/test_research_multi_turn_token_regression.py
+++ b/edd/eval/test_research_multi_turn_token_regression.py
@@ -119,7 +119,10 @@ class TestGiantsThreadTokenRegression(TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
         self.tm = ThreadManager(root_dir=self.tmpdir)
-        self.thread = self.tm.new()
+        # NOTE: the Thread is created INSIDE the stub context in the test body, not
+        # here — Thread.__init__ eagerly builds its agent (calls create_research_agent),
+        # so it must be constructed while stub_research_subagent() is patched or the
+        # mock is too late and the real (SearXNG-hitting) subagent gets built.
 
     def tearDown(self):
         try:
@@ -148,6 +151,8 @@ class TestGiantsThreadTokenRegression(TestCase):
         # research report per turn drives the orchestrator's context/summarization path
         # without real search, and turns the ~40-min real-search run into minutes.
         with stub_research_subagent(_CANNED_REPORT):
+            # Build the Thread INSIDE the patch — its __init__ eagerly builds the agent.
+            self.thread = self.tm.new()
             r1 = self._send("turn 1", TURN_1)
             logger.info("turn 1 response (first 300 chars): %s", str(r1)[:300])
             r2 = self._send("turn 2", TURN_2)

--- a/edd/eval/test_research_multi_turn_token_regression.py
+++ b/edd/eval/test_research_multi_turn_token_regression.py
@@ -151,7 +151,7 @@ class TestGiantsThreadTokenRegression(TestCase):
         # This eval tests the CALLER-facing overflow guard (no BadRequestError leaks
         # past retry/rollback across 3 turns), not search behavior — so a large canned
         # research report per turn drives the orchestrator's context/summarization path
-        # without real search, and turns the ~40-min real-search run into minutes.
+        # without real search — rate-limit-free, deterministic, and faster than real search.
         with stub_research_subagent(_CANNED_REPORT):
             # Build the Thread INSIDE the patch — its __init__ eagerly builds the agent.
             self.thread = self.tm.new()

--- a/edd/eval/test_research_multi_turn_token_regression.py
+++ b/edd/eval/test_research_multi_turn_token_regression.py
@@ -41,10 +41,17 @@ is about context-size handling, not answer correctness.  Lenient
 `assertTrue` on response presence is included only as a sanity check
 that turns landed at all.
 
-This test is intentionally network-bound: the failing pattern only
-appears when real research tools accumulate real web-search results.
-Mocking the tools would not reproduce the message-buildup that
-overflows the cap.
+The research subagent is MOCKED (a large canned report per turn via
+``stub_research_subagent``) — see ``AGENTS.md`` testing guideline #5:
+real search rate-limits SearXNG, and this eval tests the caller-facing
+overflow guard, not search behavior.  The canned report drives the
+orchestrator's context/summarization path across the three turns
+without SearXNG, turning the ~40-min real-search run into ~14 min and
+removing rate-limit false-negatives.  (Historical note: the original
+``BadRequestError`` was a 53k-context older model; on the current 131k
+model this run passes without forcing overflow — it is a plumbing
+regression guard for the summarizer/retry wiring, which the mocked
+context still exercises.)
 """
 import logging
 import os

--- a/edd/eval/utils.py
+++ b/edd/eval/utils.py
@@ -3,9 +3,11 @@ import functools
 import os
 import shutil
 import subprocess
+from contextlib import contextmanager
 from unittest.mock import patch
 from unittest import TestCase
 from langchain_core.messages import ToolMessage, AIMessage
+from langchain_core.runnables import RunnableLambda
 # One source of truth for "the same URL" — the prod guard defines it, the eval
 # imports it, so the spy's provenance accounting can't drift from the guard's.
 from assist.middleware.url_provenance import normalize_url
@@ -40,6 +42,28 @@ def build_thread_repo(tmp: str, branch: str) -> str:
     _git("config", "user.name", "A", cwd=workspace)
     _git("checkout", "-b", branch, cwd=workspace)
     return workspace
+
+
+@contextmanager
+def stub_research_subagent(findings="(stubbed research findings)"):
+    """Patch ``create_research_agent`` so the research subagent returns ``findings``
+    immediately — no real search, so the eval is rate-limit-free (no SearXNG burst)
+    and deterministic (canned findings vs stochastic search).
+
+    The orchestrator still ISSUES the ``task`` dispatch (the ``research-agent``
+    ``CompiledSubAgent`` stays registered — only the runnable behind it is stubbed),
+    so evals that count research *dispatches* still work; only the subagent's
+    expensive internals are skipped.  Pass a large ``findings`` string to drive
+    context deterministically.  See ``AGENTS.md`` testing guideline #5 and
+    ``docs/2026-07-06-research-eval-mocking.org``.  ALWAYS use this in an eval that
+    triggers research but is not itself testing research/search behavior.
+    """
+    def _stub(*args, **kwargs):
+        return RunnableLambda(
+            lambda state: {"messages": list((state or {}).get("messages", []))
+                           + [AIMessage(content=findings)]})
+    with patch("assist.agent.create_research_agent", _stub):
+        yield
 
 
 class AgentTestMixin:

--- a/edd/eval/utils.py
+++ b/edd/eval/utils.py
@@ -63,7 +63,8 @@ def stub_research_subagent(findings="(stubbed research findings)"):
     construction time, so the patch must be active THEN.  Building the agent/Thread in
     ``setUp`` or before the ``with`` block silently binds the REAL subagent and the mock
     has no effect (the eval then hits SearXNG anyway).  Do:
-    ``with stub_research_subagent(...): agent = create_agent(...); agent.message(...)``.
+    ``with stub_research_subagent(...): agent = AgentHarness(create_agent(...)); agent.message(...)``
+    (``create_agent`` returns a compiled graph; ``AgentHarness`` gives it ``.message()``).
     """
     def _stub(*args, **kwargs):
         return RunnableLambda(

--- a/edd/eval/utils.py
+++ b/edd/eval/utils.py
@@ -57,6 +57,13 @@ def stub_research_subagent(findings="(stubbed research findings)"):
     context deterministically.  See ``AGENTS.md`` testing guideline #5 and
     ``docs/2026-07-06-research-eval-mocking.org``.  ALWAYS use this in an eval that
     triggers research but is not itself testing research/search behavior.
+
+    USAGE CONSTRAINT — construct the agent/Thread INSIDE this context.  ``create_agent``
+    (and ``Thread.__init__``, which calls it eagerly) build the research subagent at
+    construction time, so the patch must be active THEN.  Building the agent/Thread in
+    ``setUp`` or before the ``with`` block silently binds the REAL subagent and the mock
+    has no effect (the eval then hits SearXNG anyway).  Do:
+    ``with stub_research_subagent(...): agent = create_agent(...); agent.message(...)``.
     """
     def _stub(*args, **kwargs):
         return RunnableLambda(


### PR DESCRIPTION
## Why
Real-search evals hit the self-hosted SearXNG, which **rate-limits under a burst** — the suite grinds for hours and trips false-negative "search unavailable" results (a throttled run mistaken for a real failure). Codified as a convention in `AGENTS.md` testing guideline #5 + `docs/2026-07-06-research-eval-mocking.org` (both already on `main`).

## What
New shared helper **`edd/eval/utils.py::stub_research_subagent(findings=...)`** — a context manager that patches `create_research_agent` so the research subagent returns canned findings immediately (no search → rate-limit-free + deterministic). The orchestrator **still issues the `task` dispatch** (the `research-agent` `CompiledSubAgent` stays registered — only the runnable behind it is stubbed), so evals that count research *dispatches* keep working. Generalizes `test_context_agent`'s existing `_stub_subagent`.

Converted the two incidental-research evals:
| eval | what it tests | mock |
|---|---|---|
| `test_location_research` | does the map skill *suppress* research **dispatch** | stub — dispatch count preserved |
| `test_research_multi_turn_token_regression` | caller-facing **overflow** guard (no `BadRequestError`) | stub w/ a large canned report to drive the orchestrator's summarization path |

**Stay real** (they test search itself): `test_research_agent`, `test_research_reliability`.
**Out of scope:** `eval_multi_turn_research` (a standalone `main()` script, not in the pytest suite).

## Results (baseline → mocked)
| eval | unmocked | mocked |
|---|---|---|
| `test_location_research` | 2/2 pass, 7–25 min, 0 rate-limit signals | passes, ~9 min, **rate-limit-free**, dispatch preserved (3/6/3/2) |
| `test_research_multi_turn_token_regression` | **40-min timeout** (never completed) | **passes in 8.3 min**, genuinely rate-limit-free |

## Design changes from review
- **Mock timing (Copilot rd2, real catch):** `Thread.__init__` builds its agent *eagerly* (`thread.py:199`). The token-regression eval created the `Thread` in `setUp()` — **outside** the `with stub_research_subagent()` block — so the patch landed too late and the eval silently ran with **real search** (an earlier "13.8 min" figure was that mis-measurement, i.e. real-search variance). Fixed by constructing the `Thread` **inside** the stub context; verified with a wiring check (`create_research_agent` *is* the stub during `Thread` build). The lesson for this helper: **build the agent/Thread inside the `with`** — the location eval was already correct (it does).

## Honest notes
- `test_location_research` is **model-latency-bound** (the model still dispatches/maps/writes), so its *speed* win is modest — the real win there is **rate-limit-freedom + determinism**.
- `test_research_multi_turn_token_regression`: on the current 131k model it passes without forcing overflow (the original `BadRequestError` was a 53k-context older model) — a plumbing regression guard for the summarizer/retry wiring, which the mocked context still exercises. That property is pre-existing, not introduced by mocking.

932 unit green. Test-only — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)