### PR TITLE
SearXNG: log each engine's outcome in the rotation

### DIFF
--- a/assist/tools.py
+++ b/assist/tools.py
@@ -243,7 +243,10 @@ def search_internet(
     for engine in _ROTATION_ENGINES:
         results, down = _query_engine(base_url, query, engine)
         if results:
+            logger.info("searxng: %s returned %d results", engine, len(results))
             return _normalize_results(results, max_results)
+        logger.info("searxng: %s %s", engine,
+                    "rate-limited/unavailable" if down else "no results")
         saw_down = saw_down or down
     # No engine returned results. If any engine was down/throttled/malformed, this is a
     # backend-availability failure — try the Tavily backup before relaying unavailable. If
@@ -251,6 +254,7 @@ def search_internet(
     if saw_down:
         tavily = _tavily_search(query, max_results)
         if tavily is not None:
+            logger.info("searxng: all engines exhausted -> tavily backup returned results")
             return tavily
         return _search_unavailable(
             f"SearXNG at {base_url}: every engine unreachable or throttled "

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -250,6 +250,27 @@ class TestSearchInternet:
         assert "https://a.com" in result
         req.post.assert_not_called()
 
+    def test_rotation_logs_each_engine_outcome(self, monkeypatch, caplog):
+        """Each engine's outcome is logged (which engine + good/bad) for observability."""
+        import logging
+        monkeypatch.setenv("ASSIST_SEARCH_URL", self.URL)
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+
+        def fake_get(url, params=None, timeout=None, **kw):
+            eng = (params or {}).get("engines")
+            if eng == "mojeek":
+                return _resp({"results": [{"title": "M", "url": "https://m.com", "content": "c"}],
+                              "unresponsive_engines": []})
+            return _resp({"results": [], "unresponsive_engines": [[eng, "CAPTCHA"]]})
+
+        with patch.object(tools, "requests") as req, \
+             caplog.at_level(logging.INFO, logger="assist.tools"):
+            req.get.side_effect = fake_get
+            tools.search_internet("q")
+        msgs = " ".join(r.message for r in caplog.records)
+        assert "searxng: google rate-limited/unavailable" in msgs
+        assert "searxng: mojeek returned 1 results" in msgs
+
     def test_rotation_all_engines_healthy_but_empty_returns_empty(self, monkeypatch):
         """Every engine up but genuinely no results → "[]" (a real no-results answer),
         NOT unavailable."""


### PR DESCRIPTION
Quick observability add on top of the rotation. Logs which engine answered and how, at INFO:
- `searxng: google rate-limited/unavailable`
- `searxng: mojeek returned 10 results`
- `searxng: <engine> no results`
- `searxng: all engines exhausted -> tavily backup returned results`

So the rotation's per-engine behaviour — and which engines are throttled at any moment — is visible in the service journal. +1 test. Stacked on the rotation+tavily branch (#185).

🤖 Generated with [Claude Code](https://claude.com/claude-code)