### PR TITLE
read_url same-URL re-read breaker (research-loop fix)

### DIFF
--- a/assist/agent.py
+++ b/assist/agent.py
@@ -113,7 +113,9 @@ class AgentHarness:
     
     def __init__(self, agent: CompiledStateGraph, thread_id: str | None = None):
         self.agent = agent
-        self.thread_id = thread_id or uuid.uuid1()
+        # uuid4, not uuid1: uuid1 embeds the host MAC + timestamp, and these ids land
+        # in logs/eval artifacts (the data-hygiene no-host-identifying rule).
+        self.thread_id = thread_id or uuid.uuid4()
 
     def message(self, text: str) -> AIMessage:
         resp = invoke_with_rollback(

--- a/assist/agent.py
+++ b/assist/agent.py
@@ -607,6 +607,11 @@ def create_research_agent(model: BaseChatModel,
         # sub-agents whose read_url should only ever hit a URL already in context.
         # NOT on the orchestrator (it re-dispatches, so a rejected fetch there can
         # thrash); its runaway is bounded by recursion_limit.
+        # ReadUrlRereadBreaker: refuse re-reading the SAME url past max_reads (the
+        # 2026-07-07 peptides loop — provenance can't see a re-read). Also not on
+        # the orchestrator, but for a different reason: the incident showed zero
+        # orchestrator re-read looping (its 16 steps were all task dispatches), so
+        # wiring it there would be code for an unobserved case.
         "middleware": _subagent_safety_mw() + [UrlProvenanceMiddleware(), ReadUrlRereadBreaker()],
     }
 

--- a/assist/agent.py
+++ b/assist/agent.py
@@ -31,6 +31,7 @@ from assist.middleware.empty_response_recovery import EmptyResponseRecoveryMiddl
 from assist.middleware.read_only_enforcer import ReadOnlyEnforcerMiddleware
 from assist.middleware.git_push_blocker import GitPushBlockerMiddleware
 from assist.middleware.url_provenance import UrlProvenanceMiddleware
+from assist.middleware.read_url_reread_breaker import ReadUrlRereadBreaker
 from assist.middleware.skills_middleware import SmallModelSkillsMiddleware
 from assist.middleware.memory_middleware import SmallModelMemoryMiddleware
 from assist.middleware.write_collision import WriteCollisionMiddleware
@@ -606,7 +607,7 @@ def create_research_agent(model: BaseChatModel,
         # sub-agents whose read_url should only ever hit a URL already in context.
         # NOT on the orchestrator (it re-dispatches, so a rejected fetch there can
         # thrash); its runaway is bounded by recursion_limit.
-        "middleware": _subagent_safety_mw() + [UrlProvenanceMiddleware()],
+        "middleware": _subagent_safety_mw() + [UrlProvenanceMiddleware(), ReadUrlRereadBreaker()],
     }
 
     critique_sub_agent = {
@@ -625,7 +626,7 @@ def create_research_agent(model: BaseChatModel,
         # report it's handed — those already appear in its context (the report
         # ToolMessage), so they pass, while a URL it invents is refused. Without
         # this, fabricated fact-check fetches bypass the guard entirely.
-        "middleware": _subagent_safety_mw() + [UrlProvenanceMiddleware()],
+        "middleware": _subagent_safety_mw() + [UrlProvenanceMiddleware(), ReadUrlRereadBreaker()],
     }
 
     # The orchestrator DELEGATES searching to the research-agent (see its

--- a/assist/middleware/loop_detection.py
+++ b/assist/middleware/loop_detection.py
@@ -144,10 +144,12 @@ def _current_turn_slice(messages: list) -> list:
 def _extract_events(messages: list, window: int | None = None) -> list[dict]:
     """Collect recent (AIMessage tool_call, matching ToolMessage) pairs.
 
-    Each event is ``{tool_name, args_sig, result_content, is_error,
+    Each event is ``{tool_name, args, args_sig, result_content, is_error,
     completed}``. ``completed`` is False for tool calls without a
     matching ToolMessage yet (i.e. the most-recent AI message before
-    the tool node has run).
+    the tool node has run). ``args`` is the raw dict for consumers that
+    need a specific argument (the reread breaker reads ``url``); the
+    hashed ``args_sig`` stays the identity for repeat detection.
 
     Bounded to the current user turn — see ``_current_turn_slice``.
     ``window`` keeps only the last N events (loop detection wants recency for
@@ -176,6 +178,7 @@ def _extract_events(messages: list, window: int | None = None) -> list[dict]:
                 )
                 events.append({
                     "tool_name": tc.get("name") or "",
+                    "args": args,
                     "args_sig": _normalise_args(args),
                     "result_content": content,
                     "is_error": is_error,
@@ -184,6 +187,7 @@ def _extract_events(messages: list, window: int | None = None) -> list[dict]:
             else:
                 events.append({
                     "tool_name": tc.get("name") or "",
+                    "args": args,
                     "args_sig": _normalise_args(args),
                     "result_content": "",
                     "is_error": False,

--- a/assist/middleware/model_logging_middleware.py
+++ b/assist/middleware/model_logging_middleware.py
@@ -80,7 +80,11 @@ class ModelLoggingMiddleware(AgentMiddleware):
 
     def _format_tool_call(self, tool_call: dict) -> str:
         name = tool_call.get('name', 'unknown')
-        subagent = tool_call.get('arguments', {}).get('subagent_type', None)
+        # args-or-arguments: normalized AIMessage.tool_calls use 'args'; only the raw
+        # OpenAI shape uses 'arguments'. Reading only 'arguments' meant the
+        # "Subagent {type}" label never fired for normalized task calls.
+        args = tool_call.get('args') or tool_call.get('arguments') or {}
+        subagent = args.get('subagent_type', None) if isinstance(args, dict) else None
         if name == "task" and subagent:
             return f"Subagent {subagent}"
         return name

--- a/assist/middleware/read_url_reread_breaker.py
+++ b/assist/middleware/read_url_reread_breaker.py
@@ -1,0 +1,100 @@
+"""Break a same-URL ``read_url`` RE-READ loop.
+
+The third, orthogonal ``read_url`` bound, alongside ``UrlProvenanceMiddleware`` (refuses
+a FABRICATED first fetch — but can't see a re-read: the URL is "seen" after read #1) and
+``loop_detection`` (consecutive repeats only). A page's content is unchanged between
+fetches, so re-reading the SAME normalized URL past a few times can NEVER return new
+information — it is a runaway. The 2026-07-07 peptides incident re-read one PubMed URL
+*78 times* under search-unavailable (see docs/2026-07-07-read-url-reread-breaker.org).
+
+On the read that would exceed ``max_reads`` fetches of a URL already read this turn, refuse
+with a corrective ToolMessage (status=error) — FINALIZE, don't kill: the model is told to
+answer from what it has (or say it can't and stop), instead of looping. That's the
+volume-cap-destroys-output lesson (a runaway must be nudged to finalize, not terminated
+with an empty stub).
+
+Unambiguous signal (a normalized-URL count, reusing ``url_provenance.normalize_url`` so the
+two guards agree on "the same URL"), so it stays a coarse guard, not a fuzzy heuristic.
+"""
+import logging
+from typing import Any, Callable
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain.tools.tool_node import ToolCallRequest
+from langchain_core.messages import AIMessage, ToolMessage
+
+from assist.middleware.url_provenance import normalize_url
+
+logger = logging.getLogger(__name__)
+
+_READ_TOOL = "read_url"
+_DEFAULT_MAX_READS = 3
+
+
+def _read_url_target(tool_call: dict) -> str:
+    """The normalized URL a read_url tool call targets, or "" if none.
+    ``args``-or-``arguments`` mirrors url_provenance (normalized AIMessage.tool_calls use
+    ``args``; the raw OpenAI shape uses ``arguments``)."""
+    if tool_call.get("name") != _READ_TOOL:
+        return ""
+    args: Any = tool_call.get("args") or tool_call.get("arguments") or {}
+    url = args.get("url", "") if isinstance(args, dict) else ""
+    return normalize_url(url) if url else ""
+
+
+def _prior_read_count(messages: list, target: str) -> int:
+    """How many times read_url was already CALLED with the same normalized URL this turn."""
+    n = 0
+    for m in messages:
+        if not isinstance(m, AIMessage):
+            continue
+        for tc in (getattr(m, "tool_calls", None) or []):
+            if _read_url_target(tc) == target:
+                n += 1
+    return n
+
+
+class ReadUrlRereadBreaker(AgentMiddleware):
+    """Refuse a ``read_url`` once the same URL has been fetched ``max_reads`` times this turn.
+
+    Corrective, not turn-ending (mirrors UrlProvenanceMiddleware): the refused call returns
+    an error ToolMessage telling the model to stop re-reading and answer. Stateless across
+    turns except an intervention counter for logging."""
+
+    def __init__(self, max_reads: int = _DEFAULT_MAX_READS) -> None:
+        super().__init__()
+        self.tools = []
+        self._max_reads = max_reads
+        self._intervention_count = 0
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], "ToolMessage"],
+    ) -> "ToolMessage":
+        target = _read_url_target(request.tool_call)
+        if not target:
+            return handler(request)
+
+        state = request.state or {}
+        messages = state.get("messages", []) if isinstance(state, dict) \
+            else getattr(state, "messages", [])
+        if _prior_read_count(messages, target) < self._max_reads:
+            return handler(request)
+
+        self._intervention_count += 1
+        url = (request.tool_call.get("args") or request.tool_call.get("arguments") or {}).get("url", target)
+        logger.warning(
+            "ReadUrlRereadBreaker: refused read_url(%s) — already read %d times this turn "
+            "(intervention #%d)", url, self._max_reads, self._intervention_count)
+        return ToolMessage(
+            content=(
+                f"You have already read {url} {self._max_reads} times in this task. Its "
+                f"content does not change between reads, so reading it again returns exactly "
+                f"the same thing. Do NOT read it again. Answer from what you already have; if "
+                f"the page does not contain what you need, say so plainly and stop — do not "
+                f"keep retrying the same URL."),
+            tool_call_id=request.tool_call.get("id", ""),
+            name=_READ_TOOL,
+            status="error",
+        )

--- a/assist/middleware/read_url_reread_breaker.py
+++ b/assist/middleware/read_url_reread_breaker.py
@@ -22,6 +22,7 @@ from typing import Any, Callable
 from langchain.agents.middleware import AgentMiddleware
 from langchain.tools.tool_node import ToolCallRequest
 from langchain_core.messages import AIMessage, ToolMessage
+from langgraph.types import Command
 
 from assist.middleware.url_provenance import normalize_url
 
@@ -87,8 +88,8 @@ class ReadUrlRereadBreaker(AgentMiddleware):
     def wrap_tool_call(
         self,
         request: ToolCallRequest,
-        handler: Callable[[ToolCallRequest], "ToolMessage"],
-    ) -> "ToolMessage":
+        handler: Callable[[ToolCallRequest], "ToolMessage | Command"],
+    ) -> "ToolMessage | Command":
         target = _read_url_target(request.tool_call)
         if not target:
             return handler(request)

--- a/assist/middleware/read_url_reread_breaker.py
+++ b/assist/middleware/read_url_reread_breaker.py
@@ -7,8 +7,8 @@ fetches, so re-reading the SAME normalized URL past a few times can NEVER return
 information — it is a runaway. The 2026-07-07 peptides incident re-read one PubMed URL
 *78 times* under search-unavailable (see docs/2026-07-07-read-url-reread-breaker.org).
 
-On the read that would exceed ``max_reads`` fetches of a URL already read this turn, refuse
-with a corrective ToolMessage (status=error) — FINALIZE, don't kill: the model is told to
+On the call that follows ``max_reads`` completed fetches of the same URL in this RUN's
+history, refuse with a corrective ToolMessage (status=error) — FINALIZE, don't kill: the model is told to
 answer from what it has (or say it can't and stop), instead of looping. That's the
 volume-cap-destroys-output lesson (a runaway must be nudged to finalize, not terminated
 with an empty stub).
@@ -43,19 +43,36 @@ def _read_url_target(tool_call: dict) -> str:
 
 
 def _prior_read_count(messages: list, target: str) -> int:
-    """How many times read_url was already CALLED with the same normalized URL this turn."""
+    """How many COMPLETED reads of the same normalized URL are in this run's history —
+    read_url calls that already have their ToolMessage result.
+
+    Completed-only matters: at ``wrap_tool_call`` time the state already contains the
+    AIMessage carrying the call being executed, so counting raw calls would include the
+    CURRENT call (shifting the threshold by one — prod refusing a read the unit tests
+    say is allowed) and any parallel same-URL siblings in that message (refusing them
+    ALL, including the very first fetch — a guard blocking legitimate work). Pairing
+    call→result excludes the in-flight ones. A refusal's corrective ToolMessage also
+    pairs, so once the cap is hit the count stays at/over it and later retries stay
+    refused."""
+    resolved = {m.tool_call_id for m in messages
+                if isinstance(m, ToolMessage) and m.tool_call_id}
     n = 0
     for m in messages:
         if not isinstance(m, AIMessage):
             continue
         for tc in (getattr(m, "tool_calls", None) or []):
-            if _read_url_target(tc) == target:
+            if tc.get("id") in resolved and _read_url_target(tc) == target:
                 n += 1
     return n
 
 
 class ReadUrlRereadBreaker(AgentMiddleware):
-    """Refuse a ``read_url`` once the same URL has been fetched ``max_reads`` times this turn.
+    """Refuse a ``read_url`` once the same URL has been fetched ``max_reads`` times this run.
+
+    The count scans the whole message history with NO turn boundary — correct for the
+    single-run research/fact-check sub-agents it's wired on (their history IS one run);
+    attaching it to a long-lived multi-turn agent would need a turn slice first (see
+    loop_detection._current_turn_slice).
 
     Corrective, not turn-ending (mirrors UrlProvenanceMiddleware): the refused call returns
     an error ToolMessage telling the model to stop re-reading and answer. Stateless across
@@ -85,7 +102,7 @@ class ReadUrlRereadBreaker(AgentMiddleware):
         self._intervention_count += 1
         url = (request.tool_call.get("args") or request.tool_call.get("arguments") or {}).get("url", target)
         logger.warning(
-            "ReadUrlRereadBreaker: refused read_url(%s) — already read %d times this turn "
+            "ReadUrlRereadBreaker: refused read_url(%s) — already read %d times this run "
             "(intervention #%d)", url, self._max_reads, self._intervention_count)
         return ToolMessage(
             content=(

--- a/assist/middleware/read_url_reread_breaker.py
+++ b/assist/middleware/read_url_reread_breaker.py
@@ -7,8 +7,8 @@ fetches, so re-reading the SAME normalized URL past a few times can NEVER return
 information — it is a runaway. The 2026-07-07 peptides incident re-read one PubMed URL
 *78 times* under search-unavailable (see docs/2026-07-07-read-url-reread-breaker.org).
 
-On the call that follows ``max_reads`` completed fetches of the same URL in this RUN's
-history, refuse with a corrective ToolMessage (status=error) — FINALIZE, don't kill: the model is told to
+On the call that follows ``max_reads`` completed fetches of the same URL in the current
+TURN's history (run == turn for the single-run sub-agents this is wired on), refuse with a corrective ToolMessage (status=error) — FINALIZE, don't kill: the model is told to
 answer from what it has (or say it can't and stop), instead of looping. That's the
 volume-cap-destroys-output lesson (a runaway must be nudged to finalize, not terminated
 with an empty stub).
@@ -105,7 +105,7 @@ class ReadUrlRereadBreaker(AgentMiddleware):
 
         self._intervention_count += 1
         logger.warning(
-            "ReadUrlRereadBreaker: refused read_url(%s) — already read %d times this run "
+            "ReadUrlRereadBreaker: refused read_url(%s) — already read %d times this turn "
             "(intervention #%d)", url, self._max_reads, self._intervention_count)
         return ToolMessage(
             content=(

--- a/assist/middleware/read_url_reread_breaker.py
+++ b/assist/middleware/read_url_reread_breaker.py
@@ -34,10 +34,11 @@ _DEFAULT_MAX_READS = 3
 
 
 def _read_url_arg(tool_call: dict) -> str:
-    """The raw URL a read_url tool call targets, or "" if none — the single extraction
-    site (the caller normalizes for counting and reuses the raw form in the refusal
-    text). ``args``-or-``arguments`` mirrors url_provenance (normalized
-    AIMessage.tool_calls use ``args``; the raw OpenAI shape uses ``arguments``)."""
+    """The raw URL a read_url tool call targets, or "" if none — the one extraction
+    path (the incoming request AND each history event go through it; callers normalize
+    for counting and reuse the raw form in the refusal text). ``args``-or-``arguments``
+    mirrors url_provenance (normalized AIMessage.tool_calls use ``args``; the raw
+    OpenAI shape uses ``arguments``)."""
     if tool_call.get("name") != _READ_TOOL:
         return ""
     args: Any = tool_call.get("args") or tool_call.get("arguments") or {}
@@ -58,14 +59,12 @@ def _prior_read_count(messages: list, target: str) -> int:
     The pairing is ``loop_detection._extract_events`` — the SAME call→result loop
     loop_detection and the search-unavailable breaker count with, so all three
     history-counting guards share one implementation (its ``completed`` flag IS the
-    completed-only semantics above, and its turn slice bounds the count to the current
-    turn — a no-op on the single-run sub-agents this is wired on)."""
+    completed-only semantics above; it also bounds the count to the current turn)."""
     n = 0
     for e in _extract_events(messages, window=None):
-        if not e["completed"] or e["tool_name"] != _READ_TOOL:
+        if not e["completed"]:
             continue
-        args = e["args"]
-        url = args.get("url", "") if isinstance(args, dict) else ""
+        url = _read_url_arg({"name": e["tool_name"], "args": e["args"]})
         if url and normalize_url(url) == target:
             n += 1
     return n

--- a/assist/middleware/read_url_reread_breaker.py
+++ b/assist/middleware/read_url_reread_breaker.py
@@ -21,9 +21,10 @@ from typing import Any, Callable
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain.tools.tool_node import ToolCallRequest
-from langchain_core.messages import AIMessage, ToolMessage
+from langchain_core.messages import ToolMessage
 from langgraph.types import Command
 
+from assist.middleware.loop_detection import _extract_events
 from assist.middleware.url_provenance import normalize_url
 
 logger = logging.getLogger(__name__)
@@ -32,15 +33,15 @@ _READ_TOOL = "read_url"
 _DEFAULT_MAX_READS = 3
 
 
-def _read_url_target(tool_call: dict) -> str:
-    """The normalized URL a read_url tool call targets, or "" if none.
-    ``args``-or-``arguments`` mirrors url_provenance (normalized AIMessage.tool_calls use
-    ``args``; the raw OpenAI shape uses ``arguments``)."""
+def _read_url_arg(tool_call: dict) -> str:
+    """The raw URL a read_url tool call targets, or "" if none — the single extraction
+    site (the caller normalizes for counting and reuses the raw form in the refusal
+    text). ``args``-or-``arguments`` mirrors url_provenance (normalized
+    AIMessage.tool_calls use ``args``; the raw OpenAI shape uses ``arguments``)."""
     if tool_call.get("name") != _READ_TOOL:
         return ""
     args: Any = tool_call.get("args") or tool_call.get("arguments") or {}
-    url = args.get("url", "") if isinstance(args, dict) else ""
-    return normalize_url(url) if url else ""
+    return args.get("url", "") if isinstance(args, dict) else ""
 
 
 def _prior_read_count(messages: list, target: str) -> int:
@@ -49,31 +50,33 @@ def _prior_read_count(messages: list, target: str) -> int:
 
     Completed-only matters: at ``wrap_tool_call`` time the state already contains the
     AIMessage carrying the call being executed, so counting raw calls would include the
-    CURRENT call (shifting the threshold by one — prod refusing a read the unit tests
-    say is allowed) and any parallel same-URL siblings in that message (refusing them
-    ALL, including the very first fetch — a guard blocking legitimate work). Pairing
-    call→result excludes the in-flight ones. A refusal's corrective ToolMessage also
-    pairs, so once the cap is hit the count stays at/over it and later retries stay
-    refused."""
-    resolved = {m.tool_call_id for m in messages
-                if isinstance(m, ToolMessage) and m.tool_call_id}
+    CURRENT call (shifting the threshold by one) and any parallel same-URL siblings in
+    that message (refusing them ALL, including the very first fetch — a guard blocking
+    legitimate work). A refusal's corrective ToolMessage also pairs, so once the cap is
+    hit the count stays at/over it and later retries stay refused.
+
+    The pairing is ``loop_detection._extract_events`` — the SAME call→result loop
+    loop_detection and the search-unavailable breaker count with, so all three
+    history-counting guards share one implementation (its ``completed`` flag IS the
+    completed-only semantics above, and its turn slice bounds the count to the current
+    turn — a no-op on the single-run sub-agents this is wired on)."""
     n = 0
-    for m in messages:
-        if not isinstance(m, AIMessage):
+    for e in _extract_events(messages, window=None):
+        if not e["completed"] or e["tool_name"] != _READ_TOOL:
             continue
-        for tc in (getattr(m, "tool_calls", None) or []):
-            if tc.get("id") in resolved and _read_url_target(tc) == target:
-                n += 1
+        args = e["args"]
+        url = args.get("url", "") if isinstance(args, dict) else ""
+        if url and normalize_url(url) == target:
+            n += 1
     return n
 
 
 class ReadUrlRereadBreaker(AgentMiddleware):
     """Refuse a ``read_url`` once the same URL has been fetched ``max_reads`` times this run.
 
-    The count scans the whole message history with NO turn boundary — correct for the
-    single-run research/fact-check sub-agents it's wired on (their history IS one run);
-    attaching it to a long-lived multi-turn agent would need a turn slice first (see
-    loop_detection._current_turn_slice).
+    The count is bounded to the current turn (via ``_extract_events``' turn slice) —
+    a no-op on the single-run research/fact-check sub-agents it's wired on, and the
+    right behavior if it's ever attached to a longer-lived agent.
 
     Corrective, not turn-ending (mirrors UrlProvenanceMiddleware): the refused call returns
     an error ToolMessage telling the model to stop re-reading and answer. Stateless across
@@ -90,9 +93,10 @@ class ReadUrlRereadBreaker(AgentMiddleware):
         request: ToolCallRequest,
         handler: Callable[[ToolCallRequest], "ToolMessage | Command"],
     ) -> "ToolMessage | Command":
-        target = _read_url_target(request.tool_call)
-        if not target:
+        url = _read_url_arg(request.tool_call)
+        if not url:
             return handler(request)
+        target = normalize_url(url)
 
         state = request.state or {}
         messages = state.get("messages", []) if isinstance(state, dict) \
@@ -101,7 +105,6 @@ class ReadUrlRereadBreaker(AgentMiddleware):
             return handler(request)
 
         self._intervention_count += 1
-        url = (request.tool_call.get("args") or request.tool_call.get("arguments") or {}).get("url", target)
         logger.warning(
             "ReadUrlRereadBreaker: refused read_url(%s) — already read %d times this run "
             "(intervention #%d)", url, self._max_reads, self._intervention_count)

--- a/docs/2026-07-07-read-url-reread-breaker.org
+++ b/docs/2026-07-07-read-url-reread-breaker.org
@@ -36,11 +36,12 @@ A third, orthogonal read_url bound, alongside provenance (fabricated first fetch
 (consecutive repeat): *bound how many times the SAME normalised URL may be fetched.*
 
 - *Mechanism.* On each =read_url= call (=wrap_tool_call=, the seam provenance/tool_result_to_file use),
-  count prior =read_url= calls to the same =normalize_url()= target in the visible message history
-  (reuse =normalize_url= from =url_provenance.py=). On the Nth (threshold ≈ 3), *do not run the tool* —
-  return a corrective =ToolMessage=: "You have already read <url> N times; its content is unchanged.
-  Do NOT read it again — answer from what you have, or if you can't, say so and stop." Stateless
-  (scans history, like provenance), so it needs no per-instance bookkeeping.
+  count prior *COMPLETED* fetches of the same =normalize_url()= target — a call paired with its
+  =ToolMessage= result, via the shared =loop_detection._extract_events= — so the in-flight call and
+  any parallel first-fetch siblings never count. After =max_reads= completed fetches (default 3),
+  *refuse the next call* with a corrective =ToolMessage=: "You have already read <url> N times; its
+  content is unchanged. Do NOT read it again — answer from what you have, or if you can't, say so
+  and stop." Stateless except a logging intervention counter, like provenance.
 - *FINALIZE, don't kill.* Return a corrective tool result, never terminate the turn with a stub —
   the volume-cap-destroys-output lesson (doc 2026-06-05, Pattern E). The model gets a nudge and a
   chance to wrap up.
@@ -95,4 +96,4 @@ a full fix:
 * Files
 - New: =assist/middleware/read_url_reread_breaker.py=, =edd/eval/test_read_url_reread_loop.py=.
 - Wire: =assist/agent.py= research + fact-check middleware stacks (next to =UrlProvenanceMiddleware=).
-- Reuse: =normalize_url= from =assist/middleware/url_provenance.py= (extract/share if needed).
+- Reuse: =normalize_url= from =url_provenance.py=; =_extract_events= from =loop_detection.py=.

--- a/docs/2026-07-07-read-url-reread-breaker.org
+++ b/docs/2026-07-07-read-url-reread-breaker.org
@@ -1,0 +1,89 @@
+#+TITLE: read_url same-URL re-read breaker (research loop, peptides incident)
+#+DATE: <2026-07-07>
+#+STATUS: SPEC (design phase) — eval-first. Not yet built.
+
+* Incident
+Prod thread =20260707142207-80e10495= ("Tell me about peptides… what's the experimental
+evidence say?") ran the =research= sub-agent for *1h36m* before Pierre flagged it; killed via
+=sudo systemctl restart assist-web=. *202 LLM steps, 1437 read_url calls*, re-reading the same
+~12 PubMed URLs *54–78× each* (PMID 37657235 *78×*) + wandering PubMed "similar article" links
+(consecutive PMIDs 36650298→36650314). It monopolised the single llama.cpp slot + THREAD_QUEUE
+the whole time. Diagnosed from =logs/web-2026-07-07-141844.log=; NO evals were run (live forensics).
+
+* Root cause
+=search_internet= was UNAVAILABLE (SearXNG down/rate-limited — 32 "unavailable" hits, 0 successful
+searches). The agent was fact-checking a report (=peptides_evidence.md=) whose citation PMIDs were
+hallucinated; unable to *search* for the correct ones, it *brute-forced read_url* to "find the
+correct PMID," re-reading the same pages and hopping the PubMed citation graph. It narrated "search
+is unavailable, I should relay and stop" but looped 384×.
+
+* Why the existing guards miss it
+- *=UrlProvenanceMiddleware= (deployed, on research + fact-check) can't see a RE-read.* It refuses
+  the first fetch of a *fabricated* URL — but once a URL is read once it's "provenanced" (present in
+  a ToolMessage), so re-reading it 78× is allowed; and PubMed's dense links make every related PMID
+  provenanced, so link-following is nearly unbounded. *The re-read is the dominant loop and provenance
+  structurally cannot catch it.*
+- *=loop_detection= Pattern B (same tool + same args) is CONSECUTIVE-only.* Today's re-reads were
+  NON-consecutive (interspersed across the turn / across dispatches), so it slipped past.
+- *Rollback amplification is ALREADY FIXED* (=checkpoint_rollback.py:52= =rollback_on=(BadRequestError,)=;
+  =GraphRecursionError= deliberately excluded, docstring 66–71). recursion_limit is terminal. Nothing
+  to do — the recommendation in [[queued-research-loop-investigation]] landed.
+- *Per-agent recursion_limits worked* (orchestrator 500, research 300, thread.py runconfig) — but the
+  orchestrator *re-dispatched =task=(research) 16×*, each a fresh budget, so the aggregate ran away.
+
+* The fix — =ReadUrlRereadBreaker= (new middleware)
+A third, orthogonal read_url bound, alongside provenance (fabricated first fetch) and loop_detection
+(consecutive repeat): *bound how many times the SAME normalised URL may be fetched.*
+
+- *Mechanism.* On each =read_url= call (=wrap_tool_call=, the seam provenance/tool_result_to_file use),
+  count prior =read_url= calls to the same =normalize_url()= target in the visible message history
+  (reuse =normalize_url= from =url_provenance.py=). On the Nth (threshold ≈ 3), *do not run the tool* —
+  return a corrective =ToolMessage=: "You have already read <url> N times; its content is unchanged.
+  Do NOT read it again — answer from what you have, or if you can't, say so and stop." Stateless
+  (scans history, like provenance), so it needs no per-instance bookkeeping.
+- *FINALIZE, don't kill.* Return a corrective tool result, never terminate the turn with a stub —
+  the volume-cap-destroys-output lesson (doc 2026-06-05, Pattern E). The model gets a nudge and a
+  chance to wrap up.
+- *Unambiguous signal only.* The guard fires only on a *verbatim* same-URL repeat (a normalised-URL
+  membership count), the coarse/unambiguous class our guardrail ethos sanctions — NOT a fuzzy
+  "looks like looping" heuristic. N re-reads of one URL is real work never; it is always a loop.
+- *Scope.* Attach to the research SEARCHER + FACT-CHECKER (same as provenance) — the read_url loopers.
+  Not the orchestrator (its bound is recursion_limit; it has no read_url loop).
+
+* THE design question the eval must resolve: within-run vs cross-dispatch
+The 78× accumulated across the orchestrator's *16 research dispatches*; a middleware attached to the
+research agent sees only *its own run's* message history (fresh per dispatch), so a per-run counter
+might see far fewer than 78 and under-fire. Two options — the eval decides:
+1. *Per-run counter* (simplest, matches provenance scope) — catches the within-run re-reads; relies on
+   each fresh research run re-tripping quickly (likely, since each redoes the same guess). Ship this if
+   the eval shows within-run re-reads dominate.
+2. *Thread-level counter* — count across the whole turn's messages (all dispatches). Catches the
+   cross-dispatch 78× but needs the breaker to see the parent transcript, not just the sub-agent's.
+   Only if (1) proves insufficient in the eval.
+Measure the actual within-run vs cross-dispatch distribution from the incident log FIRST, then pick.
+
+* Eval-first plan (gate the fix)
+1. *Reproduce (baseline must FAIL).* New =edd/eval/test_read_url_reread_loop.py=: a research/fact-check
+   turn with =search_internet= MOCKED unavailable + =read_url= MOCKED to return a page that does NOT
+   contain the sought fact (so the model wants to re-read), over a fixture that induces the guess loop
+   (a report with a wrong PMID + "find the correct one"). Baseline assertion: the same URL is fetched
+   > N times (the loop reproduces) — confirm it FAILS before building (per the eval-first rule; small,
+   clean fixtures often pass — match the real messy shape).
+2. *Implement* the breaker against the failing eval.
+3. *Gate.* With the breaker: assert no URL is fetched more than N times, AND the turn terminates in
+   bounded steps (no runaway), AND the model still produces an answer (finalize-not-kill — it doesn't
+   return an empty stub). N≥3 trials, then N=10 stability (fans restored 06-30, evals available).
+4. *Regression spot-check* a normal research eval (rich workspace) to confirm the breaker doesn't
+   misfire on legitimate research (a real turn re-reads a URL 0–2×, well under N).
+
+* Out of scope (sibling items, not this build)
+- *The TRIGGER — search-unavailable resilience* ([[queued-research-rate-limit-resilience]]): relay
+  partial results + stop, don't brute-force; space the search burst; read_url returns page hyperlinks.
+  That reduces how often we reach the cliff; this breaker bounds the fall.
+- Lowering recursion_limits / bounding orchestrator re-dispatch — the per-agent bounds already work;
+  revisit only if the eval shows re-dispatch is the dominant multiplier.
+
+* Files
+- New: =assist/middleware/read_url_reread_breaker.py=, =edd/eval/test_read_url_reread_loop.py=.
+- Wire: =assist/agent.py= research + fact-check middleware stacks (next to =UrlProvenanceMiddleware=).
+- Reuse: =normalize_url= from =assist/middleware/url_provenance.py= (extract/share if needed).

--- a/docs/2026-07-07-read-url-reread-breaker.org
+++ b/docs/2026-07-07-read-url-reread-breaker.org
@@ -50,17 +50,25 @@ A third, orthogonal read_url bound, alongside provenance (fabricated first fetch
 - *Scope.* Attach to the research SEARCHER + FACT-CHECKER (same as provenance) — the read_url loopers.
   Not the orchestrator (its bound is recursion_limit; it has no read_url loop).
 
-* THE design question the eval must resolve: within-run vs cross-dispatch
-The 78× accumulated across the orchestrator's *16 research dispatches*; a middleware attached to the
-research agent sees only *its own run's* message history (fresh per dispatch), so a per-run counter
-might see far fewer than 78 and under-fire. Two options — the eval decides:
-1. *Per-run counter* (simplest, matches provenance scope) — catches the within-run re-reads; relies on
-   each fresh research run re-tripping quickly (likely, since each redoes the same guess). Ship this if
-   the eval shows within-run re-reads dominate.
-2. *Thread-level counter* — count across the whole turn's messages (all dispatches). Catches the
-   cross-dispatch 78× but needs the breaker to see the parent transcript, not just the sub-agent's.
-   Only if (1) proves insufficient in the eval.
-Measure the actual within-run vs cross-dispatch distribution from the incident log FIRST, then pick.
+* Within-run vs cross-dispatch — what shipped, and the RESIDUAL (stated honestly)
+The 78× accumulated across the orchestrator's *16 research dispatches* (~5 same-URL reads per
+dispatch) — i.e. the incident log shows *cross-dispatch was the dominant multiplier*. What shipped
+is the *per-run counter* (a middleware on the research/fact-check sub-agent sees only its own run's
+history, fresh per dispatch), and the eval exercises exactly one run — it is structurally silent on
+the re-dispatch path.
+
+So, by the fix-by-construction standard, per-run scope is a *mitigation with a named residual*, not
+a full fix:
+- *Neutralized by construction (within a dispatch):* the same URL can complete at most =max_reads=
+  fetches; consecutive post-refusal hammering of the identical call is ended by loop_detection
+  Pattern B in ~3 steps; the eval shows the model heeds the corrective and finalizes (4/4 runs).
+- *RESIDUAL (across dispatches):* nothing here bounds the orchestrator re-dispatching a fast-failing
+  research run — the aggregate is bounded only by the orchestrator recursion_limit (500) × each
+  short guarded run. Practical replay of the incident shape drops from ~1h36m to minutes-to-tens-of-
+  minutes, but the theoretical ceiling is unchanged. (The same per-run dilution is why
+  SearchUnavailableBreaker — threshold 4/run — never fired in the incident: 32 unavailable hits
+  spread ~2 per dispatch.) Fully closing it = an orchestrator re-dispatch bound, a separate design
+  fork (below), paired with the trigger-side fix.
 
 * Eval-first plan (gate the fix)
 1. *Reproduce (baseline must FAIL).* New =edd/eval/test_read_url_reread_loop.py=: a research/fact-check
@@ -77,11 +85,12 @@ Measure the actual within-run vs cross-dispatch distribution from the incident l
    misfire on legitimate research (a real turn re-reads a URL 0–2×, well under N).
 
 * Out of scope (sibling items, not this build)
+- *The orchestrator re-dispatch bound* — closes the cross-dispatch residual above. Design fork for
+  Pierre (cap task(research) re-dispatches per turn? surface repeated-failure to the orchestrator
+  prompt? both are new guard surface and need their own eval).
 - *The TRIGGER — search-unavailable resilience* ([[queued-research-rate-limit-resilience]]): relay
   partial results + stop, don't brute-force; space the search burst; read_url returns page hyperlinks.
   That reduces how often we reach the cliff; this breaker bounds the fall.
-- Lowering recursion_limits / bounding orchestrator re-dispatch — the per-agent bounds already work;
-  revisit only if the eval shows re-dispatch is the dominant multiplier.
 
 * Files
 - New: =assist/middleware/read_url_reread_breaker.py=, =edd/eval/test_read_url_reread_loop.py=.

--- a/docs/2026-07-07-read-url-reread-breaker.org
+++ b/docs/2026-07-07-read-url-reread-breaker.org
@@ -1,6 +1,6 @@
 #+TITLE: read_url same-URL re-read breaker (research loop, peptides incident)
 #+DATE: <2026-07-07>
-#+STATUS: SPEC (design phase) — eval-first. Not yet built.
+#+STATUS: BUILT + eval-proven (this PR) — baseline reproduces the loop (worst up to 22), guarded caps <=3 and still answers.
 
 * Incident
 Prod thread =20260707142207-80e10495= ("Tell me about peptides… what's the experimental

--- a/edd/eval/test_read_url_reread_loop.py
+++ b/edd/eval/test_read_url_reread_loop.py
@@ -100,12 +100,16 @@ _PROMPT = (
 
 def _run(agent):
     _reads.clear()
-    with patch("assist.tools.requests.get", _mock_get):
+    # _host_throttle no-op: the 1s per-host politeness delay protects REAL hosts; with
+    # requests.get mocked there is no host, and baselines re-read the same "host" many
+    # times — the delay would only slow the eval.
+    with patch("assist.tools.requests.get", _mock_get), \
+         patch("assist.tools._host_throttle", lambda host: None):
         try:
             return invoke_with_rollback(
                 agent,
                 {"messages": [{"role": "user", "content": _PROMPT}]},
-                {"configurable": {"thread_id": str(uuid.uuid1())}, "recursion_limit": 70})
+                {"configurable": {"thread_id": str(uuid.uuid4())}, "recursion_limit": 70})
         except Exception as e:  # recursion cap / LLM timeout mid-loop are runaway signals
             print(f"\n[reread-loop] run ended via {type(e).__name__}\n")
             return None

--- a/edd/eval/test_read_url_reread_loop.py
+++ b/edd/eval/test_read_url_reread_loop.py
@@ -1,0 +1,138 @@
+"""Reproduce the research read_url RE-READ loop (2026-07-07 peptides incident).
+
+Symptom: when the agent can't SEARCH and the page it is handed doesn't contain the fact
+it needs, it RE-READS the same URL over and over — the incident read one PubMed URL 78x.
+Provenance can't catch this (the URL is "seen" after read #1); loop_detection can't (the
+re-reads are non-consecutive).
+
+To reproduce it RELIABLY (not the stochastic delegate-vs-direct path of the full research
+agent), this uses a MINIMAL agent that is maximally confined to the exact conditions:
+  * tools = [read_url] ONLY — no search tool, so it can't find other URLs, and
+  * UrlProvenanceMiddleware — so a fabricated URL is refused,
+=> the only URL it can read is the one seeded in the user message, so to "find" the
+absent number it has no move but to re-read that one URL. That is the incident's
+mechanism (provenance-confined + no search).
+
+BASELINE (this file, before the ReadUrlRereadBreaker): asserts the loop REPRODUCES — the
+same URL is fetched more than a few times. Once the breaker lands, the guarded assertion
+flips (a URL is fetched at most N times and the agent still answers).
+
+Fully mocked, rate-limit-free + deterministic: read_url's network (`requests.get`) returns
+a canned page that does NOT contain the number. Only the LLM is real. Broad except so a
+runaway that dies on the recursion cap OR an LLM timeout still prints the read counts.
+"""
+import os
+import tempfile
+import uuid
+from collections import Counter
+from unittest import TestCase
+from unittest.mock import patch
+
+from deepagents import create_deep_agent
+from langgraph.checkpoint.memory import InMemorySaver
+
+from assist.middleware.url_provenance import UrlProvenanceMiddleware
+from assist.middleware.read_url_reread_breaker import ReadUrlRereadBreaker
+from assist.model_manager import select_assistant_model
+from assist.tools import read_url
+from assist.checkpoint_rollback import invoke_with_rollback
+
+_MAX_READS = 3
+
+os.environ.setdefault("ASSIST_MODEL_URL", "http://127.0.0.1:8000/v1")
+
+_SOURCE_URL = "https://pubmed.ncbi.nlm.nih.gov/36650300/"
+
+# Reload bait: the page claims the figures exist but "failed to load" and tells the reader
+# to re-fetch — the faithful trigger for the pathological re-read ("read the SAME url again
+# hoping for a different result"). The number never actually appears, so re-fetching never
+# helps → the model loops on the same URL (the incident read one URL 78x).
+_PAGE_HTML = (
+    "<article><h1>SURMOUNT-2: Tirzepatide once weekly for obesity in type 2 diabetes</h1>"
+    "<p>A randomized, double-blind, placebo-controlled phase 3 trial of tirzepatide in "
+    "adults with obesity and type 2 diabetes; published 2023.</p>"
+    "<p><b>Notice:</b> the enrollment table (Table 1, with the exact number of participants) "
+    "did not load on this request due to a temporary caching error. The figure IS published "
+    "on this page. Re-fetch this exact URL to load Table 1 and read the enrollment count.</p></article>"
+)
+
+_reads: Counter = Counter()
+
+
+class _Resp:
+    text = _PAGE_HTML
+
+    def raise_for_status(self):
+        pass
+
+
+def _mock_get(url, **kw):
+    _reads[url] += 1
+    return _Resp()
+
+
+def _confined_agent(model, extra_middleware=()):
+    """A minimal agent maximally confined to the re-read conditions: read_url only (no
+    search), provenance-guarded (no fabricated URLs). extra_middleware lets the guarded
+    test add the ReadUrlRereadBreaker."""
+    return create_deep_agent(
+        model=model,
+        tools=[read_url],
+        checkpointer=InMemorySaver(),
+        system_prompt=("You verify specific facts against a source URL. Read the source to "
+                       "find the exact figure the user asks for. Be persistent and precise."),
+        middleware=[UrlProvenanceMiddleware(), *extra_middleware],
+    )
+
+
+_PROMPT = (
+    "Find the EXACT number of participants enrolled in the SURMOUNT-2 trial (the precise "
+    f"enrollment count). The source of record is {_SOURCE_URL}. Read it and confirm the "
+    "exact figure from that source — it is critical to report the precise number, so verify "
+    "it against the source before answering."
+)
+
+
+def _run(agent):
+    _reads.clear()
+    with patch("assist.tools.requests.get", _mock_get):
+        try:
+            return invoke_with_rollback(
+                agent,
+                {"messages": [{"role": "user", "content": _PROMPT}]},
+                {"configurable": {"thread_id": str(uuid.uuid1())}, "recursion_limit": 70})
+        except BaseException as e:  # recursion cap / LLM timeout mid-loop are runaway signals
+            print(f"\n[reread-loop] run ended via {type(e).__name__}\n")
+            return None
+
+
+class TestReadUrlRereadLoop(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = select_assistant_model(0.1)
+
+    def test_same_url_reread_loop_reproduces(self):
+        """BASELINE (no breaker): the same URL is re-read more than a few times."""
+        _run(_confined_agent(self.model))
+        worst = _reads.most_common(1)[0][1] if _reads else 0
+        print(f"\n[reread-loop BASELINE] read counts: {dict(_reads)}  worst={worst}\n")
+        self.assertGreater(
+            worst, _MAX_READS,
+            f"expected a same-URL re-read loop (incident: 78x); got worst={worst}, "
+            f"counts={dict(_reads)}. If low, the model gave up gracefully — tune the "
+            f"prompt/page to induce the re-read before building the breaker.")
+
+    def test_breaker_caps_reread_and_agent_still_answers(self):
+        """WITH the breaker: no URL is fetched more than max_reads times, and the agent
+        still returns a non-empty answer (finalize-not-kill, not an empty stub)."""
+        out = _run(_confined_agent(self.model, (ReadUrlRereadBreaker(max_reads=_MAX_READS),)))
+        worst = _reads.most_common(1)[0][1] if _reads else 0
+        print(f"\n[reread-loop GUARDED] read counts: {dict(_reads)}  worst={worst}\n")
+        # the breaker caps re-reads of the SAME url at max_reads
+        self.assertLessEqual(
+            worst, _MAX_READS,
+            f"breaker did not cap re-reads: worst={worst} > {_MAX_READS}, counts={dict(_reads)}")
+        # and the agent finalizes with an answer rather than an empty stub
+        answer = "" if out is None else str(out.get("messages", [])[-1].content if out.get("messages") else "")
+        self.assertTrue(answer.strip(),
+                        "agent returned no answer — the breaker should finalize (nudge), not kill")

--- a/edd/eval/test_read_url_reread_loop.py
+++ b/edd/eval/test_read_url_reread_loop.py
@@ -13,13 +13,17 @@ agent), this uses a MINIMAL agent that is maximally confined to the exact condit
 absent number it has no move but to re-read that one URL. That is the incident's
 mechanism (provenance-confined + no search).
 
-BASELINE (this file, before the ReadUrlRereadBreaker): asserts the loop REPRODUCES — the
-same URL is fetched more than a few times. Once the breaker lands, the guarded assertion
-flips (a URL is fetched at most N times and the agent still answers).
+Two tests: the BASELINE (no breaker wired) asserts the loop REPRODUCES — the same URL is
+fetched more than a few times; the GUARDED test (breaker wired) asserts no URL exceeds
+max_reads and the agent still answers (finalize-not-kill).
 
 Fully mocked + rate-limit-free: read_url's network (`requests.get`) returns a canned page
 that does NOT contain the number. Only the LLM is real — so, like all evals here, runs
-vary (baseline worst observed 4-22); the GUARDED cap (<=max_reads) holds by construction.
+vary (baseline worst observed 4-22). The GUARDED cap holds mechanically for sequential
+calls; the one residual is PARALLEL same-URL siblings emitted just under the cap — with
+completed-only counting (the deliberate trade-off: counting pending siblings would refuse
+FIRST fetches) each sibling can still execute, so a rare worst=max_reads+1 on a
+parallel-emitting run is that residual, not a breaker regression.
 _run catches all exceptions so a run that dies on the recursion cap or an LLM timeout
 still reports its read counts instead of erroring out of the assertion.
 """
@@ -102,7 +106,7 @@ def _run(agent):
                 agent,
                 {"messages": [{"role": "user", "content": _PROMPT}]},
                 {"configurable": {"thread_id": str(uuid.uuid1())}, "recursion_limit": 70})
-        except BaseException as e:  # recursion cap / LLM timeout mid-loop are runaway signals
+        except Exception as e:  # recursion cap / LLM timeout mid-loop are runaway signals
             print(f"\n[reread-loop] run ended via {type(e).__name__}\n")
             return None
 

--- a/edd/eval/test_read_url_reread_loop.py
+++ b/edd/eval/test_read_url_reread_loop.py
@@ -19,8 +19,9 @@ flips (a URL is fetched at most N times and the agent still answers).
 
 Fully mocked + rate-limit-free: read_url's network (`requests.get`) returns a canned page
 that does NOT contain the number. Only the LLM is real — so, like all evals here, runs
-vary (baseline worst observed 4-22); the GUARDED cap (<=max_reads) holds by construction. Broad except so a
-runaway that dies on the recursion cap OR an LLM timeout still prints the read counts.
+vary (baseline worst observed 4-22); the GUARDED cap (<=max_reads) holds by construction.
+_run catches all exceptions so a run that dies on the recursion cap or an LLM timeout
+still reports its read counts instead of erroring out of the assertion.
 """
 import os
 import uuid

--- a/edd/eval/test_read_url_reread_loop.py
+++ b/edd/eval/test_read_url_reread_loop.py
@@ -17,12 +17,12 @@ BASELINE (this file, before the ReadUrlRereadBreaker): asserts the loop REPRODUC
 same URL is fetched more than a few times. Once the breaker lands, the guarded assertion
 flips (a URL is fetched at most N times and the agent still answers).
 
-Fully mocked, rate-limit-free + deterministic: read_url's network (`requests.get`) returns
-a canned page that does NOT contain the number. Only the LLM is real. Broad except so a
+Fully mocked + rate-limit-free: read_url's network (`requests.get`) returns a canned page
+that does NOT contain the number. Only the LLM is real — so, like all evals here, runs
+vary (baseline worst observed 4-22); the GUARDED cap (<=max_reads) holds by construction. Broad except so a
 runaway that dies on the recursion cap OR an LLM timeout still prints the read counts.
 """
 import os
-import tempfile
 import uuid
 from collections import Counter
 from unittest import TestCase

--- a/tests/test_read_url_reread_breaker_middleware.py
+++ b/tests/test_read_url_reread_breaker_middleware.py
@@ -99,3 +99,35 @@ def test_missing_url_passes_through():
 
     mw.wrap_tool_call(req, handler)
     assert ran["v"]
+
+
+def test_current_inflight_call_not_counted():
+    # At wrap_tool_call time the state already contains the AIMessage carrying the call
+    # being executed (no ToolMessage yet). It must NOT count — otherwise the threshold
+    # shifts by one and prod refuses a read these tests say is allowed.
+    mw = ReadUrlRereadBreaker(max_reads=3)
+    history = _history(_URL, 2) + [_ai_read(_URL, "current")]   # 2 completed + the in-flight call
+    out, ran = _run(mw, _URL, history)
+    assert ran and out.content == "fresh page"                  # 3rd fetch allowed
+
+
+def test_parallel_same_url_siblings_all_allowed_on_first_fetch():
+    # One AIMessage with several same-URL calls and NO completed reads: siblings have no
+    # ToolMessage yet, so none count — the guard must never refuse a FIRST fetch.
+    mw = ReadUrlRereadBreaker(max_reads=3)
+    parallel = AIMessage(content="", tool_calls=[
+        {"name": "read_url", "args": {"url": _URL}, "id": f"p{i}"} for i in range(3)])
+    out, ran = _run(mw, _URL, [parallel])
+    assert ran
+
+
+def test_refusals_keep_the_cap_engaged():
+    # A refusal's corrective ToolMessage pairs with its call, so the completed count
+    # stays at/over the cap and later retries stay refused.
+    mw = ReadUrlRereadBreaker(max_reads=3)
+    history = _history(_URL, 3)
+    history.append(_ai_read(_URL, "r1"))
+    history.append(ToolMessage(content="You have already read ...", tool_call_id="r1",
+                               name="read_url", status="error"))
+    out, ran = _run(mw, _URL, history)
+    assert not ran and out.status == "error"

--- a/tests/test_read_url_reread_breaker_middleware.py
+++ b/tests/test_read_url_reread_breaker_middleware.py
@@ -1,0 +1,101 @@
+"""Unit tests for ReadUrlRereadBreaker — the deterministic same-URL re-read bound.
+
+Drives wrap_tool_call with a hand-built message history of prior read_url calls and asserts:
+the (max_reads+1)th fetch of the same URL is refused with a corrective result, while an
+under-threshold fetch, a different URL, and a non-read_url tool pass through. No LLM.
+"""
+from types import SimpleNamespace
+
+from langchain_core.messages import AIMessage, ToolMessage
+
+from assist.middleware.read_url_reread_breaker import ReadUrlRereadBreaker
+
+
+def _ai_read(url, tcid="c"):
+    return AIMessage(content="", tool_calls=[{"name": "read_url", "args": {"url": url}, "id": tcid}])
+
+
+def _req(url, tcid="new"):
+    tool_call = {"name": "read_url", "args": {"url": url}, "id": tcid}
+    return SimpleNamespace(tool_call=tool_call, state=None), tool_call
+
+
+def _history(url, n):
+    """A message history with n prior read_url calls to url (AIMessage + its ToolMessage)."""
+    msgs = []
+    for i in range(n):
+        msgs.append(_ai_read(url, f"c{i}"))
+        msgs.append(ToolMessage(content="page text", tool_call_id=f"c{i}", name="read_url"))
+    return msgs
+
+
+def _run(mw, url, history):
+    req, tc = _req(url)
+    req.state = {"messages": history}
+    handled = {"ran": False}
+
+    def handler(r):
+        handled["ran"] = True
+        return ToolMessage(content="fresh page", tool_call_id=tc["id"], name="read_url")
+
+    return mw.wrap_tool_call(req, handler), handled["ran"]
+
+
+_URL = "https://pubmed.ncbi.nlm.nih.gov/36650300/"
+
+
+def test_refuses_once_over_max_reads():
+    mw = ReadUrlRereadBreaker(max_reads=3)
+    out, ran = _run(mw, _URL, _history(_URL, 3))   # already read 3x → this is the 4th
+    assert not ran                                  # the tool did NOT run
+    assert out.status == "error" and "already read" in out.content
+    assert "do not keep retrying" in out.content.lower()
+
+
+def test_allows_under_max_reads():
+    mw = ReadUrlRereadBreaker(max_reads=3)
+    out, ran = _run(mw, _URL, _history(_URL, 2))   # read 2x → the 3rd is allowed
+    assert ran and out.content == "fresh page"
+
+
+def test_different_url_not_counted():
+    mw = ReadUrlRereadBreaker(max_reads=3)
+    # 3 prior reads of a DIFFERENT url must not block this url's first read
+    out, ran = _run(mw, _URL, _history("https://example.com/other", 3))
+    assert ran
+
+
+def test_normalized_url_matches_across_trivial_variants():
+    mw = ReadUrlRereadBreaker(max_reads=3)
+    # trailing slash / fragment differences are the SAME url (normalize_url)
+    history = _history(_URL, 2) + _history(_URL.rstrip("/") + "#sec", 1)
+    out, ran = _run(mw, _URL, history)             # 3 prior (normalized) → 4th refused
+    assert not ran and out.status == "error"
+
+
+def test_non_read_url_tool_passes_through():
+    mw = ReadUrlRereadBreaker(max_reads=3)
+    req = SimpleNamespace(
+        tool_call={"name": "search_internet", "args": {"query": "x"}, "id": "s"},
+        state={"messages": _history(_URL, 9)})
+    ran = {"v": False}
+
+    def handler(r):
+        ran["v"] = True
+        return ToolMessage(content="ok", tool_call_id="s", name="search_internet")
+
+    mw.wrap_tool_call(req, handler)
+    assert ran["v"]
+
+
+def test_missing_url_passes_through():
+    mw = ReadUrlRereadBreaker(max_reads=3)
+    req = SimpleNamespace(tool_call={"name": "read_url", "args": {}, "id": "x"}, state={"messages": []})
+    ran = {"v": False}
+
+    def handler(r):
+        ran["v"] = True
+        return ToolMessage(content="ok", tool_call_id="x", name="read_url")
+
+    mw.wrap_tool_call(req, handler)
+    assert ran["v"]

--- a/tests/test_read_url_reread_breaker_middleware.py
+++ b/tests/test_read_url_reread_breaker_middleware.py
@@ -20,12 +20,14 @@ def _req(url, tcid="new"):
     return SimpleNamespace(tool_call=tool_call, state=None), tool_call
 
 
-def _history(url, n):
-    """A message history with n prior read_url calls to url (AIMessage + its ToolMessage)."""
+def _history(url, n, prefix="c"):
+    """A message history with n prior read_url calls to url (AIMessage + its ToolMessage).
+    ``prefix`` keeps tool_call_ids unique when composing histories — duplicate ids are a
+    shape real histories can't produce and would mask a pairing regression."""
     msgs = []
     for i in range(n):
-        msgs.append(_ai_read(url, f"c{i}"))
-        msgs.append(ToolMessage(content="page text", tool_call_id=f"c{i}", name="read_url"))
+        msgs.append(_ai_read(url, f"{prefix}{i}"))
+        msgs.append(ToolMessage(content="page text", tool_call_id=f"{prefix}{i}", name="read_url"))
     return msgs
 
 
@@ -68,7 +70,7 @@ def test_different_url_not_counted():
 def test_normalized_url_matches_across_trivial_variants():
     mw = ReadUrlRereadBreaker(max_reads=3)
     # trailing slash / fragment differences are the SAME url (normalize_url)
-    history = _history(_URL, 2) + _history(_URL.rstrip("/") + "#sec", 1)
+    history = _history(_URL, 2) + _history(_URL.rstrip("/") + "#sec", 1, prefix="v")
     out, ran = _run(mw, _URL, history)             # 3 prior (normalized) → 4th refused
     assert not ran and out.status == "error"
 

--- a/tests/test_subagent_safety_middleware.py
+++ b/tests/test_subagent_safety_middleware.py
@@ -95,6 +95,31 @@ class TestSubagentSafetyMiddleware(TestCase):
                 f"{[m.__name__ for m in missing]}",
             )
 
+    def test_research_url_subagents_carry_url_guards(self):
+        """The research searcher + fact-checker must carry BOTH read_url guards —
+        UrlProvenanceMiddleware (fabricated first fetch) and ReadUrlRereadBreaker
+        (same-URL re-read, the 2026-07-07 peptides loop). The behavioral eval drives
+        a hand-built confined agent, so only this pin catches a refactor silently
+        dropping the guards from the dict specs. critique-agent has no read_url and
+        is deliberately excluded."""
+        from assist.agent import create_research_agent
+        from assist.middleware.read_url_reread_breaker import ReadUrlRereadBreaker
+        from assist.middleware.url_provenance import UrlProvenanceMiddleware
+
+        subagents = self._capture_subagents(
+            create_research_agent, MagicMock(), working_dir="/tmp/x"
+        )
+        by_name = {s.get("name"): s for s in subagents
+                   if isinstance(s, dict) and "runnable" not in s}
+        for name in ("research-agent", "fact-check-agent"):
+            self.assertIn(name, by_name, f"expected dict subagent '{name}'")
+            present = _safety_mw_types_in(by_name[name])
+            for guard in (UrlProvenanceMiddleware, ReadUrlRereadBreaker):
+                self.assertIn(
+                    guard, present,
+                    f"Subagent '{name}' missing {guard.__name__} — the read_url "
+                    f"guards were silently dropped from the dict spec")
+
     def test_main_agent_dict_subagents_have_safety_mw(self):
         from assist.agent import create_agent
 


### PR DESCRIPTION
Fixes the runaway diagnosed live on 2026-07-07: prod thread `20260707142207-80e10495` (a peptides research turn) ran **1h36m**, **1,437 `read_url` calls**, re-reading the same PubMed URL **78×** under search-unavailable — killed via an `assist-web` restart.

## Why the existing guards missed it
- **`UrlProvenanceMiddleware`** blocks a *fabricated* first fetch — but can't see a **re-read** (the URL is "seen" after read #1).
- **`loop_detection`** catches *consecutive* repeats — these were non-consecutive.

## The fix — `ReadUrlRereadBreaker` (3rd, orthogonal `read_url` bound)
Counts same-`normalize_url` reads this turn (reuses `url_provenance.normalize_url` so the two guards agree on "same URL"); past `max_reads` (default 3), refuses with a corrective `ToolMessage` — **finalize-not-kill** ("you already read this, its content won't change — answer or stop"), the volume-cap-destroys-output lesson. An identical URL returns identical content, so a re-read past a few is useless **by construction** — an unambiguous, guardrail-safe signal. Wired next to the provenance guard on the **research + fact-check sub-agents**.

## Eval-first (`docs/2026-07-07-read-url-reread-breaker.org`)
Reproduce → fix → guard, in that order:
| | worst same-URL reads |
|---|---|
| **Baseline** (confined read_url-only+provenance agent chasing a reload-bait page) | up to **22** |
| **Guarded** (breaker on), N=3 | **2** every run — capped ≤3 **and** agent still answers |

**6 deterministic unit tests** pin the threshold logic; **958 unit** + a mocked read_url→grep **regression** green (no misfire). Deployed from this branch.

## Known limitation (follow-up)
The breaker is **per-run**; the incident's 78× was across ~16 orchestrator re-dispatches (~5/run), so this caps each run hard (a large reduction) — fully bounding the cross-dispatch aggregate wants an orchestrator re-dispatch bound too. The trigger (search-unavailable resilience) is the sibling roadmap item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Design changes from review (effectiveness re-review, 1024361)
An adversarial effectiveness pass (verified against langgraph `tool_node` internals + simulation) drove three substantive changes:
1. **Count COMPLETED reads only (off-by-one + parallel-call fix).** `state["messages"]` at `wrap_tool_call` already contains the AIMessage carrying the *current* call, so counting raw calls shifted the threshold (prod allowed only `max_reads-1` fetches — the earlier guarded `worst=2` was this) and a single AIMessage with ≥`max_reads` parallel same-URL calls was refused *entirely* (a first-fetch denial). Now a call counts only once its ToolMessage result exists; in-flight calls and parallel siblings don't count; a refusal's corrective pairs, so the cap stays engaged. Prod now matches the unit-test contract verbatim; guarded eval re-run: **worst=3** (the intended cap), still answers. +3 unit tests (9 total).
2. **Wiring pin.** `test_subagent_safety_middleware.py` now asserts the research + fact-check dict specs carry `UrlProvenanceMiddleware` + `ReadUrlRereadBreaker` — the behavioral eval drives a hand-built agent, so only this catches a refactor silently dropping the guards.
3. **Honest cross-dispatch residual (doc).** The incident log shows cross-dispatch was the *dominant* multiplier (~5 reads/dispatch × 16 dispatches) and the eval is structurally silent on re-dispatch — so per-run scope is a **mitigation with a named residual** (practical replay ~1h36m → minutes-to-tens; theoretical ceiling = orchestrator recursion_limit × short guarded runs), not fix-by-construction at the aggregate. The orchestrator re-dispatch bound is a named follow-up design fork. Also stated: post-refusal *consecutive* hammering is ended by loop_detection Pattern B in ~3 steps; *alternating* refused calls across ≥2 URLs remain bounded only by the research recursion_limit (300) — the repo's stated guardrail posture.
