### PR TITLE
Persistent per-thread /tmp + text-fallback render + render-skill guidance

### DIFF
--- a/assist/sandbox_manager.py
+++ b/assist/sandbox_manager.py
@@ -334,10 +334,18 @@ class SandboxManager:
             # container's /tmp so it survives the per-turn container teardown (the
             # container's own /tmp would be lost with it).  Lets the agent stash a
             # file under /tmp (e.g. a renderable .md copy) that outlives the turn and
-            # is reachable by the web renderer.  Created here (idempotent) owned by
-            # the same host user as work_dir, so the run-as uid can write it.
+            # is reachable by the web renderer.  Created here (idempotent) + aligned to
+            # the SAME uid:gid the container runs as (work_dir's owner) so the run-as
+            # uid can write it even if the web process's own uid differs from work_dir's
+            # owner (best-effort chown: a no-op when they already match, the common case).
             tmp_dir = os.path.join(os.path.dirname(work_dir), "tmp")
-            os.makedirs(tmp_dir, exist_ok=True)
+            if not os.path.isdir(tmp_dir):
+                os.makedirs(tmp_dir, exist_ok=True)
+                try:
+                    os.chown(tmp_dir, st.st_uid, st.st_gid)
+                except OSError:
+                    pass  # not permitted (web non-root, uids differ) — mount still
+                          # works when web uid == work_dir owner (the deployment case)
 
             container = client.containers.run(
                 SANDBOX_IMAGE,

--- a/assist/sandbox_manager.py
+++ b/assist/sandbox_manager.py
@@ -330,12 +330,22 @@ class SandboxManager:
                 for k, v in os.environ.items()
                 if k.startswith("ASSIST_")
             })
+            # Persistent /tmp: a host dir SIBLING of work_dir, bind-mounted at the
+            # container's /tmp so it survives the per-turn container teardown (the
+            # container's own /tmp would be lost with it).  Lets the agent stash a
+            # file under /tmp (e.g. a renderable .md copy) that outlives the turn and
+            # is reachable by the web renderer.  Created here (idempotent) owned by
+            # the same host user as work_dir, so the run-as uid can write it.
+            tmp_dir = os.path.join(os.path.dirname(work_dir), "tmp")
+            os.makedirs(tmp_dir, exist_ok=True)
+
             container = client.containers.run(
                 SANDBOX_IMAGE,
                 detach=True,
                 remove=True,
                 user=user_arg,
-                volumes={work_dir: {"bind": "/workspace", "mode": "rw"}},
+                volumes={work_dir: {"bind": "/workspace", "mode": "rw"},
+                         tmp_dir: {"bind": "/tmp", "mode": "rw"}},
                 working_dir="/workspace",
                 stdin_open=True,
                 tty=False,

--- a/assist/thread_manager.py
+++ b/assist/thread_manager.py
@@ -344,6 +344,16 @@ class ThreadManager:
         return os.path.join(self.thread_dir(tid),
                             self.DEFAULT_THREAD_WORKING_DIRECTORY)
 
+    # A persistent scratch dir mounted at the sandbox's /tmp (sandbox_manager),
+    # SIBLING of the working dir (not under it, so it isn't part of the agent's
+    # /workspace project tree).  Unlike the per-turn container's ephemeral /tmp,
+    # this lives on the host and survives across turns — so a file the agent
+    # writes to /tmp (e.g. a .md copy of a non-showable file, to render) is still
+    # there next turn and is reachable by the web renderer.  Removed with the
+    # thread dir on hard_delete.
+    def thread_tmp_dir(self, tid: str) -> str:
+        return os.path.join(self.thread_dir(tid), "tmp")
+
     def make_default_working_dir(self, tdir: str) -> str:
         wdir = self.DEFAULT_THREAD_WORKING_DIRECTORY
         working_dir = os.path.join(tdir, wdir)

--- a/assist/web_skills/render/SKILL.md
+++ b/assist/web_skills/render/SKILL.md
@@ -76,7 +76,8 @@ type: file
 path: /tmp/sub_research.md
 ```
 
-`/tmp` persists for the turn and renders like the workspace, so this is the way
+`/tmp` is a per-thread scratch dir that persists across turns and renders like the
+workspace, so this is the way
 to show a nicely-formatted version of a file whose own extension wouldn't format.
 Use it when converting adds value; otherwise just render the original path as
 plain text (above).

--- a/assist/web_skills/render/SKILL.md
+++ b/assist/web_skills/render/SKILL.md
@@ -14,8 +14,11 @@ type: file
 path: /workspace/PATH-TO-THE-FILE
 ```
 
-Replace `PATH-TO-THE-FILE` with the real file in the user's workspace (for
-example `path: /workspace/fitness.org`).
+Replace `PATH-TO-THE-FILE` with the real file — either in the user's workspace
+(e.g. `path: /workspace/fitness.org`) or under `/tmp` (e.g.
+`path: /tmp/summary.md`). **`/tmp` is a persistent scratch directory** that
+renders exactly like the workspace, so you can `write_file` a file there to show
+it (see "Showing a file that isn't .org/.md/.pdf" below).
 
 ## Showing only part of a file
 
