### PR TITLE
read_url: write full content to a file + grep on demand (drops the cap; moots #137)

### DIFF
--- a/assist/agent.py
+++ b/assist/agent.py
@@ -23,6 +23,7 @@ from assist.middleware.model_logging_middleware import ModelLoggingMiddleware
 from assist.middleware.json_validation_middleware import JsonValidationMiddleware
 from assist.middleware.tool_name_sanitization import ToolNameSanitizationMiddleware
 from assist.middleware.output_sanitization import OutputSanitizationMiddleware
+from assist.middleware.read_url_to_file import ReadUrlToFileMiddleware
 from assist.middleware.bad_request_retry import BadRequestRetryMiddleware
 from assist.middleware.loop_detection import LoopDetectionMiddleware
 from assist.middleware.search_unavailable_breaker import SearchUnavailableBreakerMiddleware
@@ -541,6 +542,10 @@ def create_research_agent(model: BaseChatModel,
         backend = create_sandbox_composite_backend(references_sandbox)
     else:
         backend = create_references_backend(working_dir)
+    # Offload large read_url results on the orchestrator too (it reads specific URLs
+    # while writing/fact-checking).  backend is only available here, after references
+    # routing is set up, so append rather than build into base_mw above.
+    base_mw.append(ReadUrlToFileMiddleware(backend))
     logging_mw = ModelLoggingMiddleware("research-agent")
 
     # Safety middleware installed on every dict-spec subagent below.
@@ -559,6 +564,10 @@ def create_research_agent(model: BaseChatModel,
     def _subagent_safety_mw():
         return [_make_retry_middleware(),
                 BadRequestRetryMiddleware(max_retries=3),
+                # Offload a large read_url result to /large_tool_results/ + hand the
+                # agent a preview + path to grep (full page reachable, context bounded).
+                # Sanitizes before writing, so it's order-independent vs the sanitizer.
+                ReadUrlToFileMiddleware(backend),
                 # Strip ANSI from sub-tool output (read_url HTML can carry
                 # raw escape sequences) before it lands in subagent state.
                 OutputSanitizationMiddleware(),

--- a/assist/middleware/read_url_to_file.py
+++ b/assist/middleware/read_url_to_file.py
@@ -1,0 +1,114 @@
+"""Offload large ``read_url`` results to a file so the agent greps them on demand.
+
+``read_url`` returns a page's full extracted text.  A long article floods the
+research subagent's context (many reads → the slow-zone / overflow the context
+work fights).  Rather than truncate — which loses everything past the cap, so the
+agent researches from page-tops only — this middleware writes the full text to
+``/large_tool_results/<tool_call_id>`` (the same prefix deepagents' built-in
+large-result eviction uses, and which its filesystem system prompt already tells
+the model to ``grep``/``read_file``) and replaces the tool result with a short
+PREVIEW + the path + a grep instruction.  So the full page stays available while
+the model-visible context is bounded to ~1kB per read BY CONSTRUCTION.
+
+Why middleware, not guidance (AGENTS.md "guidance first"): offload is I/O plumbing
+the model can't do itself — you cannot instruct it to shrink a ToolMessage the
+framework has already appended to its context.  That is the ethos's own exception
+("middleware only when guidance provably can't").  The behavioral half — actually
+grepping the file — is carried by the prompt (see ``sub_research.txt.j2``) + the
+framework's existing ``/large_tool_results/`` grep guidance.
+
+Rides the exact state-write path deepagents' own ``FilesystemMiddleware`` uses:
+``StateBackend.write`` during ``wrap_tool_call`` queues into the current graph
+state, so a later ``read_file``/``grep`` in the same turn reads it back.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+from deepagents.backends.utils import sanitize_tool_call_id
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware.types import ToolCallRequest
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
+
+from assist.middleware.output_sanitization import _sanitize
+
+logger = logging.getLogger(__name__)
+
+# Offload only above this floor.  A short page — or an ``Error fetching URL:``
+# string — is smaller than what a grep-the-file instruction would send the model
+# after, so returning it inline (as today) is strictly better than making the
+# small model chase an all-but-empty file.  Comfortably below any real article,
+# far below deepagents' own 80k-char eviction floor.
+_OFFLOAD_FLOOR_CHARS = 4000
+_PREVIEW_CHARS = 600
+_ERROR_PREFIX = "Error fetching URL:"   # read_url's bare-string error shape (tools.py)
+
+
+def _preview_message(msg: ToolMessage, url: str, path: str, full_len: int) -> ToolMessage:
+    preview = str(msg.content)[:_PREVIEW_CHARS]
+    body = (
+        f"Fetched {url}. Full page text ({full_len} chars) saved to {path} — this is "
+        f"a PREVIEW ONLY (first {_PREVIEW_CHARS} chars):\n{preview}\n… [truncated] "
+        f"To find a specific fact, number, date, name, or quote, DO NOT answer from "
+        f"this preview — grep the file: grep(pattern=\"<keyword>\", path=\"{path}\") "
+        f"then read_file around the match."
+    )
+    return msg.model_copy(update={"content": body})
+
+
+class ReadUrlToFileMiddleware(AgentMiddleware):
+    """Offload ``read_url`` results larger than the floor to ``/large_tool_results/``.
+
+    Sync (``wrap_tool_call``) + async (``awrap_tool_call``) — the research/fact-check
+    subagents invoke through the async path.  Anything that isn't a large ``read_url``
+    ``ToolMessage`` passes through untouched, and any failure falls back to the
+    original result (never break the research path on an offload bug).
+    """
+
+    name = "ReadUrlToFileMiddleware"
+
+    def __init__(self, backend):
+        super().__init__()
+        self.backend = backend
+
+    def _offload(self, request: ToolCallRequest, result):
+        if request.tool_call.get("name") != "read_url":
+            return result
+        if not isinstance(result, ToolMessage) or not isinstance(result.content, str):
+            return result
+        content = result.content
+        if content.startswith(_ERROR_PREFIX) or len(content) <= _OFFLOAD_FLOOR_CHARS:
+            return result
+        # Sanitize before persisting so a later grep/read_file can't re-inject raw
+        # ANSI/control bytes (the BadRequest-outage class) from the offloaded file.
+        content = _sanitize(content)
+        path = f"/large_tool_results/{sanitize_tool_call_id(result.tool_call_id)}"
+        write = self.backend.write(path, content)
+        if getattr(write, "error", None):
+            logger.warning("ReadUrlToFile: write to %s failed: %s", path, write.error)
+            return result
+        url = (request.tool_call.get("args") or {}).get("url", "the page")
+        return _preview_message(result, url, path, len(content))
+
+    def _safe_offload(self, request, result):
+        try:
+            return self._offload(request, result)
+        except Exception as e:  # never block the tool path on an offload bug
+            logger.warning("ReadUrlToFile: skipped due to %s: %s", type(e).__name__, e)
+            return result
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        return self._safe_offload(request, handler(request))
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler,
+    ):
+        return self._safe_offload(request, await handler(request))

--- a/assist/middleware/read_url_to_file.py
+++ b/assist/middleware/read_url_to_file.py
@@ -46,8 +46,12 @@ _PREVIEW_CHARS = 600
 _ERROR_PREFIX = "Error fetching URL:"   # read_url's bare-string error shape (tools.py)
 
 
-def _preview_message(msg: ToolMessage, url: str, path: str, full_len: int) -> ToolMessage:
-    preview = str(msg.content)[:_PREVIEW_CHARS]
+def _preview_message(msg: ToolMessage, content: str, url: str, path: str) -> ToolMessage:
+    # Preview from the SANITIZED content (same string written to the file), so the
+    # model-visible preview can't carry raw ANSI/control bytes regardless of where
+    # OutputSanitizationMiddleware sits relative to this one.
+    preview = content[:_PREVIEW_CHARS]
+    full_len = len(content)
     body = (
         f"Fetched {url}. Full page text ({full_len} chars) saved to {path} — this is "
         f"a PREVIEW ONLY (first {_PREVIEW_CHARS} chars):\n{preview}\n… [truncated] "
@@ -90,7 +94,7 @@ class ReadUrlToFileMiddleware(AgentMiddleware):
             logger.warning("ReadUrlToFile: write to %s failed: %s", path, write.error)
             return result
         url = (request.tool_call.get("args") or {}).get("url", "the page")
-        return _preview_message(result, url, path, len(content))
+        return _preview_message(result, content, url, path)
 
     def _safe_offload(self, request, result):
         try:

--- a/assist/templates/deepagents/sub_research.txt.j2
+++ b/assist/templates/deepagents/sub_research.txt.j2
@@ -11,6 +11,7 @@ How to use `read_url` (follow this procedure):
 2. If you need a page's full text, copy ONE `url` value VERBATIM from a results list and pass that to `read_url`. Read at most 2 pages.
 3. The `url` you pass to `read_url` must be one you copied from a results list. You do not know what URLs exist — only the search results do. To find more pages, run another `search_internet`; never type a URL yourself.
 4. If a `read_url` errors, do not call it again or a variant of it — move to a different result URL.
+5. For a long page, `read_url` returns a short PREVIEW plus a file path (the full text is saved there). When you need a specific fact — an exact number, date, name, or quote — that isn't in the preview, do NOT answer from the preview: `grep(pattern="<the keyword>", path="<the returned path>")` and read around the match.
 
 Example — suppose search_internet returned:
 `[{"title": "Casio F-91W", "url": "https://shop.example/f91w", "content": "..."}]`

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -179,10 +179,10 @@ def read_url(url: str) -> str:
     Returns the page's main article text where the page marks one
     (``<article>``/``<main>``) so the char budget holds signal, not nav/footer
     chrome; degrades to a whole-page text strip (scripts/styles removed) when
-    the page marks no article. Capped at 24000 chars (~6k tokens) — enough to hold a
-    typical article's full main text, not just the top; a realistic research turn does
-    ~5 reads so the subagent context stays well under the slow zone (measured ~15-20k).
-    (A genuinely huge page still truncates here; read_url→file+grep is the follow-up.)
+    the page marks no article. Returns the FULL extracted text (not truncated) —
+    ReadUrlToFileMiddleware offloads a large result to a file and hands the agent a
+    preview + path to grep, so full page content stays reachable without flooding
+    context. The error path returns a short ``Error fetching URL:`` string inline.
 
     Per-host throttled (~1s between calls to the same host) so a burst of
     fetches to different sites isn't artificially serialised, but a tight
@@ -198,7 +198,7 @@ def read_url(url: str) -> str:
             timeout=15,
         )
         resp.raise_for_status()
-        return _extract_main_content(resp.text)[:24000]
+        return _extract_main_content(resp.text)
     except Exception as e:
         return f"Error fetching URL: {e}"
 

--- a/docs/2026-07-06-read-url-to-file.org
+++ b/docs/2026-07-06-read-url-to-file.org
@@ -57,7 +57,7 @@ grepping — is carried by the prompt + the framework's grep guidance.
 * Eval (new shape: mock the fetch, rate-limit-free)
 =edd/eval/test_read_url_deep_content.py= — a fictional venue (unguessable capacity 88,204)
 with the fact at ~32000 chars, PAST the 24k cap; =requests.get= + search mocked.
-- *Baseline (current main, 24k cap):* FAILED — the agent can't reach the fact (truncated).
+- *Baseline (pre-change, 24k cap):* FAILED — the agent can't reach the fact (truncated).
 - *With the feature: 3/3 PASS* — the agent greps the offloaded file → reaches the fact.
 Plus 6 middleware unit tests (bounded-by-construction at the seam: full content → file,
 ~1kB preview out; floor/error/Command/write-error paths). 938 unit green.

--- a/docs/2026-07-06-read-url-to-file.org
+++ b/docs/2026-07-06-read-url-to-file.org
@@ -1,0 +1,73 @@
+#+TITLE: read_url → file: full page content, greppable on demand
+#+DATE: <2026-07-06>
+#+STATUS: BUILT + eval-proven (branch read-url-to-file). Design-reviewed (2 lenses). Moots #137.
+
+* Problem
+=read_url= returned truncated page text (a 4000-char cap, raised to 24000 this session as
+an interim fix). Even 24k truncates: the research agent works from page-TOPS and can't
+reach a fact buried deeper. Removing the cap without offload would REINTRODUCE context
+bloat (many reads × full pages → the slow-zone #137 targets; measured subagent peak ~13.6k
+with the cap). Pierre: write the full page to a FILE and grep it on demand — fix by
+construction, not a window trick.
+
+* Design (mechanism (b): a small tool-targeted offload middleware)
+=read_url= returns the FULL extracted text (uncapped). A new
+=ReadUrlToFileMiddleware= (=assist/middleware/read_url_to_file.py=, ~110 LOC, clones
+=OutputSanitizationMiddleware='s sync+async =wrap_tool_call= shape) intercepts a =read_url=
+result and, when it exceeds a floor, writes the full content to
+=/large_tool_results/<sanitize_tool_call_id(tool_call_id)>= and returns a bounded
+PREVIEW (~600 chars) + the path + a grep instruction. Subagent context is bounded to the
+preview (~1kB) BY CONSTRUCTION, regardless of page size.
+
+*Why =/large_tool_results/=:* it's the exact prefix deepagents' built-in large-result
+eviction uses, already routed to ephemeral =StateBackend= in every research backend
+(=backends.py:63=), and the framework's filesystem system prompt ALREADY tells the model
+to =grep=/=read_file= it — so the behavioral guidance comes free; the sub_research prompt
+adds one checkable reinforcement line.
+
+*Rejected:* (a) making =read_url= backend-aware (pushes deepagents I/O into a pure
+boundary fn — bad layering); (c) uncap + rely on deepagents' 20k-token (=80k-char) offload
+(medium 24-80k-char pages re-flood context; and the threshold is hardcoded/unexposed, a
+2nd FilesystemMiddleware double-registers tools).
+
+* The two design-review revisions (folded in)
+1. *Floor, not literal "always".* Offload only above ~4000 chars; a short page or an
+   =Error fetching URL:= string returns inline — else the small model chases an all-but-
+   empty file. Still effectively "always" for any real article.
+2. *Sanitize before writing.* =read_url= HTML can carry raw ANSI/control bytes (the
+   BadRequest-outage class). The middleware =_sanitize=s the content before the file write,
+   so a later grep/read_file can't re-inject raw bytes — order-independent vs the sanitizer.
+
+* Correctness (the make-or-break, design-review-verified)
+The backend write during =wrap_tool_call= lands in the state a later =grep=/=read_file=
+reads — because deepagents' OWN =FilesystemMiddleware.wrap_tool_call= does exactly this
+(writes =/large_tool_results/= during the hook via =StateBackend.write=, reads back later);
+the feature rides the identical proven path. Ordering: our middleware is INNER of the
+auto-installed FilesystemMiddleware, so it offloads first and the outer one no-ops on the
+small preview (no double-eviction). Write-error → fall back to the original (never break
+research). =Command=/non-=ToolMessage= pass through.
+
+* Ethos: guidance-first honored
+"Guidance over middleware" targets BEHAVIORAL guards that re-do the model's judgment.
+Offload is I/O plumbing the model can't do itself — you can't instruct it to shrink a
+ToolMessage the framework already appended to its context. That's the ethos's own
+exception ("middleware only when guidance provably can't"). The behavioral half — actually
+grepping — is carried by the prompt + the framework's grep guidance.
+
+* Eval (new shape: mock the fetch, rate-limit-free)
+=edd/eval/test_read_url_deep_content.py= — a fictional venue (unguessable capacity 88,204)
+with the fact at ~32000 chars, PAST the 24k cap; =requests.get= + search mocked.
+- *Baseline (current main, 24k cap):* FAILED — the agent can't reach the fact (truncated).
+- *With the feature: 3/3 PASS* — the agent greps the offloaded file → reaches the fact.
+Plus 6 middleware unit tests (bounded-by-construction at the seam: full content → file,
+~1kB preview out; floor/error/Command/write-error paths). 938 unit green.
+
+* Moots #137
+#137 added an earlier-summarization TRIGGER to lower the probability of subagent overflow.
+This bounds per-read context to a ~1kB preview BY CONSTRUCTION regardless of page size or
+read count — the peak #137 chased (~13.6k measured) is now bounded structurally. Recommend
+closing #137 as superseded.
+
+* Follow-up (roadmapped, not here)
+Semantic search over the offloaded pages (embed chunks → query "find the part about X") —
+better than grep for fuzzy queries, but heavier; only if grep-on-file proves insufficient.

--- a/edd/eval/test_read_url_deep_content.py
+++ b/edd/eval/test_read_url_deep_content.py
@@ -1,14 +1,15 @@
 """Eval: can the research agent reach content BURIED DEEP in a page (beyond the
-first 4000 chars)?  This is the gate for the read_url-to-file change (B): read_url
-should write the full extracted content to a file + return a preview, and the agent
-should GREP the file for specifics.
+read_url cap)?  This is the gate for the read_url-to-file change: read_url should
+write the full extracted content to a file + return a preview, and the agent should
+GREP the file for specifics.
 
-BASELINE (current main, read_url capped at 4000 chars): a fact ~8000 chars into the
-page is TRUNCATED away — the agent can't see it → should FAIL.  WITH the change: the
-full page is offloaded to a file and the agent greps it → should PASS.
+BASELINE (current main, read_url capped at 24000 chars): the fact ~32000 chars into
+the page is TRUNCATED away — the agent can't see it → should FAIL.  WITH the change:
+the full page is offloaded to a file and the agent greps it → should PASS.
 
 Rate-limit-free: `requests.get` is mocked to return a canned large page (no SearXNG,
-no network); read_url's REAL extraction + cap/offload logic runs on it.
+no network) — the "new eval shape" (mock the network/search boundary); read_url's REAL
+extraction + cap/offload logic runs on it.
 """
 import os
 import tempfile
@@ -23,14 +24,15 @@ from edd.eval.utils import build_thread_repo, cleanup_workspace
 os.environ.setdefault("ASSIST_MODEL_URL", "http://127.0.0.1:8000/v1")
 
 # A canned article about a FICTIONAL venue (so the model CANNOT answer from training
-# data — it must actually read the page).  The DEEP FACT sits ~7000 chars into the
-# extracted text — past read_url's 4000-char cap — so the baseline (capped) can't see it.
+# data — it must actually read the page).  The DEEP FACT sits ~32000 chars into the
+# extracted text — PAST read_url's current 24000-char cap — so the baseline (capped)
+# can't see it; only writing the full page to a file + grepping it reaches the fact.
 _CAPACITY = "88,204"   # a made-up, unguessable number for a made-up venue
 _DEEP_FACT = f"The Vantalux Coliseum's exact seating capacity is {_CAPACITY} seats."
 _TOP = ("<article><h1>Vantalux Coliseum</h1>"
         + ("<p>The Vantalux Coliseum is a multipurpose arena in the fictional city of "
            "Brindlemark. It hosts the regional Gravball championships and is noted for "
-           "its retractable canopy and the famous echoing north stand. </p>") * 40)
+           "its retractable canopy and the famous echoing north stand. </p>") * 200)
 _HTML = _TOP + f"<h2>Facts</h2><p>{_DEEP_FACT} It opened in 2011.</p></article>"
 
 
@@ -65,7 +67,7 @@ class TestReadUrlDeepContent(TestCase):
         self.addCleanup(SandboxManager.cleanup, self.workspace)
 
     def test_agent_reaches_deep_fact(self):
-        """The answer (41,915) lives ~8000 chars into the page — past the 4k cap.
+        """The answer (88,204) lives ~32000 chars into the page — past the 24k cap.
         Baseline (main) can't see it → fails; with read_url→file + grep → passes."""
         with patch("assist.tools.requests.get", _mock_get), \
              patch("assist.tools.search_internet", _mock_search), \
@@ -77,5 +79,5 @@ class TestReadUrlDeepContent(TestCase):
         ans = str(out)
         found = _CAPACITY in ans or _CAPACITY.replace(",", "") in ans.replace(",", "")
         self.assertTrue(found,
-                        f"agent did not reach the deep fact (capacity {_CAPACITY}) — the 4k "
+                        f"agent did not reach the deep fact (capacity {_CAPACITY}) — the 24k "
                         f"cap truncates it, so it needs read_url->file + grep. Answer:\n{ans[:600]}")

--- a/edd/eval/test_read_url_deep_content.py
+++ b/edd/eval/test_read_url_deep_content.py
@@ -3,7 +3,7 @@ read_url cap)?  This is the gate for the read_url-to-file change: read_url shoul
 write the full extracted content to a file + return a preview, and the agent should
 GREP the file for specifics.
 
-BASELINE (current main, read_url capped at 24000 chars): the fact ~32000 chars into
+BASELINE (before this change — read_url capped at 24000 chars): the fact ~32000 chars into
 the page is TRUNCATED away — the agent can't see it → should FAIL.  WITH the change:
 the full page is offloaded to a file and the agent greps it → should PASS.
 
@@ -25,7 +25,7 @@ os.environ.setdefault("ASSIST_MODEL_URL", "http://127.0.0.1:8000/v1")
 
 # A canned article about a FICTIONAL venue (so the model CANNOT answer from training
 # data — it must actually read the page).  The DEEP FACT sits ~32000 chars into the
-# extracted text — PAST read_url's current 24000-char cap — so the baseline (capped)
+# extracted text — PAST read_url's former 24000-char cap — so the baseline (capped)
 # can't see it; only writing the full page to a file + grepping it reaches the fact.
 _CAPACITY = "88,204"   # a made-up, unguessable number for a made-up venue
 _DEEP_FACT = f"The Vantalux Coliseum's exact seating capacity is {_CAPACITY} seats."
@@ -67,7 +67,7 @@ class TestReadUrlDeepContent(TestCase):
         self.addCleanup(SandboxManager.cleanup, self.workspace)
 
     def test_agent_reaches_deep_fact(self):
-        """The answer (88,204) lives ~32000 chars into the page — past the 24k cap.
+        """The answer (88,204) lives ~32000 chars into the page — past the former 24k cap.
         Baseline (main) can't see it → fails; with read_url→file + grep → passes."""
         with patch("assist.tools.requests.get", _mock_get), \
              patch("assist.tools.search_internet", _mock_search), \
@@ -80,4 +80,4 @@ class TestReadUrlDeepContent(TestCase):
         found = _CAPACITY in ans or _CAPACITY.replace(",", "") in ans.replace(",", "")
         self.assertTrue(found,
                         f"agent did not reach the deep fact (capacity {_CAPACITY}) — the 24k "
-                        f"cap truncates it, so it needs read_url->file + grep. Answer:\n{ans[:600]}")
+                        f"was past the former cap; with read_url->file the agent must GREP the offloaded file to reach it (offload/grep likely broke). Answer:\n{ans[:600]}")

