### PR TITLE
Message timing indicators + single-word thread-list statuses

### DIFF
--- a/docs/2026-07-08-message-timing-indicators.org
+++ b/docs/2026-07-08-message-timing-indicators.org
@@ -11,13 +11,14 @@ Fact: langchain =BaseMessage= has no timestamp; the langgraph checkpoint has a p
 
 * Design decisions
 - *LIVE (part 2):* store one =started_at= field in the existing =status.json= when a turn begins. =render_thread= embeds a *server-computed* =baseline_seconds = now - started_at=; a tiny inline JS ticks it up locally via =performance.now()= delta. No polling, no server round-trips, no clock-skew dependency (the page has NO client polling today — threads.py:1105).
-- *COMPLETED (part 1):* a per-thread sidecar =turn_timings.json= (mirrors the existing =merge_conflict.json= trio in state.py:233-289), a JSON object keyed by *human-message ordinal* → ={started_at, seconds}=. Written off-loop by =_process_message= at its success exits; read on-loop by =render_thread= (one small missing-ok JSON read, exactly like =_get_status= / =_get_conflict=).
+- *COMPLETED (part 1):* a per-thread sidecar =turn_timings.json= (mirrors the existing =merge_conflict.json= trio in state.py:233-289), a flat JSON object keyed by *human-message ordinal* → *seconds* (an int). (Design-review fix: NOT ={started_at, seconds}= — nothing reads a sidecar =started_at=; the badge is a pure duration and =started_at= lives in =status.json= for the live timer only. A copy here is a dead field.) Written off-loop by =_process_message= at its success exits; read on-loop by =render_thread= (one small missing-ok JSON read, exactly like =_get_status= / =_get_conflict=).
   - Rejected =AIMessage.response_metadata= (touches the model/middleware hot path + checkpoint round-trip) and checkpoint-=ts= derivation (fiddly, couples render to langgraph internals).
-  - Keyed by *human-message ordinal* (count of HumanMessages), NOT raw message index: computable identically on write (=chat.get_raw_messages()=) and read (count of ="user"= dicts), append-only, robust to errored/pre-feature turns. Crucially this keeps =assist/thread.py= =_messages_to_dicts= UNTOUCHED, so the exact-equality render tests (tests/test_render.py:319-348) stay green.
-- *Single-word statuses (part 3):* rewrite =STAGE_LABELS= (state.py:321-328) in place. This dict feeds both the list page (threads.py:188,194) and the in-thread banner (threads.py:523) — one source of truth (see O1).
+  - Keyed by *human-message ordinal* (count of HumanMessages), NOT raw message index: append-only, robust to errored/pre-feature turns, keeps =assist/thread.py= =_messages_to_dicts= UNTOUCHED (render tests stay green). *Design-review fix (fix-by-construction):* count the ordinal ONE way on BOTH sides — a single shared helper over the raw =HumanMessage= list — NOT write-side raw + read-side ="user"= dicts (two counters over two representations that silently misalign if the 1:1 HumanMessage↔"user"-dict mapping ever breaks). The render pass computes an =index→seconds= map from the raw messages once, then consults it in the existing reversed loop. A render test must pin badge-on-correct-bubble across a thread containing a tool-only turn AND a review submission.
+- *Single-word statuses (part 3):* Pierre scoped this to the *thread-list page*. Use a list-only single-word mapping at the list call sites (threads.py:188,194); LEAVE the full =STAGE_LABELS= sentences on the in-thread banner (threads.py:523). *Design-review fix (I1):* the earlier "rewrite the shared dict in place" also shortened the in-thread banner — a surface Pierre didn't name, where the sentences carry real "why" info (esp. =paused= / =queued=). The two-line duplication is trivial and does not justify downgrading the banner. (O1 resolved: list-only.)
 
 * Why it's event-loop-safe (load-bearing — single-worker uvicorn)
-- *Writes only off the loop.* =_process_message= runs as a sync BackgroundTask / on the =_ResumeScheduler= thread (threads.py:792, 1334-1343), never on the asyncio loop. The sidecar write + the =started_at= write ride the existing =_set_status= calls (which already do blocking file I/O there). No new on-loop I/O, no new locks.
+- *The =started_at= write adds NO new on-loop blocking.* (Design-review correction: the earlier "writes only off the loop" was FALSE — =_mark_pending= (threads.py:1101, called inline from =async def post_message=:1359) and =create_thread_with_message= (:1039) DO write =status.json= on the loop today.) The change only adds one extra key (=started_at=) to the =pending_kwargs= those calls already pass to the pre-existing on-loop =_set_status= → =_atomic_write=. No NEW =_atomic_write= call, no lock, no subprocess lands on the loop — just one more dict field + one =datetime.now()=. Do NOT later add real blocking I/O to =_mark_pending= trusting an "off-loop" invariant that doesn't hold.
+- *The heavy write (sidecar =_append_timing=) is confined off-loop.* It runs ONLY at =_process_message='s success exits, and =_process_message= is always off the loop (BackgroundTask / =_ResumeScheduler= / =_SCHEDULER= thread — threads.py:1373,1287,1334-1340,1193), never inline from an =async def=.
 - *Reads on the loop are the established pattern.* =render_thread= reads one small JSON with no lock — exactly what =_get_status= (state.py:335) / =_get_conflict= (state.py:237) already do.
 - *One writer per tid.* THREAD_QUEUE + the serial =_ResumeScheduler= serialize all turns for a tid; =_atomic_write= covers crash-safety. Different tids → different files.
 
@@ -51,12 +52,20 @@ Fact: langchain =BaseMessage= has no timestamp; the langgraph checkpoint has a p
 - *Pre-feature / errored / page-reopen:* ={}=/=.get= misses → no badge, no crash; errored turn rolls back → no entry; reopen mid-turn recomputes baseline from =status.json= =started_at=.
 - *Supersede / HITL-reject loops* (threads.py:882-905): resume the same turn, no new HumanMessage → ordinal unchanged → one entry at the final success exit.
 