@@ -48,6 +51,35 @@ Use `lines:` for org/md and `pages:` for pdf. Always write a range as `N-M` (for
 a single line or page use the same number twice, e.g. `pages: 3-3`). The range in
 the block must be numbers you resolved — never put a description like
 `lines: the backups section` in the block. Omit the range to show the whole file.
+
+## Showing a file that isn't .org / .md / .pdf
+
+`.org`, `.md`, and `.pdf` render richly (formatted). **Any other file still
+renders — as plain text.** So you CAN show a `.txt`, `.py`, `.j2`, log, config,
+or extension-less file directly:
+
+```render
+type: file
+path: /workspace/assist/templates/deepagents/sub_research.txt.j2
+```
+
+**When the file would read better converted, convert it first.** If a file is
+easily turned into markdown/org — a template like `sub_research.txt.j2` (really
+just prompt text), a `.txt` that's already markdown-shaped, notes you want
+cleaned up — `write_file` a converted copy under `/tmp` and render THAT:
+
+```
+write_file  /tmp/sub_research.md   ← the file's content (as markdown)
+```
+```render
+type: file
+path: /tmp/sub_research.md
+```
+
+`/tmp` persists for the turn and renders like the workspace, so this is the way
+to show a nicely-formatted version of a file whose own extension wouldn't format.
+Use it when converting adds value; otherwise just render the original path as
+plain text (above).
 
 ## Maps — show places and routes on a map
 
@@ -107,8 +139,9 @@ replacement for the research and recommendations.
 - Emit the render block **instead of** reading the file and summarizing or
   pasting its contents. The block displays the actual file; a summary is not
   what the user asked for.
-- Only `.org`, `.md`, and `.pdf` files render. For any other type, read and
-  summarize it instead (no render block).
+- `.org`, `.md`, and `.pdf` render richly; any other file renders as plain text,
+  or convert it to a `/tmp/*.md` copy first (see "Showing a file that isn't
+  .org/.md/.pdf"). Either way, SHOW the file — don't fall back to summarizing.
 - If you don't know the exact path, find the file first (e.g. `glob`), then
   emit the block with its real path.
 - You may add a short sentence before the block (e.g. "Here's your file:"), but

--- a/edd/eval/test_render_agent.py
+++ b/edd/eval/test_render_agent.py
@@ -129,6 +129,64 @@ class TestRenderAgent(TestCase):
             f"blocks: {blocks}",
         )
 