--- a/tests/test_read_url_to_file_middleware.py
+++ b/tests/test_read_url_to_file_middleware.py
@@ -5,6 +5,8 @@ the model-visible result is small (preview + path + grep instruction) regardless
 page size, and the stub backend received the FULL content.  Un-mocked at the seam
 that matters (no LLM).
 """
+from types import SimpleNamespace
+
 from langchain_core.messages import ToolMessage
 from langgraph.types import Command
 
@@ -20,10 +22,7 @@ class _StubBackend:
     def write(self, path, content):
         self.written[path] = content
         # mimic StateBackend.write's return shape (has .error / .path)
-        class _R:
-            error = "exists" if self._existing else None
-            path = None
-        return _R()
+        return SimpleNamespace(error=("exists" if self._existing else None), path=None)
 
 
 class _Req:

--- a/tests/test_read_url_to_file_middleware.py
+++ b/tests/test_read_url_to_file_middleware.py
@@ -1,0 +1,95 @@
+"""Unit tests for ReadUrlToFileMiddleware — the bounded-by-construction seam.
+
+Drives wrap_tool_call with a fake read_url ToolMessage + a stub backend and asserts:
+the model-visible result is small (preview + path + grep instruction) regardless of
+page size, and the stub backend received the FULL content.  Un-mocked at the seam
+that matters (no LLM).
+"""
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
+
+from assist.middleware.read_url_to_file import (
+    ReadUrlToFileMiddleware, _OFFLOAD_FLOOR_CHARS, _PREVIEW_CHARS)
+
+
+class _StubBackend:
+    def __init__(self, existing=False):
+        self.written = {}
+        self._existing = existing
+
+    def write(self, path, content):
+        self.written[path] = content
+        # mimic StateBackend.write's return shape (has .error / .path)
+        class _R:
+            error = "exists" if self._existing else None
+            path = None
+        return _R()
+
+
+class _Req:
+    def __init__(self, name="read_url", url="https://example.com/x"):
+        self.tool_call = {"name": name, "args": {"url": url}}
+
+
+def _msg(content, tcid="call_1"):
+    return ToolMessage(content=content, tool_call_id=tcid)
+
+
+def _run(mw, req, result):
+    return mw.wrap_tool_call(req, lambda r: result)
+
+
+def test_large_read_url_offloaded_to_file_and_bounded():
+    backend = _StubBackend()
+    mw = ReadUrlToFileMiddleware(backend)
+    full = "The capacity is 88,204 seats. " + ("filler text. " * 3000)   # >> floor
+    out = _run(mw, _Req(), _msg(full))
+    # the file got the FULL content:
+    assert len(backend.written) == 1
+    path, written = next(iter(backend.written.items()))
+    assert path.startswith("/large_tool_results/")
+    assert "88,204" in written and len(written) == len(full)
+    # the model-visible message is BOUNDED (preview + path + grep instruction):
+    assert isinstance(out, ToolMessage)
+    assert len(out.content) < _PREVIEW_CHARS + 500
+    assert path in out.content and "grep(" in out.content
+
+
+def test_small_read_url_returned_inline():
+    backend = _StubBackend()
+    mw = ReadUrlToFileMiddleware(backend)
+    small = "x" * (_OFFLOAD_FLOOR_CHARS - 1)
+    out = _run(mw, _Req(), _msg(small))
+    assert out.content == small and not backend.written   # untouched, no file
+
+
+def test_error_string_returned_inline():
+    backend = _StubBackend()
+    mw = ReadUrlToFileMiddleware(backend)
+    err = "Error fetching URL: timeout"
+    out = _run(mw, _Req(), _msg(err))
+    assert out.content == err and not backend.written
+
+
+def test_non_read_url_tool_untouched():
+    backend = _StubBackend()
+    mw = ReadUrlToFileMiddleware(backend)
+    big = "y" * 50000
+    out = _run(mw, _Req(name="search_internet"), _msg(big))
+    assert out.content == big and not backend.written
+
+
+def test_write_error_falls_back_to_original():
+    backend = _StubBackend(existing=True)   # write returns an error
+    mw = ReadUrlToFileMiddleware(backend)
+    full = "z" * 50000
+    out = _run(mw, _Req(), _msg(full))
+    assert out.content == full   # fell back to the original, not a broken preview
+
+
+def test_command_result_passes_through():
+    backend = _StubBackend()
+    mw = ReadUrlToFileMiddleware(backend)
+    cmd = Command(update={"messages": []})
+    out = _run(mw, _Req(), cmd)
+    assert out is cmd and not backend.written

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -325,9 +325,10 @@ class TestReadUrlExtraction:
         # else a doc ending mid-token (here a bare entity) returns empty.
         assert "tail text" in tools._extract_main_content("<article>tail text &amp")
 
-    def test_truncates_to_24000(self):
-        # over the cap -> truncated to 24000; a 9k page (under the cap) is returned whole.
-        assert len(self._read("<article><p>" + ("x" * 30000) + "</p></article>")) == 24000
+    def test_returns_full_content_uncapped(self):
+        # read_url no longer truncates — it returns the full extracted text; the
+        # large-result offload to a file is ReadUrlToFileMiddleware's job now.
+        assert len(self._read("<article><p>" + ("x" * 30000) + "</p></article>")) == 30000
         assert len(self._read("<article><p>" + ("x" * 9000) + "</p></article>")) == 9000
 
     def test_error_path_unchanged(self):


### PR DESCRIPTION
## Problem
`read_url` returned truncated page text (a 24k-char cap — raised from 4k this session as an interim fix). Even 24k truncates: the research agent works from **page-tops** and can't reach a fact buried deeper. Removing the cap without offload would reintroduce context bloat (many reads × full pages → the slow-zone PR #137 targets).

## Fix (by construction)
`read_url` returns the **full** extracted text; a new **`ReadUrlToFileMiddleware`** offloads a result >4k chars to `/large_tool_results/<tool_call_id>` (the prefix deepagents already tells the model to grep) and returns a **~1kB preview + path + grep instruction**. Full page reachable; subagent context bounded to the preview **by construction**, regardless of page size.

## Head-to-head (eval-first)
`edd/eval/test_read_url_deep_content.py` — a fictional venue (unguessable capacity `88,204`) with the fact at ~32k chars, past the cap; `requests.get` + search **mocked** (rate-limit-free).

| | result |
|---|---|
| **Baseline** (24k cap) | **FAILED** — agent can't reach the deep fact (truncated) |
| **With the feature** | **3/3 PASS** — agent greps the offloaded file and reaches it |

Plus **6 middleware unit tests** (bounded-by-construction at the seam) + **938 unit green**.

## Design (reviewed, 2 lenses + adversarial)
- **Mechanism:** a small tool-targeted offload middleware (clones `OutputSanitizationMiddleware`'s sync+async shape). Rejected making read_url backend-aware (bad layering) and relying on deepagents' 80k-char offload (medium pages re-flood; threshold hardcoded).
- **Correctness (make-or-break):** the backend-write-during-`wrap_tool_call` rides deepagents' **own proven** `FilesystemMiddleware` state-write path; our middleware is inner, so the outer one no-ops on the small preview (no double-eviction).
- **Design-review revisions folded in:** offload above a **floor** (~4k — tiny pages/errors stay inline, don't send the model after an empty file); **sanitize before writing** (raw ANSI can't re-inject via a later grep).
- **Ethos:** "guidance over middleware" respected — offload is I/O plumbing the model can't do itself (you can't instruct it to shrink a ToolMessage the framework already appended); the grep *behavior* is carried by the prompt.
- **Adversarial review: clean** — path from `sanitize_tool_call_id` (no traversal), `StateBackend`-confined, all read_url consumers covered.

## Moots #137
#137 added an earlier-summarization *trigger* to lower the probability of subagent overflow. This bounds per-read context to a ~1kB preview **by construction** — the peak #137 chased (~13.6k measured) is now bounded structurally. **Suggest closing #137 as superseded.**

Deployed from this branch for live-testing. `docs/2026-07-06-read-url-to-file.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)