-* Open questions / risks
-- *O1* — shared STAGE_LABELS shortens the in-thread banner too (recommended: one source of truth; else add list-only SHORT_STAGE_LABELS).
-- *O2* — badge on =awaiting_approval= turns: recommend record + render only on plain assistant bubbles.
-- *O3* — wall-clock vs active-time for paused turns: recommend wall-clock.
-- *R1* — sidecar grows one entry/turn (threads are tens of turns; YAGNI a cap for v1).
-- *R2* — =started_at= at submit includes queue-wait behind other threads → honest "human→reply", matches the live timer; a long queue-wait shows a large elapsed even for a fast turn. Recommend include.
+* Resolved by design-review (as-built decisions)
+- *O1 → list-only* (interfaces/intention I1): single words on the thread-list page only; banner keeps sentences.
+- *Sidecar value → flat =seconds=* (simplicity #1): no dead =started_at= copy.
+- *Ordinal join → one shared counter over the raw HumanMessage list* (interfaces C1 / simplicity #2), pinned by a tool-only-+-review-submission render test.
+- *Event-loop rationale corrected* (liveness #1): safe because the field rides a pre-existing on-loop atomic write (no NEW blocking); heavy sidecar write is off-loop.
+- *C4* — =started_at= is SUBMIT time (includes queue-wait); add a one-line comment so a reader doesn't assume processing-start (or name it =submitted_at=).
+- *C5* — badge attaches to "the last =assistant=-role bubble strictly before the next =user= bubble" (no double-badge; tools-only tail gets none). O2: record on awaiting_approval, render only on plain assistant bubbles.
+- *C3* — test =_format_elapsed= parity on BOTH the Python badge and the JS timer (=59→"59s"=, =60→"1m 0s"=, =3600→"1h 0m"=).
+
+* Remaining risks / accepted
+- *O3 (accept)* — paused-turn elapsed is WALL-CLOCK incl. pause + queue-wait; the scheduler's =accumulated_active_ms= is deliberately unused. Matches the live timer.
+- *I2 (accept, optional polish)* — a fast turn submitted behind a long research turn shows a large elapsed ("8m") that reads as "AI was slow" when it was queued; a tooltip ("includes Nm queued") would disambiguate. Not blocking.
+- *I4 (note)* — no client polling today, so the live timer keeps ticking after the turn completes until the user reloads; moot (the user must reload to see the reply anyway) → on reload it snaps to the frozen badge.
+- *R1* — sidecar grows one entry/turn (tens/thread; YAGNI a cap for v1).
 - *R3* — one extra off-loop =get_state= per turn to count HumanMessages (negligible).
 - *R4* — turns in-flight at deploy have no =started_at=/entry → spinner-without-timer + no badge; self-heals next turn.
 

--- a/docs/2026-07-08-message-timing-indicators.org
+++ b/docs/2026-07-08-message-timing-indicators.org
@@ -1,0 +1,67 @@
+#+TITLE: Message timing indicators + single-word thread-list statuses (web UI)
+#+DATE: <2026-07-08>
+#+STATUS: DESIGN (Phase 1). Smallest change that satisfies the 3 requirements; agent/checkpoint hot path + assist/thread.py deliberately untouched.
+
+* Requirements
+1. *Elapsed human→AI* on each completed turn — a small badge on the assistant reply (e.g. "14s", "2m 5s").
+2. *Live WIP elapsed* — while a turn is processing, show time from the last human message to now, ticking.
+3. *Single-word statuses* on the thread-list page (STAGE_LABELS are currently sentences).
+
+Fact: langchain =BaseMessage= has no timestamp; the langgraph checkpoint has a per-superstep =ts= but the checkpoint→message mapping is fiddly. So we stamp times ourselves, off the agent path.
+
+* Design decisions
+- *LIVE (part 2):* store one =started_at= field in the existing =status.json= when a turn begins. =render_thread= embeds a *server-computed* =baseline_seconds = now - started_at=; a tiny inline JS ticks it up locally via =performance.now()= delta. No polling, no server round-trips, no clock-skew dependency (the page has NO client polling today — threads.py:1105).
+- *COMPLETED (part 1):* a per-thread sidecar =turn_timings.json= (mirrors the existing =merge_conflict.json= trio in state.py:233-289), a JSON object keyed by *human-message ordinal* → ={started_at, seconds}=. Written off-loop by =_process_message= at its success exits; read on-loop by =render_thread= (one small missing-ok JSON read, exactly like =_get_status= / =_get_conflict=).
+  - Rejected =AIMessage.response_metadata= (touches the model/middleware hot path + checkpoint round-trip) and checkpoint-=ts= derivation (fiddly, couples render to langgraph internals).
+  - Keyed by *human-message ordinal* (count of HumanMessages), NOT raw message index: computable identically on write (=chat.get_raw_messages()=) and read (count of ="user"= dicts), append-only, robust to errored/pre-feature turns. Crucially this keeps =assist/thread.py= =_messages_to_dicts= UNTOUCHED, so the exact-equality render tests (tests/test_render.py:319-348) stay green.
+- *Single-word statuses (part 3):* rewrite =STAGE_LABELS= (state.py:321-328) in place. This dict feeds both the list page (threads.py:188,194) and the in-thread banner (threads.py:523) — one source of truth (see O1).
+
+* Why it's event-loop-safe (load-bearing — single-worker uvicorn)
+- *Writes only off the loop.* =_process_message= runs as a sync BackgroundTask / on the =_ResumeScheduler= thread (threads.py:792, 1334-1343), never on the asyncio loop. The sidecar write + the =started_at= write ride the existing =_set_status= calls (which already do blocking file I/O there). No new on-loop I/O, no new locks.
+- *Reads on the loop are the established pattern.* =render_thread= reads one small JSON with no lock — exactly what =_get_status= (state.py:335) / =_get_conflict= (state.py:237) already do.
+- *One writer per tid.* THREAD_QUEUE + the serial =_ResumeScheduler= serialize all turns for a tid; =_atomic_write= covers crash-safety. Different tids → different files.
+
+* Steps (Phase 2)
+** Part 3 — single-word statuses (first; smallest, isolates a rename)
+1. state.py:321-328 — =STAGE_LABELS= values → single words: Initializing / Cloning / Starting / Queued / Processing / Paused. Keys + BUSY_STAGES/INIT_STAGES unchanged.
+2. No call-site changes (threads.py:188,194,523 already use =.get=). Set the banner fallback (threads.py:523) to a single word ("Working").
+
+** Part 2 — live WIP timer
+3. Establish =started_at= via the existing =pending_kwargs= mechanism:
+   - =_mark_pending= (threads.py:1101-1139) idle→busy: include =started_at=now= (elapsed counts from the user's submit → includes queue-wait; see R2).
+   - =create_thread_with_message= (threads.py:1051): =started_at=now= in the initializing write.
+   - =_process_message= (threads.py:808-812): =started_at = _get_status(tid).get("started_at") or now=, put in =pending_kwargs= so every busy =_set_status= (starting_sandbox/processing/queued/paused) re-persists it. =or now= fallback covers scheduled/SMS turns.
+   - Resume preserves it by construction (the =paused= status at line 954 carries =started_at=), so elapsed + timer span the pause. Terminal =ready= (line 937) drops =pending_kwargs= → =started_at= gone → timer stops.
+4. =render_thread= banner (threads.py:520-529): when busy + =started_at= present, emit =baseline_seconds= into a =<span class="elapsed" data-baseline="…">= + an inline script (near threads.py:724) that ticks locally. Absent =started_at= while busy → spinner, no timer (graceful).
+
+** Part 1 — completed-turn badges
+5. state.py — sidecar trio mirroring the conflict file: =_timings_path=, =_get_timings= (missing/corrupt→={}=, never raises), =_append_timing= (read-modify-write + =_atomic_write=). Only =_get_timings= runs on the loop (bare missing-ok read).
+6. =_process_message= success exits (threads.py:934 awaiting_approval, 937 ready): =ordinal = #HumanMessages in chat.get_raw_messages()= (thread.py:312), =seconds = now - started_at=, =_append_timing(...)=. The pause path returns early (line 955) so exactly one entry per turn across pauses.
+7. =_format_elapsed(seconds)= → "14s" | "2m 5s" | "1h 3m" (JS side a 3-line mirror).
+8. =render_thread= reverse loop (threads.py:482-518): load =timings= once; forward-pass build =index→elapsed= map by counting ="user"= dicts; attach to the *concluding assistant reply* of each turn; emit a muted =<span>= badge (threads.py:506-508). =dict.get= throughout → no entry → no badge.
+
+** Tests
+9. Unit: =_format_elapsed= boundaries; =_get_timings= missing/corrupt→={}=.
+10. Render (symptom not proxy): seed =turn_timings.json= for a 3-turn thread, assert the badge is on the CORRECT assistant bubble; busy thread with =started_at= → baseline span + script present; pre-feature thread (no sidecar) → no crash, no badge.
+11. Event-loop: =render_thread= returns promptly with the sidecar present, no lock taken. tests/test_render.py:319-348 stays green UNCHANGED (proof thread.py is untouched).
+
+* Edge cases (chosen behavior)
+- *Paused/resumed turn:* elapsed is WALL-CLOCK from human message to completion, INCLUDING pause + queue-wait (the user-meaningful "time to answer"); the scheduler's =accumulated_active_ms= is internal, not used. Timer keeps ticking through the pause. (O3 — confirm vs active-time.)
+- *Timezone:* the badge is a DURATION, never a wall-clock time → tz-irrelevant; server-computed baseline + client-local increment → no skew.
+- *Pre-feature / errored / page-reopen:* ={}=/=.get= misses → no badge, no crash; errored turn rolls back → no entry; reopen mid-turn recomputes baseline from =status.json= =started_at=.
+- *Supersede / HITL-reject loops* (threads.py:882-905): resume the same turn, no new HumanMessage → ordinal unchanged → one entry at the final success exit.
+
+* Open questions / risks
+- *O1* — shared STAGE_LABELS shortens the in-thread banner too (recommended: one source of truth; else add list-only SHORT_STAGE_LABELS).
+- *O2* — badge on =awaiting_approval= turns: recommend record + render only on plain assistant bubbles.
+- *O3* — wall-clock vs active-time for paused turns: recommend wall-clock.
+- *R1* — sidecar grows one entry/turn (threads are tens of turns; YAGNI a cap for v1).
+- *R2* — =started_at= at submit includes queue-wait behind other threads → honest "human→reply", matches the live timer; a long queue-wait shows a large elapsed even for a fast turn. Recommend include.
+- *R3* — one extra off-loop =get_state= per turn to count HumanMessages (negligible).
+- *R4* — turns in-flight at deploy have no =started_at=/entry → spinner-without-timer + no badge; self-heals next turn.
+
+* Critical files
+- manage/web/threads.py (worker + render + banner)
+- manage/web/state.py (STAGE_LABELS + sidecar trio)
+- assist/thread.py (read-only reference: get_raw_messages:312; _messages_to_dicts:30 stays untouched)
+- tests/test_render.py (must stay green unchanged; add timing render tests here or tests/test_web_timing.py)

--- a/docs/2026-07-08-message-timing-indicators.org
+++ b/docs/2026-07-08-message-timing-indicators.org
@@ -13,7 +13,7 @@ Fact: langchain =BaseMessage= has no timestamp; the langgraph checkpoint has a p
 - *LIVE (part 2):* store one =started_at= field in the existing =status.json= when a turn begins. =render_thread= embeds a *server-computed* =baseline_seconds = now - started_at=; a tiny inline JS ticks it up locally via =performance.now()= delta. No polling, no server round-trips, no clock-skew dependency (the page has NO client polling today — threads.py:1105).
 - *COMPLETED (part 1):* a per-thread sidecar =turn_timings.json= (mirrors the existing =merge_conflict.json= trio in state.py:233-289), a flat JSON object keyed by *human-message ordinal* → *seconds* (an int). (Design-review fix: NOT ={started_at, seconds}= — nothing reads a sidecar =started_at=; the badge is a pure duration and =started_at= lives in =status.json= for the live timer only. A copy here is a dead field.) Written off-loop by =_process_message= at its success exits; read on-loop by =render_thread= (one small missing-ok JSON read, exactly like =_get_status= / =_get_conflict=).
   - Rejected =AIMessage.response_metadata= (touches the model/middleware hot path + checkpoint round-trip) and checkpoint-=ts= derivation (fiddly, couples render to langgraph internals).
-  - Keyed by *human-message ordinal* (count of HumanMessages), NOT raw message index: append-only, robust to errored/pre-feature turns, keeps =assist/thread.py= =_messages_to_dicts= UNTOUCHED (render tests stay green). *Design-review fix (fix-by-construction):* count the ordinal ONE way on BOTH sides — a single shared helper over the raw =HumanMessage= list — NOT write-side raw + read-side ="user"= dicts (two counters over two representations that silently misalign if the 1:1 HumanMessage↔"user"-dict mapping ever breaks). The render pass computes an =index→seconds= map from the raw messages once, then consults it in the existing reversed loop. A render test must pin badge-on-correct-bubble across a thread containing a tool-only turn AND a review submission.
+  - Keyed by *human-message ordinal*, NOT raw message index: append-only, robust to errored/pre-feature turns, keeps =assist/thread.py= =_messages_to_dicts= UNTOUCHED (render tests stay green). *Fix-by-construction:* the ordinal is the count of ="user"=-role dicts in =chat.get_messages()=, computed by the SAME predicate on both sides — write side via =_human_ordinal(chat.get_messages())=, read side an inlined running count over the same =get_messages()= dicts. One representation + one predicate, so the two can't drift (the earlier draft said "raw HumanMessage list"; as-built both sides count the rendered ="user"= dicts). The render pass builds an =index→seconds= map from =chat.get_messages()= once, then consults it in the render loop. A render test pins badge-on-correct-bubble across a thread with a tool-only turn AND a review submission.
 - *Single-word statuses (part 3):* Pierre scoped this to the *thread-list page*. Use a list-only single-word mapping at the list call sites (threads.py:188,194); LEAVE the full =STAGE_LABELS= sentences on the in-thread banner (threads.py:523). *Design-review fix (I1):* the earlier "rewrite the shared dict in place" also shortened the in-thread banner — a surface Pierre didn't name, where the sentences carry real "why" info (esp. =paused= / =queued=). The two-line duplication is trivial and does not justify downgrading the banner. (O1 resolved: list-only.)
 
 * Why it's event-loop-safe (load-bearing — single-worker uvicorn)
@@ -24,8 +24,8 @@ Fact: langchain =BaseMessage= has no timestamp; the langgraph checkpoint has a p
 
 * Steps (Phase 2)
 ** Part 3 — single-word statuses (first; smallest, isolates a rename)
-1. state.py:321-328 — =STAGE_LABELS= values → single words: Initializing / Cloning / Starting / Queued / Processing / Paused. Keys + BUSY_STAGES/INIT_STAGES unchanged.
-2. No call-site changes (threads.py:188,194,523 already use =.get=). Set the banner fallback (threads.py:523) to a single word ("Working").
+1. state.py — add a separate =LIST_STAGE_LABELS= (single words: Initializing / Cloning / Starting / Queued / Processing / Paused); LEAVE =STAGE_LABELS= sentences unchanged (list-only per I1). Keys + BUSY_STAGES/INIT_STAGES unchanged.
+2. Point the thread-list badges (render_index, threads.py:~192,197) at =LIST_STAGE_LABELS=; the in-thread banner keeps =STAGE_LABELS= sentences.
 
 ** Part 2 — live WIP timer
 3. Establish =started_at= via the existing =pending_kwargs= mechanism:
@@ -55,7 +55,7 @@ Fact: langchain =BaseMessage= has no timestamp; the langgraph checkpoint has a p
 * Resolved by design-review (as-built decisions)
 - *O1 → list-only* (interfaces/intention I1): single words on the thread-list page only; banner keeps sentences.
 - *Sidecar value → flat =seconds=* (simplicity #1): no dead =started_at= copy.
-- *Ordinal join → one shared counter over the raw HumanMessage list* (interfaces C1 / simplicity #2), pinned by a tool-only-+-review-submission render test.
+- *Ordinal join → one counting predicate (="user"= dicts in =chat.get_messages()=) on both sides* (interfaces C1 / simplicity #2), pinned by a tool-only-+-review-submission render test.
 - *Event-loop rationale corrected* (liveness #1): safe because the field rides a pre-existing on-loop atomic write (no NEW blocking); heavy sidecar write is off-loop.
 - *C4* — =started_at= is SUBMIT time (includes queue-wait); add a one-line comment so a reader doesn't assume processing-start (or name it =submitted_at=).
 - *C5* — badge attaches to "the last =assistant=-role bubble strictly before the next =user= bubble" (no double-badge; tools-only tail gets none). O2: record on awaiting_approval, render only on plain assistant bubbles.

--- a/manage/web/state.py
+++ b/manage/web/state.py
@@ -327,6 +327,18 @@ STAGE_LABELS = {
     "paused": "Paused for a quicker turn — will resume...",
 }
 
+# Single-word variants for the compact thread-LIST page only. The in-thread banner
+# keeps the fuller STAGE_LABELS sentences — it has room and the sentence explains *why*
+# a thread is busy (esp. queued/paused). List rows are dense, so one word each reads better.
+LIST_STAGE_LABELS = {
+    "initializing": "Initializing",
+    "cloning": "Cloning",
+    "starting_sandbox": "Starting",
+    "queued": "Queued",
+    "processing": "Processing",
+    "paused": "Paused",
+}
+
 
 def _status_path(tid: str) -> str:
     return os.path.join(MANAGER.thread_dir(tid), "status.json")
@@ -352,6 +364,39 @@ def _set_status(tid: str, stage: str, **kwargs) -> None:
     # Errors don't mark (the "error" badge, above "new" in precedence, covers them).
     if stage in ("ready", "awaiting_approval"):
         _mark_unseen_response(tid)
+
+
+# --- Per-turn timing (completed human→AI elapsed) -------------------------
+# A per-thread sidecar keyed by human-message ordinal → elapsed seconds (int), the
+# durations shown as badges on completed replies. Separate from status.json (which holds
+# only the single CURRENT status and drops started_at at ready) because it must carry N
+# completed-turn durations; separate from the messages/checkpoint (langchain messages have
+# no timestamp, and stamping them would touch assist/thread.py + break the render tests).
+# Mirrors the merge_conflict.json trio: written off-loop by _process_message's success
+# exits, read on-loop by render_thread (a bare missing-ok read, no lock — same as
+# _get_status / _get_conflict). One writer per tid (THREAD_QUEUE + serial resume), and
+# _atomic_write makes a concurrent render-read see the whole old or whole new file.
+def _timings_path(tid: str) -> str:
+    return os.path.join(MANAGER.thread_dir(tid), "turn_timings.json")
+
+
+def _get_timings(tid: str) -> dict:
+    """Map of human-message ordinal (str) → elapsed seconds (int). {} if missing/corrupt."""
+    path = _timings_path(tid)
+    if not os.path.isfile(path):
+        return {}
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def _append_timing(tid: str, ordinal: int, seconds: float) -> None:
+    """Record one completed turn's elapsed. Read-modify-write of the small dict; off-loop."""
+    timings = _get_timings(tid)
+    timings[str(ordinal)] = round(seconds)
+    _atomic_write(_timings_path(tid), json.dumps(timings))
 
 
 # --- "unseen AI response" badge state -------------------------------------

--- a/manage/web/state.py
+++ b/manage/web/state.py
@@ -392,7 +392,11 @@ def _get_timings(tid: str) -> dict:
     try:
         with open(path) as f:
             data = json.load(f)
-        return data if isinstance(data, dict) else {}
+        if not isinstance(data, dict):
+            return {}
+        # Enforce the {ordinal: number} contract so a malformed value (e.g. {"1": "oops"})
+        # can't reach _format_elapsed's int(round(...)) and crash the on-loop render.
+        return {k: v for k, v in data.items() if isinstance(v, (int, float))}
     except Exception:
         return {}
 

--- a/manage/web/state.py
+++ b/manage/web/state.py
@@ -381,13 +381,18 @@ def _timings_path(tid: str) -> str:
 
 
 def _get_timings(tid: str) -> dict:
-    """Map of human-message ordinal (str) → elapsed seconds (int). {} if missing/corrupt."""
+    """Map of human-message ordinal (str) → elapsed seconds (int). {} if missing/corrupt.
+
+    Validates the parsed value is a dict: a syntactically-valid but wrong-shaped file
+    (a bare number/bool/list/string) parses fine but would break the on-loop render's
+    ``str(ord) in timings`` / index — so anything non-dict degrades to {} (no badges)."""
     path = _timings_path(tid)
     if not os.path.isfile(path):
         return {}
     try:
         with open(path) as f:
-            return json.load(f)
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
     except Exception:
         return {}
 

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -1036,11 +1036,12 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
         if dm and dm.changes():
             last_assistant = resp if resp else "assistant update"
             dm.sync(last_assistant)
-        # The turn may have paused on a send_reply HITL interrupt (the agent proposed a
-        # reply). Surface it for approval instead of marking the turn done.
-        # Record this turn's wall-clock elapsed (submit → completion) keyed by turn
-        # ordinal, for the completed-reply badge. Off-loop; the pause path returns before
-        # here, so exactly one entry is written per turn (at its final completion).
+        # Record this turn's wall-clock elapsed (submit → completion) keyed by turn ordinal,
+        # for the completed-reply badge. Off-loop. Runs at BOTH success exits below (ready
+        # and awaiting_approval), keyed by the turn ordinal — so a HITL turn records
+        # human→proposal here, then the approve resume (started_at preserved, same ordinal)
+        # overwrites it with human→final-reply. The quantum-pause path returns earlier
+        # (ThreadPauseRequested) without reaching here, so a paused slice records nothing.
         try:
             _append_timing(tid, _human_ordinal(chat.get_messages()),
                            (_now_ms() - started_at) / 1000.0)

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -18,6 +18,7 @@ import re
 import secrets
 import subprocess
 import threading
+import time
 import urllib.parse
 from datetime import datetime, timezone
 
@@ -63,6 +64,8 @@ from manage.web.state import (
     SCHEDULE_STORE,
     SUBSCRIPTION_STORE,
     STAGE_LABELS,
+    LIST_STAGE_LABELS,
+    _append_timing,
     _clear_conflict,
     _domain_selector_html,
     _evict_caches,
@@ -70,6 +73,7 @@ from manage.web.state import (
     _get_domain_manager,
     _get_sandbox_backend,
     _get_status,
+    _get_timings,
     _has_unmerged_changes,
     _has_unseen_response,
     _clear_unseen_response,
@@ -185,13 +189,13 @@ def render_index(query: str = "") -> str:
             badge = (
                 f'<span style="font-size:.7rem; color:#6b7280; background:#fafafa;'
                 f' border:1px solid #e5e7eb; padding:.1rem .4rem; border-radius:10px;'
-                f' margin-right:.4rem;">{html.escape(STAGE_LABELS.get(stage, stage))}</span>'
+                f' margin-right:.4rem;">{html.escape(LIST_STAGE_LABELS.get(stage, stage))}</span>'
             )
         elif stage in BUSY_STAGES:
             badge = (
                 f'<span style="font-size:.7rem; color:#6b7280; background:#fafafa;'
                 f' border:1px solid #e5e7eb; padding:.1rem .4rem; border-radius:10px;'
-                f' margin-right:.4rem;">{html.escape(STAGE_LABELS.get(stage, stage))}</span>'
+                f' margin-right:.4rem;">{html.escape(LIST_STAGE_LABELS.get(stage, stage))}</span>'
             )
         elif stage == "error":
             badge = (
@@ -355,6 +359,53 @@ def _tools_summary(names) -> str:
     return html.escape(", ".join(seen)) if seen else "tool call"
 
 
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _format_elapsed(seconds: float) -> str:
+    """Human duration for a timing badge: "14s" | "2m 5s" | "1h 3m". Mirrored by the
+    JS ticker in _ELAPSED_TICKER_SCRIPT — keep the two boundary rules in sync (tested)."""
+    s = max(0, int(round(seconds)))
+    if s < 60:
+        return f"{s}s"
+    m, s = divmod(s, 60)
+    if m < 60:
+        return f"{m}m {s}s"
+    h, m = divmod(m, 60)
+    return f"{h}h {m}m"
+
+
+def _human_ordinal(msgs: list[dict]) -> int:
+    """The turn ordinal = count of user-role bubbles. Counted the SAME way (over
+    chat.get_messages() dicts) on the write side (recording) and the read side
+    (badge placement), so the two can't drift — the design's single-counter rule."""
+    return sum(1 for m in msgs if m.get("role") == "user")
+
+
+# Live WIP timer: a page renders once (no polling), so the server emits a baseline
+# elapsed and JS ticks it up locally via performance.now() — no server round-trip, no
+# clock-skew. Formatting mirrors _format_elapsed. Safe if no .elapsed node is present.
+_ELAPSED_TICKER_SCRIPT = """<script>
+(function () {
+  var el = document.querySelector('.status-banner .elapsed');
+  if (!el) return;
+  var base = parseInt(el.getAttribute('data-baseline') || '0', 10) || 0;
+  var t0 = performance.now();
+  function fmt(s) {
+    s = Math.max(0, Math.round(s));
+    if (s < 60) return s + 's';
+    var m = Math.floor(s / 60), r = s % 60;
+    if (m < 60) return m + 'm ' + r + 's';
+    var h = Math.floor(m / 60); return h + 'h ' + (m % 60) + 'm';
+  }
+  function tick() { el.textContent = fmt(base + (performance.now() - t0) / 1000); }
+  tick();
+  setInterval(tick, 1000);
+})();
+</script>"""
+
+
 def render_thread(
     tid: str,
     chat: Thread | None,
@@ -400,6 +451,22 @@ def render_thread(
 
     # During the initial setup stages there is no agent state worth showing yet.
     msgs: list[dict] = [] if is_init or chat is None else chat.get_messages()
+
+    # Completed-turn elapsed badges: map each turn's CONCLUDING assistant bubble (the last
+    # assistant strictly before the next user bubble) to its recorded elapsed seconds.
+    # Built over the PERSISTED messages here — before the pending bubble is appended below,
+    # and the append doesn't shift these indices. Keyed by the same user-bubble ordinal the
+    # write side records (_human_ordinal). dict miss → pre-feature/errored turn → no badge.
+    _timings = _get_timings(tid)
+    _badge_at: dict[int, int] = {}
+    if _timings:
+        _ord = 0
+        for _i, _m in enumerate(msgs):
+            _r = _m.get("role")
+            if _r == "user":
+                _ord += 1
+            elif _r == "assistant" and _ord and str(_ord) in _timings:
+                _badge_at[_i] = _timings[str(_ord)]  # overwrites → ends as the LAST one
 
     # While busy, surface the pending (just-submitted) message as a user
     # bubble so it's visible right after the redirect — unless the agent has
@@ -480,7 +547,7 @@ def render_thread(
         """
 
     rendered = []
-    for m in reversed(msgs):
+    for _i, m in reversed(list(enumerate(msgs))):
         role = html.escape(m.get("role", ""))
         raw = str(m.get("content", ""))
         if role == "assistant":
@@ -504,7 +571,14 @@ def render_thread(
                       f'<div class="content">{content_html}</div></details>')
         else:
             cls = "user" if role == "user" else "assistant"
-            bubble = (f'<div class="msg {cls}"><div class="role">{role}</div>'
+            # Completed-turn elapsed badge on the turn's concluding assistant reply.
+            badge = ""
+            if role == "assistant" and _i in _badge_at:
+                badge = (f'<span class="elapsed-badge" title="time from your message to '
+                         f'this reply" style="margin-left:.5rem; color:#9ca3af; '
+                         f'font-size:.75rem; font-weight:normal;">'
+                         f'{html.escape(_format_elapsed(_badge_at[_i]))}</span>')
+            bubble = (f'<div class="msg {cls}"><div class="role">{role}{badge}</div>'
                       f'<div class="content">{content_html}</div></div>')
         rendered.append(bubble)
     if busy:
@@ -517,15 +591,24 @@ def render_thread(
         )
     body = "\n".join(rendered) or "<p><em>No messages yet.</em></p>"
 
-    # Status banner
+    # Status banner (in-thread: keeps the fuller STAGE_LABELS sentence). While busy, a live
+    # elapsed timer counts from the turn's submit — server emits the baseline, JS ticks it.
     status_banner = ""
     if busy:
         label = STAGE_LABELS.get(stage, "Working...")
+        elapsed_span = ""
+        started_at = status.get("started_at")
+        if started_at:
+            baseline = max(0, (_now_ms() - started_at) // 1000)
+            elapsed_span = (f'<span class="elapsed" data-baseline="{baseline}" '
+                            f'style="margin-left:.5rem; color:#9ca3af; font-size:.8rem;"></span>')
         status_banner = (
             f'<div class="status-banner">'
             f'<span class="spinner"></span>'
             f'<span>{html.escape(label)}</span>'
+            f'{elapsed_span}'
             f'</div>'
+            f'{_ELAPSED_TICKER_SCRIPT if elapsed_span else ""}'
         )
     elif stage == "error":
         err = html.escape(status.get("error", "Unknown error"))
@@ -807,6 +890,14 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
     # survives the pause window instead of vanishing until the turn completes.
     _pending_msg = text if text else pending_text
     pending_kwargs = {"pending_message": _pending_msg} if _pending_msg else {}
+    # Turn-start origin for the elapsed badge + live WIP timer: reuse the started_at already
+    # in status (a queued/paused/resumed turn keeps the original submit time, so elapsed
+    # spans the queue wait + any pause) or stamp now for turns with no upstream setter
+    # (scheduled/SMS). Carried through every BUSY _set_status via pending_kwargs; the
+    # terminal ready/awaiting_approval writes omit pending_kwargs, so it clears and the
+    # live timer stops.
+    started_at = _get_status(tid).get("started_at") or _now_ms()
+    pending_kwargs["started_at"] = started_at
     # The pending draft's sender, captured NOW before any _set_status below overwrites it —
     # used by the supersede path to decide whether a new message folds into the pending reply.
     prior_pending_sender = _get_status(tid).get("pending_sender") or ""
@@ -929,6 +1020,14 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
             dm.sync(last_assistant)
         # The turn may have paused on a send_reply HITL interrupt (the agent proposed a
         # reply). Surface it for approval instead of marking the turn done.
+        # Record this turn's wall-clock elapsed (submit → completion) keyed by turn
+        # ordinal, for the completed-reply badge. Off-loop; the pause path returns before
+        # here, so exactly one entry is written per turn (at its final completion).
+        try:
+            _append_timing(tid, _human_ordinal(chat.get_messages()),
+                           (_now_ms() - started_at) / 1000.0)
+        except Exception as e:
+            logging.warning("turn-timing record failed for %s: %s", tid, e)
         pending = chat.pending_reply()
         if pending:
             _set_status(tid, "awaiting_approval",
@@ -1048,7 +1147,8 @@ async def create_thread_with_message(
     chat = MANAGER.new()
     tid = chat.thread_id
     selected = domain or (DOMAINS[0] if DOMAINS else None)
-    _set_status(tid, "initializing", pending_message=text, domain=selected or "")
+    _set_status(tid, "initializing", pending_message=text, domain=selected or "",
+                started_at=_now_ms())
     background_tasks.add_task(_initialize_thread, tid, text, selected,
                              _build_rider(sent_at, tz, lat, lon))
     return RedirectResponse(url=f"/thread/{tid}", status_code=303)
@@ -1136,7 +1236,10 @@ def _mark_pending(tid: str, text: str) -> None:
         return
     holder_tid = THREAD_QUEUE.peek_holder()
     stage = "queued" if (holder_tid is not None and holder_tid != tid) else "processing"
-    _set_status(tid, stage, pending_message=text)
+    # Stamp the turn-start origin at submit (this is the idle→busy edge — the guard above
+    # returns for an already-busy thread, so we never reset a mid-turn turn's clock).
+    # _now_ms() is a bare time read — event-loop-safe, no I/O/lock (see the docstring).
+    _set_status(tid, stage, pending_message=text, started_at=_now_ms())
 
 
 def _build_rider(sent_at: str | None, tz: str | None,

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -461,16 +461,23 @@ def render_thread(
     _timings = _get_timings(tid)
     badge_at: dict[int, int] = {}
     if _timings:
+        # Attach each turn's elapsed to ONLY its concluding assistant bubble — the LAST
+        # content-only assistant before the next user. Tracking the last index per turn (vs
+        # marking every assistant) avoids a double-badge when a turn has >1 content assistant
+        # (e.g. a retry / empty-response recovery emits two).
         _ord = 0
+        _last = None
         for _i, _m in enumerate(msgs):
             _r = _m.get("role")
             if _r == "user":
+                if _last is not None and str(_ord) in _timings:
+                    badge_at[_last] = _timings[str(_ord)]  # close the turn that just ended
                 _ord += 1
-            elif _r == "assistant" and _ord and str(_ord) in _timings:
-                # Keyed by message index; a turn has exactly one content-only assistant
-                # bubble (_messages_to_dicts routes tool-call AIMessages to "tools"), so
-                # this marks that turn's single concluding reply — no double-badging.
-                badge_at[_i] = _timings[str(_ord)]
+                _last = None
+            elif _r == "assistant":
+                _last = _i
+        if _last is not None and str(_ord) in _timings:
+            badge_at[_last] = _timings[str(_ord)]  # close the final turn
 
     # While busy, surface the pending (just-submitted) message as a user
     # bubble so it's visible right after the redirect — unless the agent has

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -364,8 +364,9 @@ def _now_ms() -> int:
 
 
 def _format_elapsed(seconds: float) -> str:
-    """Human duration for a timing badge: "14s" | "2m 5s" | "1h 3m". Mirrored by the
-    JS ticker in _ELAPSED_TICKER_SCRIPT — keep the two boundary rules in sync (tested)."""
+    """Human duration for a timing badge: "14s" | "2m 5s" | "1h 3m". The JS ticker in
+    _ELAPSED_TICKER_SCRIPT is a hand-kept mirror — keep its boundary rules identical to
+    this (this Python side is unit-tested; the JS copy is not run in tests)."""
     s = max(0, int(round(seconds)))
     if s < 60:
         return f"{s}s"
@@ -458,7 +459,7 @@ def render_thread(
     # and the append doesn't shift these indices. Keyed by the same user-bubble ordinal the
     # write side records (_human_ordinal). dict miss → pre-feature/errored turn → no badge.
     _timings = _get_timings(tid)
-    _badge_at: dict[int, int] = {}
+    badge_at: dict[int, int] = {}
     if _timings:
         _ord = 0
         for _i, _m in enumerate(msgs):
@@ -466,7 +467,10 @@ def render_thread(
             if _r == "user":
                 _ord += 1
             elif _r == "assistant" and _ord and str(_ord) in _timings:
-                _badge_at[_i] = _timings[str(_ord)]  # overwrites → ends as the LAST one
+                # Keyed by message index; a turn has exactly one content-only assistant
+                # bubble (_messages_to_dicts routes tool-call AIMessages to "tools"), so
+                # this marks that turn's single concluding reply — no double-badging.
+                badge_at[_i] = _timings[str(_ord)]
 
     # While busy, surface the pending (just-submitted) message as a user
     # bubble so it's visible right after the redirect — unless the agent has
@@ -573,11 +577,11 @@ def render_thread(
             cls = "user" if role == "user" else "assistant"
             # Completed-turn elapsed badge on the turn's concluding assistant reply.
             badge = ""
-            if role == "assistant" and _i in _badge_at:
+            if role == "assistant" and _i in badge_at:
                 badge = (f'<span class="elapsed-badge" title="time from your message to '
                          f'this reply" style="margin-left:.5rem; color:#9ca3af; '
                          f'font-size:.75rem; font-weight:normal;">'
-                         f'{html.escape(_format_elapsed(_badge_at[_i]))}</span>')
+                         f'{html.escape(_format_elapsed(badge_at[_i]))}</span>')
             bubble = (f'<div class="msg {cls}"><div class="role">{role}{badge}</div>'
                       f'<div class="content">{content_html}</div></div>')
         rendered.append(bubble)
@@ -847,7 +851,11 @@ def _initialize_thread(tid: str, text: str, domain: str | None,
     """Background task: clone the repo, start sandbox, process the first message."""
     try:
         if domain:
-            _set_status(tid, "cloning", pending_message=text, domain=domain)
+            # Carry started_at through the cloning write (_set_status is a full replace):
+            # otherwise a domain thread's elapsed baseline resets at clone-completion,
+            # excluding the clone+init the user has been waiting through since submit.
+            _set_status(tid, "cloning", pending_message=text, domain=domain,
+                        started_at=_get_status(tid).get("started_at"))
             try:
                 dm = DomainManager(
                     MANAGER.thread_default_working_dir(tid),
@@ -989,7 +997,8 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
                                             "%s; new message archived but not triaged this turn", tid)
                             _set_status(tid, "awaiting_approval",
                                         pending_reply=chat.pending_reply().get("text", ""),
-                                        pending_sender=prior_pending_sender)
+                                        pending_sender=prior_pending_sender,
+                                        started_at=started_at)
                             return
                         if same_sender:
                             text = _SUPERSEDE_RIDER + text
@@ -1030,8 +1039,12 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
             logging.warning("turn-timing record failed for %s: %s", tid, e)
         pending = chat.pending_reply()
         if pending:
+            # Preserve started_at so the HITL approve/reject resume reuses the original
+            # submit time — the approved reply's badge then shows human→final-reply, not
+            # the approval-reaction latency (the resume re-records this turn's ordinal).
             _set_status(tid, "awaiting_approval",
-                        pending_reply=pending.get("text", ""), pending_sender=sender or "")
+                        pending_reply=pending.get("text", ""), pending_sender=sender or "",
+                        started_at=started_at)
         else:
             _set_status(tid, "ready")
     except ThreadPauseRequested:

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -902,9 +902,10 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
     # Turn-start origin for the elapsed badge + live WIP timer: reuse the started_at already
     # in status (a queued/paused/resumed turn keeps the original submit time, so elapsed
     # spans the queue wait + any pause) or stamp now for turns with no upstream setter
-    # (scheduled/SMS). Carried through every BUSY _set_status via pending_kwargs; the
-    # terminal ready/awaiting_approval writes omit pending_kwargs, so it clears and the
-    # live timer stops.
+    # (scheduled/SMS). Carried through every BUSY _set_status via pending_kwargs. The
+    # terminal `ready` write omits it → it clears and the live timer stops; `awaiting_approval`
+    # explicitly re-passes it (started_at=started_at below) so a HITL approve reuses the
+    # original submit time (awaiting_approval isn't BUSY, so no timer renders meanwhile).
     started_at = _get_status(tid).get("started_at") or _now_ms()
     pending_kwargs["started_at"] = started_at
     # The pending draft's sender, captured NOW before any _set_status below overwrites it —

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -551,7 +551,8 @@ def render_thread(
         """
 
     rendered = []
-    for _i, m in reversed(list(enumerate(msgs))):
+    for _i in range(len(msgs) - 1, -1, -1):
+        m = msgs[_i]
         role = html.escape(m.get("role", ""))
         raw = str(m.get("content", ""))
         if role == "assistant":

--- a/tests/test_web_timing.py
+++ b/tests/test_web_timing.py
@@ -1,0 +1,101 @@
+"""Message-timing indicators (web UI): completed-turn elapsed badges + live WIP timer.
+
+Symptom-level render tests (per CLAUDE.md): render the actual HTML and assert the badge
+lands on the CORRECT assistant bubble, the live timer is present when busy, and a
+pre-feature thread (no sidecar) renders with no badge and no crash. Plus the sidecar
+read/write round-trip and the formatter boundaries.
+"""
+import pytest
+
+from manage.web import state as st
+from manage.web import threads as th
+from manage.web.threads import _format_elapsed, _human_ordinal, render_thread
+
+
+def test_format_elapsed_boundaries():
+    assert _format_elapsed(0) == "0s"
+    assert _format_elapsed(14) == "14s"
+    assert _format_elapsed(59) == "59s"
+    assert _format_elapsed(60) == "1m 0s"
+    assert _format_elapsed(125) == "2m 5s"
+    assert _format_elapsed(3600) == "1h 0m"
+    assert _format_elapsed(3785) == "1h 3m"
+
+
+def test_get_timings_missing_and_corrupt(tmp_path, monkeypatch):
+    d = tmp_path / "t"
+    d.mkdir()
+    monkeypatch.setattr(st.MANAGER, "thread_dir", lambda tid: str(d))
+    assert st._get_timings("t") == {}          # missing → {}
+    (d / "turn_timings.json").write_text("{ not json")
+    assert st._get_timings("t") == {}          # corrupt → {} (never raises)
+    st._append_timing("t", 1, 14.4)
+    st._append_timing("t", 2, 125.6)
+    assert st._get_timings("t") == {"1": 14, "2": 126}  # rounded ints
+
+
+def test_human_ordinal_counts_user_bubbles():
+    msgs = [{"role": "user"}, {"role": "assistant"}, {"role": "tools"},
+            {"role": "user"}, {"role": "assistant"}]
+    assert _human_ordinal(msgs) == 2
+
+
+class _FakeThread:
+    def __init__(self, msgs):
+        self._m = msgs
+
+    def get_messages(self):
+        return self._m
+
+
+@pytest.fixture
+def thread_env(tmp_path, monkeypatch):
+    d = tmp_path / "t1"
+    d.mkdir()
+    monkeypatch.setattr(st.MANAGER, "thread_dir", lambda tid: str(d))
+    # render_thread derives the title (would otherwise hit the model) — stub it.
+    monkeypatch.setattr(th, "_thread_title", lambda tid: "Test thread")
+    return "t1"
+
+
+def _two_turns():
+    # Turn 1: q1 → a1. Turn 2: q2 → (tool bubble) → a2 (the concluding reply).
+    return [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "ANSWER-ONE"},
+        {"role": "user", "content": "q2"},
+        {"role": "tools", "content": "did a thing", "names": ["read_url"]},
+        {"role": "assistant", "content": "ANSWER-TWO"},
+    ]
+
+
+def test_badge_lands_on_the_correct_assistant_bubble(thread_env):
+    st._set_status("t1", "ready")
+    st._append_timing("t1", 1, 14)
+    st._append_timing("t1", 2, 125)
+    html = render_thread("t1", _FakeThread(_two_turns()))
+    assert html.count("elapsed-badge") == 2
+    # Rendered newest-first: turn-2 bubble (2m 5s + ANSWER-TWO) before turn-1 (14s + ANSWER-ONE).
+    # This ordering pins each badge to ITS turn's reply, not just "both appear somewhere".
+    assert html.index("2m 5s") < html.index("ANSWER-TWO") < html.index("14s") < html.index("ANSWER-ONE")
+
+
+def test_no_sidecar_renders_no_badge_and_does_not_crash(thread_env):
+    st._set_status("t1", "ready")  # no _append_timing → no turn_timings.json
+    html = render_thread("t1", _FakeThread(_two_turns()))
+    assert "elapsed-badge" not in html
+    assert "ANSWER-ONE" in html and "ANSWER-TWO" in html  # still renders the conversation
+
+
+def test_busy_thread_shows_live_timer_with_baseline_and_ticker(thread_env):
+    st._set_status("t1", "processing", started_at=th._now_ms() - 5000)  # 5s ago
+    html = render_thread("t1", _FakeThread(_two_turns()))
+    assert 'class="elapsed"' in html            # the ticking span
+    assert 'data-baseline="5"' in html          # server-computed baseline (~5s)
+    assert "setInterval" in html                # the JS ticker is included
+
+
+def test_busy_without_started_at_degrades_to_spinner_no_timer(thread_env):
+    st._set_status("t1", "processing")          # pre-feature in-flight turn: no started_at
+    html = render_thread("t1", _FakeThread(_two_turns()))
+    assert "status-banner" in html and 'class="elapsed"' not in html

--- a/tests/test_web_timing.py
+++ b/tests/test_web_timing.py
@@ -80,6 +80,25 @@ def test_badge_lands_on_the_correct_assistant_bubble(thread_env):
     assert html.index("2m 5s") < html.index("ANSWER-TWO") < html.index("14s") < html.index("ANSWER-ONE")
 
 
+def test_badge_ordinal_counts_a_review_submission_as_a_user_turn(thread_env):
+    # A review submission renders as a "user" bubble (different render branch, same role),
+    # so the ordinal count must include it and the badge must land on ITS reply — the
+    # design's C1 "span a review submission" case.
+    from manage.web.review import _REVIEW_HEADER
+    msgs = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "ANSWER-ONE"},
+        {"role": "user", "content": _REVIEW_HEADER + "\nlooks good, ship it"},
+        {"role": "assistant", "content": "ANSWER-REVIEW"},
+    ]
+    st._set_status("t1", "ready")
+    st._append_timing("t1", 1, 10)
+    st._append_timing("t1", 2, 200)  # the review turn is ordinal 2
+    html = render_thread("t1", _FakeThread(msgs))
+    assert html.count("elapsed-badge") == 2
+    assert html.index("3m 20s") < html.index("ANSWER-REVIEW") < html.index("10s") < html.index("ANSWER-ONE")
+
+
 def test_no_sidecar_renders_no_badge_and_does_not_crash(thread_env):
     st._set_status("t1", "ready")  # no _append_timing → no turn_timings.json
     html = render_thread("t1", _FakeThread(_two_turns()))

--- a/tests/test_web_timing.py
+++ b/tests/test_web_timing.py
@@ -99,6 +99,22 @@ def test_badge_ordinal_counts_a_review_submission_as_a_user_turn(thread_env):
     assert html.index("3m 20s") < html.index("ANSWER-REVIEW") < html.index("10s") < html.index("ANSWER-ONE")
 
 
+def test_badge_only_on_last_assistant_when_a_turn_has_multiple(thread_env):
+    # A single turn can produce >1 content-only assistant bubble (a retry / empty-response
+    # recovery). Only the LAST (concluding) reply gets the badge — no double-badge.
+    msgs = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "FIRST-DRAFT"},
+        {"role": "assistant", "content": "FINAL-ANSWER"},
+    ]
+    st._set_status("t1", "ready")
+    st._append_timing("t1", 1, 30)
+    html = render_thread("t1", _FakeThread(msgs))
+    assert html.count("elapsed-badge") == 1                       # not two
+    # Rendered newest-first: FINAL-ANSWER (with the 30s badge) then FIRST-DRAFT (no badge).
+    assert html.index("30s") < html.index("FINAL-ANSWER") < html.index("FIRST-DRAFT")
+
+
 def test_no_sidecar_renders_no_badge_and_does_not_crash(thread_env):
     st._set_status("t1", "ready")  # no _append_timing → no turn_timings.json
     html = render_thread("t1", _FakeThread(_two_turns()))

--- a/tests/test_web_timing.py
+++ b/tests/test_web_timing.py
@@ -106,12 +106,26 @@ def test_no_sidecar_renders_no_badge_and_does_not_crash(thread_env):
     assert "ANSWER-ONE" in html and "ANSWER-TWO" in html  # still renders the conversation
 
 
-def test_busy_thread_shows_live_timer_with_baseline_and_ticker(thread_env):
-    st._set_status("t1", "processing", started_at=th._now_ms() - 5000)  # 5s ago
+def test_busy_thread_shows_live_timer_with_baseline_and_ticker(thread_env, monkeypatch):
+    # Freeze the clock so the baseline is deterministic (real wall-clock would let a slow
+    # render floor to 6+ under load — the flaky assertion Copilot flagged).
+    monkeypatch.setattr(th, "_now_ms", lambda: 1_000_000)
+    st._set_status("t1", "processing", started_at=1_000_000 - 5000)  # exactly 5s ago
     html = render_thread("t1", _FakeThread(_two_turns()))
     assert 'class="elapsed"' in html            # the ticking span
-    assert 'data-baseline="5"' in html          # server-computed baseline (~5s)
+    assert 'data-baseline="5"' in html          # server-computed baseline (deterministic)
     assert "setInterval" in html                # the JS ticker is included
+
+
+def test_get_timings_ignores_valid_but_non_dict_json(tmp_path, monkeypatch):
+    # A syntactically-valid but wrong-shaped file must degrade to {} (no badges), not
+    # crash the on-loop render on `str(ord) in timings` / indexing.
+    d = tmp_path / "t"
+    d.mkdir()
+    monkeypatch.setattr(st.MANAGER, "thread_dir", lambda tid: str(d))
+    for bad in ("5", "true", "[]", '"oops"', "null"):
+        (d / "turn_timings.json").write_text(bad)
+        assert st._get_timings("t") == {}
 
 
 def test_busy_without_started_at_degrades_to_spinner_no_timer(thread_env):

--- a/tests/test_web_timing.py
+++ b/tests/test_web_timing.py
@@ -126,6 +126,9 @@ def test_get_timings_ignores_valid_but_non_dict_json(tmp_path, monkeypatch):
     for bad in ("5", "true", "[]", '"oops"', "null"):
         (d / "turn_timings.json").write_text(bad)
         assert st._get_timings("t") == {}
+    # A dict is fine, but non-numeric VALUES are dropped (they'd crash _format_elapsed):
+    (d / "turn_timings.json").write_text('{"1": 14, "2": "oops", "3": null}')
+    assert st._get_timings("t") == {"1": 14}
 
 
 def test_busy_without_started_at_degrades_to_spinner_no_timer(thread_env):


### PR DESCRIPTION
## What
Three web-UI additions:
1. **Elapsed badge** on each completed AI reply (time from your message to the reply).
2. **Live timer** on in-progress turns (ticks from submit; through queue-wait + pauses).
3. **Single-word statuses** on the thread-**list** page (the in-thread banner keeps its fuller sentences).

## How (smallest change; agent/checkpoint hot path untouched)
- **Live timer**: `started_at` stamped in `status.json` at submit, carried through the busy stages, dropped at `ready`/`awaiting_approval`. `render_thread` emits a server-computed baseline; an inline JS ticker increments it locally (`performance.now()` delta) — no polling, no clock-skew.
- **Completed badges**: a per-thread `turn_timings.json` sidecar (mirrors the `merge_conflict.json` trio), keyed by human-message ordinal → elapsed seconds. Written off-loop at `_process_message`'s success exits; read on-loop by `render_thread` (a bare missing-ok read, like `_get_status`). The ordinal is counted the same way (`role=="user"` over `chat.get_messages()`) on write + read, so they can't drift. `assist/thread.py` is untouched, so the exact-equality render tests stay green.
- **List statuses**: `LIST_STAGE_LABELS` (single words) at the list call sites only.

## Design + review
- Design doc: `docs/2026-07-08-message-timing-indicators.org` (3-lens design-review, 0 blockers — folded: dropped a dead sidecar field, unified the ordinal counter, corrected the event-loop rationale, list-only labels).
- Code-review team (event-loop + correctness; simplicity + design-adherence): 0 blockers, 2 IMPORTANT (both fixed) — `started_at` was dropped by the full-replace `_set_status` on the `cloning` and `awaiting_approval` writes (domain-thread + HITL-approve wrong-elapsed); now carried through. Event-loop lens clean (no new on-loop lock/blocking).

## Tests
8 web-timing tests incl. a symptom-level badge-on-correct-bubble assertion (spanning a tool-only turn + a review submission), the live timer, and graceful degradation (pre-feature thread → no badge, no crash). 1011 total green.

## Known limitation
No client polling today, so the live timer keeps ticking after completion until the page is reloaded (moot — the reply only appears on reload anyway, where it snaps to the frozen badge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)