+    def _write_paths(self, agent) -> list:
+        """Paths the agent wrote/edited this turn (write_file / edit_file tool calls)."""
+        from langchain_core.messages import AIMessage
+        paths = []
+        for m in agent.all_messages():
+            if not isinstance(m, AIMessage):
+                continue
+            for tc in (getattr(m, "tool_calls", None) or []):
+                if tc.get("name") in ("write_file", "edit_file"):
+                    args = tc.get("args") or tc.get("arguments") or {}
+                    if isinstance(args, dict):
+                        p = args.get("file_path") or args.get("path") or ""
+                        if p:
+                            paths.append(str(p))
+        return paths
+
+    def test_shows_unsupported_file_instead_of_summarizing(self):
+        """The 2026-07-08 regression: asked to SHOW a file whose extension isn't
+        .org/.md/.pdf (here a .txt.j2 template), the agent must render it — either
+        the file directly (it now renders as text) OR a converted /tmp/*.md copy —
+        NOT fall back to reading + summarizing it."""
+        fs = dict(_personal_workspace())
+        fs["research_prompt.txt.j2"] = (
+            "You are a dedicated researcher. Conduct thorough research and cite sources. "
+            "MARKER-QZX7 always cite provenance.")
+        agent = self.create_agent(fs)
+        agent.message("Show me the research_prompt.txt.j2 file")
+        blocks = self._render_block_paths(agent)
+        writes = self._write_paths(agent)
+        # a render block for the original unsupported file (text fallback) OR for a
+        # /tmp/*.md the agent wrote from it — either way it chose to SHOW, not summarize.
+        showed_original = any("research_prompt.txt.j2" in b for b in blocks)
+        showed_tmp_copy = (any("/tmp/" in b and ".md" in b.lower() for b in blocks)
+                           and any("/tmp/" in w and w.lower().endswith(".md") for w in writes))
+        self.assertTrue(
+            showed_original or showed_tmp_copy,
+            f"expected a render block for the .txt.j2 (direct text) or a /tmp/*.md copy "
+            f"of it; render blocks: {blocks}; writes: {writes}",
+        )
+
+    def test_converts_unsupported_file_to_tmp_md_when_asked_formatted(self):
+        """The copy/modify-for-render path specifically: asked to show an unsupported
+        file NICELY FORMATTED, the agent writes a converted /tmp/*.md and renders that
+        (using the now-persistent /tmp scratch dir)."""
+        fs = dict(_personal_workspace())
+        fs["notes.py"] = "# TODO: MARKER-PY42\nprint('backups run nightly')\n"
+        agent = self.create_agent(fs)
+        agent.message("Show me notes.py nicely formatted as markdown")
+        blocks = self._render_block_paths(agent)
+        writes = self._write_paths(agent)
+        wrote_tmp_md = any("/tmp/" in w and w.lower().endswith(".md") for w in writes)
+        rendered_tmp = any("/tmp/" in b and ".md" in b.lower() for b in blocks)
+        self.assertTrue(
+            wrote_tmp_md and rendered_tmp,
+            f"expected the agent to write a /tmp/*.md copy AND render it; "
+            f"writes: {writes}; render blocks: {blocks}",
+        )
+
     def test_emits_page_range(self):
         """Section by page: 'show page N of <pdf>' carries a pages: range."""
         from pypdf import PdfWriter

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -1292,6 +1292,7 @@ _SHOW_PAGE_CSS = (
     "line-height:1.55;color:#171717}pre,code{background:#fafafa;border-radius:4px}"
     "pre{padding:.6rem;overflow:auto}table{border-collapse:collapse}"
     "td,th{border:1px solid #e5e7eb;padding:.3rem .5rem}img{max-width:100%}"
+    "pre.show-text{white-space:pre-wrap;word-break:break-word;font-size:.85rem}"
 )
 
 # The /show page renders AGENT-generated md/org.  The md path (python-markdown)
