### PR TITLE
UI: minimal monochrome color scheme

### DIFF
--- a/manage/web/diff.py
+++ b/manage/web/diff.py
@@ -173,30 +173,30 @@ def render_file_diff(
 
 
 _DIFF_CSS = """
-.diff-file { margin: .6rem 0; border: 1px solid #d0d7de; border-radius: 6px; overflow: hidden; background: #fff; }
-.diff-file > summary { padding: .5rem .75rem; background: #f6f8fa; cursor: pointer; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .85rem; display: flex; gap: .6rem; align-items: center; flex-wrap: wrap; list-style: none; }
+.diff-file { margin: .6rem 0; border: 1px solid #e5e7eb; border-radius: 6px; overflow: hidden; background: #fff; }
+.diff-file > summary { padding: .5rem .75rem; background: #fafafa; cursor: pointer; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .85rem; display: flex; gap: .6rem; align-items: center; flex-wrap: wrap; list-style: none; }
 .diff-file > summary::-webkit-details-marker { display: none; }
-.diff-file > summary::before { content: "▶"; font-size: .7rem; color: #57606a; transition: transform .15s; }
+.diff-file > summary::before { content: "▶"; font-size: .7rem; color: #6b7280; transition: transform .15s; }
 .diff-file[open] > summary::before { transform: rotate(90deg); }
-.diff-file[open] > summary { border-bottom: 1px solid #d0d7de; }
+.diff-file[open] > summary { border-bottom: 1px solid #e5e7eb; }
 .diff-stats { font-size: .75rem; font-family: ui-monospace, monospace; }
-.diff-stats .add { color: #1a7f37; }
-.diff-stats .del { color: #cf222e; }
-.diff-binary-badge, .diff-truncated-badge { font-size: .7rem; background: #ddf4ff; color: #0969da; border: 1px solid #b6e3ff; padding: .05rem .4rem; border-radius: 10px; }
-.diff-truncated-badge { background: #fff8c5; color: #9a6700; border-color: #d4a72c; }
+.diff-stats .add { color: #15803d; }
+.diff-stats .del { color: #b91c1c; }
+.diff-binary-badge, .diff-truncated-badge { font-size: .7rem; background: #fafafa; color: #6b7280; border: 1px solid #e5e7eb; padding: .05rem .4rem; border-radius: 10px; }
+.diff-truncated-badge { background: #fafafa; color: #a16207; border-color: #e5e7eb; }
 .diff-rows { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .8rem; line-height: 1.4; overflow-x: auto; }
 .diff-row { padding: 0 .5rem; white-space: pre; min-height: 1.2em; border-left: 3px solid transparent; }
-.diff-row.diff-add { background: #e6ffec; border-left-color: #abf2bc; }
-.diff-row.diff-del { background: #ffebe9; border-left-color: #ffabab; }
+.diff-row.diff-add { background: #eaf7ee; border-left-color: #a3d9b1; }
+.diff-row.diff-del { background: #fdeeee; border-left-color: #e6a8a8; }
 .diff-row.diff-ctx { background: #fff; }
-.diff-row.diff-hunk { background: #ddf4ff; color: #57606a; font-weight: 600; }
-.diff-row.diff-meta { background: #f6f8fa; color: #57606a; font-size: .75rem; }
+.diff-row.diff-hunk { background: #fafafa; color: #6b7280; font-weight: 600; }
+.diff-row.diff-meta { background: #fafafa; color: #6b7280; font-size: .75rem; }
 .diff-row[data-key] { cursor: pointer; }
-.diff-row[data-key]:hover { outline: 1px solid #0969da; outline-offset: -1px; }
-.diff-binary { padding: .6rem .75rem; color: #57606a; font-style: italic; font-size: .85rem; }
-.diff-truncated { padding: .6rem .75rem; background: #fff8c5; color: #57606a; font-size: .85rem; }
-.diff-truncated a { color: #0969da; text-decoration: underline; }
-.diff-overflow { padding: .6rem .75rem; background: #fff8c5; border: 1px solid #d4a72c; border-radius: 6px; color: #57606a; font-size: .85rem; margin: .6rem 0; }
+.diff-row[data-key]:hover { outline: 1px solid #171717; outline-offset: -1px; }
+.diff-binary { padding: .6rem .75rem; color: #6b7280; font-style: italic; font-size: .85rem; }
+.diff-truncated { padding: .6rem .75rem; background: #fafafa; color: #6b7280; font-size: .85rem; }
+.diff-truncated a { color: #171717; text-decoration: underline; }
+.diff-overflow { padding: .6rem .75rem; background: #fafafa; border: 1px solid #e5e7eb; border-left: 3px solid #a16207; border-radius: 6px; color: #171717; font-size: .85rem; margin: .6rem 0; }
 """
 
 

--- a/manage/web/evals.py
+++ b/manage/web/evals.py
@@ -13,13 +13,13 @@ from manage.web.threads import _PULL_TO_REFRESH_SCRIPT
 
 def _status_cell_style(status: str | None) -> str:
     if status == "passed":
-        return "background:#c6efce; color:#276221;"
+        return "background:#eaf7ee; color:#15803d;"
     if status in ("failed", "error"):
-        return "background:#ffc7ce; color:#9c0006;"
+        return "background:#fdeeee; color:#b91c1c;"
     if status == "skipped":
-        return "background:#ffeb9c; color:#9c5700;"
+        return "background:#fdf6e3; color:#a16207;"
     # never run
-    return "background:#fff; color:#aaa;"
+    return "background:#ffffff; color:#6b7280;"
 
 
 def render_evals() -> str:
@@ -32,7 +32,7 @@ def render_evals() -> str:
         <html><head><title>Eval Results</title>
         <style>body{{font-family:sans-serif;margin:0}}
         .container{{max-width:1200px;margin:0 auto;padding:1rem}}
-        .nav a{{display:inline-flex;align-items:center;min-height:44px;padding:.6rem .8rem;border-radius:6px;text-decoration:none;touch-action:manipulation}}</style></head>
+        .nav a{{display:inline-flex;align-items:center;min-height:44px;padding:.6rem .8rem;border-radius:6px;color:#171717;text-decoration:underline;touch-action:manipulation}}</style></head>
         <body><div class="container">
         <div class="nav"><a href="/">← Back</a></div>
         <h1 style="font-size:1.4rem">Eval Results</h1>{body}{_PULL_TO_REFRESH_SCRIPT}</div></body></html>"""
@@ -48,8 +48,8 @@ def render_evals() -> str:
     all_keys.sort()
 
     # Header row: run IDs
-    header_cells = "<th style='min-width:7rem;padding:.4rem .5rem;font-size:.75rem;text-align:center;border:1px solid #ddd;background:#f5f5f5;white-space:nowrap'>"
-    header_cells += "</th><th style='min-width:7rem;padding:.4rem .5rem;font-size:.75rem;text-align:center;border:1px solid #ddd;background:#f5f5f5;white-space:nowrap'>".join(
+    header_cells = "<th style='min-width:7rem;padding:.4rem .5rem;font-size:.75rem;text-align:center;border:1px solid #e5e7eb;background:#fafafa;white-space:nowrap'>"
+    header_cells += "</th><th style='min-width:7rem;padding:.4rem .5rem;font-size:.75rem;text-align:center;border:1px solid #e5e7eb;background:#fafafa;white-space:nowrap'>".join(
         html.escape(r["id"]) for r in runs
     )
     header_cells += "</th>"
@@ -61,10 +61,10 @@ def render_evals() -> str:
         passed = sum(1 for t in run["tests"].values() if t["status"] == "passed")
         failed = sum(1 for t in run["tests"].values() if t["status"] in ("failed", "error"))
         stat_cells += (
-            f"<td style='text-align:center;padding:.3rem .4rem;border:1px solid #ddd;"
-            f"font-size:.75rem;background:#f9f9f9'>"
-            f"<span style='color:#276221'>✓{passed}</span> "
-            f"<span style='color:#9c0006'>✗{failed}</span>"
+            f"<td style='text-align:center;padding:.3rem .4rem;border:1px solid #e5e7eb;"
+            f"font-size:.75rem;background:#fafafa'>"
+            f"<span style='color:#15803d'>✓{passed}</span> "
+            f"<span style='color:#b91c1c'>✗{failed}</span>"
             f"</td>"
         )
 
@@ -79,10 +79,10 @@ def render_evals() -> str:
         tooltip = html.escape(key)
 
         row_cells = (
-            f"<td style='padding:.35rem .6rem;border:1px solid #ddd;white-space:nowrap;"
+            f"<td style='padding:.35rem .6rem;border:1px solid #e5e7eb;white-space:nowrap;"
             f"font-size:.8rem;position:sticky;left:0;background:#fafafa;z-index:1'>"
             f"<span title='{tooltip}'>{short}</span>"
-            f"<div style='font-size:.68rem;color:#888;margin-top:.1rem'>{class_part}</div></td>"
+            f"<div style='font-size:.68rem;color:#6b7280;margin-top:.1rem'>{class_part}</div></td>"
         )
 
         for run in runs:
@@ -95,7 +95,7 @@ def render_evals() -> str:
             if result:
                 tip = html.escape((result["message"][:120] if result["message"] else status) or "")
                 row_cells += (
-                    f"<td style='text-align:center;border:1px solid #ddd;padding:0;{cell_style}'>"
+                    f"<td style='text-align:center;border:1px solid #e5e7eb;padding:0;{cell_style}'>"
                     f"<a href='{href}' style='display:block;padding:.35rem .4rem;"
                     f"text-decoration:none;color:inherit;font-size:.8rem;font-weight:600' "
                     f"title='{tip}'>"
@@ -103,7 +103,7 @@ def render_evals() -> str:
                 )
             else:
                 row_cells += (
-                    f"<td style='text-align:center;border:1px solid #ddd;{cell_style}'>"
+                    f"<td style='text-align:center;border:1px solid #e5e7eb;{cell_style}'>"
                     f"<span style='font-size:.8rem'>–</span></td>"
                 )
 
@@ -119,15 +119,15 @@ def render_evals() -> str:
         <style>
           body {{ font-family: sans-serif; margin: 0; }}
           .container {{ max-width: 100%; padding: 1rem; }}
-          .nav a {{ display: inline-flex; align-items: center; min-height: 44px; padding: .6rem .8rem; border-radius: 6px; text-decoration: none; touch-action: manipulation; }}
+          .nav a {{ display: inline-flex; align-items: center; min-height: 44px; padding: .6rem .8rem; border-radius: 6px; color: #171717; text-decoration: underline; touch-action: manipulation; }}
           .table-wrap {{ overflow-x: auto; margin-top: 1rem; }}
           table {{ border-collapse: collapse; font-size: .85rem; }}
-          th {{ padding: .4rem .5rem; border: 1px solid #ddd; background: #f5f5f5;
+          th {{ padding: .4rem .5rem; border: 1px solid #e5e7eb; background: #fafafa;
                 font-size: .75rem; white-space: nowrap; text-align: center; }}
-          tr:hover td {{ filter: brightness(0.95); }}
+          tr:hover td {{ filter: brightness(0.98); }}
           .legend {{ display: flex; gap: 1rem; margin: .5rem 0 1rem; font-size: .82rem; flex-wrap: wrap; }}
           .legend-item {{ display: flex; align-items: center; gap: .3rem; }}
-          .legend-swatch {{ width: 14px; height: 14px; border-radius: 3px; border: 1px solid #ccc; }}
+          .legend-swatch {{ width: 14px; height: 14px; border-radius: 3px; border: 1px solid #e5e7eb; }}
         </style>
       </head>
       <body>
@@ -135,20 +135,20 @@ def render_evals() -> str:
           <div class="nav"><a href="/">← Back</a></div>
           <h1 style="font-size:1.4rem; margin-bottom:.5rem">Eval Results</h1>
           <div class="legend">
-            <div class="legend-item"><div class="legend-swatch" style="background:#c6efce"></div> Pass</div>
-            <div class="legend-item"><div class="legend-swatch" style="background:#ffc7ce"></div> Fail / Error</div>
-            <div class="legend-item"><div class="legend-swatch" style="background:#ffeb9c"></div> Skipped</div>
-            <div class="legend-item"><div class="legend-swatch" style="background:#fff; border:1px solid #ccc"></div> Not run</div>
+            <div class="legend-item"><div class="legend-swatch" style="background:#eaf7ee"></div> Pass</div>
+            <div class="legend-item"><div class="legend-swatch" style="background:#fdeeee"></div> Fail / Error</div>
+            <div class="legend-item"><div class="legend-swatch" style="background:#fdf6e3"></div> Skipped</div>
+            <div class="legend-item"><div class="legend-swatch" style="background:#fff; border:1px solid #e5e7eb"></div> Not run</div>
           </div>
           <div class="table-wrap">
             <table>
               <thead>
                 <tr>
-                  <th style="min-width:220px;text-align:left;padding:.4rem .6rem;border:1px solid #ddd;background:#f5f5f5;position:sticky;left:0;z-index:2">Test</th>
+                  <th style="min-width:220px;text-align:left;padding:.4rem .6rem;border:1px solid #e5e7eb;background:#fafafa;position:sticky;left:0;z-index:2">Test</th>
                   {header_cells}
                 </tr>
                 <tr>
-                  <td style="border:1px solid #ddd;background:#f9f9f9;padding:.3rem .6rem;font-size:.75rem;color:#666;position:sticky;left:0;z-index:2">Pass ✓ / Fail ✗</td>
+                  <td style="border:1px solid #e5e7eb;background:#fafafa;padding:.3rem .6rem;font-size:.75rem;color:#6b7280;position:sticky;left:0;z-index:2">Pass ✓ / Fail ✗</td>
                   {stat_cells}
                 </tr>
               </thead>
@@ -186,14 +186,14 @@ def render_eval_detail(run_id: str, test_key: str) -> str:
     class_name = "::".join(parts[:-1]) if len(parts) > 1 else ""
 
     message_html = (
-        f"<pre style='background:#f8f8f8;border:1px solid #ddd;padding:.8rem 1rem;"
+        f"<pre style='background:#fafafa;border:1px solid #e5e7eb;padding:.8rem 1rem;"
         f"border-radius:6px;overflow-x:auto;white-space:pre-wrap;word-break:break-word;"
         f"font-size:.82rem'>{html.escape(result['message'])}</pre>"
         if result["message"] else ""
     )
     details_html = (
         f"<h3 style='font-size:1rem;margin-top:1.5rem'>Traceback</h3>"
-        f"<pre style='background:#f8f8f8;border:1px solid #ddd;padding:.8rem 1rem;"
+        f"<pre style='background:#fafafa;border:1px solid #e5e7eb;padding:.8rem 1rem;"
         f"border-radius:6px;overflow-x:auto;white-space:pre-wrap;word-break:break-word;"
         f"font-size:.8rem'>{html.escape(result['details'])}</pre>"
         if result["details"] else ""
@@ -207,7 +207,7 @@ def render_eval_detail(run_id: str, test_key: str) -> str:
         <style>
           body {{ font-family: sans-serif; margin: 0; }}
           .container {{ max-width: 900px; margin: 0 auto; padding: 1rem; }}
-          .nav a {{ display: inline-flex; align-items: center; min-height: 44px; padding: .6rem .8rem; border-radius: 6px; text-decoration: none; touch-action: manipulation; }}
+          .nav a {{ display: inline-flex; align-items: center; min-height: 44px; padding: .6rem .8rem; border-radius: 6px; color: #171717; text-decoration: underline; touch-action: manipulation; }}
           .badge {{ display: inline-block; padding: .3rem .8rem; border-radius: 12px;
                     font-weight: 600; font-size: .9rem; }}
         </style>
@@ -216,23 +216,23 @@ def render_eval_detail(run_id: str, test_key: str) -> str:
         <div class="container">
           <div class="nav"><a href="/evals">← Eval Results</a></div>
           <h1 style="font-size:1.3rem; margin:.8rem 0 .2rem">{html.escape(short_name)}</h1>
-          <div style="color:#666; font-size:.85rem; margin-bottom:1rem">{html.escape(class_name)}</div>
+          <div style="color:#6b7280; font-size:.85rem; margin-bottom:1rem">{html.escape(class_name)}</div>
 
           <table style="border-collapse:collapse; font-size:.9rem; margin-bottom:1rem">
             <tr>
-              <td style="padding:.3rem .8rem .3rem 0; color:#555; font-weight:500">Run</td>
+              <td style="padding:.3rem .8rem .3rem 0; color:#6b7280; font-weight:500">Run</td>
               <td style="padding:.3rem 0">{html.escape(run_id)}</td>
             </tr>
             <tr>
-              <td style="padding:.3rem .8rem .3rem 0; color:#555; font-weight:500">Timestamp</td>
+              <td style="padding:.3rem .8rem .3rem 0; color:#6b7280; font-weight:500">Timestamp</td>
               <td style="padding:.3rem 0">{html.escape(run.get('timestamp', ''))}</td>
             </tr>
             <tr>
-              <td style="padding:.3rem .8rem .3rem 0; color:#555; font-weight:500">Duration</td>
+              <td style="padding:.3rem .8rem .3rem 0; color:#6b7280; font-weight:500">Duration</td>
               <td style="padding:.3rem 0">{result['time']:.2f}s</td>
             </tr>
             <tr>
-              <td style="padding:.3rem .8rem .3rem 0; color:#555; font-weight:500">Status</td>
+              <td style="padding:.3rem .8rem .3rem 0; color:#6b7280; font-weight:500">Status</td>
               <td style="padding:.3rem 0">
                 <span class="badge" style="{cell_style}">{html.escape(status.upper())}</span>
               </td>

--- a/manage/web/review.py
+++ b/manage/web/review.py
@@ -135,7 +135,7 @@ def render_review_page(tid: str, chat: Thread | None) -> str:
           <title>Review — {html.escape(title)}</title>
           <style>body {{ font-family: sans-serif; margin: 0; }}
                  .container {{ max-width: 900px; margin: 0 auto; padding: 1rem; }}
-                 .nav a {{ display: inline-flex; align-items: center; min-height: 44px; padding: .6rem .8rem; border-radius: 6px; text-decoration: none; touch-action: manipulation; }}</style>
+                 .nav a {{ display: inline-flex; align-items: center; min-height: 44px; padding: .6rem .8rem; border-radius: 6px; color: #171717; text-decoration: underline; touch-action: manipulation; }}</style>
         </head><body>
           <div class="container">
             <div class="nav"><a href="/thread/{tid}">← Back to thread</a></div>
@@ -161,25 +161,25 @@ def render_review_page(tid: str, chat: Thread | None) -> str:
         <style>
           body {{ font-family: sans-serif; margin: 0; background: #fff; -webkit-tap-highlight-color: rgba(0,0,0,0.05); }}
           .container {{ max-width: 1100px; margin: 0 auto; padding: 1rem; }}
-          .nav a {{ text-decoration: none; padding: .6rem .8rem; min-height: 44px; display: inline-flex; align-items: center; border-radius: 6px; color: #0969da; touch-action: manipulation; }}
+          .nav a {{ text-decoration: underline; padding: .6rem .8rem; min-height: 44px; display: inline-flex; align-items: center; border-radius: 6px; color: #171717; touch-action: manipulation; }}
           h1 {{ font-size: 1.3rem; margin: .5rem 0; }}
-          .review-header {{ position: sticky; top: 0; background: #fff; padding: .8rem 0; border-bottom: 1px solid #d0d7de; z-index: 10; margin-bottom: 1rem; }}
+          .review-header {{ position: sticky; top: 0; background: #fff; padding: .8rem 0; border-bottom: 1px solid #e5e7eb; z-index: 10; margin-bottom: 1rem; }}
           /* font-size: 16px on every editable input prevents iOS zoom on focus. */
-          .review-header textarea {{ width: 100%; min-height: 4.5rem; box-sizing: border-box; padding: .7rem; border: 1px solid #d0d7de; border-radius: 6px; font-family: inherit; font-size: 16px; resize: vertical; }}
-          .review-header label {{ display: block; font-size: .85rem; color: #57606a; margin-bottom: .3rem; }}
+          .review-header textarea {{ width: 100%; min-height: 4.5rem; box-sizing: border-box; padding: .7rem; border: 1px solid #e5e7eb; border-radius: 6px; font-family: inherit; font-size: 16px; resize: vertical; }}
+          .review-header label {{ display: block; font-size: .85rem; color: #6b7280; margin-bottom: .3rem; }}
           .review-actions {{ display: flex; align-items: center; gap: .6rem; margin-top: .6rem; flex-wrap: wrap; }}
-          .submit-btn {{ background: #1a7f37; color: #fff; border: 1px solid #156529; padding: .7rem 1.2rem; min-height: 44px; font-size: 16px; font-weight: 600; border-radius: 6px; cursor: pointer; touch-action: manipulation; }}
-          .submit-btn:hover:not(:disabled) {{ background: #156529; }}
-          .submit-btn:disabled {{ background: #94d3a2; border-color: #94d3a2; color: #fff; cursor: not-allowed; }}
-          .cancel-link {{ color: #57606a; text-decoration: none; font-size: .95rem; padding: .7rem .9rem; min-height: 44px; display: inline-flex; align-items: center; touch-action: manipulation; }}
-          .cancel-link:hover {{ color: #24292f; }}
-          .comment-count {{ font-size: .85rem; color: #57606a; }}
-          .busy-note {{ background: #fff8c5; border: 1px solid #d4a72c; padding: .5rem .75rem; border-radius: 6px; color: #57606a; font-size: .85rem; margin-top: .5rem; }}
-          .comment-editor {{ margin: .3rem .5rem .6rem 1rem; padding: .6rem; background: #f6f8fa; border: 1px solid #d0d7de; border-radius: 6px; }}
-          .comment-editor textarea {{ width: 100%; min-height: 4rem; box-sizing: border-box; padding: .6rem; border: 1px solid #d0d7de; border-radius: 4px; font-family: inherit; font-size: 16px; resize: vertical; }}
+          .submit-btn {{ background: #171717; color: #fff; border: 1px solid #171717; padding: .7rem 1.2rem; min-height: 44px; font-size: 16px; font-weight: 600; border-radius: 6px; cursor: pointer; touch-action: manipulation; }}
+          .submit-btn:hover:not(:disabled) {{ background: #000; }}
+          .submit-btn:disabled {{ background: #fafafa; border-color: #e5e7eb; color: #6b7280; cursor: not-allowed; }}
+          .cancel-link {{ color: #171717; text-decoration: underline; font-size: .95rem; padding: .7rem .9rem; min-height: 44px; display: inline-flex; align-items: center; touch-action: manipulation; }}
+          .cancel-link:hover {{ color: #000; }}
+          .comment-count {{ font-size: .85rem; color: #6b7280; }}
+          .busy-note {{ background: #fafafa; border: 1px solid #e5e7eb; border-left: 3px solid #a16207; padding: .5rem .75rem; border-radius: 6px; color: #171717; font-size: .85rem; margin-top: .5rem; }}
+          .comment-editor {{ margin: .3rem .5rem .6rem 1rem; padding: .6rem; background: #fafafa; border: 1px solid #e5e7eb; border-radius: 6px; }}
+          .comment-editor textarea {{ width: 100%; min-height: 4rem; box-sizing: border-box; padding: .6rem; border: 1px solid #e5e7eb; border-radius: 4px; font-family: inherit; font-size: 16px; resize: vertical; }}
           .comment-editor .editor-actions {{ display: flex; justify-content: flex-end; gap: .4rem; margin-top: .5rem; }}
-          .comment-editor button {{ font-size: .9rem; padding: .55rem .9rem; min-height: 36px; border-radius: 4px; cursor: pointer; border: 1px solid #d0d7de; background: #fff; color: #57606a; touch-action: manipulation; }}
-          .comment-editor button:hover {{ background: #f6f8fa; }}
+          .comment-editor button {{ font-size: .9rem; padding: .55rem .9rem; min-height: 36px; border-radius: 4px; cursor: pointer; border: 1px solid #e5e7eb; background: #fff; color: #171717; touch-action: manipulation; }}
+          .comment-editor button:hover {{ background: #fafafa; }}
           {_DIFF_CSS}
         </style>
       </head>
@@ -199,7 +199,7 @@ def render_review_page(tid: str, chat: Thread | None) -> str:
                 <span id="comment-count" class="comment-count">No line comments yet</span>
               </div>
               {busy_note}
-              <div style="font-size:.8rem; color:#57606a; margin-top:.5rem">
+              <div style="font-size:.8rem; color:#6b7280; margin-top:.5rem">
                 Click any line in the diff below to leave a comment.  Drafts persist in this browser until you submit.
               </div>
             </div>

--- a/manage/web/schedules.py
+++ b/manage/web/schedules.py
@@ -48,12 +48,13 @@ def _render(scheds) -> str:
   body {{ font-family: system-ui, sans-serif; margin: 1rem; }}
   .topbar {{ display: flex; gap: .5rem; align-items: center; margin-bottom: 1rem; }}
   table {{ border-collapse: collapse; width: 100%; }}
-  th, td {{ text-align: left; padding: .5rem; border-bottom: 1px solid #ddd; vertical-align: top; }}
+  th, td {{ text-align: left; padding: .5rem; border-bottom: 1px solid #e5e7eb; vertical-align: top; }}
   td.prompt {{ max-width: 28rem; }}
-  .paused {{ color: #999; }}
-  .btn {{ display: inline-block; padding: .4rem .7rem; border-radius: 6px; border: 1px solid #ccc;
-          background: #f5f5f5; text-decoration: none; color: #222; cursor: pointer; }}
-  .btn-secondary {{ background: #fff; }}
+  .paused {{ color: #6b7280; }}
+  .btn {{ display: inline-block; padding: .4rem .7rem; border-radius: 6px; border: 1px solid #e5e7eb;
+          background: #ffffff; text-decoration: none; color: #171717; cursor: pointer; }}
+  .btn:hover {{ background: #fafafa; }}
+  .btn-secondary {{ background: #ffffff; }}
 </style></head><body>
   <div class="topbar"><a href="/" class="btn">&larr; Threads</a><h2>Scheduled prompts</h2></div>
   {body}

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -120,7 +120,7 @@ _PULL_TO_REFRESH_SCRIPT = """<script>
   var startY=0, pulling=false, MAX=90, TRIGGER=65;
   var bar=document.createElement('div');
   bar.style.cssText='position:fixed;top:0;left:0;right:0;height:0;overflow:hidden;'
-    +'display:flex;align-items:flex-end;justify-content:center;background:#1d4ed8;'
+    +'display:flex;align-items:flex-end;justify-content:center;background:#171717;'
     +'color:#fff;font-size:14px;z-index:9999;transition:height .2s ease;';
   var label=document.createElement('div'); label.style.padding='.4rem'; bar.appendChild(label);
   document.body.appendChild(bar);
@@ -181,20 +181,20 @@ def render_index(query: str = "") -> str:
             # the user can tell their message is held behind another
             # thread (vs. actively running).
             badge = (
-                f'<span style="font-size:.7rem; color:#1e3a5f; background:#e1ecf4;'
-                f' border:1px solid #b6d4ef; padding:.1rem .4rem; border-radius:10px;'
+                f'<span style="font-size:.7rem; color:#6b7280; background:#fafafa;'
+                f' border:1px solid #e5e7eb; padding:.1rem .4rem; border-radius:10px;'
                 f' margin-right:.4rem;">{html.escape(STAGE_LABELS.get(stage, stage))}</span>'
             )
         elif stage in BUSY_STAGES:
             badge = (
-                f'<span style="font-size:.7rem; color:#555; background:#fff3cd;'
-                f' border:1px solid #ffeeba; padding:.1rem .4rem; border-radius:10px;'
+                f'<span style="font-size:.7rem; color:#6b7280; background:#fafafa;'
+                f' border:1px solid #e5e7eb; padding:.1rem .4rem; border-radius:10px;'
                 f' margin-right:.4rem;">{html.escape(STAGE_LABELS.get(stage, stage))}</span>'
             )
         elif stage == "error":
             badge = (
-                '<span style="font-size:.7rem; color:#721c24; background:#f8d7da;'
-                ' border:1px solid #f5c6cb; padding:.1rem .4rem; border-radius:10px;'
+                '<span style="font-size:.7rem; color:#b91c1c; background:#fafafa;'
+                ' border:1px solid #e5e7eb; padding:.1rem .4rem; border-radius:10px;'
                 ' margin-right:.4rem;">error</span>'
             )
         elif _has_urgent(tid):
@@ -202,8 +202,8 @@ def render_index(query: str = "") -> str:
             # Stronger than "new" (above it), still below the live process-state
             # badges (a running/errored thread is actionable now). Red pill.
             badge = (
-                '<span style="font-size:.7rem; color:#fff; background:#dc2626;'
-                ' border:1px solid #b91c1c; padding:.1rem .4rem; border-radius:10px;'
+                '<span style="font-size:.7rem; color:#b91c1c; background:#fafafa;'
+                ' border:1px solid #e5e7eb; padding:.1rem .4rem; border-radius:10px;'
                 ' margin-right:.4rem;">urgent</span>'
             )
         elif _has_unseen_response(tid):
@@ -213,8 +213,8 @@ def render_index(query: str = "") -> str:
             # "new" yet), ABOVE "unmerged" (a response to read beats a housekeeping
             # reminder) — per Pierre.  Blue/green, distinct from the others.
             badge = (
-                '<span style="font-size:.7rem; color:#0b5c2e; background:#d7f3e3;'
-                ' border:1px solid #9fdcbb; padding:.1rem .4rem; border-radius:10px;'
+                '<span style="font-size:.7rem; color:#6b7280; background:#fafafa;'
+                ' border:1px solid #e5e7eb; padding:.1rem .4rem; border-radius:10px;'
                 ' margin-right:.4rem;">new</span>'
             )
         elif _has_unmerged_changes(tid):
@@ -222,8 +222,8 @@ def render_index(query: str = "") -> str:
             # Strictly secondary to the process-state badges above —
             # only shows when the thread is otherwise idle.
             badge = (
-                '<span style="font-size:.7rem; color:#7c4a1d; background:#fef0e0;'
-                ' border:1px solid #fbcfa0; padding:.1rem .4rem; border-radius:10px;'
+                '<span style="font-size:.7rem; color:#6b7280; background:#fafafa;'
+                ' border:1px solid #e5e7eb; padding:.1rem .4rem; border-radius:10px;'
                 ' margin-right:.4rem;">unmerged</span>'
             )
         items.append(
@@ -243,7 +243,7 @@ def render_index(query: str = "") -> str:
         )
     items_html = "\n".join(items)
     search_status = (
-        f'<p style="font-size:.85rem; color:#666; margin:.2rem 0 .6rem;">'
+        f'<p style="font-size:.85rem; color:#6b7280; margin:.2rem 0 .6rem;">'
         f'{matched} match{"" if matched == 1 else "es"} for '
         f'&ldquo;{html.escape(q)}&rdquo; &middot; <a href="/">clear</a></p>'
     ) if q else ""
@@ -263,23 +263,25 @@ def render_index(query: str = "") -> str:
              44 pt touch-target guidance — enough to tap reliably on mobile. */
           li {{ margin: .4rem 0; display: flex; align-items: stretch; gap: .25rem; }}
           .thread-link {{ flex: 1; display: flex; align-items: center; padding: .85rem .8rem; border-radius: 6px; min-height: 44px; text-decoration: none; color: inherit; touch-action: manipulation; }}
-          .thread-link:hover {{ background: #f3f6fa; }}
-          .thread-link:active {{ background: #e7edf4; }}
-          .del-btn {{ background: none; border: none; color: #999; cursor: pointer; font-size: 1.4rem; padding: 0 .8rem; border-radius: 6px; min-width: 44px; min-height: 44px; touch-action: manipulation; }}
-          .del-btn:hover {{ color: #c00; background: #fee; }}
-          .del-btn:active {{ background: #fdd; }}
+          .thread-link:hover {{ background: #fafafa; }}
+          .thread-link:active {{ background: #f3f4f6; }}
+          .del-btn {{ background: none; border: none; color: #6b7280; cursor: pointer; font-size: 1.4rem; padding: 0 .8rem; border-radius: 6px; min-width: 44px; min-height: 44px; touch-action: manipulation; }}
+          .del-btn:hover {{ color: #b91c1c; background: #fafafa; }}
+          .del-btn:active {{ background: #f3f4f6; }}
           a:active, a:focus {{ outline: none; }}
           /* inline-flex so the same .btn class works on both <button>
              and <a> (e.g., the Evals link in the topbar): the 44 px
              min-height needs flex centering or the text floats up. */
-          .btn {{ display: inline-flex; align-items: center; justify-content: center; padding: .7rem 1rem; min-height: 44px; border: 1px solid #333; border-radius: 8px; background: #eee; color: inherit; font-size: 16px; text-decoration: none; cursor: pointer; touch-action: manipulation; box-sizing: border-box; }}
-          .new-thread-form {{ margin-bottom: 1.5rem; padding: 1rem; background: #f9f9f9; border-radius: 8px; border: 1px solid #ddd; }}
+          .btn {{ display: inline-flex; align-items: center; justify-content: center; padding: .7rem 1rem; min-height: 44px; border: 1px solid #e5e7eb; border-radius: 8px; background: #ffffff; color: #171717; font-size: 16px; text-decoration: none; cursor: pointer; touch-action: manipulation; box-sizing: border-box; }}
+          .btn:hover {{ background: #fafafa; }}
+          .new-thread-form {{ margin-bottom: 1.5rem; padding: 1rem; background: #fafafa; border-radius: 8px; border: 1px solid #e5e7eb; }}
           /* font-size: 16px (not 1rem) explicitly prevents iOS Safari from
              auto-zooming on focus.  Anything below 16px triggers the zoom. */
-          .new-thread-form textarea {{ width: 100%; min-height: 5rem; box-sizing: border-box; padding: .8rem; border: 1px solid #ccc; border-radius: 6px; font-family: inherit; font-size: 16px; resize: vertical; }}
-          .new-thread-form textarea:focus {{ outline: 2px solid #4a90e2; border-color: #4a90e2; }}
+          .new-thread-form textarea {{ width: 100%; min-height: 5rem; box-sizing: border-box; padding: .8rem; border: 1px solid #e5e7eb; border-radius: 6px; font-family: inherit; font-size: 16px; resize: vertical; }}
+          .new-thread-form textarea:focus {{ outline: 2px solid #171717; border-color: #171717; }}
           .new-thread-form select {{ font-size: 16px; padding: .6rem; min-height: 44px; }}
-          .new-thread-btn {{ margin-top: .6rem; display: none; }}
+          .new-thread-btn {{ margin-top: .6rem; display: none; background: #171717; color: #fff; border-color: #171717; }}
+          .new-thread-btn:hover {{ background: #000; }}
           .new-thread-btn.visible {{ display: block; }}
           @media (max-width: 480px) {{
             .btn {{ width: 100%; }}
@@ -313,7 +315,7 @@ def render_index(query: str = "") -> str:
           <form method="get" action="/" style="margin:0 0 .6rem;">
             <input type="search" name="q" value="{html.escape(q)}"
                    placeholder="Search threads..." aria-label="Search threads"
-                   style="width:100%; box-sizing:border-box; padding:.7rem .8rem; font-size:16px; border:1px solid #ccc; border-radius:6px;" />
+                   style="width:100%; box-sizing:border-box; padding:.7rem .8rem; font-size:16px; border:1px solid #e5e7eb; border-radius:6px;" />
           </form>
           {search_status}
           <ul>
@@ -361,7 +363,7 @@ def render_thread(
     can_rename = not (busy or is_init)
     rename_button = (
         '<button type="button" onclick="showRename()" aria-label="Rename thread" '
-        'style="background:none; border:none; color:#999; cursor:pointer; '
+        'style="background:none; border:none; color:#6b7280; cursor:pointer; '
         'font-size:1rem; padding:.2rem .4rem; line-height:1;">&#x270e;</button>'
     ) if can_rename else ""
     # Stacked: full-width input on its own line, Save/Cancel on the line below
@@ -372,7 +374,7 @@ def render_thread(
         f'<input type="text" name="description" value="{html.escape(title)}" '
         f'maxlength="120" required aria-label="Thread name" '
         f'style="width:100%; box-sizing:border-box; padding:.6rem .7rem; '
-        f'font-size:16px; border:1px solid #ccc; border-radius:6px;" />'
+        f'font-size:16px; border:1px solid #e5e7eb; border-radius:6px;" />'
         f'<div style="display:flex; gap:.5rem;">'
         f'<button class="btn" type="submit" style="min-height:auto; padding:.5rem 1rem;">Save</button>'
         f'<button class="btn btn-secondary" type="button" onclick="hideRename()" '
@@ -550,62 +552,64 @@ def render_thread(
           /* inline-flex centers the back-link text vertically inside
              the 44 px min-height; inline-block leaves the text floating
              at the top of the box. */
-          .nav a {{ display: inline-flex; align-items: center; padding: .6rem .8rem; min-height: 44px; border-radius: 6px; text-decoration: none; touch-action: manipulation; }}
+          .nav a {{ display: inline-flex; align-items: center; padding: .6rem .8rem; min-height: 44px; border-radius: 6px; color: #171717; text-decoration: underline; touch-action: manipulation; }}
           .msg {{ margin: .6rem 0; padding: .6rem .8rem; border-radius: 8px; max-width: 100%; word-wrap: break-word; overflow-wrap: anywhere; }}
-          .msg.user {{ background: #e6f3ff; border: 1px solid #b5dbff; }}
-          .msg.assistant {{ background: #f6f6f6; border: 1px solid #ddd; }}
+          .msg.user {{ background: #ffffff; border: 1px solid #e5e7eb; }}
+          .msg.assistant {{ background: #fafafa; border: 1px solid #e5e7eb; }}
           /* A file embed lifted from a ```render block, shown inline in the
              assistant bubble (org/md rendered page, or pdf viewer). */
           .show-embed {{ margin: .5rem 0; }}
-          .show-file {{ width: 100%; height: 65vh; border: 1px solid #e3e3e3; border-radius: 6px; background: #fff; }}
-          .show-map {{ width: 100%; height: 55vh; border: 1px solid #e3e3e3; border-radius: 6px; background: #fff; }}
+          .show-file {{ width: 100%; height: 65vh; border: 1px solid #e5e7eb; border-radius: 6px; background: #fff; }}
+          .show-map {{ width: 100%; height: 55vh; border: 1px solid #e5e7eb; border-radius: 6px; background: #fff; }}
           /* Pseudo-fullscreen (no Fullscreen API — reliable for a null-origin
              sandboxed iframe): fill the viewport, caption bar stays visible to exit. */
           .show-embed.fs {{ position: fixed; inset: 0; z-index: 10000; margin: 0; background: #fff; display: flex; flex-direction: column; }}
           .show-embed.fs .show-map {{ flex: 1 1 auto; height: auto; border: 0; border-radius: 0; }}
           .show-embed.fs .show-cap {{ flex: 0 0 auto; padding: .4rem .6rem; }}
           .show-cap {{ font-size: .85rem; margin-top: .3rem; }}
-          .role {{ font-size: .8rem; color: #555; margin-bottom: .2rem; text-transform: uppercase; }}
+          .role {{ font-size: .8rem; color: #6b7280; margin-bottom: .2rem; text-transform: uppercase; }}
           /* font-size: 16px on every editable form input — prevents iOS
              Safari from auto-zooming into the field on focus.  Anything
              below 16px (including 0.95rem) triggers the zoom. */
-          form textarea {{ width: 100%; min-height: 6rem; height: 24vh; box-sizing: border-box; padding: .6rem; font-family: inherit; font-size: 16px; border: 1px solid #ccc; border-radius: 6px; }}
+          form textarea {{ width: 100%; min-height: 6rem; height: 24vh; box-sizing: border-box; padding: .6rem; font-family: inherit; font-size: 16px; border: 1px solid #e5e7eb; border-radius: 6px; }}
           form {{ margin-top: 1rem; }}
-          .btn {{ display: inline-flex; align-items: center; justify-content: center; padding: .7rem 1rem; min-height: 44px; border: 1px solid #333; border-radius: 8px; background: #eee; color: inherit; font-size: 16px; text-decoration: none; cursor: pointer; touch-action: manipulation; box-sizing: border-box; }}
-          .btn-secondary {{ background: #ddd; }}
-          .approval-banner {{ background: #fff3cd; border: 1px solid #ffe69c; padding: .8rem; margin: .5rem 0; border-radius: 6px; color: #664d03; }}
+          .btn {{ display: inline-flex; align-items: center; justify-content: center; padding: .7rem 1rem; min-height: 44px; border: 1px solid #171717; border-radius: 8px; background: #171717; color: #fff; font-size: 16px; text-decoration: none; cursor: pointer; touch-action: manipulation; box-sizing: border-box; }}
+          .btn:hover {{ background: #000; }}
+          .btn-secondary {{ background: #ffffff; color: #171717; border-color: #e5e7eb; }}
+          .btn-secondary:hover {{ background: #fafafa; }}
+          .approval-banner {{ background: #fafafa; border: 1px solid #e5e7eb; border-left: 3px solid #a16207; padding: .8rem; margin: .5rem 0; border-radius: 6px; color: #171717; }}
           .approval-form {{ margin-top: .5rem; }}
-          .approval-draft {{ width: 100%; min-height: 3rem; height: auto; box-sizing: border-box; padding: .5rem; font-family: inherit; font-size: 16px; border: 1px solid #ccc; border-radius: 6px; }}
+          .approval-draft {{ width: 100%; min-height: 3rem; height: auto; box-sizing: border-box; padding: .5rem; font-family: inherit; font-size: 16px; border: 1px solid #e5e7eb; border-radius: 6px; }}
           .approval-actions {{ display: flex; gap: .5rem; flex-wrap: wrap; margin-top: .5rem; }}
-          .success-msg {{ background: #d4edda; border: 1px solid #c3e6cb; padding: .8rem; margin: .5rem 0; border-radius: 6px; color: #155724; }}
+          .success-msg {{ background: #fafafa; border: 1px solid #e5e7eb; border-left: 3px solid #15803d; padding: .8rem; margin: .5rem 0; border-radius: 6px; color: #171717; }}
           .modal {{ display: none; position: fixed; z-index: 1000; left: 0; top: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.4); }}
           .modal-content {{ background: #fff; margin: 10% auto; padding: 1.5rem; width: min(95%, 500px); border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); box-sizing: border-box; }}
           .modal-content h3 {{ margin-top: 0; }}
-          .modal-content textarea {{ width: 100%; min-height: 100px; padding: .6rem; border: 1px solid #ccc; border-radius: 4px; font-family: inherit; font-size: 16px; box-sizing: border-box; }}
+          .modal-content textarea {{ width: 100%; min-height: 100px; padding: .6rem; border: 1px solid #e5e7eb; border-radius: 4px; font-family: inherit; font-size: 16px; box-sizing: border-box; }}
           .modal-content label {{ display: block; margin-bottom: .5rem; font-weight: 500; }}
           .button-group {{ display: flex; gap: .5rem; margin-top: 1rem; }}
           .diff-container {{ margin: 1rem 0 .5rem; }}
           .diff-actions {{ display: flex; justify-content: flex-end; gap: .5rem; margin-bottom: .6rem; flex-wrap: wrap; }}
-          .merge-btn {{ background: #28a745; color: white; border: 1px solid #1e7e34; padding: .65rem .9rem; min-height: 44px; font-size: .95rem; white-space: nowrap; touch-action: manipulation; }}
-          .merge-btn:hover {{ background: #218838; border-color: #1c7430; }}
-          .push-btn {{ background: #0366d6; color: white; border: 1px solid #024ea4; padding: .65rem .9rem; min-height: 44px; font-size: .95rem; white-space: nowrap; touch-action: manipulation; }}
-          .push-btn:hover {{ background: #024ea4; border-color: #023672; }}
-          .review-btn {{ display: inline-flex; align-items: center; padding: .65rem .9rem; min-height: 44px; font-size: .95rem; white-space: nowrap; text-decoration: none; color: #24292f; background: #f6f8fa; border: 1px solid #d0d7de; border-radius: 8px; touch-action: manipulation; }}
-          .review-btn:hover {{ background: #eaeef2; }}
-          .conflict-banner {{ background: #fff3f3; border: 1px solid #f5c6cb; padding: .8rem 1rem; margin: .8rem 0; border-radius: 6px; color: #721c24; font-size: .95rem; }}
+          .merge-btn {{ background: #171717; color: white; border: 1px solid #171717; padding: .65rem .9rem; min-height: 44px; font-size: .95rem; white-space: nowrap; touch-action: manipulation; }}
+          .merge-btn:hover {{ background: #000; border-color: #000; }}
+          .push-btn {{ background: #171717; color: white; border: 1px solid #171717; padding: .65rem .9rem; min-height: 44px; font-size: .95rem; white-space: nowrap; touch-action: manipulation; }}
+          .push-btn:hover {{ background: #000; border-color: #000; }}
+          .review-btn {{ display: inline-flex; align-items: center; padding: .65rem .9rem; min-height: 44px; font-size: .95rem; white-space: nowrap; text-decoration: none; color: #171717; background: #ffffff; border: 1px solid #e5e7eb; border-radius: 8px; touch-action: manipulation; }}
+          .review-btn:hover {{ background: #fafafa; }}
+          .conflict-banner {{ background: #fafafa; border: 1px solid #e5e7eb; border-left: 3px solid #b91c1c; padding: .8rem 1rem; margin: .8rem 0; border-radius: 6px; color: #171717; font-size: .95rem; }}
           .conflict-banner ul {{ margin: .4rem 0 .4rem 1.2rem; padding: 0; }}
-          .conflict-banner code {{ background: #fbe9eb; padding: 0 .25rem; border-radius: 3px; }}
+          .conflict-banner code {{ background: #f3f4f6; padding: 0 .25rem; border-radius: 3px; }}
           {_DIFF_CSS}
-          .error-msg {{ background: #f8d7da; border: 1px solid #f5c6cb; padding: .8rem; margin: .5rem 0; border-radius: 6px; color: #721c24; }}
-          .status-banner {{ display: flex; align-items: center; gap: .6rem; background: #fff3cd; border: 1px solid #ffeeba; color: #856404; padding: .6rem .8rem; margin: .5rem 0; border-radius: 6px; font-size: .9rem; }}
-          .spinner {{ width: 14px; height: 14px; border: 2px solid #d6ad00; border-top-color: transparent; border-radius: 50%; display: inline-block; animation: spin 1s linear infinite; }}
+          .error-msg {{ background: #fafafa; border: 1px solid #e5e7eb; border-left: 3px solid #b91c1c; padding: .8rem; margin: .5rem 0; border-radius: 6px; color: #171717; }}
+          .status-banner {{ display: flex; align-items: center; gap: .6rem; background: #fafafa; border: 1px solid #e5e7eb; border-left: 3px solid #a16207; color: #171717; padding: .6rem .8rem; margin: .5rem 0; border-radius: 6px; font-size: .9rem; }}
+          .spinner {{ width: 14px; height: 14px; border: 2px solid #6b7280; border-top-color: transparent; border-radius: 50%; display: inline-block; animation: spin 1s linear infinite; }}
           @keyframes spin {{ to {{ transform: rotate(360deg); }} }}
           .placeholder .dots span {{ display: inline-block; animation: blink 1.4s infinite both; opacity: .2; font-weight: bold; font-size: 1.4rem; line-height: 0; }}
           .placeholder .dots span:nth-child(2) {{ animation-delay: .2s; }}
           .placeholder .dots span:nth-child(3) {{ animation-delay: .4s; }}
           @keyframes blink {{ 0%, 80%, 100% {{ opacity: .2; }} 40% {{ opacity: 1; }} }}
-          form textarea[disabled] {{ background: #f5f5f5; cursor: not-allowed; }}
-          .btn[disabled] {{ background: #eee; color: #aaa; cursor: not-allowed; border-color: #ddd; }}
+          form textarea[disabled] {{ background: #fafafa; cursor: not-allowed; }}
+          .btn[disabled] {{ background: #fafafa; color: #6b7280; cursor: not-allowed; border-color: #e5e7eb; }}
           @media (max-width: 480px) {{
             .msg {{ padding: .5rem .6rem; }}
             .button-group {{ flex-direction: column; }}
@@ -618,8 +622,8 @@ def render_thread(
           <div class="nav" style="display:flex; justify-content:space-between; align-items:center;">
             <a href="/">← All threads</a>
             <button type="button" onclick="copyThreadId(this)"
-                    style="background:none; border:1px solid #d0d7de; border-radius:6px;
-                           color:#57606a; cursor:pointer; font-size:.8rem; padding:.3rem .6rem;
+                    style="background:none; border:1px solid #e5e7eb; border-radius:6px;
+                           color:#171717; cursor:pointer; font-size:.8rem; padding:.3rem .6rem;
                            touch-action:manipulation;">Copy ID</button>
           </div>
           <script>
@@ -665,7 +669,7 @@ def render_thread(
               <button class="btn" type="submit" {form_disabled}>Send</button>
               <button class="btn btn-secondary" type="button" onclick="showCaptureModal()" {form_disabled}>Capture Conversation</button>
             </div>
-            <div style="font-size:.85rem; color:#666; margin-top:.4rem;">{form_note}</div>
+            <div style="font-size:.85rem; color:#6b7280; margin-top:.4rem;">{form_note}</div>
           </form>
 
           <!-- Capture Modal -->
@@ -1254,9 +1258,9 @@ def _existing_thread_dir(tid: str) -> str:
 
 _SHOW_PAGE_CSS = (
     "body{font-family:sans-serif;max-width:780px;margin:1rem auto;padding:0 1rem;"
-    "line-height:1.55;color:#222}pre,code{background:#f5f5f5;border-radius:4px}"
+    "line-height:1.55;color:#171717}pre,code{background:#fafafa;border-radius:4px}"
     "pre{padding:.6rem;overflow:auto}table{border-collapse:collapse}"
-    "td,th{border:1px solid #ccc;padding:.3rem .5rem}img{max-width:100%}"
+    "td,th{border:1px solid #e5e7eb;padding:.3rem .5rem}img{max-width:100%}"
 )
 
 # The /show page renders AGENT-generated md/org.  The md path (python-markdown)


### PR DESCRIPTION
Per Pierre — a **stark near-black monochrome** scheme (the most minimal option). Color-only; no layout/spacing/font changes.

## Palette
- Ink text `#171717` on white; secondary `#6b7280`; hairline borders `#e5e7eb`; subtle surface `#fafafa`.

## Per element
- **Buttons** — primary near-black (`#171717` bg, white text); secondary white + hairline outline. All blue/green Bootstrap fills gone.
- **Links** — ink, underlined (no blue).
- **Pull-to-refresh bar** — `#171717` (was blue).
- **Banners** (error/success/warning/conflict/status) — loud fills → `#fafafa` + a `3px` muted left-rule (red `#b91c1c` / green `#15803d` / amber `#a16207`) + ink text.
- **List badges** — quiet hairline outline + `#6b7280` (error/urgent keep muted-red text).
- **Diffs** — kept red/green for readability but **muted** (soft desaturated backgrounds) — a diff is unreadable without them.
- **Map markers** — left as functional data-viz (readability over pure monochrome, same call as diffs).

5 files (incl. `diff.py`, where `_DIFF_CSS` lives). 946 unit green. **First pass — color is iterative**, so expect tuning from Pierre's eye before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)