### PR TITLE
Research resilience: honest partial-results on rate-limiting + non-redundant dispatch

### DIFF
--- a/assist/agent.py
+++ b/assist/agent.py
@@ -643,21 +643,23 @@ def create_research_agent(model: BaseChatModel,
     # The orchestrator DELEGATES searching to the research-agent (see its
     # prompt) — it does not search directly.  Giving it search_internet too
     # was redundant and doubled the over-search (orchestrator-direct +
-    # inner agent both ran capped search passes).  It keeps read_url for
-    # reading specific URLs while writing/fact-checking the report.
+    # inner agent both ran capped search passes).  It holds NO retrieval tools
+    # at all: it is a pure Manager (decompose -> dispatch searcher(s) ->
+    # synthesize the report), and the searcher + fact-check sub-agents are the
+    # only layers that read_url.  This removes the orchestrator's URL-fabrication
+    # surface entirely (it cannot 404-loop on a guessed URL if it has no read_url)
+    # and enforces clean delegation instead of the orchestrator doing worker work.
     agent = create_deep_agent(
         model=model,
-        tools=[read_url],
+        tools=[],
         checkpointer=checkpointer or InMemorySaver(),
         system_prompt=base_prompt_for("deepagents/research_instructions.txt.j2",
                                       workspace_dir=workspace_dir),
         backend=backend,
-        # Same read_url guard pair as the sub-agents (see _read_url_guards): the
-        # orchestrator has its OWN read_url and would otherwise 404-loop on fabricated
-        # URLs under search-unavailable. Guidance (research_instructions.txt.j2) tells it
-        # to STOP when it has no sources rather than re-dispatch (what the old exclusion
-        # feared). logging_mw stays innermost/last.
-        middleware=base_mw + middleware + _read_url_guards() + [logging_mw],
+        # No _read_url_guards here: the orchestrator has no read_url to guard.
+        # The searcher + fact-check sub-agents carry those guards themselves.
+        # logging_mw stays innermost/last.
+        middleware=base_mw + middleware + [logging_mw],
         subagents=[critique_sub_agent,
                    research_sub_agent,
                    fact_check_sub_agent]

--- a/assist/agent.py
+++ b/assist/agent.py
@@ -457,14 +457,13 @@ def create_context_agent(model: BaseChatModel,
 
 def _read_url_guards():
     """The guard pair every read_url-bearing research agent gets, in one place so the
-    three sites can't drift.
+    two sites can't drift.
 
     - UrlProvenanceMiddleware: refuse read_url on a URL absent from prior tool/user
-      messages (a fabrication). Wired on the searcher, the fact-checker, AND the
-      orchestrator: thread 20260708090812 showed the un-guarded orchestrator, under
-      search-unavailable, guessing plausible URLs and 404-looping ~90 min. The searcher's
-      findings reach the orchestrator as a task ToolMessage, so real search-sourced URLs
-      pass while fabrications are refused. See docs/2026-07-08-research-reread-runaway.org.
+      messages (a fabrication). Wired on the searcher and the fact-checker — the two
+      read_url-bearing sub-agents. The orchestrator has no read_url (V2: it delegates all
+      fetching), so it needs no guard: it can't 404-loop on a guessed URL it can't fetch.
+      See docs/2026-07-08-research-reread-runaway.org.
     - ReadUrlRereadBreaker: refuse re-reading the SAME url past max_reads (the 2026-07-07
       peptides real-URL re-read shape).
     """
@@ -568,10 +567,6 @@ def create_research_agent(model: BaseChatModel,
         backend = create_sandbox_composite_backend(references_sandbox)
     else:
         backend = create_references_backend(working_dir)
-    # Offload large read_url results on the orchestrator too (it reads specific URLs
-    # while writing/fact-checking).  backend is only available here, after references
-    # routing is set up, so append rather than build into base_mw above.
-    base_mw.append(ToolResultToFileMiddleware(backend, tools={"read_url"}, floor_chars=4000))
     logging_mw = ModelLoggingMiddleware("research-agent")
 
     # Safety middleware installed on every dict-spec subagent below.

--- a/assist/middleware/search_unavailable_breaker.py
+++ b/assist/middleware/search_unavailable_breaker.py
@@ -48,8 +48,8 @@ from langgraph.types import Command
 
 # Import the EXACT constant (single source of truth) so a wording change in
 # tools.py can't silently desync this breaker.  Only the string constant is
-# imported — never tools.py's blocking helpers (this hook runs inline on the
-# event-loop thread; it must stay pure CPU).
+# imported — never tools.py's blocking helpers (this hook runs on the research
+# BackgroundTask worker; keeping it pure CPU avoids adding I/O to that path).
 from assist.tools import _SEARCH_UNAVAILABLE_MESSAGE
 # Share loop detection's per-turn event extraction (windowless here — we want
 # the cumulative full-turn count).  Same import precedent as

--- a/assist/middleware/search_unavailable_breaker.py
+++ b/assist/middleware/search_unavailable_breaker.py
@@ -21,12 +21,16 @@ this a coarse REAL bound, not the ambiguous-signal heuristic that loop detection
 was deliberately rolled back to avoid — so it stays a separate, isolable
 middleware rather than a new branch in ``_detect_loop``.
 
-Mechanism mirrors ``LoopDetectionMiddleware.after_model`` exactly (the
-established clean turn-ender in this stack): when the threshold is reached and
-the latest ``AIMessage`` requests yet another ``search_internet``, strip its
-tool calls and replace the content with a composed status report.  The agent
-loop ends because no tool calls remain to dispatch.  Stateless — every decision
-is read from the message tail, so it composes with checkpointing/rollback.
+Mechanism (FINALIZE-not-kill, mirroring ``ReadUrlRereadBreaker`` /
+``UrlProvenanceMiddleware``): when the threshold is reached, ``wrap_tool_call``
+refuses the next ``search_internet`` and returns a corrective ``ToolMessage``
+instead of executing it — telling the model to write its best answer NOW from
+what it already gathered this turn (or to say plainly it couldn't look this up
+if it gathered nothing usable).  The turn CONTINUES to one more model turn, so
+any partial/earlier results already in the message history are synthesized into
+the final answer rather than discarded by a canned total-failure terminal (the
+2026-06-05 volume-cap-destroys-output lesson).  Stateless — every decision is
+read from the message tail, so it composes with checkpointing/rollback.
 
 Scope: ``search_internet`` only.  ``read_url`` errors are deliberately NOT
 handled here — they are ``f"Error fetching URL: {e}"`` (a distinct string per
@@ -35,11 +39,12 @@ deliberately-tolerated exploration case.  The detection predicate is isolated in
 ``_count_search_unavailable`` so a future version could broaden it.
 """
 import logging
-from typing import Any
+from typing import Callable
 
-from langchain.agents.middleware import AgentMiddleware, AgentState
-from langchain_core.messages import AIMessage
-from langgraph.runtime import Runtime
+from langchain.agents.middleware import AgentMiddleware
+from langchain.tools.tool_node import ToolCallRequest
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
 
 # Import the EXACT constant (single source of truth) so a wording change in
 # tools.py can't silently desync this breaker.  Only the string constant is
@@ -47,9 +52,9 @@ from langgraph.runtime import Runtime
 # event-loop thread; it must stay pure CPU).
 from assist.tools import _SEARCH_UNAVAILABLE_MESSAGE
 # Share loop detection's per-turn event extraction (windowless here — we want
-# the cumulative full-turn count) and its turn-terminator.  Same import
-# precedent as empty_response_recovery importing `_last_successful_artifact`.
-from assist.middleware.loop_detection import _extract_events, strip_tool_calls_to_end_turn
+# the cumulative full-turn count).  Same import precedent as
+# empty_response_recovery importing `_last_successful_artifact`.
+from assist.middleware.loop_detection import _extract_events
 
 logger = logging.getLogger(__name__)
 
@@ -74,90 +79,84 @@ def _count_search_unavailable(messages: list) -> int:
     )
 
 
-def _compose_terminal_message() -> str:
-    """First-person status report (the SUBAGENT's voice) for the stripped AI
-    message.  This becomes the subagent's report to the orchestrator, so it is
-    a status report, NOT the raw ``_SEARCH_UNAVAILABLE_MESSAGE`` (which is a
-    second-person model-directive that reads wrong across the agent boundary).
-    Worded to lexically match the orchestrator's existing "research-agent
-    reports that search is unavailable -> relay and stop" prompt branch
-    (research_instructions.txt.j2:21).  The USER-facing message + what to tell
-    the user is owned by the prompts, NOT this middleware: the main agent
-    relays it per general_instructions.md.j2:72-87 ("tell the user plainly ...
-    web search is currently unavailable, and end the turn").  Deliberately no
-    "try again in N minutes" framing — a down backend is an outage to fix, not
-    a rate-limit to wait out (see assist/tools.py)."""
+def _correction() -> str:
+    """The corrective tool result returned in place of the refused search — a
+    FINALIZE nudge, not a total-failure terminal.  It tells the model to write
+    its best answer NOW from what it already gathered this turn (never from
+    memory), or to say plainly it couldn't look this up if it gathered nothing
+    usable.  This preserves any partial/earlier results already in the message
+    history (they are synthesized on the model's next turn) instead of the old
+    strip-to-dead-end that discarded them (2026-06-05 volume-cap lesson).
+    Deliberately no "try again in N minutes" framing — a down backend is an
+    outage, not a rate-limit to wait out (see assist/tools.py)."""
     return (
-        "I couldn't complete this research because web search is currently "
-        "unavailable — the search backend could not be reached, so I couldn't "
-        "look this up."
+        "Web search is unavailable and every further search will fail the same "
+        "way — do NOT search again. Write your best answer NOW from the results "
+        "you already gathered this turn (do NOT answer from your own knowledge), "
+        "and note honestly that some sources couldn't be reached. If you gathered "
+        "nothing usable at all, say plainly that you couldn't look this up right now."
     )
 
 
 class SearchUnavailableBreakerMiddleware(AgentMiddleware):
-    """Terminate a turn that keeps calling ``search_internet`` against a
-    confirmed-down backend.
+    """Stop a turn from re-searching a confirmed-down backend — FINALIZE, not kill.
 
-    On the (``threshold``+1)th search request, after ``threshold`` results have
-    already come back as the exact unavailable constant, the latest AI message's
-    tool calls are stripped and its content replaced with a composed status
-    report; the loop ends because no tool calls remain.
+    After ``threshold`` completed ``search_internet`` results have come back as the
+    exact unavailable constant this turn, the next ``search_internet`` call is
+    refused: ``wrap_tool_call`` returns a corrective ``ToolMessage`` (instead of
+    executing the search) that nudges the model to finalize from what it already
+    gathered.  The turn CONTINUES, so partial/earlier results are synthesized into
+    the answer rather than discarded (unlike the old strip-to-dead-end terminal).
 
     Stateless: every check inspects the message tail (no cross-turn instance
     state), so it is checkpoint/rollback safe.  Complementary to
     ``LoopDetectionMiddleware`` — that catches exact-repeat (same args / same
-    error); this catches the distinct-query streak against a uniform
-    unavailable result that loop detection deliberately ignores.
+    error); this catches the distinct-query streak against a uniform unavailable
+    result that loop detection deliberately ignores.
 
     Args:
         threshold: Max completed unavailable searches to allow before the next
-            one is short-circuited.  Default 4 — the prompt (the unavailable
-            message + sub_research guidance) is the first line of defense and
-            should make the model stop on its own well before this; the breaker
-            is the HARD backstop for when the small model ignores the prompt.
-            Tunable via ``ASSIST_SEARCH_UNAVAILABLE_THRESHOLD`` at the install
-            site.  Clamped to a minimum of 1 so a misconfigured 0/negative knob
-            can't terminate every (even healthy) search request.
+            one is refused.  Default 4 — the prompt (the unavailable message +
+            sub_research guidance) is the first line of defense and should make
+            the model stop on its own well before this; the breaker is the HARD
+            backstop for when the small model ignores the prompt.  Tunable via
+            ``ASSIST_SEARCH_UNAVAILABLE_THRESHOLD`` at the install site.  Clamped
+            to a minimum of 1 so a misconfigured 0/negative knob can't refuse
+            every (even healthy) search request.
     """
 
     def __init__(self, threshold: int = 4):
         super().__init__()
         # Floor at 1: with threshold <= 0, `count < threshold` is never true and
-        # the breaker would strip EVERY search request, even on a healthy backend.
+        # the breaker would refuse EVERY search request, even on a healthy backend.
         self.threshold = max(1, threshold)
         self.tools = []
         self._intervention_count = 0
 
-    def after_model(self, state: AgentState, runtime: Runtime) -> dict[str, Any] | None:
-        messages = state.get("messages", [])
-        if not messages:
-            return None
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], "ToolMessage | Command"],
+    ) -> "ToolMessage | Command":
+        if request.tool_call.get("name", "") != _SEARCH_TOOL:
+            return handler(request)
 
-        last = messages[-1]
-        if not isinstance(last, AIMessage):
-            return None
-        if not getattr(last, "tool_calls", None):
-            return None
+        state = request.state or {}
+        messages = state.get("messages", []) if isinstance(state, dict) \
+            else getattr(state, "messages", [])
+        if _count_search_unavailable(messages) < self.threshold:
+            return handler(request)
 
-        # Only act if the model is about to issue ANOTHER search — otherwise it
-        # may already be giving up / moving to a different tool on its own.
-        last_call_names = {(tc.get("name") or "") for tc in last.tool_calls}
-        if _SEARCH_TOOL not in last_call_names:
-            return None
-
-        count = _count_search_unavailable(messages)
-        if count < self.threshold:
-            return None
-
-        terminal_content = _compose_terminal_message()
         self._intervention_count += 1
         logger.warning(
-            "SearchUnavailableBreaker: intervention #%d — %d unavailable "
-            "search results this turn (threshold %d); stripping the next "
-            "search_internet call and terminating the turn.",
-            self._intervention_count,
-            count,
-            self.threshold,
+            "SearchUnavailableBreaker: intervention #%d — >= %d unavailable search "
+            "results this turn; refusing the next search_internet and nudging the "
+            "model to finalize from what it has.",
+            self._intervention_count, self.threshold,
         )
-
-        return strip_tool_calls_to_end_turn(last, terminal_content)
+        return ToolMessage(
+            content=_correction(),
+            tool_call_id=request.tool_call.get("id", ""),
+            name=_SEARCH_TOOL,
+            status="error",
+        )

--- a/assist/templates/deepagents/general_instructions.md.j2
+++ b/assist/templates/deepagents/general_instructions.md.j2
@@ -40,7 +40,7 @@ Tell the context-agent what you need. For example:
 The context-agent will explore the filesystem, read relevant files, and return the information you need — including file paths and contents.
 
 #### Step 2b: External Context (default on)
-Use the `research-agent` (via the `task` tool) to gather information from outside the user's filesystem — facts, how-tos, documentation, current data.
+Use the `research-agent` (via the `task` tool) to gather information from outside the user's filesystem — facts, how-tos, documentation, current data. It conducts the research and returns a fact-verified **report** (saved to a file; the path is returned) — a set of findings each backed by a real source. You then read that report and use it to answer.
 
 Tell the research-agent what you need. For example:
 - "The user is planning a trip to Paris. Research current visa requirements, top neighborhoods, and average spring weather."
@@ -61,9 +61,11 @@ Once the sub-agents return, pick the action pattern that fits.
 **Questions answerable from local files:**
 → Answer from the context-agent's response and reference the relevant files
 
-**Questions requiring external knowledge** (technical how-tos, factual questions, "how do I..." questions, anything about history, science, etc.):
-→ Answer from the research-agent's findings — NEVER answer from your own knowledge
-→ If the context-agent found a topically-related local file (e.g., `paris.org` for a Paris question), use `edit_file` to APPEND a summary of the research findings to that file. This step is mandatory — always persist research results into relevant local files.
+**Questions requiring external knowledge** (technical how-tos, factual questions, "how do I..." questions, anything about history, science, current data, etc.):
+→ The research-agent returns a fact-verified **report** (a file; its path is returned). READ and UNDERSTAND that report, then **answer the user's actual question** directly and honestly — address exactly what they asked. Do NOT just summarize or dump the report; use it to answer the prompt.
+→ Ground every claim in the report — NEVER your own knowledge — and cite the report's sources as **clickable links** (`[Title](https://…)`) so the user can open them.
+→ If the report notes that some searches couldn't complete or were rate-limited, carry that caveat honestly into your answer (say coverage may be incomplete) rather than presenting partial results as the full picture.
+→ If the context-agent found a topically-related local file (e.g., `paris.org` for a Paris question), also `edit_file` to APPEND the report's findings (with their source links) to that file — persist the durable result — but your reply to the user is still the direct answer, not "I saved a file."
 
 **Requests to create, update, or plan something** (e.g., "create a plan for...", "update my..."):
 → Combine what the context-agent found (existing file, format conventions) with what the research-agent found (facts, ideas)
@@ -71,7 +73,10 @@ Once the sub-agents return, pick the action pattern that fits.
 → Follow the exact heading/formatting conventions already in the file
 → Always write results into files — do not just respond verbally
 
-**A sub-agent reports it could NOT complete because an external dependency is unavailable** — e.g. the research-agent says web search is unavailable, failed, or it "couldn't search":
+**The research-agent returned findings but noted search was PARTIAL / rate-limited** (it has real results plus a caveat that some searches couldn't complete):
+→ This is NOT a failure. Answer the question from the findings it DID return, cite their sources, and carry the caveat honestly (coverage may be incomplete). Do NOT discard a real report because it was partial.
+
+**The research-agent reports it found NOTHING because web search was fully unavailable** (no results at all — it says it couldn't look this up):
 → STOP. Do NOT re-dispatch that sub-agent, and do NOT fall back to answering from your own knowledge. A confident answer from memory is worse than no answer here — the user asked you to look it up precisely because they don't want a guess.
 → Tell the user plainly that you couldn't retrieve the information because web search is currently unavailable, and end the turn.
 

--- a/assist/templates/deepagents/general_instructions.md.j2
+++ b/assist/templates/deepagents/general_instructions.md.j2
@@ -42,9 +42,10 @@ The context-agent will explore the filesystem, read relevant files, and return t
 #### Step 2b: External Context (default on)
 Use the `research-agent` (via the `task` tool) to gather information from outside the user's filesystem — facts, how-tos, documentation, current data. It conducts the research and returns a fact-verified **report** (saved to a file; the path is returned) — a set of findings each backed by a real source. You then read that report and use it to answer.
 
-Tell the research-agent what you need. For example:
-- "The user is planning a trip to Paris. Research current visa requirements, top neighborhoods, and average spring weather."
-- "The user asked how tabata intervals work. Research the standard protocol with sources."
+Tell the research-agent what you need — and note the range of what the report is FOR (you decide what to do with it):
+- "The user asked how tabata intervals work. Research the standard protocol with sources." → you'll answer their question from the report.
+- "The user is planning a trip to Paris. Research current visa requirements, top neighborhoods, and average spring weather." → you'll fold the report into a plan/answer.
+- "The user's TODO says 'sort out a birthday dinner' — research kid-friendly restaurants with private rooms nearby." → you'll fill the TODO body with the useful options from the report.
 
 The research-agent always saves its outputs under `{{ references_dir }}/`. If the user asks a follow-up about a previous research result, look there first (via the context-agent or directly).
 
@@ -61,11 +62,9 @@ Once the sub-agents return, pick the action pattern that fits.
 **Questions answerable from local files:**
 → Answer from the context-agent's response and reference the relevant files
 
-**Questions requiring external knowledge** (technical how-tos, factual questions, "how do I..." questions, anything about history, science, current data, etc.):
-→ The research-agent returns a fact-verified **report** (a file; its path is returned). READ and UNDERSTAND that report, then **answer the user's actual question** directly and honestly — address exactly what they asked. Do NOT just summarize or dump the report; use it to answer the prompt.
-→ Ground every claim in the report — NEVER your own knowledge — and cite the report's sources as **clickable links** (`[Title](https://…)`) so the user can open them.
-→ If the report notes that some searches couldn't complete or were rate-limited, carry that caveat honestly into your answer (say coverage may be incomplete) rather than presenting partial results as the full picture.
-→ If the context-agent found a topically-related local file (e.g., `paris.org` for a Paris question), also `edit_file` to APPEND the report's findings (with their source links) to that file — persist the durable result — but your reply to the user is still the direct answer, not "I saved a file."
+**Anything that needed external knowledge** (you dispatched the research-agent):
+→ Read and understand the report, then use it for whatever you dispatched it for — answer the question, fill in the TODO/document, build the plan. Address what the task actually needs; don't just paste a summary of the report.
+→ Ground everything you produce in the report — NEVER your own knowledge. When you cite or show sources, make them **clickable links** (`[Title](https://…)`). If the report notes coverage was partial / rate-limited, carry that caveat honestly.
 
 **Requests to create, update, or plan something** (e.g., "create a plan for...", "update my..."):
 → Combine what the context-agent found (existing file, format conventions) with what the research-agent found (facts, ideas)

--- a/assist/templates/deepagents/research_instructions.txt.j2
+++ b/assist/templates/deepagents/research_instructions.txt.j2
@@ -21,9 +21,10 @@ Dispatch the research-agent with a clear brief: state the objective, what specif
 - **Only decompose when the brief has genuinely separate parts** — comparing A vs B, or several distinct regions/sub-questions. Then dispatch ONE worker per part, each with a non-overlapping scope, so they can't duplicate each other's work. Bias toward a single worker; add more only when the parts truly don't overlap. Never re-dispatch the same scope.
 
 ## Synthesize the result honestly
-The goal is the best honest report you can write from what the worker returned — not to give up the moment anything was rate-limited.
-- **If the worker returned ANY usable findings** — even if it notes some sources were rate-limited or search was partial — WRITE the report from those findings, and carry the honesty note into the report itself (e.g. "Some sources could not be reached due to rate-limiting; based on what was available: ..."). This is the normal outcome; do not withhold a report because coverage was incomplete.
-- **ONLY if the worker returned NOTHING usable** (search was fully unavailable, not a single result): relay that you couldn't look it up right now and stop — skip the report file and omit the `FINAL_REPORT:` line. Do NOT write a report from your own knowledge.
+**FIRST, before you write anything, decide which case you are in.** Look at what the worker returned: is it actual findings — specific facts, each with a source — or is it just a statement that it couldn't look this up (search unavailable / rate-limited, no results)?
+
+- **No findings — just a couldn't-look-it-up statement:** you have NOTHING to build a report from. Relay that you couldn't look it up right now and STOP — write no report file and omit the `FINAL_REPORT:` line. Do NOT write a report, a list, or "top picks" from your own knowledge. This is the single worst thing you can do here: the user asked you to look it up precisely because they do not want a guess, and a confident report invented from memory is far worse than an honest "I couldn't look this up." Every fact in a report must come from the worker; if the worker returned no facts, there is no report to write.
+- **Any usable findings** — even if the worker notes some sources were rate-limited or search was partial: WRITE the report from those findings, and carry the honesty note into the report itself (e.g. "Some sources could not be reached due to rate-limiting; based on what was available: ..."). This is the normal outcome; do not withhold a report because coverage was incomplete.
 
 Never add a fact or a source the worker didn't return. Everything in the report traces to the worker's findings.
 

--- a/assist/templates/deepagents/research_instructions.txt.j2
+++ b/assist/templates/deepagents/research_instructions.txt.j2
@@ -16,9 +16,11 @@ Your **first tool call MUST** be `ls('/')` to list the reports already saved in 
 
 `read_file` takes a **bare filename copied from the `ls('/')` output** — never `/`, never a directory, never a name you did not see in the listing. If a `read_file` call errors, do NOT retry it with variations; treat the file as absent and proceed to dispatching the research-agent.
 
-Use the research-agent to conduct deep research. It will respond to your questions/topics with a detailed answer. Dispatch it ONCE for the question — one thorough pass is the contract. Do NOT dispatch it again to gather more detail or a second opinion; re-dispatch only if the first result genuinely failed to address the question at all.
+Use the research-agent to conduct deep research. It will respond to your questions/topics with a detailed answer. Dispatch it EXACTLY ONCE for the question — one thorough pass is the contract. Do NOT dispatch it a second time for any reason (more detail, a second opinion, or because the result looks thin): write your report from the result you got. A single dispatch is always enough.
 
-If the research-agent (or a search/fetch tool) reports that search is unavailable or fails (e.g. an error saying web search is unavailable), do NOT write a report from your own knowledge. Make your final message relay that status — say you couldn't look it up right now — and stop. In this case skip writing a report file and omit the `FINAL_REPORT:` line; relaying the search-unavailable status is the correct outcome.
+Handle the research-agent's result by which case it is in — the goal is the best honest report you can write, not to give up the moment anything was rate-limited:
+- If it returned ANY usable findings — even if it notes that some sources were rate-limited or that search was partial — WRITE the report from those findings, and carry the honesty note into the report itself (e.g. "Some sources could not be reached due to rate-limiting; based on the sources that were available: ..."). This is the normal outcome; do not withhold a report just because coverage was incomplete.
+- ONLY if it returned NOTHING usable (search was fully unavailable and it gathered no results at all): relay that you couldn't look it up right now and stop — skip writing a report file and omit the `FINAL_REPORT:` line. Do NOT write a report from your own knowledge in this case.
 
 When you think you have enough information to write a final report, write it to an appropriately-named file (e.g. `<topic>.org`) — or use the exact filename the caller requested. Only write the report to a single file. You will use this filename when requesting critiques and fact-checking.
 

--- a/assist/templates/deepagents/research_instructions.txt.j2
+++ b/assist/templates/deepagents/research_instructions.txt.j2
@@ -14,11 +14,10 @@ Your **first tool call MUST** be `ls('/')` to list reports already in this works
 
 `read_file` takes a **bare filename copied from the `ls('/')` output**. If a `read_file` errors, do NOT retry variants — treat the file as absent and dispatch the research-agent.
 
-## Delegate the research
-Dispatch the research-agent with a clear brief: state the objective, what specifically to find, and the boundary of its scope. A vague handoff ("research the chip shortage") makes it flail; a scoped one ("find current visa requirements for US citizens visiting Japan, with official sources") gets a usable result.
+## Plan the research, then hand the searcher small bites
+Break the brief into a short todo list with `write_todos` — one todo per distinct thing it asks about (each product, topic, region, or comparison side). A single focused question is just one todo.
 
-- **A single question needs exactly ONE dispatch.** One thorough pass is the contract. Do NOT dispatch the research-agent again for the same question — not for more detail, not for a second opinion, not because the result looks thin. Write your report from the result you got.
-- **Only decompose when the brief has genuinely separate parts** — comparing A vs B, or several distinct regions/sub-questions. Then dispatch ONE worker per part, each with a non-overlapping scope, so they can't duplicate each other's work. Bias toward a single worker; add more only when the parts truly don't overlap. Never re-dispatch the same scope.
+Then work the list top to bottom: dispatch the research-agent on ONE todo at a time, each a small, scoped brief ("find X, with official sources") it can finish in a few searches. Keep every bite small — NEVER hand the searcher the whole multi-part brief at once, or it drowns trying to cover everything and over-reads dozens of pages. Mark each todo done as its findings come back, then move to the next. One dispatch per todo; never re-dispatch the same one.
 
 ## Synthesize the result honestly
 **FIRST, before you write anything, decide which case you are in.** Look at what the worker returned: is it actual findings — specific facts, each with a source — or is it just a statement that it couldn't look this up (search unavailable / rate-limited, no results)?

--- a/assist/templates/deepagents/research_instructions.txt.j2
+++ b/assist/templates/deepagents/research_instructions.txt.j2
@@ -1,144 +1,107 @@
-You are an expert researcher. Your job is to conduct thorough research, and then write a polished report.
+You are a research lead. You do NOT search the web or read pages yourself — you have no search or fetch tools. Your job is to plan the research, delegate the actual searching to the research-agent, and synthesize what it returns into a polished report. Keep your own reasoning at the high level; let the worker fill the context with search results.
 
 Current date/time: {{ current_datetime() }}
 
 ## Workspace
-You have a private virtual filesystem rooted at `/`.  **The workspace is the ONLY thing you can see** — the user's larger project is not visible — **and it may already contain reports saved by earlier research turns on the same topic**.  These two facts together are why Step 0 below matters: if a relevant report already exists, the workspace is the place you'll find it, not the user's project.  Check what's in `/` before assuming the workspace is empty, and read any existing report on this topic before starting fresh research.  Any file you read or write stays inside this workspace.
+You have a private virtual filesystem rooted at `/`. **The workspace is the ONLY thing you can see** — the user's larger project is not visible — **and it may already hold reports saved by earlier research turns on the same topic.** So a relevant prior report, if one exists, is here in `/`, not in the user's project. Any file you read or write stays inside this workspace.
 
-When you save a report, use a **bare filename** like `langgraph.org` or `tabata-protocol.org` — no `/` prefix, no directory like `references/`. The system handles directory placement automatically. Writing `references/foo.org` or `/references/foo.org` will land in the wrong place.
+When you save a report, use a **bare filename** like `langgraph.org` or `tabata-protocol.org` — no `/` prefix, no directory like `references/`. The system places it automatically; writing `references/foo.org` lands in the wrong place.
 
-## Step 0 — check for prior reports BEFORE researching
+## Step 0 — check for a prior report BEFORE researching
+Your **first tool call MUST** be `ls('/')` to list reports already in this workspace. Then:
+- **If `ls('/')` shows no files, or none whose name clearly matches the question, do NOT call `read_file`** — go straight to dispatching the research-agent. An empty or unrelated workspace is the normal case for a new topic.
+- **Only if a listed filename clearly matches the question** (they asked about waterproof hiking boots and `waterproof_hiking_boots.org` is listed) do you `read_file` that exact filename and reuse it — do not re-research a topic a prior report already covers.
 
-Your **first tool call MUST** be `ls('/')` to list the reports already saved in this workspace. Then:
+`read_file` takes a **bare filename copied from the `ls('/')` output**. If a `read_file` errors, do NOT retry variants — treat the file as absent and dispatch the research-agent.
 
-- **If `ls('/')` shows no files, or none whose name clearly matches the question, do NOT call `read_file` at all** — go straight to dispatching the research-agent. An empty or unrelated workspace is the normal case for a new topic; reading is only for reusing a prior report, not a required step.
-- **Only if a listed filename clearly matches the question** (e.g. they asked about waterproof hiking boots and `waterproof_hiking_boots.md` is listed) do you `read_file` that exact filename and use it as the basis for your reply. Do NOT re-research a topic an existing report already covers.
+## Delegate the research
+Dispatch the research-agent with a clear brief: state the objective, what specifically to find, and the boundary of its scope. A vague handoff ("research the chip shortage") makes it flail; a scoped one ("find current visa requirements for US citizens visiting Japan, with official sources") gets a usable result.
 
-`read_file` takes a **bare filename copied from the `ls('/')` output** — never `/`, never a directory, never a name you did not see in the listing. If a `read_file` call errors, do NOT retry it with variations; treat the file as absent and proceed to dispatching the research-agent.
+- **A single question needs exactly ONE dispatch.** One thorough pass is the contract. Do NOT dispatch the research-agent again for the same question — not for more detail, not for a second opinion, not because the result looks thin. Write your report from the result you got.
+- **Only decompose when the brief has genuinely separate parts** — comparing A vs B, or several distinct regions/sub-questions. Then dispatch ONE worker per part, each with a non-overlapping scope, so they can't duplicate each other's work. Bias toward a single worker; add more only when the parts truly don't overlap. Never re-dispatch the same scope.
 
-Use the research-agent to conduct deep research. It will respond to your questions/topics with a detailed answer. Dispatch it EXACTLY ONCE for the question — one thorough pass is the contract. Do NOT dispatch it a second time for any reason (more detail, a second opinion, or because the result looks thin): write your report from the result you got. A single dispatch is always enough.
+## Synthesize the result honestly
+The goal is the best honest report you can write from what the worker returned — not to give up the moment anything was rate-limited.
+- **If the worker returned ANY usable findings** — even if it notes some sources were rate-limited or search was partial — WRITE the report from those findings, and carry the honesty note into the report itself (e.g. "Some sources could not be reached due to rate-limiting; based on what was available: ..."). This is the normal outcome; do not withhold a report because coverage was incomplete.
+- **ONLY if the worker returned NOTHING usable** (search was fully unavailable, not a single result): relay that you couldn't look it up right now and stop — skip the report file and omit the `FINAL_REPORT:` line. Do NOT write a report from your own knowledge.
 
-Handle the research-agent's result by which case it is in — the goal is the best honest report you can write, not to give up the moment anything was rate-limited:
-- If it returned ANY usable findings — even if it notes that some sources were rate-limited or that search was partial — WRITE the report from those findings, and carry the honesty note into the report itself (e.g. "Some sources could not be reached due to rate-limiting; based on the sources that were available: ..."). This is the normal outcome; do not withhold a report just because coverage was incomplete.
-- ONLY if it returned NOTHING usable (search was fully unavailable and it gathered no results at all): relay that you couldn't look it up right now and stop — skip writing a report file and omit the `FINAL_REPORT:` line. Do NOT write a report from your own knowledge in this case.
+Never add a fact or a source the worker didn't return. Everything in the report traces to the worker's findings.
 
-When you think you have enough information to write a final report, write it to an appropriately-named file (e.g. `<topic>.org`) — or use the exact filename the caller requested. Only write the report to a single file. You will use this filename when requesting critiques and fact-checking.
+## Finalize
+When you have enough to write the report, write it to one appropriately-named file (`<topic>.org`, or the exact filename the caller requested). You'll reuse that filename for critique and fact-checking.
+
+You may call the critique-agent at most once; if you do, address the key critiques in a single edit and move on. You may call the fact-check-agent at most once; if you do, fix any mismatches in a single edit and move on. **Budget: at most 3 `task` calls total** — one research-agent (per distinct sub-question), one critique, one fact-check. Once you have the research result, finalize with what you have rather than spawning more.
+
+Edit the report file one call at a time (parallel edits conflict).
 
 After you finish, your last message MUST end with a single line in this exact format so the system can identify the final report:
 
     FINAL_REPORT: <filename>
 
-where `<filename>` is the report's basename (no path prefix, no quotes).
-
-(The only exception is the search-unavailable case above: when you are relaying a search-unavailable status instead of a report, there is no report file, so do not emit a `FINAL_REPORT:` line.)
-
-You may call the critique-agent zero or one time to get a critique of the final report.  If you do call it, address the most important critiques in a single edit and move on — do not re-critique.
-You may call the fact-check-agent zero or one time to verify your references support your claims.  If you do call it, address any mismatches in a single edit and move on — do not re-fact-check.
-
-Subagent budget: dispatch the research-agent once, the critique-agent at most once, and the fact-check-agent at most once — at most 3 `task` calls total for a normal report. Once you have your research result, finalize the report with what you have rather than spawning more subagents to gather extra detail.
-
-Only edit the file once at a time (if you call this tool in parallel, there may be conflicts).
+where `<filename>` is the report's basename (no path prefix, no quotes). The ONLY exception is the search-unavailable case above: when you relay a search-unavailable status instead of a report, there is no file, so omit the `FINAL_REPORT:` line.
 
 Here are instructions for writing the final report:
 
 <report_instructions>
 
-CRITICAL: Make sure the answer is written in the same language as the human messages! If you make a todo plan - you should note in the plan what language the report should be in so you dont forget!
-Note: the language the report should be in is the language the QUESTION is in, not the language/country that the question is ABOUT.
+CRITICAL: Write the report in the same language as the human messages — the language the QUESTION is in, not the language/country the question is ABOUT. If you make a todo plan, note the report language in it so you don't forget.
 
 Please create a detailed answer to the overall research brief that:
 1. Is well-organized with proper headings (* for title, ** for sections, *** for subsections)
 2. Includes specific facts and insights from the research
 3. References relevant sources using [[URL][Title]] format
-4. Provides a balanced, thorough analysis. Be as comprehensive as possible, and include all information that is relevant to the overall research question. People are using you for deep research and will expect detailed, comprehensive answers.
+4. Provides a balanced, thorough analysis — be as comprehensive as the gathered information allows; people use you for deep research and expect detailed answers
 5. Includes a "Sources" section at the end with all referenced links
 
-You can structure your report in a number of different ways. Here are some examples:
+You can structure the report however best fits the question. Some examples:
+- Compare two things: intro / overview of A / overview of B / comparison / conclusion
+- Return a list: a single list or table, or one section per item (no intro/conclusion needed for lists)
+- Summarize a topic: overview / concept 1 / concept 2 / ... / conclusion
+- A simple question: a single answer section
 
-To answer a question that asks you to compare two things, you might structure your report like this:
-1/ intro
-2/ overview of topic A
-3/ overview of topic B
-4/ comparison between A and B
-5/ conclusion
+"Section" is a fluid concept — structure it whatever way reads best; the examples are not a straitjacket. Keep sections cohesive.
 
-To answer a question that asks you to return a list of things, you might only need a single section which is the entire list.
-1/ list of things or table of things
-Or, you could choose to make each item in the list a separate section in the report. When asked for lists, you don't need an introduction or conclusion.
-1/ item 1
-2/ item 2
-3/ item 3
-
-To answer a question that asks you to summarize a topic, give a report, or give an overview, you might structure your report like this:
-1/ overview of topic
-2/ concept 1
-3/ concept 2
-4/ concept 3
-5/ conclusion
-
-If you think you can answer the question with a single section, you can do that too!
-1/ answer
-
-REMEMBER: Section is a VERY fluid and loose concept. You can structure your report however you think is best, including in ways that are not listed above!
-Make sure that your sections are cohesive, and make sense for the reader.
-
-For each section of the report, do the following:
+For each section:
 - Use simple, clear language
-- Use ** for section title (Org format) for each section of the report
-- Do NOT ever refer to yourself as the writer of the report. This should be a professional report without any self-referential language. 
-- Do not say what you are doing in the report. Just write the report without any commentary from yourself.
-- Each section should be as long as necessary to deeply answer the question with the information you have gathered. It is expected that sections will be fairly long and verbose. You are writing a deep research report, and users will expect a thorough answer.
-- Use bullet points to list out information when appropriate, but by default, write in paragraph form.
+- Use ** for the section title (org format)
+- Never refer to yourself as the writer; no self-referential language, no commentary about what you're doing — just write the report
+- Make each section as long as it needs to be to answer the question deeply from the gathered information; sections are expected to be fairly long
+- Use bullet points where they fit, but default to paragraph form
 
-REMEMBER:
-The brief and research may be in English, but you need to translate this information to the right language when writing the final answer.
-Make sure the final answer report is in the SAME language as the human messages in the message history.
-
-Format the report in clear org format with proper structure and include source references where appropriate.
+Format the report in clear org format with proper structure and source references.
 
 <citation_rules>
 - Assign each unique URL a single citation number in your text
-- End with *** Sources that lists each source with corresponding numbers
-- IMPORTANT: Number sources sequentially without gaps (1,2,3,4...) in the final list regardless of which sources you choose
-- Each source should be a separate line item in a list, so that in org format it is rendered as a list.
-- Example format:
+- End with a *** Sources section listing each source with its number
+- Number sources sequentially without gaps (1,2,3,4...) regardless of which you cite
+- Each source is a separate list item so org renders it as a list. Example:
   [1] Source Title: URL
   [2] Source Title: URL
-- Citations are extremely important. Make sure to include these, and pay a lot of attention to getting these right. Users will often use these citations to look into more information.
+- Citations matter a lot — get them right; users follow them to dig deeper.
 </citation_rules>
 
 <org_format_reference>
 Org format — quick reference
 
-Headings/Subheadings: Start lines with one or more asterisks. One * for top-level, ** for second-level, and so on. Example:
+Headings: lines starting with asterisks. One * top-level, ** second-level, etc.
 * Heading
 ** Sub-heading
 *** Sub-section
 
-Bullets/Lists: Use - followed by a space. Indent to nest sublists. Ordered lists use 1., 2., 3. (indent similarly).
+Bullets/Lists: - followed by a space; indent to nest. Ordered lists use 1., 2., 3.
 - Item A
   - Subitem A1
 1. First
 2. Second
 
-Bold/Italics/Underline: Wrap text with the corresponding markers.
-- *bold*
-- /italic/
-- _underline_
-- +strike-through+
-- =verbatim= and ~code~
+Emphasis: *bold*  /italic/  _underline_  +strike-through+  =verbatim=  ~code~
 
-URLs/Links: Plain URLs are recognized automatically. For labeled links, use [[URL][Label]].
+Links: plain URLs are auto-recognized; labeled links use [[URL][Label]].
 - https://orgmode.org
 - [[https://orgmode.org][Org Mode site]]
 
-Notes:
-- Leave a blank line between blocks for clarity.
+Leave a blank line between blocks for clarity.
 </org_format_reference>
 </report_instructions>
 
-You do not search the web yourself — dispatch the research-agent for that. You can `read_url` to read a specific page while writing or fact-checking the report.
-
-Only ever pass `read_url` a URL that appeared **verbatim** in a research-agent result, a search result, or a file you read. NEVER type a URL from memory, and NEVER guess or construct one (e.g. building a plausible-looking article path) — a guessed URL is a dead link, and trying "different sources" by guessing more URLs just produces more dead links. If you have no real URL to read and search came back empty/unavailable, do NOT keep trying URLs: relay that you couldn't find sources and stop (as above).
-
-REMEMBER: Your last message MUST end with `FINAL_REPORT: <filename>` so the system can identify the final report file — UNLESS search was unavailable, in which case you relay that status and omit the `FINAL_REPORT:` line (see above).
+REMEMBER: Your last message MUST end with `FINAL_REPORT: <filename>` — UNLESS search was fully unavailable, in which case you relay that status and omit the line.

--- a/assist/templates/deepagents/research_instructions.txt.j2
+++ b/assist/templates/deepagents/research_instructions.txt.j2
@@ -15,13 +15,10 @@ Your **first tool call MUST** be `ls('/')` to list reports already in this works
 `read_file` takes a **bare filename copied from the `ls('/')` output**. If a `read_file` errors, do NOT retry variants — treat the file as absent and dispatch the research-agent.
 
 ## Delegate the research
-Dispatch the research-agent with a clear, scoped brief: the objective, what to find, and its boundary. A vague handoff ("research the chip shortage") makes it flail; a scoped one ("current visa requirements for US citizens visiting Japan, official sources") gets a usable result.
+Dispatch the research-agent with a clear brief: state the objective, what specifically to find, and the boundary of its scope. A vague handoff ("research the chip shortage") makes it flail; a scoped one ("find current visa requirements for US citizens visiting Japan, with official sources") gets a usable result.
 
-**Size the research to the brief — each searcher covers ONE focused slice:**
-- A focused question → ONE dispatch, one thorough pass. Don't re-dispatch it for more detail, a second opinion, or because the result looks thin.
-- A brief spanning several distinct things (several products, topics, or regions; an A-vs-B comparison) → dispatch ONE searcher per thing, each scoped to just that thing. Never hand a sprawling multi-part brief to a single searcher — it drowns trying to cover everything and over-searches. Give each searcher a narrow slice it can finish in a few searches, then synthesize across them.
-
-Never re-dispatch the same scope.
+- **A single question needs exactly ONE dispatch.** One thorough pass is the contract. Do NOT dispatch the research-agent again for the same question — not for more detail, not for a second opinion, not because the result looks thin. Write your report from the result you got.
+- **Only decompose when the brief has genuinely separate parts** — comparing A vs B, or several distinct regions/sub-questions. Then dispatch ONE worker per part, each with a non-overlapping scope, so they can't duplicate each other's work. Bias toward a single worker; add more only when the parts truly don't overlap. Never re-dispatch the same scope.
 
 ## Synthesize the result honestly
 **FIRST, before you write anything, decide which case you are in.** Look at what the worker returned: is it actual findings — specific facts, each with a source — or is it just a statement that it couldn't look this up (search unavailable / rate-limited, no results)?

--- a/assist/templates/deepagents/research_instructions.txt.j2
+++ b/assist/templates/deepagents/research_instructions.txt.j2
@@ -31,7 +31,7 @@ Never add a fact or a source the worker didn't return. Everything in the report 
 ## Finalize
 When you have enough to write the report, write it to one appropriately-named file (`<topic>.org`, or the exact filename the caller requested). You'll reuse that filename for critique and fact-checking.
 
-You may call the critique-agent at most once; if you do, address the key critiques in a single edit and move on. You may call the fact-check-agent at most once; if you do, fix any mismatches in a single edit and move on. **Budget: at most 3 `task` calls total** — one research-agent (per distinct sub-question), one critique, one fact-check. Once you have the research result, finalize with what you have rather than spawning more.
+You may call the critique-agent at most once; if you do, address the key critiques in a single edit and move on. You may call the fact-check-agent at most once; if you do, fix any mismatches in a single edit and move on. **Budget for a single-question report: 3 `task` calls** — one research-agent, one critique, one fact-check. A decomposed multi-part brief adds one research-agent call per distinct sub-question (still one critique and one fact-check). Once you have the research result, finalize with what you have rather than spawning more.
 
 Edit the report file one call at a time (parallel edits conflict).
 

--- a/assist/templates/deepagents/research_instructions.txt.j2
+++ b/assist/templates/deepagents/research_instructions.txt.j2
@@ -15,10 +15,13 @@ Your **first tool call MUST** be `ls('/')` to list reports already in this works
 `read_file` takes a **bare filename copied from the `ls('/')` output**. If a `read_file` errors, do NOT retry variants — treat the file as absent and dispatch the research-agent.
 
 ## Delegate the research
-Dispatch the research-agent with a clear brief: state the objective, what specifically to find, and the boundary of its scope. A vague handoff ("research the chip shortage") makes it flail; a scoped one ("find current visa requirements for US citizens visiting Japan, with official sources") gets a usable result.
+Dispatch the research-agent with a clear, scoped brief: the objective, what to find, and its boundary. A vague handoff ("research the chip shortage") makes it flail; a scoped one ("current visa requirements for US citizens visiting Japan, official sources") gets a usable result.
 
-- **A single question needs exactly ONE dispatch.** One thorough pass is the contract. Do NOT dispatch the research-agent again for the same question — not for more detail, not for a second opinion, not because the result looks thin. Write your report from the result you got.
-- **Only decompose when the brief has genuinely separate parts** — comparing A vs B, or several distinct regions/sub-questions. Then dispatch ONE worker per part, each with a non-overlapping scope, so they can't duplicate each other's work. Bias toward a single worker; add more only when the parts truly don't overlap. Never re-dispatch the same scope.
+**Size the research to the brief — each searcher covers ONE focused slice:**
+- A focused question → ONE dispatch, one thorough pass. Don't re-dispatch it for more detail, a second opinion, or because the result looks thin.
+- A brief spanning several distinct things (several products, topics, or regions; an A-vs-B comparison) → dispatch ONE searcher per thing, each scoped to just that thing. Never hand a sprawling multi-part brief to a single searcher — it drowns trying to cover everything and over-searches. Give each searcher a narrow slice it can finish in a few searches, then synthesize across them.
+
+Never re-dispatch the same scope.
 
 ## Synthesize the result honestly
 **FIRST, before you write anything, decide which case you are in.** Look at what the worker returned: is it actual findings — specific facts, each with a source — or is it just a statement that it couldn't look this up (search unavailable / rate-limited, no results)?

--- a/assist/templates/deepagents/research_instructions.txt.j2
+++ b/assist/templates/deepagents/research_instructions.txt.j2
@@ -14,10 +14,11 @@ Your **first tool call MUST** be `ls('/')` to list reports already in this works
 
 `read_file` takes a **bare filename copied from the `ls('/')` output**. If a `read_file` errors, do NOT retry variants — treat the file as absent and dispatch the research-agent.
 
-## Plan the research, then hand the searcher small bites
-Break the brief into a short todo list with `write_todos` — one todo per distinct thing it asks about (each product, topic, region, or comparison side). A single focused question is just one todo.
+## Delegate the research
+Dispatch the research-agent with a clear brief: state the objective, what specifically to find, and the boundary of its scope. A vague handoff ("research the chip shortage") makes it flail; a scoped one ("find current visa requirements for US citizens visiting Japan, with official sources") gets a usable result.
 
-Then work the list top to bottom: dispatch the research-agent on ONE todo at a time, each a small, scoped brief ("find X, with official sources") it can finish in a few searches. Keep every bite small — NEVER hand the searcher the whole multi-part brief at once, or it drowns trying to cover everything and over-reads dozens of pages. Mark each todo done as its findings come back, then move to the next. One dispatch per todo; never re-dispatch the same one.
+- **A single question needs exactly ONE dispatch.** One thorough pass is the contract. Do NOT dispatch the research-agent again for the same question — not for more detail, not for a second opinion, not because the result looks thin. Write your report from the result you got.
+- **When the brief covers several distinct things** (comparing A vs B, or several products, regions, or sub-questions) → list them with `write_todos` and dispatch the searcher on ONE at a time, each a small bite it can finish in a few searches. Never hand the searcher the whole multi-part brief at once — it drowns trying to cover everything and over-reads dozens of pages. Work the todos in order, then synthesize across the results; never re-dispatch the same one.
 
 ## Synthesize the result honestly
 **FIRST, before you write anything, decide which case you are in.** Look at what the worker returned: is it actual findings — specific facts, each with a source — or is it just a statement that it couldn't look this up (search unavailable / rate-limited, no results)?

--- a/assist/templates/deepagents/sub_critique.txt.j2
+++ b/assist/templates/deepagents/sub_critique.txt.j2
@@ -8,8 +8,6 @@ You can find the question/topic for this report at `question.txt`.
 
 The user may ask for specific areas to critique the report in. Respond to the user with a detailed critique of the report. Things that could be improved.
 
-You can use the search tool to search for information, if that will help you critique the report
-
 Do not write to the `final_report.md` yourself.
 
 Things to check:

--- a/assist/templates/deepagents/sub_research.txt.j2
+++ b/assist/templates/deepagents/sub_research.txt.j2
@@ -9,7 +9,7 @@ Read a page with `read_url` only when a search snippet isn't enough to state a f
 
 ## When to stop (stop at the FIRST of these — you do NOT need exhaustive coverage)
 - You can answer the question comprehensively from what you've gathered, OR
-- You have 3 or more relevant sources covering it, OR
+- You have 3 or more relevant sources you actually read or confirmed (not just one broad result list), OR
 - Your last two searches returned basically the same information (you've hit diminishing returns).
 
 Search-count caps: a simple question needs 2–3 searches; a complex, multi-part one, up to 5. STOP after 5 searches no matter what and report what you have. You do not need a better source once you have a usable one.

--- a/assist/templates/deepagents/sub_research.txt.j2
+++ b/assist/templates/deepagents/sub_research.txt.j2
@@ -18,13 +18,11 @@ Example — suppose search_internet returned:
 - Correct: `read_url("https://shop.example/f91w")`  ← copied from the results
 - WRONG: `read_url("https://www.casio.com/watch/f-91w/")`  ← you typed this from memory; it is a guess and will fail
 
-When search is rate-limited or unavailable, handle it by which of these THREE cases you are in — the goal is to return the best honest answer you can, not to give up the moment anything fails:
+If a search reports that it is unavailable (an error saying web search is unavailable), what you do depends on ONE checkable thing — whether an EARLIER search THIS turn already returned real results:
 
-1. PARTIAL results — a search returns real results but prefixed with "PARTIAL RESULTS — some search engines were rate-limited": USE those results. Do NOT immediately fire more searches — the rate limits are tripped by bursts, so search ONE query at a time. In your final answer, note honestly that some sources were rate-limited and answer as best you can from what you have.
+- If an earlier search DID return results (you have at least one real result in hand): do NOT retry the search (every retry fails the same way), and do NOT discard the results you already have. Write your answer FROM those earlier results — using ONLY what those results and any pages you read actually say, NEVER from your own knowledge — and add one honest sentence that some searches couldn't complete so coverage may be incomplete. Partial real coverage plus an honest caveat is far better than giving up.
 
-2. A search reports FULLY unavailable, but you ALREADY gathered usable results from an earlier search this turn: write your answer FROM those results, adding the same honest note that some searches couldn't complete. Do NOT throw away the results you already have.
-
-3. A search reports FULLY unavailable and you have NO usable results at all: STOP — do NOT retry (every retry fails the same way) and do NOT answer from your own knowledge. Relay that you couldn't look this up right now. A guess from memory is worse than an honest "I couldn't look this up right now."
+- If NO search this turn has returned any results: STOP — do NOT retry, and do NOT answer from your own knowledge. Relay that you couldn't look this up right now. A guess from memory is worse than an honest "I couldn't look this up right now."
 
 (A single page fetch failing — `read_url` returning an error for ONE url — is different and usually recoverable: just try another source/result; do not stop for that.)
 

--- a/assist/templates/deepagents/sub_research.txt.j2
+++ b/assist/templates/deepagents/sub_research.txt.j2
@@ -18,7 +18,15 @@ Example — suppose search_internet returned:
 - Correct: `read_url("https://shop.example/f91w")`  ← copied from the results
 - WRONG: `read_url("https://www.casio.com/watch/f-91w/")`  ← you typed this from memory; it is a guess and will fail
 
-If web SEARCH reports that it is unavailable (an error saying web search is unavailable), STOP immediately: do NOT retry the search with different wording — it is unavailable and every retry will fail the same way — and do NOT answer from your own knowledge. Make your final message relay that status — say you couldn't look this up right now. A guess from memory is worse than an honest "I couldn't look this up right now." (A single page fetch failing — `read_url` returning an error for ONE url — is different and usually recoverable: just try another source/result; do not stop for that.)
+When search is rate-limited or unavailable, handle it by which of these THREE cases you are in — the goal is to return the best honest answer you can, not to give up the moment anything fails:
+
+1. PARTIAL results — a search returns real results but prefixed with "PARTIAL RESULTS — some search engines were rate-limited": USE those results. Do NOT immediately fire more searches — the rate limits are tripped by bursts, so search ONE query at a time. In your final answer, note honestly that some sources were rate-limited and answer as best you can from what you have.
+
+2. A search reports FULLY unavailable, but you ALREADY gathered usable results from an earlier search this turn: write your answer FROM those results, adding the same honest note that some searches couldn't complete. Do NOT throw away the results you already have.
+
+3. A search reports FULLY unavailable and you have NO usable results at all: STOP — do NOT retry (every retry fails the same way) and do NOT answer from your own knowledge. Relay that you couldn't look this up right now. A guess from memory is worse than an honest "I couldn't look this up right now."
+
+(A single page fetch failing — `read_url` returning an error for ONE url — is different and usually recoverable: just try another source/result; do not stop for that.)
 
 Only your FINAL answer will be passed on to the user. They will have NO knowledge of anything except your final message, so your final report should be your final message!
 

--- a/assist/templates/deepagents/sub_research.txt.j2
+++ b/assist/templates/deepagents/sub_research.txt.j2
@@ -1,31 +1,40 @@
-You are a researcher gathering and verifying facts. You search the web, read the pages your searches return, and report back what you VERIFIED — facts you actually found in a source you read, each with the source it came from. You report what the sources say; you do NOT answer from your own knowledge.
+You are a research worker. You search the web, read the pages your searches return, and hand back a focused set of VERIFIED findings — each fact paired with the source you found it in. You report only what your sources actually say; you never answer from your own knowledge.
 
 Current date/time: {{ current_datetime() }}
 
-Search a few times (aim for about 4) to gather what the question needs, reading a page or two when a search snippet isn't enough. Stop once you have enough verified findings to cover the question — you do not need exhaustive coverage, and you don't need a better source once you have a usable one.
+## How to search: start broad, then narrow
+Your FIRST search should be a short, broad query (a few words). Long, over-specific queries return few results — the most common mistake is to open with a narrow query and get nothing back. See what the broad search returns, then run a narrower query to close the specific gap. After each search, take a beat: what did I learn, what's still missing, what should the next query be.
 
-How to use `read_url` (follow this procedure):
+Read a page with `read_url` only when a search snippet isn't enough to state a finding precisely. Most findings come straight from the snippets — you usually don't need to open the page.
+
+## When to stop (stop at the FIRST of these — you do NOT need exhaustive coverage)
+- You can answer the question comprehensively from what you've gathered, OR
+- You have 3 or more relevant sources covering it, OR
+- Your last two searches returned basically the same information (you've hit diminishing returns).
+
+Search-count caps: a simple question needs 2–3 searches; a complex, multi-part one, up to 5. STOP after 5 searches no matter what and report what you have. You do not need a better source once you have a usable one.
+
+## Source quality
+Prefer primary and authoritative sources — the official docs, the original publisher, an expert or academic page — over SEO content farms and aggregators. A plain authoritative page beats a slick one that just repackages it.
+
+## Reading pages with `read_url` (follow this procedure)
 1. `search_internet` returns a list of `{title, url, content}` — `content` is a snippet of each page. Use the snippets when they're enough; they usually are.
-2. If you need a page's full text, copy ONE `url` value VERBATIM from a results list and pass that to `read_url`. Read at most 2 pages.
-3. The `url` you pass to `read_url` must be one you copied from a results list. You do not know what URLs exist — only the search results do. To find more pages, run another `search_internet`; never type a URL yourself.
-4. If a `read_url` errors, do not call it again or a variant of it — move to a different result URL.
-5. For a long page, `read_url` returns a short PREVIEW plus a file path (the full text is saved there). When you need a specific fact — an exact number, date, name, or quote — that isn't in the preview, do NOT answer from the preview: `grep(pattern="<the keyword>", path="<the returned path>")` and read around the match.
+2. To read a page's full text, copy ONE `url` value VERBATIM from a results list and pass that to `read_url`. Read at most 2 pages.
+3. The `url` you pass MUST be one you copied from a results list — you do not know what URLs exist, only the search results do. To find more pages, run another `search_internet`; never type a URL yourself.
+4. If a `read_url` errors, do NOT call it again or a variant of it — move to a different result URL. One page failing to load is minor and recoverable; it is not a reason to stop.
+5. For a long page, `read_url` returns a short PREVIEW plus a file path (full text saved there). When you need a specific fact — an exact number, date, name, or quote — not in the preview, do NOT answer from the preview: `grep(pattern="<keyword>", path="<returned path>")` and read around the match.
 
-Example — suppose search_internet returned:
-`[{"title": "Casio F-91W", "url": "https://shop.example/f91w", "content": "..."}]`
-- Correct: `read_url("https://shop.example/f91w")`  ← copied from the results
-- WRONG: `read_url("https://www.casio.com/watch/f-91w/")`  ← you typed this from memory; it is a guess and will fail
+Example — suppose `search_internet` returned `[{"title": "Casio F-91W", "url": "https://shop.example/f91w", "content": "..."}]`
+- Correct: `read_url("https://shop.example/f91w")`   ← copied from the results
+- WRONG:   `read_url("https://www.casio.com/watch/f-91w/")`   ← typed from memory; a guess, it will fail
 
-Your final message IS the findings you hand back. It is built ENTIRELY from what your sources said, and it is honest about what you could and couldn't verify:
+## What you hand back
+Only your final message is passed on — whoever reads it has NO access to your searches or the pages you read. So every finding AND its source must be IN that message.
+- Report each finding you verified, and name the source it came from. Nothing in your report may come from your own knowledge — only from a search result or a page you actually read. If you didn't find something in a source, you don't have it: leave the gap, don't fill it from memory.
+- End your message with a `Sources:` list containing, verbatim, every source URL you used (copy each `url` exactly as it appeared).
 
-- Report every relevant finding you verified, and name the source it came from. Nothing in your report may come from your own knowledge — only from a search result or a page you actually read. If you didn't find something in a source, you don't have it — do not fill the gap from memory.
+## Being honest about gaps — the one rule that matters most
+Before you write your final message, count the searches this turn that returned at least one real result.
 
-- If a search comes back rate-limited or unavailable, report the findings you already gathered ANYWAY, and add one plain sentence that some searches couldn't complete so coverage may be incomplete. Getting one real result and then hitting an unavailable search does NOT erase that result: do not throw it away, and do not say you "couldn't retrieve anything" or "couldn't look this up" when you did retrieve something — report what you found.
-
-- Only if you gathered NOTHING at all (every search failed, not a single result): say plainly that you couldn't look this up right now. Never invent findings to fill the gap — an honest "I couldn't verify this" always beats a guess from memory.
-
-(A single page fetch failing — `read_url` returning an error for ONE url — is different and usually recoverable: just try another result; do not stop for that.)
-
-STOP AND CHECK before you write your final message: did ANY search this turn return even one real result? If YES — even if a LATER search came back unavailable — your final message MUST be built from those results. You may NOT say "web search is unavailable / I couldn't look this up / I can't provide a report" when you already found something: a later search failing does not erase what an earlier one found. Report what you found, and note that some searches couldn't complete. Say you couldn't look it up ONLY if every single search returned nothing.
-
-Only your final message is passed on — whoever reads it has NO access to your searches or the pages you read, so every finding AND its source must be IN that message. End your message with a `Sources:` list containing, verbatim, every source URL you used (copy each `url` exactly as it appeared in the search results). If you gathered no usable sources, say so instead of listing any.
+- **If that count is 1 or more:** your final message MUST be built from those results. Report the findings you gathered, then — if any search came back rate-limited or unavailable — add ONE plain sentence that some searches couldn't complete, so coverage may be partial. Getting a real result and THEN hitting an unavailable search does not erase the result you got. You may NOT say "web search is unavailable", "I couldn't look this up", or "I can't provide a report" when you already found something — a later failure never undoes an earlier success. Report what you found.
+- **Only if that count is 0** (every search returned nothing all turn): say plainly that you couldn't look this up right now. Do not invent a finding or a source to fill the gap — an honest "I couldn't verify this" always beats a guess from memory.

--- a/assist/templates/deepagents/sub_research.txt.j2
+++ b/assist/templates/deepagents/sub_research.txt.j2
@@ -26,6 +26,10 @@ If a search reports that it is unavailable (an error saying web search is unavai
 
 (A single page fetch failing — `read_url` returning an error for ONE url — is different and usually recoverable: just try another source/result; do not stop for that.)
 
+CHECK BEFORE WRITING YOUR FINAL MESSAGE: look back over every search you ran this turn and ask "did ANY of them return even one real result?"
+- If YES — even if LATER searches came back unavailable — your final message MUST report what those results say. You may NOT write "I wasn't able to retrieve any information" / "I couldn't look this up" / "I can't put together a report": you DID retrieve something, so present it, and add one sentence that some later searches couldn't complete so coverage may be incomplete. Throwing away a real result you already have because a later search failed is the single biggest mistake here.
+- If NO search returned anything at all: then, and only then, relay that you couldn't look this up right now.
+
 Only your FINAL answer will be passed on to the user. They will have NO knowledge of anything except your final message, so your final report should be your final message!
 
 End your final message with a `Sources:` list containing, verbatim, every source URL you used — copy each `url` exactly as it appeared in the search results. This is required: whoever reads your answer can only open or verify a URL that appears in your final message, so a source you don't list cannot be read or cited afterwards. If you found no usable sources, say so instead of listing any.

--- a/assist/templates/deepagents/sub_research.txt.j2
+++ b/assist/templates/deepagents/sub_research.txt.j2
@@ -1,13 +1,11 @@
-You are a dedicated researcher. Your job is to conduct research based on the users questions.
+You are a researcher gathering and verifying facts. You search the web, read the pages your searches return, and report back what you VERIFIED — facts you actually found in a source you read, each with the source it came from. You report what the sources say; you do NOT answer from your own knowledge.
 
 Current date/time: {{ current_datetime() }}
 
-Conduct focused research and then reply to the user with a detailed answer to their question.
-
-Stop searching once you can answer the question. Aim for about 4 searches — you do NOT need exhaustive coverage, and you do not need to keep searching for a better source once you have a usable answer. A handful of good results plus, if useful, one or two page reads is enough. Then write your final answer.
+Search a few times (aim for about 4) to gather what the question needs, reading a page or two when a search snippet isn't enough. Stop once you have enough verified findings to cover the question — you do not need exhaustive coverage, and you don't need a better source once you have a usable one.
 
 How to use `read_url` (follow this procedure):
-1. `search_internet` returns a list of `{title, url, content}` — `content` is a snippet of each page. Answer from the snippets when you can; they are usually enough.
+1. `search_internet` returns a list of `{title, url, content}` — `content` is a snippet of each page. Use the snippets when they're enough; they usually are.
 2. If you need a page's full text, copy ONE `url` value VERBATIM from a results list and pass that to `read_url`. Read at most 2 pages.
 3. The `url` you pass to `read_url` must be one you copied from a results list. You do not know what URLs exist — only the search results do. To find more pages, run another `search_internet`; never type a URL yourself.
 4. If a `read_url` errors, do not call it again or a variant of it — move to a different result URL.
@@ -18,18 +16,14 @@ Example — suppose search_internet returned:
 - Correct: `read_url("https://shop.example/f91w")`  ← copied from the results
 - WRONG: `read_url("https://www.casio.com/watch/f-91w/")`  ← you typed this from memory; it is a guess and will fail
 
-If a search reports that it is unavailable (an error saying web search is unavailable), what you do depends on ONE checkable thing — whether an EARLIER search THIS turn already returned real results:
+Your final message IS the findings you hand back. It is built ENTIRELY from what your sources said, and it is honest about what you could and couldn't verify:
 
-- If an earlier search DID return results (you have at least one real result in hand): do NOT retry the search (every retry fails the same way), and do NOT discard the results you already have. Write your answer FROM those earlier results — using ONLY what those results and any pages you read actually say, NEVER from your own knowledge — and add one honest sentence that some searches couldn't complete so coverage may be incomplete. Partial real coverage plus an honest caveat is far better than giving up.
+- Report every relevant finding you verified, and name the source it came from. Nothing in your report may come from your own knowledge — only from a search result or a page you actually read. If you didn't find something in a source, you don't have it — do not fill the gap from memory.
 
-- If NO search this turn has returned any results: STOP — do NOT retry, and do NOT answer from your own knowledge. Relay that you couldn't look this up right now. A guess from memory is worse than an honest "I couldn't look this up right now."
+- If a search comes back rate-limited or unavailable, report the findings you already gathered ANYWAY, and add one plain sentence that some searches couldn't complete so coverage may be incomplete. Getting one real result and then hitting an unavailable search does NOT erase that result: do not throw it away, and do not say you "couldn't retrieve anything" or "couldn't look this up" when you did retrieve something — report what you found.
 
-(A single page fetch failing — `read_url` returning an error for ONE url — is different and usually recoverable: just try another source/result; do not stop for that.)
+- Only if you gathered NOTHING at all (every search failed, not a single result): say plainly that you couldn't look this up right now. Never invent findings to fill the gap — an honest "I couldn't verify this" always beats a guess from memory.
 
-CHECK BEFORE WRITING YOUR FINAL MESSAGE: look back over every search you ran this turn and ask "did ANY of them return even one real result?"
-- If YES — even if LATER searches came back unavailable — your final message MUST report what those results say. You may NOT write "I wasn't able to retrieve any information" / "I couldn't look this up" / "I can't put together a report": you DID retrieve something, so present it, and add one sentence that some later searches couldn't complete so coverage may be incomplete. Throwing away a real result you already have because a later search failed is the single biggest mistake here.
-- If NO search returned anything at all: then, and only then, relay that you couldn't look this up right now.
+(A single page fetch failing — `read_url` returning an error for ONE url — is different and usually recoverable: just try another result; do not stop for that.)
 
-Only your FINAL answer will be passed on to the user. They will have NO knowledge of anything except your final message, so your final report should be your final message!
-
-End your final message with a `Sources:` list containing, verbatim, every source URL you used — copy each `url` exactly as it appeared in the search results. This is required: whoever reads your answer can only open or verify a URL that appears in your final message, so a source you don't list cannot be read or cited afterwards. If you found no usable sources, say so instead of listing any.
+Only your final message is passed on — whoever reads it has NO access to your searches or the pages you read, so every finding AND its source must be IN that message. End your message with a `Sources:` list containing, verbatim, every source URL you used (copy each `url` exactly as it appeared in the search results). If you gathered no usable sources, say so instead of listing any.

--- a/assist/templates/deepagents/sub_research.txt.j2
+++ b/assist/templates/deepagents/sub_research.txt.j2
@@ -26,4 +26,6 @@ Your final message IS the findings you hand back. It is built ENTIRELY from what
 
 (A single page fetch failing — `read_url` returning an error for ONE url — is different and usually recoverable: just try another result; do not stop for that.)
 
+STOP AND CHECK before you write your final message: did ANY search this turn return even one real result? If YES — even if a LATER search came back unavailable — your final message MUST be built from those results. You may NOT say "web search is unavailable / I couldn't look this up / I can't provide a report" when you already found something: a later search failing does not erase what an earlier one found. Report what you found, and note that some searches couldn't complete. Say you couldn't look it up ONLY if every single search returned nothing.
+
 Only your final message is passed on — whoever reads it has NO access to your searches or the pages you read, so every finding AND its source must be IN that message. End your message with a `Sources:` list containing, verbatim, every source URL you used (copy each `url` exactly as it appeared in the search results). If you gathered no usable sources, say so instead of listing any.

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -270,29 +270,19 @@ def search_internet(
             )
         return "[]"
 
+    # Results present: return them. We deliberately DON'T flag a per-call "partial" note
+    # when some engines are in `unresponsive_engines` — on a metasearch, one engine being
+    # throttled/timed-out while 15+ others return a full result set is the routine healthy
+    # case (verified: 3/4 healthy queries had a throttled engine yet 17-32 results), so
+    # noting it would falsely caveat nearly every report and needlessly self-throttle the
+    # searcher. The rate-limit case that MATERIALLY matters — a search that comes back with
+    # NOTHING because engines failed — is handled by the zero-results branch above; the
+    # searcher/orchestrator guidance then uses whatever earlier results it already has.
     normalized = [
         {"title": r.get("title", ""), "url": r.get("url", ""),
          "content": r.get("content", "")}
         for r in results[:max_results]
     ]
-    # Partial-results signal: results came back, but if some engines were rate-limited /
-    # unresponsive this set is INCOMPLETE. Surface it (the same `unresponsive_engines` list
-    # the zero-results branch trusts — a coarse, real, by-construction signal, not a
-    # heuristic) so the agent USES these results AND is honest about the gap, rather than
-    # treating them as complete or later giving up entirely. Distinct from
-    # _SEARCH_UNAVAILABLE_MESSAGE (which stays for zero-results-ever).
-    unresponsive = payload.get("unresponsive_engines", [])
-    if isinstance(unresponsive, list) and unresponsive:
-        engines = ", ".join(
-            str(e[0]) if isinstance(e, (list, tuple)) and e else str(e)
-            for e in unresponsive
-        )
-        return (
-            "PARTIAL RESULTS — some search engines were rate-limited and returned nothing "
-            f"({engines}). The results below are incomplete; use them to answer as best you "
-            "can and note the rate-limiting in your final answer.\n"
-            + str(normalized)
-        )
     return str(normalized)
 
 

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -267,6 +267,15 @@ def search_internet(
                 f"{type(unresponsive).__name__}"
             )
         if unresponsive:
+            # Resilience fallback: the scraped GENERAL engines (brave/ddg/startpage)
+            # get CAPTCHA'd/rate-limited under research load, so `general` comes back
+            # empty. Before failing the whole search, retry the keyless-API research
+            # engines in the `science` category (pubmed/arxiv/crossref/...) — proper
+            # APIs that don't rate-limit and cover factual/scientific queries well. If
+            # they answer, use those rather than losing the turn to a throttle.
+            fallback = _science_fallback(base_url, query, max_results)
+            if fallback is not None:
+                return fallback
             return _search_unavailable(
                 f"SearXNG at {base_url} returned no results and engines failed: "
                 f"{unresponsive}"
@@ -281,12 +290,40 @@ def search_internet(
     # searcher. The rate-limit case that MATERIALLY matters — a search that comes back with
     # NOTHING because engines failed — is handled by the zero-results branch above; the
     # searcher/orchestrator guidance then uses whatever earlier results it already has.
-    normalized = [
+    return _normalize_results(results, max_results)
+
+
+def _normalize_results(results: list, max_results: int) -> str:
+    """SearXNG results -> the model-facing `[{title,url,content}, ...]` string."""
+    return str([
         {"title": r.get("title", ""), "url": r.get("url", ""),
          "content": r.get("content", "")}
         for r in results[:max_results]
-    ]
-    return str(normalized)
+    ])
+
+
+def _science_fallback(base_url: str, query: str, max_results: int) -> str | None:
+    """Retry `query` against the `science` category (keyless-API engines: pubmed,
+    arxiv, crossref, ...). Returns normalized results, or None if the fallback
+    itself is empty/unreachable (so the caller reports the original unavailability).
+    These engines don't rate-limit like the scraped general engines, so this keeps
+    factual/scientific research alive when the general engines are throttled."""
+    try:
+        resp = requests.get(
+            base_url.rstrip("/") + "/search",
+            params={"q": query, "format": "json", "categories": "science"},
+            timeout=_SEARXNG_TIMEOUT_S,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    results = payload.get("results")
+    if not isinstance(results, list) or not results:
+        return None
+    return _normalize_results(results, max_results)
 
 
 # --- Local travel: real-world time/distance via the self-hosted MOTIS engine ---

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -275,6 +275,24 @@ def search_internet(
          "content": r.get("content", "")}
         for r in results[:max_results]
     ]
+    # Partial-results signal: results came back, but if some engines were rate-limited /
+    # unresponsive this set is INCOMPLETE. Surface it (the same `unresponsive_engines` list
+    # the zero-results branch trusts — a coarse, real, by-construction signal, not a
+    # heuristic) so the agent USES these results AND is honest about the gap, rather than
+    # treating them as complete or later giving up entirely. Distinct from
+    # _SEARCH_UNAVAILABLE_MESSAGE (which stays for zero-results-ever).
+    unresponsive = payload.get("unresponsive_engines", [])
+    if isinstance(unresponsive, list) and unresponsive:
+        engines = ", ".join(
+            str(e[0]) if isinstance(e, (list, tuple)) and e else str(e)
+            for e in unresponsive
+        )
+        return (
+            "PARTIAL RESULTS — some search engines were rate-limited and returned nothing "
+            f"({engines}). The results below are incomplete; use them to answer as best you "
+            "can and note the rate-limiting in your final answer.\n"
+            + str(normalized)
+        )
     return str(normalized)
 
 

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -47,10 +47,13 @@ _SEARXNG_TIMEOUT_S = 10.0
 # wait out.
 _SEARCH_UNAVAILABLE_MESSAGE = (
     "Web search is unavailable — the search backend could not be reached or "
-    "returned an unusable response. STOP: do not search again, and do not "
-    "retry with a different query — it will keep failing the same way. Do NOT "
-    "answer from your own knowledge. Your final message must tell the user you "
-    "couldn't look this up because web search is currently unavailable."
+    "returned an unusable response. Do not search again (it will keep failing "
+    "the same way), and never answer from your own knowledge. What to do next "
+    "depends on what you already have: if an EARLIER search this turn already "
+    "returned real results, do NOT discard them — write your answer from those "
+    "results and add that some searches couldn't complete, so coverage may be "
+    "incomplete. Only if you have gathered NOTHING usable at all should your "
+    "final message say you couldn't look this up right now."
 )
 
 

--- a/dockerfiles/searxng/settings.yml
+++ b/dockerfiles/searxng/settings.yml
@@ -17,12 +17,26 @@
 use_default_settings:
   engines:
     keep_only:
+      # Scraped general-web engines. High coverage, but they CAPTCHA / rate-limit
+      # this host's IP under a burst of research searches — when they all trip, a
+      # general search returns nothing.
       - duckduckgo
       - google
       - brave
       - startpage
       - mojeek
       - wikipedia
+      # Keyless-API research engines (SearXNG `science` category). Proper APIs that
+      # do NOT rate-limit like the scraped engines, so they stay up under load.
+      # `search_internet` (assist/tools.py) retries the `science` category through
+      # these when the general engines come back unavailable — keeping factual /
+      # scientific research alive through a general-engine throttle. They are NOT in
+      # the general category (that pollutes non-research queries with academic hits).
+      - wikidata
+      - pubmed
+      - crossref
+      - arxiv
+      - semantic scholar
 
 server:
   # Replaced per host by scripts/searxng.sh, which renders a copy of this file

--- a/docs/2026-07-08-research-audit.org
+++ b/docs/2026-07-08-research-audit.org
@@ -1,0 +1,415 @@
+#+TITLE: Research subsystem audit — redundant-call tendency + honest partial-results-on-rate-limit
+#+DATE: <2026-07-08>
+#+STATUS: DESIGN / AUDIT TO READ (no code). Guidance-first per AGENTS.md §"prefer guidance over middleware".
+#+AUTHOR: audit for Pierre
+
+* Scope & method
+Factual audit of the research subsystem (=create_research_agent= + its trio, =search_internet= /
+=read_url=, and the four shipped guardrails) against every research incident doc in =docs/= and the
+=roadmap.org= research items. Two central asks drive it:
+1. Research must NOT tend toward REDUNDANT/wasteful calls (Part 2).
+2. On RATE-LIMITED / PARTIAL search, the agent must be HONEST about being throttled and still return
+   the best report it can — instead of giving up on "search unavailable" (Part 3).
+Every claim is cited =file:line=. Parts 1–4 are factual (no opinions); Part 5 is the proposal.
+
+* PART 1 — Factual map of the research graph
+
+** The four agents and how a result crosses each boundary
+The research flow is a 4-agent tree, itself a sub-agent of the general agent:
+: general-agent  --task-->  research-agent (ORCHESTRATOR)
+:                              |-- task --> research-agent  (SEARCHER)   [search_internet, read_url]
+:                              |-- task --> critique-agent               [NO tools]
+:                              |-- task --> fact-check-agent              [read_url]
+
+*Boundary rule (load-bearing, verified in deepagents):* a sub-agent's result reaches its parent as a
+SINGLE =ToolMessage= whose content is either the sub-agent's =structured_response= (JSON) or, absent
+that, *the last non-empty AIMessage text* (=deepagents/middleware/subagents.py:495-519=). None of the
+research/orchestrator sub-agents set =response_format=, so *only the final AIMessage text crosses*.
+Concretely: the SEARCHER's =search_internet= and =read_url= =ToolMessage=s are DISCARDED — the
+orchestrator sees only the searcher's final prose. This is the single most important architectural
+constraint for Part 3: any partial-status + partial-findings MUST be in that final message or they are
+lost.
+
+** Orchestrator — =create_research_agent= (=agent.py:474-696=)
+- System prompt: =research_instructions.txt.j2= (=agent.py:652=).
+- Tools: =[read_url]= ONLY (=agent.py:650=). It does NOT search; it delegates searching to the searcher
+  (=agent.py:643-647= comment: giving it =search_internet= was "redundant and doubled the over-search").
+  It keeps =read_url= to read specific URLs while writing/fact-checking.
+- Middleware (=agent.py:660=): =base_mw + <shared trio> + _read_url_guards() + [logging_mw]=, where
+  - =base_mw= (=agent.py:492-574=): JsonValidation(strict=False, if absent), BadRequestRetry(3),
+    OutputSanitization, WriteCollision, LoopDetection, ThreadQueue, EmptyResponseRecovery,
+    ToolResultToFile({read_url}, floor 4000).
+  - shared trio passed from =create_agent= (=agent.py:337=): [retry, json_validation, tool_name].
+  - =_read_url_guards()= (=agent.py:458-471=) = =[UrlProvenanceMiddleware(), ReadUrlRereadBreaker()]=.
+    Added to the orchestrator by PR #182 (this is the fabrication-404 fix — see Part 2.5).
+- recursion_limit: =RollbackRunnable(agent, recursion_limit=300)= (=agent.py:677=). Hitting it is
+  TERMINAL: =GraphRecursionError= is NOT in =RollbackRunnable='s =rollback_on= (docstring =agent.py:666-676=;
+  =checkpoint_rollback.py= =rollback_on=(BadRequestError,)=), so no ~7x rollback multiplication.
+- Wrapped in =ReferencesCleanupRunnable= (=agent.py:692-696=): prunes intermediate drafts, keeps only
+  the final report in =references/=.
+- Result to general agent: final AIMessage text (typically ending =FINAL_REPORT: <filename>=, matched by
+  =research_cleanup.py='s =_FINAL_REPORT_LINE=).
+
+** Searcher — dict sub-agent "research-agent" (=agent.py:618-624=)
+- System prompt: =sub_research.txt.j2=. Tools: =[search_internet, read_url]=.
+- Middleware: =_subagent_safety_mw() + _read_url_guards()= (=agent.py:623=).
+  =_subagent_safety_mw()= (=agent.py:590-616=): retry, BadRequestRetry(3), ToolResultToFile({read_url},4000),
+  OutputSanitization, LoopDetection, *SearchUnavailableBreaker(threshold 4)*, ThreadQueue,
+  EmptyResponseRecovery. Plus =_read_url_guards()= = Provenance + RereadBreaker.
+- recursion_limit: NONE set explicitly in =agent.py= for the dict sub-agents (unlike the orchestrator's
+  300 and the context-agent's 500 at =agent.py:455=). They run under the nested-graph default when the
+  orchestrator's =task= tool invokes them. *Factual gap:* the searcher/critique/fact-check volume ceiling
+  is not an explicit coarse bound in our code — worth noting for Part 2.
+- Result to orchestrator: its final AIMessage text only (search =ToolMessage=s discarded).
+
+** Critique — dict sub-agent "critique-agent" (=agent.py:626-631=)
+- System prompt: =sub_critique.txt.j2=. *Tools: NONE* (no =tools= key at =agent.py:626-631=).
+- Middleware: =_subagent_safety_mw()= only (=agent.py:630=) — includes SearchUnavailableBreaker +
+  ToolResultToFile({read_url}), both INERT here (no search/read tools). Uniform-stack rationale
+  (=agent.py:355-361= comment on the peer dev-critique).
+- *Finding (prompt/tool mismatch):* =sub_critique.txt.j2:11= tells it "You can use the search tool to
+  search for information" — but the agent has no search tool. Dead instruction; a small model may waste a
+  step trying to call a tool it lacks. (Distinct from the DEV critique-agent =create_agent=
+  installs at =agent.py:341-362= with =dev_critique.md.j2=.)
+
+** Fact-checker — dict sub-agent "fact-check-agent" (=agent.py:633-641=)
+- System prompt: =fact_checker.md.j2=. Tools: =[read_url]=.
+- Middleware: =_subagent_safety_mw() + _read_url_guards()= (=agent.py:640=).
+- Own budget guidance: =fact_checker.md.j2:19-21= "AT MOST 10 read_url calls; AT MOST ONCE per URL". The
+  reread breaker (cap 3/URL/run) is a hard backstop under this.
+- *Finding (fixed-filename coupling):* =sub_critique.txt.j2:5-7= and =fact_checker.md.j2:5= read the report
+  at the hard-coded =final_report.md= and the topic at =question.txt=, while the orchestrator writes
+  =<topic>.org= and its subagent descriptions say "You MUST provide the file" (=agent.py:628,635=). The
+  fixed-filename convention vs the orchestrator's chosen basename is a latent coupling; note it, verify in
+  transcripts whether the small model resolves it.
+
+** The tools (=assist/tools.py=)
+*=search_internet= (=tools.py:206-278=)* — self-hosted SearXNG, no fallback. Result branches:
+- No =ASSIST_SEARCH_URL= → =_search_unavailable(...)= (=tools.py:222-226=).
+- Unreachable / non-2xx / bad JSON → unavailable (=tools.py:235-236=).
+- Non-dict body / missing =results= / non-list =results= → unavailable (=tools.py:242-253=).
+- *Empty results* (=tools.py:254-271=): if =unresponsive_engines= is a non-empty list → unavailable
+  (=tools.py:266-270=); else → ="[]"= (genuine empty, =tools.py:271=).
+- *Non-empty results* (=tools.py:273-278=): normalizes =[{title,url,content}]= and returns it —
+  *WITHOUT consulting =unresponsive_engines= at all*. This line is the crux of Part 3.
+- =_SEARCH_UNAVAILABLE_MESSAGE= (=tools.py:48-54=) is a second-person directive ("STOP: do not search
+  again … tell the user you couldn't look this up"). No wait-time framing (a down backend is an outage,
+  not a wait-out; =tools.py:45-47=). =SearchUnavailableBreaker= imports this exact constant
+  (=search_unavailable_breaker.py:48=) as its single source of truth.
+*=read_url= (=tools.py:176-203=)* — per-host throttle (1s), extracts main content, returns FULL text
+(offloaded to file by ToolResultToFile). Error path returns inline ="Error fetching URL: {e}"=
+(=tools.py:203=) — a *distinct string per URL*, deliberately not counted by the breaker
+(=search_unavailable_breaker.py:31-35=).
+
+** The four shipped guardrails
+- =UrlProvenanceMiddleware= (#182, =url_provenance.py=): refuses =read_url= on a URL absent from any prior
+  =ToolMessage=/=HumanMessage= (=_seen_urls= =:100-122=; excludes AIMessage to stop self-laundering).
+  Corrective (not turn-ending). Now on ALL THREE read_url agents (=_read_url_guards()=). Rejection copy
+  handles the empty-allow-list case (=_correction= =:137-160=): "you have no sourced URLs … stop".
+- =ReadUrlRereadBreaker= (#178, =read_url_reread_breaker.py=): refuses the (=max_reads=+1)th fetch of the
+  SAME normalized URL in the current TURN (default 3, =:34=). Corrective (finalize-not-kill, =:111-121=).
+  Counts COMPLETED fetches via =loop_detection._extract_events= (=:49-71=). *Per-run/per-turn scope →
+  resets across orchestrator re-dispatches* (the named residual, doc 2026-07-07 §"cross-dispatch").
+- =SearchUnavailableBreakerMiddleware= (#138, =search_unavailable_breaker.py=): after =threshold= (4,
+  env =ASSIST_SEARCH_UNAVAILABLE_THRESHOLD=) results equal the EXACT unavailable constant in the turn
+  (=_count_search_unavailable= =:59-74=, window=None), strips the next =search_internet= call and
+  *terminates the turn* with a canned first-person "couldn't complete … web search is currently
+  unavailable" (=_compose_terminal_message= =:77-94=; =after_model= strip-to-end =:131-163=). Fires on
+  the searcher (and inertly on critique). *This is a strip-to-DEAD-END terminal, the exact shape the
+  2026-06-05 volume-cap-destroys-output doc warns against* — see Part 3.
+- =LoopDetectionMiddleware= (=loop_detection.py=): only two CONSECUTIVE exact-repeat patterns — (A)
+  same mutating tool + same error, (B) same tool + same args. Read-only tools (search/read) and
+  distinct-arg exploration are DELIBERATELY transparent to it (rolled back to 2 patterns per PR #128;
+  the volume-cap Patterns E/F were REMOVED — =agent.py:666-676= comment "Pattern-E/F caps removed").
+
+* PART 2 — Redundant-call audit
+
+For each tendency: the governing guidance/guard, whether the bound is coarse+real or ambiguous, and
+where the small model actually over-calls (incident-cited).
+
+** 2.1 Over-SEARCH (searcher)
+- Guidance: =sub_research.txt.j2:7= "Aim for about 4 searches … you do not need to keep searching once
+  you have a usable answer"; =:11= "Read at most 2 pages".
+- Hard bound: NONE specific to volume. The old =_RESEARCH_TOOL_VOLUME_CAP=6= (Pattern E) was REMOVED.
+  LoopDetection ignores distinct-query streaks by design. SearchUnavailableBreaker only counts the exact
+  unavailable constant — it does NOT bound HEALTHY over-search. So healthy over-search is bounded ONLY by
+  soft guidance + the searcher's (unset-in-code) nested recursion default.
+- Coarse/real vs ambiguous: intentionally soft — AGENTS.md warns that "many distinct searches" is real
+  work and must not be guard-capped. This is acceptable by ethos; the risk is only wall-clock, not a
+  runaway.
+- Where it over-calls: =docs/2026-06-05-research-volume-cap-destroys-output.org= — the James-Blake
+  two-subject query ran 6–8 searches and the (then-present) cap fired and destroyed the output. The
+  lesson there was that the *cap* was the fault, not the over-search. Verdict: over-search is not the
+  redundancy problem; do not re-add a volume cap.
+
+** 2.2 Re-DISPATCH (orchestrator → searcher)
+- Guidance: =research_instructions.txt.j2:19= "Dispatch it ONCE … re-dispatch only if the first result
+  genuinely failed to address the question at all"; =:36= "at most 3 task calls total".
+- Hard bound: NONE (Pattern F removed). Only =recursion_limit=300= caps the aggregate.
+- Coarse/real vs ambiguous: *AMBIGUOUS.* "genuinely failed to address the question at all" is a
+  judgment loophole the small model can rationalize into repeated dispatches. This is the cross-dispatch
+  multiplier.
+- Where it over-calls: =docs/2026-07-07-read-url-reread-breaker.org= — the peptides orchestrator
+  *re-dispatched the searcher 16×*, each a fresh guard budget, aggregating 1437 read_url calls / 78×
+  same-URL. The per-run reread breaker + per-run SearchUnavailableBreaker both *diluted* across those
+  dispatches (threshold 4/run never fired: 32 unavailable hits ≈ 2/dispatch). NOTE: the later b37c712b
+  runaway (2026-07-08) was confirmed SINGLE-dispatch, so re-dispatch is a real but not the dominant
+  driver — the 2026-07-08 doc explicitly recommends NOT building a cross-dispatch guard.
+
+** 2.3 Re-READ (same-URL rereads)
+- Guard: =ReadUrlRereadBreaker= caps 3 fetches/URL/run (coarse+real, unambiguous — a page's content is
+  unchanged, so re-read N>3 is never real work). On all three read_url agents.
+- Residual: per-run scope resets across re-dispatches (2.2). Bounded across dispatches only by
+  recursion_limit.
+- Where it over-calls: peptides PMID 37657235 read *78×* (doc 2026-07-07); b37c712b re-read/guessed URLs
+  108,278× (doc 2026-07-08). *Both were TRIGGERED by search being unavailable* — the agent brute-forced
+  =read_url= as a substitute for the search it couldn't run. This ties 2.3 directly to Part 3.
+
+** 2.4 Re-CRITIQUE / Re-FACT-CHECK
+- Guidance: =research_instructions.txt.j2:33-34,36= "critique-agent zero or one time … fact-check-agent
+  zero or one time … at most once … at most 3 task calls total". Each is instructed to address findings
+  "in a single edit and move on — do not re-critique/re-fact-check".
+- Additive value: yes — critique improves prose, fact-check verifies citations support claims. They are
+  not redundant PASSES per se; the redundancy risk is only re-invoking them, which guidance caps at 1
+  each (soft, no guard). Bound is ambiguous (soft) but low-blast (each is one dispatch).
+- The fact-checker has its own internal bounds (=fact_checker.md.j2:19-21=, 10 reads / once-per-URL) plus
+  the reread breaker.
+
+** 2.5 The fabrication-404 loop (#182) — redundancy exemplar
+- =docs/2026-07-08-research-reread-runaway.org=: under search-unavailable, the ORCHESTRATOR (which has
+  its own =read_url= and, pre-#182, no provenance guard) FABRICATED plausible URLs, got 404, and looped —
+  *108,278 "404 Not Found" vs 10 successes, 0 successful searches, ~90 min*. Every 404 read was a wasted
+  call.
+- Governed now by: =UrlProvenanceMiddleware= added to the orchestrator (#182, =_read_url_guards()=
+  =agent.py:471=), which makes the fabricated fetch UNREACHABLE by construction (a URL in no ToolMessage
+  is refused). This is the coarse+real, by-construction fix — the redundancy is eliminated at the source,
+  not probabilistically reduced.
+
+** 2.6 Bottom line of Part 2
+The redundancy tendencies split cleanly:
+- Bounded coarse+real by construction: same-URL reread (2.3, reread breaker), fabricated reads (2.5,
+  provenance). Good.
+- Bounded only by soft guidance: over-search (2.1 — acceptable per ethos), re-dispatch (2.2 —
+  ambiguous "genuinely failed" loophole), re-critique/fact-check (2.4 — low blast).
+- The single biggest *driver* of the worst redundancy incidents (peptides, b37c712b) is NOT any of these
+  in isolation — it is *search-unavailable pushing the agent to substitute brute-force =read_url= for
+  search.* Fixing Part 3 (honest partial-results, stop-don't-thrash) is therefore ALSO the highest-
+  leverage redundancy fix. The two asks converge.
+
+* PART 3 — Rate-limit / partial-results audit (the real 2026-07-08 event)
+
+Real event class: SearXNG's free upstream engines rate-limit under a burst — brave "too many requests"
+→ Suspended, ddg/startpage CAPTCHA (=roadmap.org:107-111=, and the 2026-07-02 coffee-shop thread
+=20260702160303=).
+
+** 3.1 Does =search_internet= distinguish partial from fully-down? Only in ONE direction.
+- *Fully-down / zero-ever:* zero results + non-empty =unresponsive_engines= → =_SEARCH_UNAVAILABLE=
+  (=tools.py:266-270=). Correct.
+- *Genuine empty:* zero results + no engine failures → ="[]"= (=tools.py:271=). Correct.
+- *PARTIAL (some engines rate-limited, but others returned results):* the non-empty path
+  (=tools.py:273-278=) returns the results and *NEVER inspects =unresponsive_engines=*. So a partially
+  rate-limited search is returned as if fully healthy — *the throttle signal is SILENTLY DROPPED.* The
+  agent cannot know it got a degraded result set.
+- Additionally, in the real coffee-shop burst the dominant shape was *mixed across CALLS*: the first
+  search fully succeeded (real results, no engine errors) and the next four returned zero-results+engine-
+  errors → =_SEARCH_UNAVAILABLE=. The tool is stateless per call, so it cannot know "an earlier call
+  succeeded"; that context lives only in the agent's message history.
+
+** 3.2 What the agents do today → they give up and DISCARD the good results
+- Searcher: =sub_research.txt.j2:21= "If web SEARCH reports that it is unavailable … STOP immediately …
+  do NOT answer from your own knowledge. Make your final message relay that status." No branch for
+  "unavailable NOW but I already have usable results from an earlier search." So on the 2nd–5th
+  unavailable hit, the guidance says stop-and-relay, abandoning the 1st good result.
+- Orchestrator: =research_instructions.txt.j2:21= "do NOT write a report from your own knowledge … relay
+  … and stop … skip writing a report file and omit the =FINAL_REPORT:= line"; and =:140= "if you have no
+  real URL … relay that you couldn't find sources and stop." Again no partial branch.
+- Net observed (=roadmap.org:99-121=): the turn returns "couldn't look this up because web search is
+  currently unavailable" *even though a real, on-point result was in hand* (the "Mission District Coffee
+  Shops for Remote Work" guide). This is NOT the runaway (#165/#182 worked — real searches, no loop, 1.5
+  min); it is the OPPOSITE failure: premature, dishonest surrender.
+
+** 3.3 The SearchUnavailableBreaker actively discards partial results
+- It counts only the EXACT constant (=search_unavailable_breaker.py:59-74=), so a PARTIAL result
+  (results + would-be signal) does not itself trip it — good. BUT in the mixed-burst shape, 4 fully-
+  unavailable calls DO reach threshold 4 and the breaker STRIPS the next search and *terminates the turn*
+  with =_compose_terminal_message()= = "I couldn't complete this research because web search is currently
+  unavailable" (=:90-94=). That canned terminal:
+  1. carries NONE of the good results already in earlier ToolMessages, and
+  2. crosses the subagent boundary as the searcher's final message (Part 1) — so the orchestrator sees
+     total failure and relays "couldn't look it up".
+- This is precisely the =docs/2026-06-05-research-volume-cap-destroys-output.org= anti-pattern (a
+  strip-to-dead-end terminal that destroys the gathered output), reproduced in the search-unavailable
+  breaker instead of the removed volume cap.
+
+** 3.4 The exact gap (named)
+The system treats *rate-limited / partial* as *total-failure* along three seams:
+(1) =search_internet= drops the partial signal on the non-empty path (=tools.py:273-278=);
+(2) the searcher/orchestrator prompts have no "use what you have + be honest" branch — only stop-and-relay;
+(3) the SearchUnavailableBreaker's terminal message asserts total failure and discards in-hand results.
+The best-effort answer is thrown away at whichever seam fires first.
+
+* PART 4 — Lessons incorporated (docs + roadmap)
+
+- =docs/2026-05-31-heed-research-agent-rate-limit-signal.org=: the FIX for cross-dispatch surrender is
+  *guidance, not a meta-loop detector* (Pierre's explicit call). Prompt gap → the model defaults to its
+  over-repeated "always research" prior. *Also introduced the structured-sentinel idea* (a
+  =SEARCH_UNAVAILABLE= sibling of =FINAL_REPORT:=) as the robust cross-boundary channel — directly
+  relevant to Part 5(b) since only the final message crosses. → Fold: prefer guidance; if the partial
+  status won't survive the two summarization hops as prose, use a sentinel line in the final message.
+- =docs/2026-06-05-research-volume-cap-destroys-output.org=: a capped research agent must FINALIZE (write
+  its answer), not die with a canned stub; strip-to-dead-end destroys output; use =jump_to:"model"= +
+  a "write your final answer NOW from what you already gathered (not from memory)" nudge. → Fold: the
+  SearchUnavailableBreaker terminal must become finalize-not-kill (Part 5b).
+- =docs/2026-07-07-read-url-reread-breaker.org=: same-URL reread bound (coarse+real, finalize-not-kill);
+  the residual is cross-dispatch reset; the TRIGGER is search-unavailability. → Fold: Part 2.3, and "fix
+  the trigger" = Part 3.
+- =docs/2026-07-08-research-reread-runaway.org=: root cause was a MISSING guard (provenance off the
+  orchestrator), not too much middleware; fix by reusing existing guards + guidance "no sources → stop,
+  don't fabricate, don't re-dispatch"; DO NOT build a cross-dispatch bound; DO NOT widen LoopDetection to
+  read-only/error heuristics (misfire risk). → Fold: Part 2.2/2.5; Part 5(a) must not add a cross-
+  dispatch guard.
+- =docs/2026-07-06-research-eval-mocking.org=: MOCK the research subagent in every non-research eval;
+  only =test_research_agent= + =test_research_reliability= do real search (rate-limit grind). The
+  partial-results eval must MOCK =search_internet= to emit the partial/mixed shapes — never real search.
+- =roadmap.org= "Research improvements":
+  - =:99-141= "Research resilience to search rate-limiting + read_url link exploration" — the exact
+    partial-results item: distinguish "backend down (0 ever)" from "burst tripped engine limits (some
+    results in hand)", keep the good results, be honest, and consider serializing/spacing the burst
+    (the 3-parallel burst is what trips the limits). Plus =read_url= returning page hyperlinks so a
+    single good result can be explored when search is throttled (provenance already permits link-
+    following; =read_url= just never exposed the links). → the queued =research-rate-limit-resilience=
+    item Part 5(b) implements.
+  - =:206-234= "Audit research turns for ADVERSE guard effects" — the false-positive lens: a guard/
+    recursion cut-off that kills GOOD work is worse than the rare runaway. The SearchUnavailableBreaker
+    discarding partial results (Part 3.3) is exactly such an adverse effect. → Part 5(b) softens it.
+  - =:142-205= "Research must NOT judge distances/travel" and the confabulated-anchor sub-item (a
+    FABRICATED address, not just a fabricated URL) — RELATED but out of scope here; note as adjacent.
+
+* PART 5 — Redesign proposal (guidance-first, minimal, honoring the ethos)
+
+** (a) Redundancy — smallest changes that stop the tendency without truncating deep research
+Principle (AGENTS.md): do NOT guard "many distinct searches / distinct reads" — that is real work. Prefer
+prompt/arg-shape fixes; name a guard only if guidance provably can't.
+
+1. *(no new guard — this is the key finding)* The by-construction bounds already cover the two runaway
+   shapes (reread breaker, provenance). The worst redundancy incidents were TRIGGERED by search-
+   unavailability (Part 2.6), so *Part 5(b) is the primary redundancy fix.* Do NOT add a cross-dispatch
+   re-dispatch guard (2026-07-08 doc: it targets a mechanism the runaway doesn't use, and it is new guard
+   surface with its own misfire risk).
+2. *(guidance, arg-shaped)* Tighten the re-dispatch loophole. =research_instructions.txt.j2:19= currently
+   permits re-dispatch "if the first result genuinely failed to address the question at all" — a
+   judgment the small model rationalizes. Replace with a checkable condition, e.g.: "Re-dispatch the
+   research-agent ONLY if its result contains NO findings and NO sources (an empty or error result). If
+   it returned ANY findings, do not re-dispatch — write the report from them." This is a constraint on an
+   observable (findings/sources present?), not a goal ("enough detail?"). Per AGENTS.md §"the
+   instruction's shape matters more than its content", the model follows a checkable condition far better.
+3. *(guidance hygiene)* Remove the dead "You can use the search tool" line from =sub_critique.txt.j2:11=
+   (the critique agent has no tools; =agent.py:626-631=) so the model doesn't burn a step on a missing
+   tool. Reconcile the fixed =final_report.md= / =question.txt= filenames in =sub_critique.txt.j2= /
+   =fact_checker.md.j2= with the orchestrator's chosen basename (verify in transcripts first — it may
+   already work via the task-prompt path; if it doesn't, that is a real redundancy/confusion source).
+   These are documentation-debt fixes, not behavior guards.
+
+** (b) Partial-results-on-rate-limit — honest best-effort, guidance-first
+Design across the three seams named in Part 3.4, in the boundary reality of Part 1 (only the final
+message crosses).
+
+*(b1) =search_internet= surfaces a DISTINCT partial/rate-limited signal (=tools.py=).*
+- On the NON-EMPTY results path (=tools.py:273-278=), also read =unresponsive_engines= (with the same
+  is-list validation already used at =:260-265=). If it is non-empty, APPEND a coarse, model-legible
+  note to the returned results, e.g. a leading line:
+  : PARTIAL RESULTS — some search engines were rate-limited and returned nothing (<engines>). The
+  : results below are incomplete; use them and note the rate-limiting in your answer.
+  Keep returning the real results. This is a coarse REAL signal (keyed on =unresponsive_engines= being a
+  non-empty list — the same by-construction predicate the fully-down branch already trusts), NOT a fuzzy
+  heuristic. It is DISTINCT from =_SEARCH_UNAVAILABLE_MESSAGE= (which stays for zero-results-ever).
+- Consider (roadmap =:126-131=) distinguishing a zero-results *rate-limit* (engines Suspended/CAPTCHA/
+  "too many requests") from a zero-results *outage* (backend unreachable) in the EMPTY branch, to word
+  the message as wait-out-able vs fix-it. Lower priority; the non-empty partial signal is the load-bearing
+  change.
+- Optional, roadmap =:132-141=: have =read_url= surface the page's outbound hyperlinks (a
+  =read_url_links= tool or an appended links section) so ONE good result can be explored when search is
+  throttled. Provenance already permits following a link that appears in a fetched ToolMessage. Adjacent
+  enhancement — validate the char budget; not required for the honesty fix.
+
+*(b2) Searcher guidance — use partial + earlier results, be honest (=sub_research.txt.j2=).*
+Replace the binary =:21= "unavailable → STOP" with a graded rule:
+- If a search returns PARTIAL RESULTS (the b1 note): USE them; do NOT immediately re-fire a burst (space
+  your searches — one at a time — since bursts trip the limits); include an honesty caveat in your final
+  answer ("some sources were rate-limited; based on what was available: …").
+- If a search returns fully-unavailable BUT you ALREADY have usable results from an earlier search THIS
+  turn: finalize from those with the caveat — do NOT discard them.
+- Only if you have NO usable results at all AND search is unavailable: relay unavailable + stop (the
+  current behavior, now the narrow case).
+Crucially (Part 1 boundary): the searcher's FINAL message must contain BOTH the findings AND the rate-
+limited caveat (its =Sources:= list is already required at =:25=). Only that message crosses.
+
+*(b3) Orchestrator guidance — write the best report you can (=research_instructions.txt.j2=).*
+Mirror b2 at =:21=: if the searcher's returned findings contain ANY usable results (even with a rate-
+limited caveat), WRITE the report from them and carry the caveat into the report ("Some sources could not
+be reached due to rate-limiting; based on the available sources: …"). Only relay-and-stop (skip
+=FINAL_REPORT:=) if the searcher returned NOTHING usable. This directly neutralizes =:21='s current
+"relay + stop, no report" over-trigger.
+
+*(b4) SearchUnavailableBreaker — finalize-not-kill (=search_unavailable_breaker.py=).*
+This is the ONE middleware change, justified because the breaker fires precisely WHEN guidance already
+failed, so guidance cannot carry the terminal behavior. Apply the 2026-06-05 lesson: instead of strip-to-
+dead-end with a total-failure message (=:90-94,163=), FINALIZE — answer the stripped call with a nudge
+ToolMessage and =jump_to:"model"= so the model takes one more turn to synthesize: "Search is unavailable
+and further searches will fail. Write your best answer NOW *from the results you already gathered this
+turn* (do not answer from memory); if you gathered nothing usable, say plainly you couldn't look this up."
+This preserves any partial results in earlier ToolMessages instead of discarding them. It is a behavior
+change to an EXISTING guard (removing an adverse effect per roadmap =:206-234=), NOT a new guard class.
+Note the =jump_to:"model"= BLOCKER from the 2026-06-05 doc (=@hook_config(can_jump_to=["model"])= must be
+declared, and a 5-line spike must confirm it re-enters the model) applies here too.
+
+*(b5) If prose won't survive the two summarization hops → sentinel (from 2026-05-31 doc).*
+If evals show the partial caveat is laundered away crossing searcher→orchestrator→general, add a
+=PARTIAL_RESULTS= / =SEARCH_RATE_LIMITED= sentinel line to the searcher's final message (sibling of
+=FINAL_REPORT:=), keyed off by the orchestrator prompt — the existing, low-plumbing cross-boundary
+channel. Start with prose (b2/b3); adopt the sentinel only if the eval calls for it.
+
+** Sequencing (eval-first, per AGENTS.md; the crucial real-search evals stay mocked elsewhere)
+1. *Reproduce (baseline must FAIL), MOCKED search only.* New eval, mock =search_internet= to emit:
+   (i) the PARTIAL shape (results + b1 note), and (ii) the MIXED-BURST shape (call #1 → real results;
+   calls #2–5 → =_SEARCH_UNAVAILABLE=). Baseline assertions: the turn RELAYS "unavailable" / returns no
+   report despite usable results (the Part 3.2/3.3 failure). Mock =read_url= too (no live network), per
+   =docs/2026-07-06-research-eval-mocking.org=. Do NOT touch =test_research_agent= /
+   =test_research_reliability= (they stay real-search, run sparingly).
+2. *Add b1* (=tools.py= partial signal). Unit test in =tests/test_tools.py=: partial payload → results +
+   note; zero+engines → unavailable; zero+none → ="[]"=.
+3. *Add b2/b3 guidance.* Eval: the agent USES partial/earlier results and emits an HONEST caveat; the
+   report is non-empty and cites the real sources. Change one prompt at a time (isolate-to-learn) and
+   measure.
+4. *Add b4* (breaker finalize-not-kill) after the =jump_to= spike. Eval: the mixed-burst turn PRESERVES
+   the good result (report cites it) instead of the canned total-failure message.
+5. *Regression.* Healthy real-search evals unchanged (partial branch is transparent when
+   =unresponsive_engines= is empty). Provenance/reread guards unaffected. Eval cadence 3/5/10.
+6. *Blast radius:* touches =agent.py= middleware behavior + =tools.py= + prompts → FULL three-phase
+   treatment per CLAUDE.md.
+
+** Risks & open questions for Pierre
+1. *jump_to feasibility (b4).* Confirm =jump_to:"model"= fires from =after_model= on the searcher's
+   compiled graph (the 2026-06-05 B1 spike). If not, fall back to answering the stripped call with the
+   nudge ToolMessage and letting the loop proceed to a normal model turn (watch dangling tool_call_id).
+2. *Partial caveat surviving two summarization hops.* Prose may be laundered searcher→orchestrator→
+   general; b5 sentinel is the fallback. Which do you prefer as the default?
+3. *Spacing the burst (roadmap :128-131).* Serializing searches reduces rate-limit tripping but slows
+   healthy turns. Do we serialize in the tool, or only guide "one search at a time"? (Guidance-first
+   suggests the latter; measure.)
+4. *"Genuinely failed" re-dispatch rewrite (a2).* The proposed checkable condition ("no findings AND no
+   sources") assumes the searcher reliably returns an empty/error result when it fails — verify against
+   transcripts (a searcher that returns a chatty "I couldn't find much" would read as non-empty).
+5. *read_url link exposure (b1 optional).* Char-budget trade-off; likely a separate =read_url_links=
+   tool. Ship the honesty fix first, then assess.
+6. *Adjacent, deliberately out of scope:* the confabulated-anchor item (fabricated ADDRESS, not URL —
+   roadmap :190-205) and the distances-belong-to-routing item (:142-189). Flagged, not addressed here.
+
+* Critical files for implementation
+- =assist/tools.py:254-278= — =search_internet= empty vs partial branches; the partial-signal change (b1).
+- =assist/middleware/search_unavailable_breaker.py:77-94,131-163= — finalize-not-kill terminal (b4).
+- =assist/templates/deepagents/sub_research.txt.j2:7,21,25= — searcher partial/earlier-results guidance (b2).
+- =assist/templates/deepagents/research_instructions.txt.j2:19,21,140= — re-dispatch condition (a2) +
+  orchestrator best-report-on-partial (b3).
+- =assist/agent.py:590-624,660,677= — middleware wiring (breaker install site) + the searcher/orchestrator
+  guard stacks the changes must not disturb.

--- a/docs/2026-07-08-research-audit.org
+++ b/docs/2026-07-08-research-audit.org
@@ -315,6 +315,12 @@ Design across the three seams named in Part 3.4, in the boundary reality of Part
 message crosses).
 
 *(b1) =search_internet= surfaces a DISTINCT partial/rate-limited signal (=tools.py=).*
+# AS-BUILT (2026-07-08): b1 was NOT adopted. A per-call "PARTIAL RESULTS" note fired on ~every
+# healthy query (3/4 healthy SearXNG queries have one throttled engine yet return 17-32 results),
+# so it was dropped — search_internet returns results PLAINLY (tests/test_tools.py enforces no
+# "PARTIAL" note when results exist). Resilience came from guidance + architecture (the prompt
+# rewrite + orchestrator-without-read_url), not a tool-level signal. The rest of this bullet is
+# the superseded original proposal, kept for the record.
 - On the NON-EMPTY results path (=tools.py:273-278=), also read =unresponsive_engines= (with the same
   is-list validation already used at =:260-265=). If it is non-empty, APPEND a coarse, model-legible
   note to the returned results, e.g. a leading line:
@@ -378,6 +384,10 @@ channel. Start with prose (b2/b3); adopt the sentinel only if the eval calls for
    =test_research_reliability= (they stay real-search, run sparingly).
 2. *Add b1* (=tools.py= partial signal). Unit test in =tests/test_tools.py=: partial payload → results +
    note; zero+engines → unavailable; zero+none → ="[]"=.
+   # AS-BUILT: b1 DROPPED (fired on healthy queries). The sequencing that shipped: rewrite the research
+   # prompts from best practices + make the orchestrator a pure lead (tools=[], no read_url), and focus
+   # the eval on the MIXED-BURST (early success then unavailable) + ALL-UNAVAILABLE shapes with the
+   # guidance/breaker preserving early results. search_internet returns results plainly.
 3. *Add b2/b3 guidance.* Eval: the agent USES partial/earlier results and emits an HONEST caveat; the
    report is non-empty and cites the real sources. Change one prompt at a time (isolate-to-learn) and
    measure.

--- a/edd/eval/test_agent.py
+++ b/edd/eval/test_agent.py
@@ -676,8 +676,8 @@ class TestSearchDownMidflightDoesNotGrind(AgentTestMixin, TestCase):
     This is the eval the handoff test lacked.  It PRIMES the model into
     retry-mode with one unsatisfying-but-valid result (so it has already
     "learned" to retry), THEN the backend goes down — every subsequent search
-    returns ``_SEARCH_UNAVAILABLE_MESSAGE``.  The strengthened prompt ("stop,
-    do not retry with a different query") is the first line of defense; the
+    returns ``_SEARCH_UNAVAILABLE_MESSAGE``.  The strengthened prompt (search
+    unavailable → stop, do not search again) is the first line of defense; the
     ``SearchUnavailableBreakerMiddleware`` is the hard backstop.  Together,
     total searches must stay bounded.  WITHOUT either, the slow model grinds
     distinct queries to the recursion_limit (observed ~75-100 searches /

--- a/edd/eval/test_research_large_multipart.py
+++ b/edd/eval/test_research_large_multipart.py
@@ -1,0 +1,127 @@
+"""Research handles a LARGE multi-part brief without degenerating.
+
+The 2026-07-09 finding (prod thread 20260709060922): on a big multi-part query
+("tell me about peptides" → 10+ distinct peptides), the lean orchestrator handed the
+WHOLE brief to a single searcher, which over-searched/over-read across every part —
+77 model calls, 65+ min, context bloat, no report — dramatically worse than a focused
+query. The flow must SIZE the research to the brief: a brief spanning many distinct
+things → bounded work per thing, not one searcher drowning. Small focused briefs
+(test_research_partial_results, test_research_reliability) must keep working — this eval
+guards the OTHER end of the range.
+
+Mocked search + fetch (per the always-mock rule): the mock answers each subtopic from
+canned data AND counts retrieval calls, so we can assert the flow stays bounded. The
+query has 6 distinct parts, each with a UNIQUE fact that can only reach the report if the
+part was actually researched — so coverage is verifiable and can't be faked from memory.
+
+Asserts the outcome, not the mechanism (decompose vs bounded-single are both fine):
+  1. Completes and writes a report (a degenerate run drowns / hits the recursion cap).
+  2. The report covers ALL 6 parts (each part's unique fact is present).
+  3. Total retrieval (search + fetch) stays BOUNDED — no over-search runaway.
+"""
+import os
+import tempfile
+from unittest.mock import patch
+
+from assist.agent import create_research_agent, AgentHarness
+from assist.model_manager import select_assistant_model
+
+os.environ.setdefault("ASSIST_MODEL_URL", "http://127.0.0.1:8000/v1")
+_SEARCH_HOST = "http://searxng.test"
+
+# 6 distinct "things", each with a UNIQUE sentinel fact. Generic (a fictional product
+# line) so nothing here is telegraphed by the research prompts, and the sentinels are
+# invented tokens that can only come from a source the agent actually read.
+_PARTS = {
+    "aurora": ("The Aurora tier uses a QUASAR-9 cooling loop.", "quasar-9"),
+    "borealis": ("The Borealis tier ships with a TIDELOCK power cell.", "tidelock"),
+    "cascade": ("The Cascade tier runs the FERNWEH-3 controller.", "fernweh-3"),
+    "drift": ("The Drift tier is rated for MARLINSPIKE certification.", "marlinspike"),
+    "ember": ("The Ember tier includes a GLIMMERWICK sensor array.", "glimmerwick"),
+    "frost": ("The Frost tier is built on the SLIPSTREAM-7 chassis.", "slipstream-7"),
+}
+_PROMPT = ("I'm evaluating the Helio product line. Tell me about each tier — Aurora, "
+           "Borealis, Cascade, Drift, Ember, and Frost — and what's distinctive about each.")
+
+
+class _Resp:
+    def __init__(self, *, json_payload=None, text=""):
+        self._json, self.text, self.status_code = json_payload, text, 200
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        pass
+
+
+def _results_for(query):
+    """Canned search hits: any part-name in the query yields that part's sentinel fact,
+    each behind its own URL (so read_url is never needed but is available)."""
+    q = query.lower()
+    hits = []
+    for name, (fact, _tok) in _PARTS.items():
+        if name in q:
+            hits.append({"title": f"Helio {name.title()} tier — spec sheet",
+                         "url": f"https://helio-specs.test/{name}",
+                         "content": fact})
+    if not hits:  # a broad query with no part name still returns the overview
+        hits = [{"title": "Helio product line overview",
+                 "url": "https://helio-specs.test/overview",
+                 "content": "The Helio line has six tiers: Aurora, Borealis, Cascade, Drift, Ember, Frost."}]
+    return hits
+
+
+def _run(counters):
+    def mock_get(url, **kw):
+        if url.startswith(_SEARCH_HOST):
+            counters["search"] += 1
+            q = (kw.get("params") or {}).get("q", "")
+            return _Resp(json_payload={"results": _results_for(q), "unresponsive_engines": []})
+        counters["fetch"] += 1
+        # read_url on a part URL → that part's fact as page text
+        name = url.rstrip("/").split("/")[-1]
+        fact = _PARTS.get(name, ("Helio overview.",))[0]
+        return _Resp(text=f"<article>{fact}</article>")
+
+    root = tempfile.mkdtemp()
+    os.makedirs(os.path.join(root, "references"), exist_ok=True)
+    agent = AgentHarness(create_research_agent(select_assistant_model(0.1), root))
+    with patch.dict(os.environ, {"ASSIST_SEARCH_URL": _SEARCH_HOST}), \
+         patch("assist.tools.requests.get", mock_get), \
+         patch("assist.tools._host_throttle", lambda host: None):
+        res = str(agent.message(_PROMPT))
+    return res, root
+
+
+def _report_text(root, res):
+    parts = [res]
+    for dp, _, fs in os.walk(root):
+        for f in fs:
+            if f.endswith((".org", ".md")):
+                with open(os.path.join(dp, f)) as fh:
+                    parts.append(fh.read())
+    return "\n".join(parts).lower()
+
+
+# Bound on total retrieval ops for a 6-part brief. Healthy: ~1-3 searches/part (whether
+# decomposed into 6 searchers or covered in a bounded sequence) + a few reads ≈ well under
+# 30. The degenerate single-searcher grind did 77+ model calls with far more retrieval.
+_RETRIEVAL_BOUND = 30
+
+
+class TestResearchLargeMultipart:
+    def test_covers_all_parts_and_stays_bounded(self):
+        counters = {"search": 0, "fetch": 0}
+        res, root = _run(counters)
+        report = _report_text(root, res)
+        total = counters["search"] + counters["fetch"]
+        missing = [tok for (_f, tok) in _PARTS.values() if tok not in report]
+        print(f"\n[large-multipart] searches={counters['search']} fetches={counters['fetch']} "
+              f"total={total} missing_parts={missing}\n  {res[:300]!r}\n")
+        # (1)+(2): a report that covers every part's unique fact
+        assert not missing, f"report must cover all 6 parts; missing sentinels: {missing}"
+        # (3): no over-search runaway — the degeneracy this eval exists to catch
+        assert total <= _RETRIEVAL_BOUND, (
+            f"retrieval runaway: {total} search+fetch calls (bound {_RETRIEVAL_BOUND}) — "
+            f"the brief was handed to an unbounded searcher instead of being sized to its parts")

--- a/edd/eval/test_research_large_multipart.py
+++ b/edd/eval/test_research_large_multipart.py
@@ -1,23 +1,18 @@
-"""Research handles a LARGE multi-part brief without degenerating.
+"""Research handles a LARGE multi-part brief without degenerating (CITATION-CHASING fixture).
 
-The 2026-07-09 finding (prod thread 20260709060922): on a big multi-part query
-("tell me about peptides" → 10+ distinct peptides), the lean orchestrator handed the
-WHOLE brief to a single searcher, which over-searched/over-read across every part —
-77 model calls, 65+ min, context bloat, no report — dramatically worse than a focused
-query. The flow must SIZE the research to the brief: a brief spanning many distinct
-things → bounded work per thing, not one searcher drowning. Small focused briefs
-(test_research_partial_results, test_research_reliability) must keep working — this eval
-guards the OTHER end of the range.
+The 2026-07-09 finding (prod thread 20260709060922, peptides): a single searcher read ~61
+distinct real medical pages for a 10-part brief — 77 model calls, 65+ min, no report.
+Clean AND messy mocks both failed to reproduce it (main == V2 == 16 ops), because the real
+driver is CITATION CHASING: real papers cite dozens of others, and the searcher follows the
+chain into an ever-expanding frontier of DISTINCT pages (the re-read breaker only catches
+re-reading the SAME url, not chasing new ones).
 
-Mocked search + fetch (per the always-mock rule): the mock answers each subtopic from
-canned data AND counts retrieval calls, so we can assert the flow stays bounded. The
-query has 6 distinct parts, each with a UNIQUE fact that can only reach the report if the
-part was actually researched — so coverage is verifiable and can't be faked from memory.
+This fixture reproduces that: each tier's page states the fact then lists ~12 citation URLs;
+each citation page expands into 8 more. A disciplined searcher reads the tier page, takes the
+fact, and stops; a chaser follows citations and explodes. 8 parts.
 
-Asserts the outcome, not the mechanism (decompose vs bounded-single are both fine):
-  1. Completes and writes a report (a degenerate run drowns / hits the recursion cap).
-  2. The report covers ALL 6 parts (each part's unique fact is present).
-  3. Total retrieval (search + fetch) stays BOUNDED — no over-search runaway.
+Baseline against MAIN first (reference), then the branch. Asserts: covers the parts + total
+retrieval stays bounded (no citation-chase runaway) + completes.
 """
 import os
 import tempfile
@@ -27,21 +22,23 @@ from assist.agent import create_research_agent, AgentHarness
 from assist.model_manager import select_assistant_model
 
 os.environ.setdefault("ASSIST_MODEL_URL", "http://127.0.0.1:8000/v1")
-_SEARCH_HOST = "http://searxng.test"
+_HOST = "http://searxng.test"          # search host (mock patches requests.get)
+_SPECS = "https://helio-specs.test"    # page host
 
-# 6 distinct "things", each with a UNIQUE sentinel fact. Generic (a fictional product
-# line) so nothing here is telegraphed by the research prompts, and the sentinels are
-# invented tokens that can only come from a source the agent actually read.
 _PARTS = {
-    "aurora": ("The Aurora tier uses a QUASAR-9 cooling loop.", "quasar-9"),
-    "borealis": ("The Borealis tier ships with a TIDELOCK power cell.", "tidelock"),
-    "cascade": ("The Cascade tier runs the FERNWEH-3 controller.", "fernweh-3"),
-    "drift": ("The Drift tier is rated for MARLINSPIKE certification.", "marlinspike"),
-    "ember": ("The Ember tier includes a GLIMMERWICK sensor array.", "glimmerwick"),
-    "frost": ("The Frost tier is built on the SLIPSTREAM-7 chassis.", "slipstream-7"),
+    "aurora":   ("uses a QUASAR-9 cooling loop",         "quasar-9"),
+    "borealis": ("ships with a TIDELOCK power cell",     "tidelock"),
+    "cascade":  ("runs the FERNWEH-3 controller",        "fernweh-3"),
+    "drift":    ("holds MARLINSPIKE certification",      "marlinspike"),
+    "ember":    ("includes a GLIMMERWICK sensor array",  "glimmerwick"),
+    "frost":    ("is built on the SLIPSTREAM-7 chassis", "slipstream-7"),
+    "gale":     ("boots the HALCYON-2 firmware",          "halcyon-2"),
+    "harbor":   ("carries a KESTREL-5 telemetry unit",   "kestrel-5"),
 }
+_NAMES = list(_PARTS)
 _PROMPT = ("I'm evaluating the Helio product line. Tell me about each tier — Aurora, "
-           "Borealis, Cascade, Drift, Ember, and Frost — and what's distinctive about each.")
+           "Borealis, Cascade, Drift, Ember, Frost, Gale, and Harbor — and what's "
+           "distinctive about each one.")
 
 
 class _Resp:
@@ -55,39 +52,54 @@ class _Resp:
         pass
 
 
-def _results_for(query):
-    """Canned search hits: any part-name in the query yields that part's sentinel fact,
-    each behind its own URL (so read_url is never needed but is available)."""
+def _search_results(query):
     q = query.lower()
-    hits = []
-    for name, (fact, _tok) in _PARTS.items():
-        if name in q:
-            hits.append({"title": f"Helio {name.title()} tier — spec sheet",
-                         "url": f"https://helio-specs.test/{name}",
-                         "content": fact})
-    if not hits:  # a broad query with no part name still returns the overview
-        hits = [{"title": "Helio product line overview",
-                 "url": "https://helio-specs.test/overview",
-                 "content": "The Helio line has six tiers: Aurora, Borealis, Cascade, Drift, Ember, Frost."}]
+    named = [n for n in _NAMES if n in q] or _NAMES[:3]
+    hits = [{"title": f"Helio {n.title()} — peer-reviewed technical review",
+             "url": f"{_SPECS}/tier/{n}",
+             "content": f"Peer-reviewed technical review of the Helio {n.title()} tier and its hardware."}
+            for n in named[:3]]
+    hits += [{"title": "Helio product line — buyer's guide",
+              "url": f"{_SPECS}/guide", "content": "Overview of the eight Helio tiers."},
+             {"title": "Helio forum — tier comparison", "url": f"{_SPECS}/forum",
+              "content": "Users compare Helio tiers; opinions vary."}]
     return hits
+
+
+def _page_text(url):
+    path = url.split(".test", 1)[-1]
+    parts = [p for p in path.split("/") if p]
+    if parts[:1] == ["tier"]:
+        name = parts[1]
+        fact = _PARTS[name][0]
+        cites = "".join(f"\n- {_SPECS}/cite/{name}/{i}" for i in range(12))
+        filler = "This review surveys the design context and prior art. " * 20
+        return (f"<article><h1>Helio {name.title()} — technical review</h1>"
+                f"<p>The Helio {name.title()} tier {fact}. It targets professional use.</p>"
+                f"<p>{filler}</p><h2>References</h2>{cites}</article>")
+    if parts[:1] == ["cite"]:
+        depth = len(parts) - 1  # how deep in the citation chain
+        more = "".join(f"\n- {_SPECS}{path}/{j}" for j in range(8)) if depth < 4 else ""
+        filler = "The cited study details methodology, cohort, and adjacent findings. " * 18
+        return (f"<article><p>Cited study {'/'.join(parts[1:])} — related background, no tier spec here.</p>"
+                f"<p>{filler}</p><h2>Further reading</h2>{more}</article>")
+    return ("<article>Helio buyer's guide: the line spans eight tiers — "
+            + ", ".join(n.title() for n in _NAMES) + ".</article>")
 
 
 def _run(counters):
     def mock_get(url, **kw):
-        if url.startswith(_SEARCH_HOST):
+        if url.startswith(_HOST):
             counters["search"] += 1
             q = (kw.get("params") or {}).get("q", "")
-            return _Resp(json_payload={"results": _results_for(q), "unresponsive_engines": []})
+            return _Resp(json_payload={"results": _search_results(q), "unresponsive_engines": []})
         counters["fetch"] += 1
-        # read_url on a part URL → that part's fact as page text
-        name = url.rstrip("/").split("/")[-1]
-        fact = _PARTS.get(name, ("Helio overview.",))[0]
-        return _Resp(text=f"<article>{fact}</article>")
+        return _Resp(text=_page_text(url))
 
     root = tempfile.mkdtemp()
     os.makedirs(os.path.join(root, "references"), exist_ok=True)
     agent = AgentHarness(create_research_agent(select_assistant_model(0.1), root))
-    with patch.dict(os.environ, {"ASSIST_SEARCH_URL": _SEARCH_HOST}), \
+    with patch.dict(os.environ, {"ASSIST_SEARCH_URL": _HOST}), \
          patch("assist.tools.requests.get", mock_get), \
          patch("assist.tools._host_throttle", lambda host: None):
         res = str(agent.message(_PROMPT))
@@ -104,24 +116,20 @@ def _report_text(root, res):
     return "\n".join(parts).lower()
 
 
-# Bound on total retrieval ops for a 6-part brief. Healthy: ~1-3 searches/part (whether
-# decomposed into 6 searchers or covered in a bounded sequence) + a few reads ≈ well under
-# 30. The degenerate single-searcher grind did 77+ model calls with far more retrieval.
-_RETRIEVAL_BOUND = 30
+_RETRIEVAL_BOUND = 50  # calibrate to main's baseline; a citation-chase grind blows past it
 
 
 class TestResearchLargeMultipart:
-    def test_covers_all_parts_and_stays_bounded(self):
+    def test_covers_parts_and_stays_bounded(self):
         counters = {"search": 0, "fetch": 0}
         res, root = _run(counters)
         report = _report_text(root, res)
         total = counters["search"] + counters["fetch"]
+        covered = [tok for (_f, tok) in _PARTS.values() if tok in report]
         missing = [tok for (_f, tok) in _PARTS.values() if tok not in report]
         print(f"\n[large-multipart] searches={counters['search']} fetches={counters['fetch']} "
-              f"total={total} missing_parts={missing}\n  {res[:300]!r}\n")
-        # (1)+(2): a report that covers every part's unique fact
-        assert not missing, f"report must cover all 6 parts; missing sentinels: {missing}"
-        # (3): no over-search runaway — the degeneracy this eval exists to catch
+              f"total={total} covered={len(covered)}/8 missing={missing}\n  {res[:300]!r}\n")
+        assert len(covered) >= 6, f"report should cover most tiers; only {len(covered)}/8, missing {missing}"
         assert total <= _RETRIEVAL_BOUND, (
             f"retrieval runaway: {total} search+fetch calls (bound {_RETRIEVAL_BOUND}) — "
-            f"the brief was handed to an unbounded searcher instead of being sized to its parts")
+            f"the searcher chased citations instead of taking each tier's fact and moving on")

--- a/edd/eval/test_research_partial_results.py
+++ b/edd/eval/test_research_partial_results.py
@@ -2,17 +2,21 @@
 
 The 2026-07-02 failure: SearXNG's upstream engines rate-limit under a burst, so the
 research turn GAVE UP ("couldn't look this up") and DISCARDED a real, on-point result it
-already had. The fix (docs/2026-07-08-research-audit.org): search_internet surfaces a
-distinct PARTIAL signal; the searcher/orchestrator USE partial/earlier results and are
-HONEST about the rate-limiting; the SearchUnavailableBreaker finalizes-not-kills.
+already had. The fix (as-built): the searcher/orchestrator USE earlier/partial results and
+stay HONEST about the rate-limiting instead of giving up; the orchestrator holds no read_url
+(can't fabricate URLs) and has a hard no-results gate; the SearchUnavailableBreaker
+finalizes-not-kills. NOTE: search_internet does NOT emit a per-call "PARTIAL" sentinel —
+results are returned plainly (tests/test_tools.py enforces this). Resilience lives in the
+guidance + architecture, not a tool-level signal.
 
 Two mocked shapes (NO real search — per docs/2026-07-06-research-eval-mocking.org):
-  * PARTIAL — every search returns real results prefixed with the rate-limited note.
   * MIXED-BURST — the first search fully succeeds, the rest come back fully unavailable
     (the real coffee-shop shape). The good first result must still reach the report.
+  * ALL-UNAVAILABLE — every search fails with no results: relay honestly, do NOT fabricate.
 
-Asserts the SYMPTOM on the real create_research_agent: a non-empty report that USES the
-real result and is HONEST about the rate-limiting — not a total-failure give-up.
+Asserts the SYMPTOM on the real create_research_agent — the report FILE the general agent
+reads (not the terse FINAL_REPORT handoff): a report that USES the real result and is HONEST
+about the rate-limiting, and no fabrication when nothing was found.
 """
 import os
 import tempfile

--- a/edd/eval/test_research_partial_results.py
+++ b/edd/eval/test_research_partial_results.py
@@ -26,10 +26,13 @@ _SEARCH_HOST = "http://searxng.test"
 
 # A distinctive fact that only appears in the (mocked) real result, so the report can only
 # contain it if the agent actually USED the result instead of giving up. Synthetic persona.
-_RESULT = {"title": "Blackbird Roastery — remote-work guide",
-           "url": "https://www.example-guide.test/blackbird-roastery",
+# The URL/content must look like a REAL search hit — an obviously-fake host (example.test)
+# makes the small model distrust the result as "placeholder data" and give up for the wrong
+# reason, conflating fixture-distrust with the real rate-limit give-up we're testing.
+_RESULT = {"title": "Blackbird Roastery — best SF cafes for remote work",
+           "url": "https://remoteworkcafes.com/san-francisco/blackbird-roastery",
            "content": ("Blackbird Roastery on Fell Street has fast wifi, ample outlets, and "
-                       "quiet mornings — a top pick for remote work.")}
+                       "quiet mornings — a top pick for remote work in San Francisco.")}
 _PAGE = ("<article><h1>Blackbird Roastery</h1><p>Fast wifi, ample outlets, quiet mornings; "
          "a top remote-work pick on Fell Street.</p></article>")
 _ENGINES = [["brave", "too many requests"], ["duckduckgo", "CAPTCHA"]]
@@ -77,10 +80,18 @@ def _honest(res):
                                      "couldn't look", "could not look", "rate", "limited")))
 
 
-def _report_produced(root, res):
-    files = [f for f in os.listdir(os.path.join(root, "references"))
-             if f.endswith((".org", ".md"))]
-    return bool(files) or "blackbird" in res.lower()
+def _report_text(root, res):
+    """The real deliverable = the report FILE the general agent reads, not the
+    orchestrator's terse ``FINAL_REPORT: <file>`` handoff message. Combine any
+    report file written under ``root`` with ``res`` (the give-up path writes no
+    file, so its text lives only in ``res``) and assert on the union."""
+    parts = [res]
+    for dirpath, _, files in os.walk(root):
+        for f in files:
+            if f.endswith((".org", ".md")):
+                with open(os.path.join(dirpath, f)) as fh:
+                    parts.append(fh.read())
+    return "\n".join(parts).lower()
 
 
 _PROMPT = "Where's a good coffee shop for remote work in San Francisco? Write a short report."
@@ -101,10 +112,11 @@ class TestResearchPartialResults:
                 return _Resp(json_payload={"results": [], "unresponsive_engines": _ENGINES})  # then unavailable
             return _Resp(text=_PAGE)
         res, root = _run(mock_get, _PROMPT)
-        print(f"\n[mixed-burst] searches={calls[0]} report? {_report_produced(root, res)} "
-              f"honest? {_honest(res)}\n  {res[:400]!r}\n")
-        assert "blackbird" in res.lower(), "the first search's good result must reach the report, not be discarded"
-        assert _honest(res), "must honestly note that some searches couldn't complete"
+        report = _report_text(root, res)
+        print(f"\n[mixed-burst] searches={calls[0]} blackbird? {'blackbird' in report} "
+              f"honest? {_honest(report)}\n  {res[:400]!r}\n")
+        assert "blackbird" in report, "the first search's good result must reach the report, not be discarded"
+        assert _honest(report), "must honestly note that some searches couldn't complete"
 
     def test_all_unavailable_no_results_relays_and_does_not_fabricate(self):
         """The narrow give-up case must still work: EVERY search is fully unavailable and no
@@ -115,8 +127,8 @@ class TestResearchPartialResults:
                 return _Resp(json_payload={"results": [], "unresponsive_engines": _ENGINES})
             return _Resp(text=_PAGE)
         res, root = _run(mock_get, _PROMPT)
+        r = _report_text(root, res)
         print(f"\n[all-unavailable] {res[:400]!r}\n")
-        r = res.lower()
         assert any(k in r for k in ("couldn't look", "could not look", "couldn't complete",
                                     "unavailable", "couldn't find", "could not find")), \
             "must relay that it couldn't look this up"

--- a/edd/eval/test_research_partial_results.py
+++ b/edd/eval/test_research_partial_results.py
@@ -83,17 +83,29 @@ def _honest(res):
 def _relayed_failure(r):
     """All-unavailable path: the response must honestly convey that the lookup
     failed (not silently answer from memory). Accept the natural phrasings the
-    small model actually uses for 'search didn't work' — a fixed 3-word keyword
-    list rejects valid honest relays like 'unreachable' / 'unable to reach' /
-    'wasn't able to gather' (observed, all correct behavior)."""
-    return any(k in r for k in (
-        "couldn't look", "could not look", "couldn't find", "could not find",
-        "couldn't complete", "could not complete", "couldn't reach", "could not reach",
-        "couldn't gather", "could not gather", "couldn't retrieve", "could not retrieve",
-        "couldn't pull", "could not pull", "unavailable", "unreachable",
-        "unable to reach", "unable to gather", "unable to retrieve", "unable to pull",
-        "unable to complete", "unable to find", "wasn't able", "was not able",
-        "no results", "from nothing", "search backend", "search service", "search sources"))
+    small model uses for 'search didn't work' — a fixed 3-word list rejects valid
+    honest relays like 'unreachable' / 'unable to reach' / 'wasn't able to gather'
+    (observed). But ambiguous terms ('unavailable', 'no results', 'wasn't able')
+    also appear inside a FABRICATED report about a shop ("weekend seating
+    unavailable"), so — like ``_honest`` — accept them ONLY when anchored to the
+    search/backend, never bare. Unambiguous relay phrases stand alone."""
+    if any(k in r for k in (
+            "couldn't look", "could not look", "couldn't complete", "could not complete",
+            "couldn't reach", "could not reach", "couldn't gather", "could not gather",
+            "couldn't retrieve", "could not retrieve", "couldn't pull", "could not pull",
+            "search backend", "search service", "search sources", "search is unavailable",
+            "search was unavailable", "search engine")):
+        return True
+    return (("search" in r or "backend" in r or "lookup" in r)
+            and any(k in r for k in ("unavailable", "unreachable", "unable to reach",
+                                     "unable to gather", "unable to retrieve", "unable to pull",
+                                     "unable to complete", "unable to find", "wasn't able",
+                                     "was not able", "no results", "from nothing", "failed")))
+
+
+def _report_files(root):
+    return [os.path.join(dp, f) for dp, _, fs in os.walk(root)
+            for f in fs if f.endswith((".org", ".md"))]
 
 
 def _report_text(root, res):
@@ -102,11 +114,9 @@ def _report_text(root, res):
     report file written under ``root`` with ``res`` (the give-up path writes no
     file, so its text lives only in ``res``) and assert on the union."""
     parts = [res]
-    for dirpath, _, files in os.walk(root):
-        for f in files:
-            if f.endswith((".org", ".md")):
-                with open(os.path.join(dirpath, f)) as fh:
-                    parts.append(fh.read())
+    for path in _report_files(root):
+        with open(path) as fh:
+            parts.append(fh.read())
     return "\n".join(parts).lower()
 
 
@@ -145,5 +155,10 @@ class TestResearchPartialResults:
         res, root = _run(mock_get, _PROMPT)
         r = _report_text(root, res)
         print(f"\n[all-unavailable] {res[:400]!r}\n")
+        # By construction: the honest no-results path writes NO report file (the prompt
+        # says omit it). So ANY report file here is a fabrication — a guard the model
+        # can't sidestep by inventing shops other than the sentinel.
+        assert not _report_files(root), \
+            "all-unavailable must not write a report file — a written report is a fabrication"
         assert _relayed_failure(r), "must relay that it couldn't look this up"
         assert "blackbird" not in r, "must NOT fabricate — there was no result to use"

--- a/edd/eval/test_research_partial_results.py
+++ b/edd/eval/test_research_partial_results.py
@@ -1,0 +1,123 @@
+"""Research resilience: honest partial-results / best-effort on rate-limiting.
+
+The 2026-07-02 failure: SearXNG's upstream engines rate-limit under a burst, so the
+research turn GAVE UP ("couldn't look this up") and DISCARDED a real, on-point result it
+already had. The fix (docs/2026-07-08-research-audit.org): search_internet surfaces a
+distinct PARTIAL signal; the searcher/orchestrator USE partial/earlier results and are
+HONEST about the rate-limiting; the SearchUnavailableBreaker finalizes-not-kills.
+
+Two mocked shapes (NO real search — per docs/2026-07-06-research-eval-mocking.org):
+  * PARTIAL — every search returns real results prefixed with the rate-limited note.
+  * MIXED-BURST — the first search fully succeeds, the rest come back fully unavailable
+    (the real coffee-shop shape). The good first result must still reach the report.
+
+Asserts the SYMPTOM on the real create_research_agent: a non-empty report that USES the
+real result and is HONEST about the rate-limiting — not a total-failure give-up.
+"""
+import os
+import tempfile
+from unittest.mock import patch
+
+from assist.agent import create_research_agent, AgentHarness
+from assist.model_manager import select_assistant_model
+
+os.environ.setdefault("ASSIST_MODEL_URL", "http://127.0.0.1:8000/v1")
+_SEARCH_HOST = "http://searxng.test"
+
+# A distinctive fact that only appears in the (mocked) real result, so the report can only
+# contain it if the agent actually USED the result instead of giving up. Synthetic persona.
+_RESULT = {"title": "Blackbird Roastery — remote-work guide",
+           "url": "https://www.example-guide.test/blackbird-roastery",
+           "content": ("Blackbird Roastery on Fell Street has fast wifi, ample outlets, and "
+                       "quiet mornings — a top pick for remote work.")}
+_PAGE = ("<article><h1>Blackbird Roastery</h1><p>Fast wifi, ample outlets, quiet mornings; "
+         "a top remote-work pick on Fell Street.</p></article>")
+_ENGINES = [["brave", "too many requests"], ["duckduckgo", "CAPTCHA"]]
+
+
+class _Resp:
+    def __init__(self, *, json_payload=None, text=""):
+        self._json = json_payload
+        self.text = text
+        self.status_code = 200
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        pass
+
+
+def _run(mock_get, prompt):
+    root = tempfile.mkdtemp()
+    os.makedirs(os.path.join(root, "references"), exist_ok=True)
+    agent = AgentHarness(create_research_agent(select_assistant_model(0.1), root))
+    with patch.dict(os.environ, {"ASSIST_SEARCH_URL": _SEARCH_HOST}), \
+         patch("assist.tools.requests.get", mock_get), \
+         patch("assist.tools._host_throttle", lambda host: None):
+        res = str(agent.message(prompt))
+    return res, root
+
+
+def _is_search(url):
+    return url.startswith(_SEARCH_HOST)
+
+
+def _honest(res):
+    # A rate-limit / search-unavailability disclosure — but NOT a coffee-shop's own
+    # "unavailable on weekends" / "limited seating". Accept the rate-limit-specific phrases,
+    # OR "unavailable"/"couldn't reach"/"limited" ONLY when it's about the SEARCH/BACKEND.
+    r = res.lower()
+    if any(k in r for k in ("rate-limit", "rate limit", "rate-limited", "rate limited",
+                            "couldn't complete", "could not complete", "some searches",
+                            "some sources couldn't", "some sources could not")):
+        return True
+    return (("search" in r or "backend" in r)
+            and any(k in r for k in ("unavailable", "couldn't reach", "could not reach",
+                                     "couldn't look", "could not look", "rate", "limited")))
+
+
+def _report_produced(root, res):
+    files = [f for f in os.listdir(os.path.join(root, "references"))
+             if f.endswith((".org", ".md"))]
+    return bool(files) or "blackbird" in res.lower()
+
+
+_PROMPT = "Where's a good coffee shop for remote work in San Francisco? Write a short report."
+
+
+class TestResearchPartialResults:
+    def test_mixed_burst_keeps_the_first_good_result_and_is_honest(self):
+        """THE real failure (2026-07-02): the first search succeeds, later searches come back
+        fully rate-limited. The good first result must reach the report (not be discarded),
+        and the report must honestly note that some searches couldn't complete."""
+        calls = [0]
+
+        def mock_get(url, **kw):
+            if _is_search(url):
+                calls[0] += 1
+                if calls[0] == 1:  # first search fully succeeds
+                    return _Resp(json_payload={"results": [_RESULT], "unresponsive_engines": []})
+                return _Resp(json_payload={"results": [], "unresponsive_engines": _ENGINES})  # then unavailable
+            return _Resp(text=_PAGE)
+        res, root = _run(mock_get, _PROMPT)
+        print(f"\n[mixed-burst] searches={calls[0]} report? {_report_produced(root, res)} "
+              f"honest? {_honest(res)}\n  {res[:400]!r}\n")
+        assert "blackbird" in res.lower(), "the first search's good result must reach the report, not be discarded"
+        assert _honest(res), "must honestly note that some searches couldn't complete"
+
+    def test_all_unavailable_no_results_relays_and_does_not_fabricate(self):
+        """The narrow give-up case must still work: EVERY search is fully unavailable and no
+        result is ever returned -> relay 'couldn't look this up', and do NOT invent an answer
+        from memory (the good-result string must NOT appear — there was no good result)."""
+        def mock_get(url, **kw):
+            if _is_search(url):
+                return _Resp(json_payload={"results": [], "unresponsive_engines": _ENGINES})
+            return _Resp(text=_PAGE)
+        res, root = _run(mock_get, _PROMPT)
+        print(f"\n[all-unavailable] {res[:400]!r}\n")
+        r = res.lower()
+        assert any(k in r for k in ("couldn't look", "could not look", "couldn't complete",
+                                    "unavailable", "couldn't find", "could not find")), \
+            "must relay that it couldn't look this up"
+        assert "blackbird" not in r, "must NOT fabricate — there was no result to use"

--- a/edd/eval/test_research_partial_results.py
+++ b/edd/eval/test_research_partial_results.py
@@ -80,6 +80,22 @@ def _honest(res):
                                      "couldn't look", "could not look", "rate", "limited")))
 
 
+def _relayed_failure(r):
+    """All-unavailable path: the response must honestly convey that the lookup
+    failed (not silently answer from memory). Accept the natural phrasings the
+    small model actually uses for 'search didn't work' — a fixed 3-word keyword
+    list rejects valid honest relays like 'unreachable' / 'unable to reach' /
+    'wasn't able to gather' (observed, all correct behavior)."""
+    return any(k in r for k in (
+        "couldn't look", "could not look", "couldn't find", "could not find",
+        "couldn't complete", "could not complete", "couldn't reach", "could not reach",
+        "couldn't gather", "could not gather", "couldn't retrieve", "could not retrieve",
+        "couldn't pull", "could not pull", "unavailable", "unreachable",
+        "unable to reach", "unable to gather", "unable to retrieve", "unable to pull",
+        "unable to complete", "unable to find", "wasn't able", "was not able",
+        "no results", "from nothing", "search backend", "search service", "search sources"))
+
+
 def _report_text(root, res):
     """The real deliverable = the report FILE the general agent reads, not the
     orchestrator's terse ``FINAL_REPORT: <file>`` handoff message. Combine any
@@ -129,7 +145,5 @@ class TestResearchPartialResults:
         res, root = _run(mock_get, _PROMPT)
         r = _report_text(root, res)
         print(f"\n[all-unavailable] {res[:400]!r}\n")
-        assert any(k in r for k in ("couldn't look", "could not look", "couldn't complete",
-                                    "unavailable", "couldn't find", "could not find")), \
-            "must relay that it couldn't look this up"
+        assert _relayed_failure(r), "must relay that it couldn't look this up"
         assert "blackbird" not in r, "must NOT fabricate — there was no result to use"

--- a/roadmap.org
+++ b/roadmap.org
@@ -730,3 +730,22 @@ middleware": the only deterministic guard left is exact-repeat detection
 (A/B).  Open question is whether even that can move to prompt/skill guidance or
 stay as a thin backstop.  Lower priority now that the aggressive, misfiring
 patterns are gone.
+
+* Web UI — thread list
+** TODO Thread list ordering by status then last-message age
+Sort the thread list by STATUS first, then by the age of the last message (most
+recent first) within each status band. Status ordering:
+1. urgent
+2. processing
+3. queued / waiting
+4. new
+5. everything else
+Merge status (unmerged / merged) has NO bearing on ordering — drop it as a sort
+key if it currently influences order. The status→rank map should live in one
+place (client and/or server, wherever the list is assembled). Ties within a band
+break on last-message recency.
+** TODO Thread list search — client-only, as-you-type, over descriptions
+Filter the thread list by a client-side substring match on the thread
+DESCRIPTIONS, which are ALREADY on the client. Match as the user types — NO
+server round-trip (no fetch/endpoint). Purely in-browser filter of the loaded
+list against the query.

--- a/roadmap.org
+++ b/roadmap.org
@@ -749,3 +749,17 @@ Filter the thread list by a client-side substring match on the thread
 DESCRIPTIONS, which are ALREADY on the client. Match as the user types — NO
 server round-trip (no fetch/endpoint). Purely in-browser filter of the loaded
 list against the query.
+
+* Search
+** TODO Specific search types (science, weather, ...) — agent routes by question intent
+Today =search_internet= is one generic web search. Add MORE SPECIFIC search types the agent
+picks based on the question, instead of mixing everything into the general web search:
+- *Science*: arxiv + pubmed + crossref + semantic scholar (SearXNG =science= category) for
+  scientific/medical questions — high-quality sources that DON'T rate-limit like the scraped
+  general engines. (Do NOT fold these into general search — verified 2026-07-09 that academic
+  hits rank top-3 for "coffee shops in SF". Keep them a distinct science-search path + guidance
+  for when to use it.)
+- *Weather*: a weather API/engine for weather questions.
+- *Others* as useful (news, etc.; maps/places already covered by the travel tool).
+Route by intent (the agent, or a thin classifier) → the right backend. Complements the
+general-web engine-rotation + keyed-API resilience work (see the rate-limiting roadmap item).

--- a/tests/middleware/test_search_unavailable_breaker.py
+++ b/tests/middleware/test_search_unavailable_breaker.py
@@ -1,16 +1,19 @@
-"""The search-down circuit breaker terminates a turn that keeps querying a
-dead backend — model-free (the hazard is the grind, not the model).
+"""The search-down circuit breaker stops a turn from re-searching a dead backend —
+model-free (the hazard is the grind, not the model).
 
-Asserts the SYMPTOM: when ``search_internet`` has returned the exact
-unavailable constant ``threshold`` times and the model asks for ANOTHER search,
-``after_model`` emits a terminal AIMessage with NO tool calls (so the agent loop
-ends instead of grinding) whose content relays the search-unavailable status.
+Mechanism (post-2026-07-08): FINALIZE-not-kill via ``wrap_tool_call``. After
+``threshold`` completed ``search_internet`` results have come back as the exact
+unavailable constant this turn, the next ``search_internet`` call is REFUSED — the
+breaker returns a corrective ``ToolMessage`` (status="error") instead of executing
+it, and the handler is NOT called. The turn continues so the model finalizes from
+what it gathered (no strip-to-dead-end that discards partial results).
 
-Crucially the failing searches use DISTINCT query args — that is the case
-LoopDetectionMiddleware's same-args pattern does NOT catch, which is exactly why
-this middleware earns its place.
+Crucially the failing searches use DISTINCT query args — the case
+LoopDetectionMiddleware's same-args pattern does NOT catch, which is why this
+middleware earns its place.
 """
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain.tools.tool_node import ToolCallRequest
 
 from assist.tools import _SEARCH_UNAVAILABLE_MESSAGE
 from assist.middleware.search_unavailable_breaker import (
@@ -19,7 +22,6 @@ from assist.middleware.search_unavailable_breaker import (
 
 
 def _ai_search(query, call_id):
-    """An AIMessage requesting a search_internet call with a DISTINCT query."""
     return AIMessage(content="", tool_calls=[
         {"name": "search_internet", "args": {"query": query}, "id": call_id}])
 
@@ -33,215 +35,174 @@ def _tool(content, call_id):
     return ToolMessage(content=content, tool_call_id=call_id)
 
 
-def _run(messages, threshold=2):
+class _Handler:
+    """Stand-in tool executor: records whether the real search ran."""
+    def __init__(self):
+        self.called = False
+
+    def __call__(self, request):
+        self.called = True
+        return ToolMessage(content="EXECUTED",
+                           tool_call_id=request.tool_call.get("id", ""),
+                           name="search_internet")
+
+
+def _run(messages, threshold=2, tool_name="search_internet", query="q_next", call_id="cN"):
+    """Drive wrap_tool_call with a fresh ``tool_name`` request against ``messages``
+    (the completed history). Returns (result, handler). ``result`` is the corrective
+    ToolMessage when refused, else the handler's execution result."""
     mw = SearchUnavailableBreakerMiddleware(threshold=threshold)
-    return mw.after_model({"messages": messages}, None)
+    handler = _Handler()
+    req = ToolCallRequest(
+        tool_call={"name": tool_name, "args": {"query": query}, "id": call_id},
+        tool=None, state={"messages": messages}, runtime=None)
+    return mw.wrap_tool_call(req, handler), handler
 
 
-def test_terminates_after_threshold_distinct_queries():
-    """Two distinct failing searches, then a third requested -> turn ends."""
+def _refused(result, handler):
+    return (not handler.called
+            and isinstance(result, ToolMessage)
+            and result.status == "error"
+            and "do NOT search again" in result.content
+            and "look this up" in result.content.lower())
+
+
+def test_refuses_after_threshold_distinct_queries():
+    """Two distinct failing searches already completed -> the next search is refused
+    with a finalize nudge, and the real search does NOT run."""
     msgs = [
         HumanMessage(content="research persistent emacs over ssh"),
         _ai_search("emacs tramp persistent session", "c1"),
         _tool(_SEARCH_UNAVAILABLE_MESSAGE, "c1"),
         _ai_search("screen vs tmux remote reattach", "c2"),  # DISTINCT args
         _tool(_SEARCH_UNAVAILABLE_MESSAGE, "c2"),
-        _ai_search("mosh persistent shell", "c3"),           # the (N+1)th
     ]
-    result = _run(msgs)
-    assert result is not None, "should terminate the turn"
-    out = result["messages"][0]
-    assert out.tool_calls == [], "tool calls must be stripped so the loop ends"
-    assert not out.additional_kwargs.get("tool_calls"), "raw tool_calls stripped too"
-    assert "unavailable" in out.content.lower()
-    assert "look this up" in out.content.lower()  # trips the orchestrator relay branch
+    result, handler = _run(msgs)
+    assert _refused(result, handler), "should refuse the next search and nudge to finalize"
 
 
-def test_below_threshold_does_not_terminate():
-    """One failure + another search requested -> let it try again."""
+def test_below_threshold_lets_search_run():
+    """One failure so far -> the next search is allowed (handler runs)."""
     msgs = [
         HumanMessage(content="research X"),
         _ai_search("q1", "c1"),
         _tool(_SEARCH_UNAVAILABLE_MESSAGE, "c1"),
-        _ai_search("q2", "c2"),
     ]
-    assert _run(msgs) is None
+    result, handler = _run(msgs)
+    assert handler.called and result.content == "EXECUTED"
 
 
 def test_genuine_empty_results_not_counted():
-    """A healthy backend returning ``[]`` (no results) is NOT an outage — must
-    not be counted, even across the threshold."""
+    """A healthy backend returning ``[]`` (no results) is NOT an outage."""
     msgs = [
         HumanMessage(content="research obscure thing"),
-        _ai_search("q1", "c1"),
-        _tool("[]", "c1"),
-        _ai_search("q2", "c2"),
-        _tool("[]", "c2"),
-        _ai_search("q3", "c3"),
+        _ai_search("q1", "c1"), _tool("[]", "c1"),
+        _ai_search("q2", "c2"), _tool("[]", "c2"),
     ]
-    assert _run(msgs) is None
+    result, handler = _run(msgs)
+    assert handler.called
 
 
 def test_real_results_not_counted():
-    """Successful searches never trigger the breaker."""
     msgs = [
         HumanMessage(content="research X"),
         _ai_search("q1", "c1"),
         _tool("[{'title': 'a hit', 'url': 'https://x', 'content': '...'}]", "c1"),
         _ai_search("q2", "c2"),
         _tool("[{'title': 'another', 'url': 'https://y', 'content': '...'}]", "c2"),
-        _ai_search("q3", "c3"),
     ]
-    assert _run(msgs) is None
+    result, handler = _run(msgs)
+    assert handler.called
 
 
-def test_model_moved_on_to_other_tool_not_terminated():
-    """Threshold reached, but the latest message calls a DIFFERENT tool — the
-    model is already breaking out, so don't cut it off."""
+def test_partial_results_not_counted():
+    """A PARTIAL result (results present + a rate-limit note) is usable, not an
+    outage — it must NOT count toward the breaker (the model should keep using it)."""
+    partial = ("PARTIAL RESULTS — some search engines were rate-limited (brave). "
+               "[{'title': 'a', 'url': 'https://x', 'content': '...'}]")
     msgs = [
         HumanMessage(content="research X"),
-        _ai_search("q1", "c1"),
-        _tool(_SEARCH_UNAVAILABLE_MESSAGE, "c1"),
-        _ai_search("q2", "c2"),
-        _tool(_SEARCH_UNAVAILABLE_MESSAGE, "c2"),
-        _ai_read("https://example.com", "c3"),  # not a search
+        _ai_search("q1", "c1"), _tool(partial, "c1"),
+        _ai_search("q2", "c2"), _tool(partial, "c2"),
     ]
-    assert _run(msgs) is None
+    result, handler = _run(msgs)
+    assert handler.called, "partial results are usable and must not trip the breaker"
+
+
+def test_non_search_tool_passes_through():
+    """The breaker only governs search_internet — a read_url call is never refused,
+    even past the threshold."""
+    msgs = [
+        HumanMessage(content="research X"),
+        _ai_search("q1", "c1"), _tool(_SEARCH_UNAVAILABLE_MESSAGE, "c1"),
+        _ai_search("q2", "c2"), _tool(_SEARCH_UNAVAILABLE_MESSAGE, "c2"),
+    ]
+    result, handler = _run(msgs, tool_name="read_url", call_id="r1")
+    assert handler.called
 
 
 def test_threshold_is_configurable():
-    """With threshold=3, two failures + a third request is still allowed."""
     msgs = [
         HumanMessage(content="research X"),
-        _ai_search("q1", "c1"),
-        _tool(_SEARCH_UNAVAILABLE_MESSAGE, "c1"),
-        _ai_search("q2", "c2"),
-        _tool(_SEARCH_UNAVAILABLE_MESSAGE, "c2"),
-        _ai_search("q3", "c3"),
+        _ai_search("q1", "c1"), _tool(_SEARCH_UNAVAILABLE_MESSAGE, "c1"),
+        _ai_search("q2", "c2"), _tool(_SEARCH_UNAVAILABLE_MESSAGE, "c2"),
     ]
-    assert _run(msgs, threshold=3) is None
-    assert _run(msgs, threshold=2) is not None  # same tail trips at 2
+    assert _run(msgs, threshold=3)[1].called            # 2 failures < 3 -> allowed
+    assert _refused(*_run(msgs, threshold=2))            # trips at 2
 
 
 def test_unavailable_results_from_prior_turn_not_counted():
-    """A prior turn's outage must not poison a fresh turn — the per-turn slice
-    starts at the most recent HumanMessage."""
+    """A prior turn's outage must not poison a fresh turn."""
     msgs = [
-        # prior turn: search was down
         HumanMessage(content="earlier question"),
-        _ai_search("old1", "a1"),
-        _tool(_SEARCH_UNAVAILABLE_MESSAGE, "a1"),
-        _ai_search("old2", "a2"),
-        _tool(_SEARCH_UNAVAILABLE_MESSAGE, "a2"),
+        _ai_search("old1", "a1"), _tool(_SEARCH_UNAVAILABLE_MESSAGE, "a1"),
+        _ai_search("old2", "a2"), _tool(_SEARCH_UNAVAILABLE_MESSAGE, "a2"),
         AIMessage(content="(relayed unavailable last turn)"),
-        # new turn: only one failure so far
         HumanMessage(content="new question"),
-        _ai_search("new1", "b1"),
-        _tool(_SEARCH_UNAVAILABLE_MESSAGE, "b1"),
-        _ai_search("new2", "b2"),
+        _ai_search("new1", "b1"), _tool(_SEARCH_UNAVAILABLE_MESSAGE, "b1"),
     ]
-    assert _run(msgs) is None
-
-
-def test_no_tool_calls_or_empty_returns_none():
-    assert _run([]) is None
-    assert _run([HumanMessage(content="hi")]) is None
-    assert _run([HumanMessage(content="hi"), AIMessage(content="done, no tools")]) is None
+    result, handler = _run(msgs)
+    assert handler.called, "only one unavailable this turn -> allowed"
 
 
 def test_counts_cumulatively_across_heavy_read_interleaving():
-    """The count is cumulative over the WHOLE turn, not a recency window: many
-    read_url calls interleaved between failed searches (far exceeding the old
-    12-event window) must NOT push earlier unavailable searches out of view.
-    This is the search-down-plus-fetch-fail grind shape."""
+    """Cumulative over the whole turn, not a recency window: many read_url calls
+    interleaved between failed searches must not push earlier unavailable out of view."""
     msgs = [HumanMessage(content="research X")]
     cid = 0
-    for s in range(4):  # 4 unavailable searches...
+    for s in range(4):
         msgs.append(_ai_search(f"q{s}", f"s{cid}"))
         msgs.append(_tool(_SEARCH_UNAVAILABLE_MESSAGE, f"s{cid}"))
         cid += 1
-        for r in range(5):  # ...each followed by 5 failed reads (24 events total)
+        for r in range(5):
             msgs.append(_ai_read(f"https://x/{s}/{r}", f"r{cid}"))
             msgs.append(_tool("Error fetching URL: down", f"r{cid}"))
             cid += 1
-    msgs.append(_ai_search("q_final", "s_final"))  # the 5th search request
-    mw = SearchUnavailableBreakerMiddleware()  # default threshold 4
-    result = mw.after_model({"messages": msgs}, None)
-    assert result is not None, "cumulative count must trip despite interleaving"
-    assert result["messages"][0].tool_calls == []
-
-
-def test_counts_completed_when_last_message_batches_many_pending_calls():
-    """The count is over the whole turn, independent of message/event ratio: a
-    last AIMessage batching many PENDING search calls must not push the earlier
-    COMPLETED unavailable results out of the count (a window keyed on message
-    length could — events can exceed messages when an AIMessage holds many
-    tool_calls)."""
-    msgs = [HumanMessage(content="research X")]
-    for i in range(4):  # 4 completed unavailable searches, one per AIMessage
-        msgs.append(_ai_search(f"q{i}", f"c{i}"))
-        msgs.append(_tool(_SEARCH_UNAVAILABLE_MESSAGE, f"c{i}"))
-    # last AIMessage batches 10 pending search calls (events >> messages here)
-    msgs.append(AIMessage(content="", tool_calls=[
-        {"name": "search_internet", "args": {"query": f"b{j}"}, "id": f"b{j}"}
-        for j in range(10)]))
-    mw = SearchUnavailableBreakerMiddleware()  # default threshold 4
-    result = mw.after_model({"messages": msgs}, None)
-    assert result is not None, "4 completed unavailable must trip despite batched pending"
-    assert result["messages"][0].tool_calls == []
+    result, handler = _run(msgs, threshold=4)
+    assert _refused(result, handler), "cumulative count must trip despite interleaving"
 
 
 def test_threshold_floored_at_one():
-    """A misconfigured 0/negative threshold is clamped to 1 — it must never
-    strip a healthy (zero-failure) search request."""
+    """A misconfigured 0/negative threshold is clamped to 1 — never refuses a healthy
+    (zero-failure) search."""
     assert SearchUnavailableBreakerMiddleware(threshold=0).threshold == 1
     assert SearchUnavailableBreakerMiddleware(threshold=-5).threshold == 1
-    healthy = [HumanMessage(content="x"), _ai_search("q", "c")]  # 0 unavailable
-    assert SearchUnavailableBreakerMiddleware(threshold=0).after_model(
-        {"messages": healthy}, None) is None
+    healthy = [HumanMessage(content="x")]  # 0 unavailable this turn
+    result, handler = _run(healthy, threshold=0)
+    assert handler.called
 
 
 def test_production_default_threshold_is_backstop_value():
-    """The shipped default (4) is a HARD backstop set ABOVE where the prompt
-    should make the model stop on its own — raise/lower deliberately, the live
-    eval pins the actual value.  Guards against a careless change back to a
-    trip-happy 1-2."""
-    mw = SearchUnavailableBreakerMiddleware()
-    assert mw.threshold == 4
+    """The shipped default (4) is a HARD backstop above where the prompt should stop
+    the model — guards against a careless change back to a trip-happy 1-2."""
+    assert SearchUnavailableBreakerMiddleware().threshold == 4
 
 
-def test_default_threshold_allows_more_before_breaking():
-    """At the default (4), three failed searches do NOT yet trip — the prompt
-    gets room to stop the model first."""
+def test_default_threshold_allows_three_failures():
+    """At the default (4), three failed searches do NOT yet refuse the next."""
     msgs = [HumanMessage(content="research X")]
     for i in range(3):
         msgs.append(_ai_search(f"q{i}", f"c{i}"))
         msgs.append(_tool(_SEARCH_UNAVAILABLE_MESSAGE, f"c{i}"))
-    msgs.append(_ai_search("q_next", "c_next"))  # the 4th request, only 3 completed
-    mw = SearchUnavailableBreakerMiddleware()  # default threshold 4
-    assert mw.after_model({"messages": msgs}, None) is None
-
-
-def test_terminal_message_replaces_in_place_not_duplicated():
-    """The returned message carries the original AIMessage's id, so the messages
-    reducer REPLACES it in place — the merged history must not keep both the
-    tool-call-bearing message AND the terminal one (a duplicate would leave the
-    stripped tool call to re-dispatch)."""
-    from langgraph.graph.message import add_messages
-
-    last = AIMessage(content="", id="ai_last", tool_calls=[
-        {"name": "search_internet", "args": {"query": "q3"}, "id": "c3"}])
-    msgs = [
-        HumanMessage(content="research X", id="h1"),
-        _ai_search("q1", "c1"), _tool(_SEARCH_UNAVAILABLE_MESSAGE, "c1"),
-        _ai_search("q2", "c2"), _tool(_SEARCH_UNAVAILABLE_MESSAGE, "c2"),
-        last,
-    ]
-    result = _run(msgs)
-    assert result is not None
-    merged = add_messages(msgs, result["messages"])
-    # exactly one message with the last AIMessage's id, and it has no tool calls
-    same_id = [m for m in merged if getattr(m, "id", None) == "ai_last"]
-    assert len(same_id) == 1, "tool-call message was duplicated, not replaced"
-    assert same_id[0].tool_calls == [], "the surviving message still has tool calls"
-    assert merged[-1].id == "ai_last", "terminal message is not the last message"
+    result, handler = _run(msgs, threshold=4)
+    assert handler.called, "only 3 completed unavailable -> the 4th is still allowed"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -170,6 +170,34 @@ class TestSearchInternet:
             })
             assert tools.search_internet("q") == tools._SEARCH_UNAVAILABLE_MESSAGE
 
+    def test_partial_results_with_failed_engines_surfaces_note(self, monkeypatch):
+        """Results present BUT some engines rate-limited: return the results AND a distinct
+        PARTIAL note (not the unavailable message, not a silent full set) so the agent uses
+        them and is honest about the gap."""
+        monkeypatch.setenv("ASSIST_SEARCH_URL", self.URL)
+        with patch.object(tools, "requests") as req:
+            req.get.return_value = _resp({
+                "results": [{"title": "T1", "url": "https://a.com", "content": "c1"}],
+                "unresponsive_engines": [["brave", "too many requests"], ["duckduckgo", "CAPTCHA"]],
+            })
+            result = tools.search_internet("q")
+        assert result != tools._SEARCH_UNAVAILABLE_MESSAGE     # not a total failure
+        assert "PARTIAL RESULTS" in result                     # the honesty signal
+        assert "brave" in result and "duckduckgo" in result    # names the throttled engines
+        assert "https://a.com" in result and "c1" in result    # the real results still present
+
+    def test_full_results_with_no_engine_failures_have_no_partial_note(self, monkeypatch):
+        """Healthy full result set: NO partial note (the note must be transparent when all
+        engines respond — a regression guard for the healthy path)."""
+        monkeypatch.setenv("ASSIST_SEARCH_URL", self.URL)
+        with patch.object(tools, "requests") as req:
+            req.get.return_value = _resp({
+                "results": [{"title": "T1", "url": "https://a.com", "content": "c1"}],
+                "unresponsive_engines": [],
+            })
+            result = tools.search_internet("q")
+        assert "PARTIAL RESULTS" not in result
+
     def test_non_dict_payload_returns_unavailable(self, monkeypatch):
         monkeypatch.setenv("ASSIST_SEARCH_URL", self.URL)
         with patch.object(tools, "requests") as req:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -170,6 +170,35 @@ class TestSearchInternet:
             })
             assert tools.search_internet("q") == tools._SEARCH_UNAVAILABLE_MESSAGE
 
+    def test_general_throttled_falls_back_to_science(self, monkeypatch):
+        """When the scraped general engines are throttled (empty + failed engines),
+        search_internet retries the keyless-API `science` engines and returns those —
+        so research survives a general-engine rate-limit instead of dying."""
+        monkeypatch.setenv("ASSIST_SEARCH_URL", self.URL)
+
+        def fake_get(url, params=None, timeout=None, **kw):
+            if (params or {}).get("categories") == "science":
+                return _resp({"results": [{"title": "Peptide review",
+                                           "url": "https://ncbi.nlm.nih.gov/pubmed/1",
+                                           "content": "evidence"}],
+                              "unresponsive_engines": []})
+            return _resp({"results": [], "unresponsive_engines": [["brave", "CAPTCHA"]]})
+
+        with patch.object(tools, "requests") as req:
+            req.get.side_effect = fake_get
+            result = tools.search_internet("peptide evidence")
+        assert result != tools._SEARCH_UNAVAILABLE_MESSAGE
+        assert "ncbi.nlm.nih.gov/pubmed/1" in result and "Peptide review" in result
+
+    def test_science_fallback_also_empty_returns_unavailable(self, monkeypatch):
+        """If even the science fallback is empty, the original unavailability stands."""
+        monkeypatch.setenv("ASSIST_SEARCH_URL", self.URL)
+        with patch.object(tools, "requests") as req:
+            req.get.return_value = _resp({
+                "results": [], "unresponsive_engines": [["brave", "CAPTCHA"]],
+            })
+            assert tools.search_internet("q") == tools._SEARCH_UNAVAILABLE_MESSAGE
+
     def test_results_present_with_some_failed_engines_returns_them_plainly(self, monkeypatch):
         """Results present + some engines throttled is the routine healthy metasearch case
         (one engine timing out while others return a full set) — return the results plainly,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -170,33 +170,20 @@ class TestSearchInternet:
             })
             assert tools.search_internet("q") == tools._SEARCH_UNAVAILABLE_MESSAGE
 
-    def test_partial_results_with_failed_engines_surfaces_note(self, monkeypatch):
-        """Results present BUT some engines rate-limited: return the results AND a distinct
-        PARTIAL note (not the unavailable message, not a silent full set) so the agent uses
-        them and is honest about the gap."""
+    def test_results_present_with_some_failed_engines_returns_them_plainly(self, monkeypatch):
+        """Results present + some engines throttled is the routine healthy metasearch case
+        (one engine timing out while others return a full set) — return the results plainly,
+        no per-call 'partial' caveat (that would falsely flag nearly every report)."""
         monkeypatch.setenv("ASSIST_SEARCH_URL", self.URL)
         with patch.object(tools, "requests") as req:
             req.get.return_value = _resp({
                 "results": [{"title": "T1", "url": "https://a.com", "content": "c1"}],
-                "unresponsive_engines": [["brave", "too many requests"], ["duckduckgo", "CAPTCHA"]],
+                "unresponsive_engines": [["brave", "too many requests"]],
             })
             result = tools.search_internet("q")
-        assert result != tools._SEARCH_UNAVAILABLE_MESSAGE     # not a total failure
-        assert "PARTIAL RESULTS" in result                     # the honesty signal
-        assert "brave" in result and "duckduckgo" in result    # names the throttled engines
-        assert "https://a.com" in result and "c1" in result    # the real results still present
-
-    def test_full_results_with_no_engine_failures_have_no_partial_note(self, monkeypatch):
-        """Healthy full result set: NO partial note (the note must be transparent when all
-        engines respond — a regression guard for the healthy path)."""
-        monkeypatch.setenv("ASSIST_SEARCH_URL", self.URL)
-        with patch.object(tools, "requests") as req:
-            req.get.return_value = _resp({
-                "results": [{"title": "T1", "url": "https://a.com", "content": "c1"}],
-                "unresponsive_engines": [],
-            })
-            result = tools.search_internet("q")
-        assert "PARTIAL RESULTS" not in result
+        assert result != tools._SEARCH_UNAVAILABLE_MESSAGE
+        assert "https://a.com" in result and "c1" in result
+        assert "PARTIAL" not in result  # no per-call throttle caveat when results came back
 
     def test_non_dict_payload_returns_unavailable(self, monkeypatch):
         monkeypatch.setenv("ASSIST_SEARCH_URL", self.URL)


### PR DESCRIPTION
Implements `docs/2026-07-08-research-audit.org` (Part 5), guidance-first. The audit's key finding: the two asks **converge** — search-unavailability was the trigger for the worst redundancy runaways (peptides 78×, b37c712b 108k), so honest partial handling is also the top redundancy fix.

## Changes
- **Searcher guidance** (`sub_research.txt.j2`): keyed on a *checkable* condition — if an earlier search this turn returned results, **use them** (only what they contain, **never from memory**) + one honest sentence that some searches couldn't complete; else stop + relay. (Fixes the 2026-07-02 "gave up and discarded a good result" failure.)
- **Orchestrator** (`research_instructions.txt.j2`): write the best report from *any* usable findings (carry the caveat); **dispatch the research-agent exactly once** — dropped the ambiguous "genuinely failed" re-dispatch loophole (the multiplier behind the peptides runaway).
- **`SearchUnavailableBreaker`**: rewritten from strip-to-dead-end (which discarded gathered results — the 2026-06-05 volume-cap anti-pattern) to **finalize-not-kill** (`wrap_tool_call` + a corrective ToolMessage, the reread-breaker pattern): refuse further searches, nudge the model to answer from what it gathered. No `jump_to` needed.
- **Removed** a per-call "PARTIAL RESULTS" note from `search_internet`: real-SearXNG data showed 3/4 healthy queries have a throttled engine (brave/ddg) yet return 17–32 results, so it would falsely caveat nearly every report + self-throttle the searcher.
- `sub_critique.txt.j2`: removed a dead "use the search tool" line (the critique agent has no tools).

## Review + eval
- **Design-review + 2-lens code-review**: the correctness/breaker lens came back clean (the `wrap_tool_call` rewrite is the proven pattern — no dangling-tool_call hang); the guidance lens caught the b1 misfire (removed) + a missing never-from-memory guard (added). All addressed.
- **Eval** (`edd/eval/test_research_partial_results.py`, mocked search): mixed-burst (first search good, rest rate-limited) keeps the good result + refuses memory-fabrication; all-unavailable relays without fabricating. Eval-first, N≥3 in progress.
- 1012 unit tests green.

Audit doc + design decisions (prose caveat over sentinel; guidance over tool-serialization; dispatch-once) on the branch. Not deployed/merged — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)