@@ -1318,18 +1319,27 @@ _SHOW_SECURITY_HEADERS = {
 # "/workspace/fitness.org", "/fitness.org", or "fitness.org".  All three name the
 # same host file under the working dir; map them before resolving.
 _SANDBOX_MOUNT = "/workspace"
+# The sandbox also bind-mounts a persistent host dir at /tmp (sandbox_manager.py),
+# so a render block may point at /tmp/foo.md — a .md copy the agent stashed for
+# rendering.  /tmp maps to the thread's tmp dir, NOT the working dir, so it's
+# resolved against its own root.
+_TMP_MOUNT = "/tmp"
 
 
 def _safe_workspace_file(tid: str, path: str) -> str | None:
-    """Resolve an AGENT path (in /workspace space) against the thread's host
-    agent working dir, traversal-safe.  Accepts ``/workspace/x``, ``/x`` and
-    ``x`` (all → ``<workdir>/x``).  Returns the host path, or None if it would
-    escape the workspace (a crafted ``../``) or is malformed (embedded NUL)."""
-    base = os.path.realpath(MANAGER.thread_default_working_dir(tid))
-    rel = path
-    if rel == _SANDBOX_MOUNT or rel.startswith(_SANDBOX_MOUNT + "/"):
-        rel = rel[len(_SANDBOX_MOUNT):]
-    rel = rel.lstrip("/")  # treat as relative to the workspace root
+    """Resolve an AGENT path against the matching thread host dir, traversal-safe.
+    ``/tmp/x`` → ``<thread>/tmp/x`` (the persistent /tmp mount); ``/workspace/x``,
+    ``/x`` and ``x`` → ``<workdir>/x``.  Returns the host path, or None if it would
+    escape its root (a crafted ``../``) or is malformed (embedded NUL)."""
+    if path == _TMP_MOUNT or path.startswith(_TMP_MOUNT + "/"):
+        base = os.path.realpath(MANAGER.thread_tmp_dir(tid))
+        rel = path[len(_TMP_MOUNT):]
+    else:
+        base = os.path.realpath(MANAGER.thread_default_working_dir(tid))
+        rel = path
+        if rel == _SANDBOX_MOUNT or rel.startswith(_SANDBOX_MOUNT + "/"):
+            rel = rel[len(_SANDBOX_MOUNT):]
+    rel = rel.lstrip("/")  # treat as relative to the chosen mount root
     try:
         target = os.path.realpath(os.path.join(base, rel))
     except ValueError:  # embedded NUL etc. -> treat as not-found, not a 500
@@ -1502,12 +1512,14 @@ def _scalar(value):
 
 
 def _render_file_block(tid: str, block: dict) -> str | None:
-    """``type: file`` renderer.  Embeds a showable workspace file, or None when
-    the path is missing / not a renderable extension (the block is then left to
-    show as a normal code block).  An optional ``lines:``/``pages:`` range is
-    carried into the embed."""
+    """``type: file`` renderer.  Embeds a workspace/tmp file, or None when the
+    path is missing (the block is then left to show as a normal code block).
+    ``.org``/``.md``/``.pdf`` render richly; ANY other file falls back to plain
+    text (the /show route escapes it) — so "show me this .j2/.py/.txt" works
+    instead of silently degrading to a raw code block.  An optional
+    ``lines:``/``pages:`` range is carried into the embed."""
     path = _scalar(block.get("path", ""))
-    if not path or os.path.splitext(path)[1].lower() not in _SHOWABLE_EXTS:
+    if not path:
         return None
     return _file_embed_html(tid, path, _scalar(block.get("lines", "")),
                             _scalar(block.get("pages", "")))
@@ -1833,8 +1845,11 @@ def show_file_view(tid: str, path: str, lines: str = "", pages: str = ""):
     elif ext == ".org":
         body = _org_to_html(src)
     else:
-        raise HTTPException(status_code=415,
-                            detail="show supports .org, .md, .pdf")
+        # Text fallback: any other file (.txt, .py, .j2, no extension, …) shows as
+        # escaped plain text in a <pre>.  html.escape neutralises any markup, so an
+        # agent-generated file can't inject HTML/JS (same guarantee as the org
+        # renderer); binary content degrades to replacement chars, not a crash.
+        body = f'<pre class="show-text">{html.escape(src)}</pre>'
     return HTMLResponse(
         f"<!doctype html><html><head><meta charset=utf-8>"
         f'<meta name=viewport content="width=device-width, initial-scale=1">'

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -84,8 +84,11 @@ class TestFileEmbed:
     def test_path_is_url_quoted(self):
         assert "my%20report.org" in _file_embed_html("t1", "my report.org")
 
-    def test_render_file_block_rejects_unshowable_ext(self):
-        assert _render_file_block("t1", {"path": "data.txt"}) is None
+    def test_render_file_block_renders_unshowable_as_text_embed(self):
+        # A non-.org/.md/.pdf file now embeds too (renders as text via /show),
+        # instead of degrading to a raw code block.
+        assert "<iframe" in _render_file_block("t1", {"path": "data.txt"})
+        assert "<iframe" in _render_file_block("t1", {"path": "/tmp/x.j2"})
 
     def test_render_file_block_rejects_empty_path(self):
         assert _render_file_block("t1", {}) is None
@@ -122,10 +125,12 @@ class TestRenderAssistantContent:
         assert "show-embed" not in out
         assert "<code" in out  # markdown rendered the fence as a code block
 
-    def test_unshowable_file_left_as_code(self):
+    def test_unshowable_file_becomes_text_embed(self):
+        # A .txt render block now lifts to an embed (text fallback), not a code block.
         raw = "```render\ntype: file\npath: notes.txt\n```"
         out = _render_assistant_content("t1", raw)
-        assert "show-embed" not in out and "<code" in out
+        assert "show-embed" in out and "/thread/t1/show?path=" in out
+        assert "```render" not in out
 
     def test_plain_markdown_untouched(self):
         out = _render_assistant_content("t1", "# Hi\n\n| a | b |\n|---|---|\n| 1 | 2 |\n")
@@ -241,11 +246,24 @@ class TestShowRoute:
             "/thread/t1/show", params={"path": "../../secret.md"})
         assert r.status_code == 404
 
-    def test_unsupported_extension_415(self, workspace):
-        (workspace / "x.txt").write_text("plain")
+    def test_non_rich_ext_renders_as_escaped_text(self, workspace):
+        # Text fallback: a .txt/.j2/etc renders (200) as escaped <pre>, and any
+        # markup in it is neutralised (can't inject HTML/JS).
+        (workspace / "x.j2").write_text("plain {{v}} <script>alert(1)</script>")
         r = TestClient(web.app, raise_server_exceptions=False).get(
-            "/thread/t1/show", params={"path": "x.txt"})
-        assert r.status_code == 415
+            "/thread/t1/show", params={"path": "x.j2"})
+        assert r.status_code == 200
+        assert 'class="show-text"' in r.text
+        assert "&lt;script&gt;" in r.text and "<script>alert" not in r.text
+
+    def test_tmp_file_resolves_and_renders(self, workspace):
+        # /tmp maps to <thread>/tmp (sibling of domain) and renders like the workspace.
+        tmp = workspace.parent / "tmp"
+        tmp.mkdir()
+        (tmp / "summary.md").write_text("# Summary\n\nhello")
+        r = TestClient(web.app, raise_server_exceptions=False).get(
+            "/thread/t1/show", params={"path": "/tmp/summary.md"})
+        assert r.status_code == 200 and "<h1>Summary</h1>" in r.text
 
     def test_route_renders_every_showable_ext(self, workspace):
         # Drift guard: _SHOWABLE_EXTS is the allow-list for the file embed AND

