### PR TITLE
UI: collapse non-response (tool-call) turns into a subtle expandable

### DIFF
--- a/assist/thread.py
+++ b/assist/thread.py
@@ -43,7 +43,8 @@ def _messages_to_dicts(raw: list) -> list[dict]:
             calls = getattr(m, "tool_calls", None)
             if calls:
                 msgs.append({"role": "tools",
-                             "content": _render_calls(calls, m.content)})
+                             "content": _render_calls(calls, m.content),
+                             "names": [tool_call_label(c) for c in calls]})
             elif m.content:
                 msgs.append({"role": "assistant", "content": m.content})
     return msgs
@@ -56,6 +57,16 @@ def _render_calls(calls: list, content) -> str:
     if content:
         return f"{s} \n> {content}" if s else str(content)
     return s
+
+
+def tool_call_label(call: dict) -> str:
+    """The display name for a tool call — the subagent for a ``task`` call, else the
+    tool name.  Used for the collapsed-turn summary in the web UI, derived from the
+    structured call (not parsed back out of the rendered text)."""
+    name = call.get("name", "none")
+    if name == "task" and call.get("args"):
+        return call["args"].get("subagent_type", "none")
+    return name
 
 
 def render_tool_call(call: dict) -> str:

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -340,6 +340,23 @@ def render_index(query: str = "") -> str:
     """
 
 
+# Anchor to a call-segment boundary (string start, or the " -- " join between calls)
+# so a tool arg / prose tail that merely contains "Calling <word>" can't inject a
+# spurious name into the summary.
+_TOOL_NAME_RE = re.compile(r"(?:\A| -- )Calling (?:subagent )?([\w.-]+)")
+
+
+def _tools_summary(raw: str) -> str:
+    """A compact, subtle label for a collapsed tool-call turn — the distinct tool
+    names in order (``read_url, grep``), so the turn reads at a glance without
+    expanding.  Falls back to ``tool call`` if the line doesn't match the pattern."""
+    seen: list[str] = []
+    for name in _TOOL_NAME_RE.findall(raw):
+        if name not in seen:
+            seen.append(name)
+    return html.escape(", ".join(seen)) if seen else "tool call"
+
+
 def render_thread(
     tid: str,
     chat: Thread | None,
@@ -481,8 +498,16 @@ def render_thread(
         else:
             # Human/user content is plain text with basic escaping
             content_html = html.escape(raw).replace("\n", "<br/>")
-        cls = "user" if role == "user" else ("tools" if role == "tools" else "assistant")
-        bubble = f"<div class=\"msg {cls}\"><div class=\"role\">{role}</div><div class=\"content\">{content_html}</div></div>"
+        if role == "tools":
+            # A non-response turn (tool calls) — big and intermediate.  Collapse it
+            # into a subtle <details> so the human/AI messages stay the focus; the
+            # summary names the tools so the turn is legible without expanding.
+            bubble = (f'<details class="msg tools"><summary>{_tools_summary(raw)}</summary>'
+                      f'<div class="content">{content_html}</div></details>')
+        else:
+            cls = "user" if role == "user" else "assistant"
+            bubble = (f'<div class="msg {cls}"><div class="role">{role}</div>'
+                      f'<div class="content">{content_html}</div></div>')
         rendered.append(bubble)
     if busy:
         rendered.insert(
@@ -556,6 +581,16 @@ def render_thread(
           .msg {{ margin: .6rem 0; padding: .6rem .8rem; border-radius: 8px; max-width: 100%; word-wrap: break-word; overflow-wrap: anywhere; }}
           .msg.user {{ background: #ffffff; border: 1px solid #e5e7eb; }}
           .msg.assistant {{ background: #fafafa; border: 1px solid #e5e7eb; }}
+          /* Non-response (tool-call) turns: a subtle collapsed <details> so they
+             don't compete with the human/AI messages.  Muted, no bubble chrome. */
+          .msg.tools {{ background: transparent; border: 0; padding: 0; margin: .35rem 0 .35rem .2rem; }}
+          .msg.tools > summary {{ list-style: none; cursor: pointer; user-select: none;
+              font-size: .75rem; color: #9ca3af; padding: .15rem 0; }}
+          .msg.tools > summary::-webkit-details-marker {{ display: none; }}
+          .msg.tools > summary::before {{ content: "\\25b8"; color: #cbd5e1; margin-right: .4rem; }}
+          .msg.tools[open] > summary::before {{ content: "\\25be"; }}
+          .msg.tools > .content {{ font-size: .82rem; color: #6b7280; margin: .15rem 0 .15rem .3rem;
+              padding: .3rem .55rem; border-left: 2px solid #e5e7eb; }}
           /* A file embed lifted from a ```render block, shown inline in the
              assistant bubble (org/md rendered page, or pdf viewer). */
           .show-embed {{ margin: .5rem 0; }}

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -340,18 +340,14 @@ def render_index(query: str = "") -> str:
     """
 
 
-# Anchor to a call-segment boundary (string start, or the " -- " join between calls)
-# so a tool arg / prose tail that merely contains "Calling <word>" can't inject a
-# spurious name into the summary.
-_TOOL_NAME_RE = re.compile(r"(?:\A| -- )Calling (?:subagent )?([\w.-]+)")
-
-
-def _tools_summary(raw: str) -> str:
+def _tools_summary(names) -> str:
     """A compact, subtle label for a collapsed tool-call turn — the distinct tool
     names in order (``read_url, grep``), so the turn reads at a glance without
-    expanding.  Falls back to ``tool call`` if the line doesn't match the pattern."""
+    expanding.  ``names`` comes from the structured tool calls (``_messages_to_dicts``),
+    so no arg/prose text can inject a spurious name.  Falls back to ``tool call``."""
     seen: list[str] = []
-    for name in _TOOL_NAME_RE.findall(raw):
+    for name in names or []:
+        name = str(name)
         if name not in seen:
             seen.append(name)
     return html.escape(", ".join(seen)) if seen else "tool call"
@@ -502,7 +498,7 @@ def render_thread(
             # A non-response turn (tool calls) — big and intermediate.  Collapse it
             # into a subtle <details> so the human/AI messages stay the focus; the
             # summary names the tools so the turn is legible without expanding.
-            bubble = (f'<details class="msg tools"><summary>{_tools_summary(raw)}</summary>'
+            bubble = (f'<details class="msg tools"><summary>{_tools_summary(m.get("names"))}</summary>'
                       f'<div class="content">{content_html}</div></details>')
         else:
             cls = "user" if role == "user" else "assistant"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -310,6 +310,18 @@ class TestMessagesToDicts:
         out = _messages_to_dicts([m])
         assert out[0]["role"] == "tools" and "read_file" in out[0]["content"]
 
+    def test_tools_dict_carries_structured_names(self):
+        # the collapsed-turn summary is built from these names, not re-parsed text
+        from assist.thread import _messages_to_dicts, tool_call_label
+        m = self._ai(tool_calls=[
+            {"name": "read_url", "args": {"url": "x"}, "id": "1"},
+            {"name": "task", "args": {"subagent_type": "research"}, "id": "2"},
+        ])
+        assert _messages_to_dicts([m])[0]["names"] == ["read_url", "research"]
+        # task → subagent; plain tool → its name
+        assert tool_call_label({"name": "task", "args": {"subagent_type": "dev"}}) == "dev"
+        assert tool_call_label({"name": "grep", "args": {}}) == "grep"
+
     def test_plain_user_and_assistant(self):
         from assist.thread import _messages_to_dicts
         from langchain_core.messages import HumanMessage

--- a/tests/test_web_tools_collapse.py
+++ b/tests/test_web_tools_collapse.py
@@ -1,6 +1,10 @@
 """The non-response (tool-call) turns collapse into a subtle <details>; the human
 and AI messages keep their existing flat-bubble treatment.  Symptom-level — assert
 against the rendered HTML.  No model/GPU.
+
+The collapsed-turn summary names come from the STRUCTURED tool calls (the dict's
+``names``, populated by ``_messages_to_dicts``), not parsed out of the rendered text —
+so arg/prose content can't inject a spurious name.
 """
 import os
 
@@ -35,12 +39,24 @@ def _render(root, msgs):
 
 def test_tools_turn_is_collapsed_details(threads_root):
     html = _render(threads_root, [
-        {"role": "tools", "content": "Calling read_url with {'url': 'x'} -- Calling grep with {'pattern': 'y'}"},
+        {"role": "tools", "names": ["read_url", "grep"],
+         "content": "Calling read_url with {'url': 'x'} -- Calling grep with {'pattern': 'y'}"},
     ])
     # a subtle collapsed <details> (no `open` attr → collapsed by default)
     assert '<details class="msg tools">' in html
     assert "<summary>read_url, grep</summary>" in html   # tool names, legible without expanding
     assert '<details class="msg tools" open' not in html
+
+
+def test_summary_from_structured_names_not_content(threads_root):
+    # even if the rendered content mentions " -- Calling read_url", the summary is
+    # driven by the structured names → no spurious name injected.
+    html = _render(threads_root, [
+        {"role": "tools", "names": ["write_file"],
+         "content": "Calling write_file with {'content': 'x -- Calling read_url with y'}"},
+    ])
+    assert "<summary>write_file</summary>" in html
+    assert "read_url" not in html.split("</summary>")[0]   # not in the summary
 
 
 def test_human_and_ai_messages_untouched(threads_root):
@@ -56,16 +72,8 @@ def test_human_and_ai_messages_untouched(threads_root):
 
 class TestToolsSummary:
     def test_names_deduped_in_order(self):
-        assert _tools_summary("Calling grep with {} -- Calling read_url with {} -- Calling grep with {}") \
-            == "grep, read_url"
+        assert _tools_summary(["grep", "read_url", "grep"]) == "grep, read_url"
 
-    def test_subagent_task_call(self):
-        assert _tools_summary("Calling subagent research with {'x': 1}") == "research"
-
-    def test_fallback_when_unmatched(self):
-        assert _tools_summary("some prose with no call") == "tool call"
-
-    def test_arg_text_containing_calling_does_not_inject(self):
-        # a write_file whose content mentions "Calling read_url ..." must not add it
-        raw = "Calling write_file with {'content': 'Calling read_url with the URL'}"
-        assert _tools_summary(raw) == "write_file"
+    def test_empty_names_fallback(self):
+        assert _tools_summary([]) == "tool call"
+        assert _tools_summary(None) == "tool call"

--- a/tests/test_web_tools_collapse.py
+++ b/tests/test_web_tools_collapse.py
@@ -1,0 +1,71 @@
+"""The non-response (tool-call) turns collapse into a subtle <details>; the human
+and AI messages keep their existing flat-bubble treatment.  Symptom-level — assert
+against the rendered HTML.  No model/GPU.
+"""
+import os
+
+import pytest
+
+from manage import web
+from manage.web import state
+from manage.web.threads import render_thread, _tools_summary
+
+
+@pytest.fixture
+def threads_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(web.MANAGER, "root_dir", str(tmp_path))
+    state.DESCRIPTION_CACHE.clear()
+    yield tmp_path
+    state.DESCRIPTION_CACHE.clear()
+
+
+class _Chat:
+    def __init__(self, msgs):
+        self._msgs = msgs
+
+    def get_messages(self):
+        return self._msgs
+
+
+def _render(root, msgs):
+    os.makedirs(root / "t1", exist_ok=True)
+    state.DESCRIPTION_CACHE["t1"] = "T"
+    return render_thread("t1", _Chat(msgs))
+
+
+def test_tools_turn_is_collapsed_details(threads_root):
+    html = _render(threads_root, [
+        {"role": "tools", "content": "Calling read_url with {'url': 'x'} -- Calling grep with {'pattern': 'y'}"},
+    ])
+    # a subtle collapsed <details> (no `open` attr → collapsed by default)
+    assert '<details class="msg tools">' in html
+    assert "<summary>read_url, grep</summary>" in html   # tool names, legible without expanding
+    assert '<details class="msg tools" open' not in html
+
+
+def test_human_and_ai_messages_untouched(threads_root):
+    html = _render(threads_root, [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "the answer"},
+    ])
+    # still flat bubbles with their role label — NOT wrapped in <details>
+    assert '<div class="msg user">' in html and '<div class="msg assistant">' in html
+    assert '<details class="msg user"' not in html
+    assert '<details class="msg assistant"' not in html
+
+
+class TestToolsSummary:
+    def test_names_deduped_in_order(self):
+        assert _tools_summary("Calling grep with {} -- Calling read_url with {} -- Calling grep with {}") \
+            == "grep, read_url"
+
+    def test_subagent_task_call(self):
+        assert _tools_summary("Calling subagent research with {'x': 1}") == "research"
+
+    def test_fallback_when_unmatched(self):
+        assert _tools_summary("some prose with no call") == "tool call"
+
+    def test_arg_text_containing_calling_does_not_inject(self):
+        # a write_file whose content mentions "Calling read_url ..." must not add it
+        raw = "Calling write_file with {'content': 'Calling read_url with the URL'}"
+        assert _tools_summary(raw) == "write_file"


### PR DESCRIPTION
Per Pierre — the **non-response turns** (the `tools` messages: AIMessage tool-call lines like "Calling read_url with {args} — Calling grep with {args}") were big and crowded out the human/AI exchange. They now collapse into a **subtle expandable `<details>`**.

## Behavior
- **Collapsed by default**, showing a muted summary of the **tool names** (`▸ read_url, grep`) so the turn reads at a glance.
- Expand (▾) for the full content (same markdown render as before).
- **Human & AI message treatments are UNCHANGED** — `.msg.user` / `.msg.assistant` bubbles are byte-identical; the new `.msg.tools` styling is transparent/borderless/muted so it recedes (CSS selectors require the `tools` class → can't bleed into user/assistant).

## Implementation
- `_tools_summary(raw)` — distinct tool names in order, `html.escape`d; regex anchored to call boundaries (`\A` or ` -- `) so a tool arg / prose containing "Calling X" can't inject a spurious name (from review).
- Subtle `.msg.tools` CSS (muted collapsed details, custom ▸/▾ markers, hairline left-rule when open).
- 6 render/unit tests (symptom-level: collapsed `<details>` + tool-name summary + human/AI untouched + the injection guard); 952 unit green.

Local review: 0 blockers / 0 important / 1 nit (the regex anchor, fixed). **Not deployed** — awaiting Pierre's go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)