--- a/tests/test_sandbox_per_turn.py
+++ b/tests/test_sandbox_per_turn.py
@@ -73,11 +73,14 @@ class TestNoReuse(_SandboxStateBase):
             patch.object(SandboxManager, "_ensure_egress_proxy_running"),
             patch("assist.sandbox_manager.os.stat", return_value=st),
             patch("assist.sandbox.DockerSandboxBackend", lambda *a, **k: MagicMock()),
+            # the persistent-/tmp dir is created for real; the work_dir here is a
+            # fake path, so stub the mkdir like os.stat above.
+            patch("assist.sandbox_manager.os.makedirs"),
         ]
 
     def test_second_call_reaps_stale_and_creates_fresh(self):
         p = self._patches()
-        with p[0], p[1], p[2], p[3]:
+        with p[0], p[1], p[2], p[3], p[4]:
             SandboxManager.get_sandbox_backend("/ws/t")
             first = SandboxManager._containers["/ws/t"]
             # Second turn for the SAME thread: must NOT reuse `first`.


### PR DESCRIPTION
Fixes the 2026-07-08 "Show research subagent markdown instructions" thread that rendered **nothing**: the agent emitted a render block for a `.txt.j2` (not a showable extension), and even its `/tmp/render_file.md` workaround was lost (the per-turn container's `/tmp` is ephemeral) and unreachable (the renderer only resolved `/workspace`). Three changes, in the order requested.

## 1. Persistent per-thread `/tmp` (the foundation)
A host dir **`<thread_dir>/tmp` — sibling of `domain`, inside the thread dir** — is bind-mounted at the sandbox container's `/tmp`, so a file the agent stashes there survives the per-turn container teardown and is reachable by the web renderer.
- `thread_manager.thread_tmp_dir(tid)`; `sandbox_manager` creates (idempotent, owned by the work_dir user so the run-as uid can write it) + mounts it; `_safe_workspace_file` resolves `/tmp/x` → `<thread>/tmp/x`, traversal-safe (each mount confined to its own root).
- Cleaned with the thread dir on `hard_delete`.

## 2. Text-fallback render
`.org`/`.md`/`.pdf` still render richly; **any other file now renders as escaped plain text** (`<pre>` via `html.escape`) instead of silently degrading to a raw code block. `_render_file_block` no longer gates on `_SHOWABLE_EXTS` (only empty path → None).

## 3. Render-skill guidance
Documents `/tmp` as a persistent scratch dir that renders like the workspace; adds "Showing a file that isn't `.org`/`.md`/`.pdf`" (render as text directly, **or** write a converted `/tmp/<name>.md` copy and render that when converting adds value — with the `sub_research.txt.j2` example); replaces the old "only `.org`/`.md`/`.pdf` render, else summarize" rule. *(Reviewed all prompts/skills: there was **no explicit anti-`/tmp` text** to remove — only the workspace-only examples, now fixed.)*

## Security
Adversarial review (0 blockers): **symlink escape is provably blocked** — the renderer `realpath`s any agent-created symlink in `/tmp` *before* the containment check, so a symlink pointing at `/etc/passwd`, the sibling `domain`, or another thread all resolve to `None` (verified with planted symlinks). Traversal blocked both directions; text served via `html.escape` in a no-scripts sandboxed iframe with security headers.

**Known broadening (accepted):** removing the extension gate means `/show` now serves *any* file in the thread's **own** `domain`/`tmp` dirs as text (not just `.org`/`.md`/`.pdf`). This is the same trust boundary `read_file` already crosses, confined per-thread, on a single-user no-auth WireGuard app — gating it to `/tmp`-only would break the actual ask (rendering a workspace `.txt.j2`), so it's flagged, not gated.

## Tests
- Unit: `/tmp` resolution + traversal (both directions), text-fallback escaping, non-rich embed; 3 old reject/415 tests flipped to the new behavior; **963 green**.
- Eval (`test_render_agent.py`, real-LLM): show-unsupported-file (direct text OR `/tmp/.md` copy) + convert-to-`/tmp/.md`-when-asked-formatted — **N=3: 6/6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)