### PR TITLE
Web thread list: order by status band, then last-message age

### DIFF
--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -168,6 +168,25 @@ _MD_EXTENSIONS = ["fenced_code", "tables"]
 _SHOWABLE_EXTS = (".org", ".md", ".pdf")
 
 
+# Thread-list ordering rank (lower sorts first). Per Pierre: STATUS first — urgent,
+# then processing/starting, then queued/waiting, then "new" (an unopened response),
+# then everything else (ready / error / unmerged / idle). Merge status has NO bearing.
+# The single source of truth for the order; the age tiebreak is handled by the caller's
+# stable sort over MANAGER.list()'s mtime-descending order.
+_STATUS_RANK_OTHER = 4
+
+
+def _thread_status_rank(tid: str, stage: str) -> int:
+    if _has_urgent(tid):
+        return 0
+    if stage == "queued":              # waiting for another thread's slot
+        return 2
+    if stage in BUSY_STAGES:           # processing / paused / initializing / cloning / starting
+        return 1
+    if _has_unseen_response(tid):      # "new" — a reply the user hasn't opened
+        return 3
+    return _STATUS_RANK_OTHER
+
 
 def render_index(query: str = "") -> str:
     q = (query or "").strip()
@@ -232,22 +251,28 @@ def render_index(query: str = "") -> str:
                 ' border:1px solid #e5e7eb; padding:.1rem .4rem; border-radius:10px;'
                 ' margin-right:.4rem;">unmerged</span>'
             )
-        items.append(
+        items.append((
+            _thread_status_rank(tid, stage),
             f'<li>'
             f'<a class="thread-link" href="/thread/{tid}">{badge}{html.escape(title)}</a>'
             f'<form action="/thread/{tid}/delete" method="post" style="margin:0">'
             f'<button type="submit" class="del-btn" aria-label="Delete thread" '
             f'onclick="return confirm(\'Permanently delete this thread? This cannot be undone.\')">&#x2715;</button>'
             f'</form></li>'
-        )
+        ))
     matched = len(items)
-    if not items:
-        items.append(
+    # Order by STATUS band first, then last-message age within the band. MANAGER.list()
+    # already returns threads mtime-descending (newest activity first), and Python's sort
+    # is STABLE, so sorting by the rank alone keeps that mtime order inside each band.
+    items.sort(key=lambda t: t[0])
+    if items:
+        items_html = "\n".join(item_html for _, item_html in items)
+    else:
+        items_html = (
             f'<li><em>No threads match &ldquo;{html.escape(q)}&rdquo;.</em> '
             f'<a href="/">clear</a></li>'
             if ql else "<li><em>No threads yet</em></li>"
         )
-    items_html = "\n".join(items)
     search_status = (
         f'<p style="font-size:.85rem; color:#6b7280; margin:.2rem 0 .6rem;">'
         f'{matched} match{"" if matched == 1 else "es"} for '

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -171,11 +171,7 @@ _SHOWABLE_EXTS = (".org", ".md", ".pdf")
 # Thread-list ordering rank (lower sorts first). Per Pierre: STATUS first — urgent,
 # then processing/starting, then queued/waiting, then "new" (an unopened response),
 # then everything else (ready / error / unmerged / idle). Merge status has NO bearing.
-# The single source of truth for the order; the age tiebreak is handled by the caller's
-# stable sort over MANAGER.list()'s mtime-descending order.
-_STATUS_RANK_OTHER = 4
-
-
+# The age tiebreak within a band is the caller's job (see render_index's sort).
 def _thread_status_rank(tid: str, stage: str) -> int:
     if _has_urgent(tid):
         return 0
@@ -185,7 +181,7 @@ def _thread_status_rank(tid: str, stage: str) -> int:
         return 1
     if _has_unseen_response(tid):      # "new" — a reply the user hasn't opened
         return 3
-    return _STATUS_RANK_OTHER
+    return 4                           # everything else — ready / error / unmerged / idle
 
 
 def render_index(query: str = "") -> str:
@@ -224,8 +220,10 @@ def render_index(query: str = "") -> str:
             )
         elif _has_urgent(tid):
             # "urgent": the agent called notify() to flag this thread time-sensitive.
-            # Stronger than "new" (above it), still below the live process-state
-            # badges (a running/errored thread is actionable now). Red pill.
+            # BADGE order only: below the live process-state badges (a running/errored
+            # thread's current state is the more informative pill), above "new". The
+            # LIST is sorted urgent-FIRST regardless (see _thread_status_rank), so an
+            # urgent+processing thread sorts to the top while still showing "processing".
             badge = (
                 '<span style="font-size:.7rem; color:#b91c1c; background:#fafafa;'
                 ' border:1px solid #e5e7eb; padding:.1rem .4rem; border-radius:10px;'

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -169,8 +169,10 @@ _SHOWABLE_EXTS = (".org", ".md", ".pdf")
 
 
 # Thread-list ordering rank (lower sorts first). Per Pierre: STATUS first — urgent,
-# then processing/starting, then queued/waiting, then "new" (an unopened response),
-# then everything else (ready / error / unmerged / idle). Merge status has NO bearing.
+# then any busy stage except queued (processing / paused / initializing / cloning /
+# starting_sandbox), then queued (waiting for a slot), then "new" (an unopened
+# response), then everything else (ready / error / unmerged / idle). Merge status
+# has NO bearing.
 # The age tiebreak within a band is the caller's job (see render_index's sort).
 def _thread_status_rank(tid: str, stage: str) -> int:
     if _has_urgent(tid):

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -179,7 +179,7 @@ def _thread_status_rank(tid: str, stage: str) -> int:
         return 0
     if stage == "queued":              # waiting for another thread's slot
         return 2
-    if stage in BUSY_STAGES:           # processing / paused / initializing / cloning / starting
+    if stage in BUSY_STAGES:           # processing / paused / initializing / cloning / starting_sandbox
         return 1
     if _has_unseen_response(tid):      # "new" — a reply the user hasn't opened
         return 3

--- a/tests/test_web_thread_ordering.py
+++ b/tests/test_web_thread_ordering.py
@@ -1,0 +1,59 @@
+"""Thread-list ordering: STATUS band first (urgent > processing > queued > new > else),
+then last-message age (newest first) within a band. Merge status has no bearing.
+See manage.web.threads._thread_status_rank. Assertions key on the /thread/<tid> href,
+which is always present regardless of the busy-stage title placeholder."""
+import os
+
+import pytest
+
+from manage import web
+from manage.web import state
+from manage.web.threads import render_index
+
+
+@pytest.fixture
+def threads_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(web.MANAGER, "root_dir", str(tmp_path))
+    monkeypatch.setattr("manage.web.threads._has_unmerged_changes", lambda tid: False)
+    state.DESCRIPTION_CACHE.clear(); state._UNSEEN.clear(); state._URGENT.clear()
+    yield tmp_path
+    state.DESCRIPTION_CACHE.clear(); state._UNSEEN.clear(); state._URGENT.clear()
+
+
+def _mk(root, tid, title="A thread"):
+    os.makedirs(root / tid, exist_ok=True)
+    state.DESCRIPTION_CACHE[tid] = title
+
+
+def _positions(html, tids):
+    return [html.index(f"/thread/{tid}") for tid in tids]
+
+
+class TestThreadListOrdering:
+    def test_status_band_order(self, threads_root):
+        # Created in a deliberately NON-status order so mtime alone wouldn't sort them right.
+        _mk(threads_root, "t_else")
+        _mk(threads_root, "t_urgent"); state._URGENT.add("t_urgent")
+        _mk(threads_root, "t_new"); state._UNSEEN.add("t_new")
+        _mk(threads_root, "t_proc"); state._set_status("t_proc", "processing")
+        _mk(threads_root, "t_queued"); state._set_status("t_queued", "queued")
+        html = render_index("")
+        pos = _positions(html, ["t_urgent", "t_proc", "t_queued", "t_new", "t_else"])
+        assert pos == sorted(pos), f"not in status order: {pos}"
+
+    def test_age_tiebreak_within_band(self, threads_root):
+        _mk(threads_root, "t_old"); _mk(threads_root, "t_new2")
+        os.utime(threads_root / "t_old", (1000, 1000))
+        os.utime(threads_root / "t_new2", (2000, 2000))  # newer -> first within the else band
+        html = render_index("")
+        assert html.index("/thread/t_new2") < html.index("/thread/t_old")
+
+    def test_merge_status_has_no_bearing(self, threads_root, monkeypatch):
+        monkeypatch.setattr("manage.web.threads._has_unmerged_changes",
+                            lambda tid: tid == "t_unmerged")
+        _mk(threads_root, "t_unmerged"); _mk(threads_root, "t_urgent")
+        state._URGENT.add("t_urgent")
+        os.utime(threads_root / "t_unmerged", (2000, 2000))  # newer, but else band
+        os.utime(threads_root / "t_urgent", (1000, 1000))    # older, but urgent -> still first
+        html = render_index("")
+        assert html.index("/thread/t_urgent") < html.index("/thread/t_unmerged")

--- a/tests/test_web_thread_ordering.py
+++ b/tests/test_web_thread_ordering.py
@@ -1,6 +1,7 @@
-"""Thread-list ordering: STATUS band first (urgent > processing > queued > new > else),
-then last-message age (newest first) within a band. Merge status has no bearing.
-See manage.web.threads._thread_status_rank. Assertions key on the /thread/<tid> href,
+"""Thread-list ordering: STATUS band first — urgent > busy (processing/paused/
+initializing/cloning/starting_sandbox) > queued > new > else — then last-message age
+(newest first) within a band. Merge status has no bearing. See
+manage.web.threads._thread_status_rank. Assertions key on the /thread/<tid> href,
 which is always present regardless of the busy-stage title placeholder."""
 import os
 
@@ -15,9 +16,13 @@ from manage.web.threads import render_index
 def threads_root(tmp_path, monkeypatch):
     monkeypatch.setattr(web.MANAGER, "root_dir", str(tmp_path))
     monkeypatch.setattr("manage.web.threads._has_unmerged_changes", lambda tid: False)
-    state.DESCRIPTION_CACHE.clear(); state._UNSEEN.clear(); state._URGENT.clear()
+    state.DESCRIPTION_CACHE.clear()
+    state._UNSEEN.clear()
+    state._URGENT.clear()
     yield tmp_path
-    state.DESCRIPTION_CACHE.clear(); state._UNSEEN.clear(); state._URGENT.clear()
+    state.DESCRIPTION_CACHE.clear()
+    state._UNSEEN.clear()
+    state._URGENT.clear()
 
 
 def _mk(root, tid, title="A thread"):
@@ -33,16 +38,21 @@ class TestThreadListOrdering:
     def test_status_band_order(self, threads_root):
         # Created in a deliberately NON-status order so mtime alone wouldn't sort them right.
         _mk(threads_root, "t_else")
-        _mk(threads_root, "t_urgent"); state._URGENT.add("t_urgent")
-        _mk(threads_root, "t_new"); state._UNSEEN.add("t_new")
-        _mk(threads_root, "t_proc"); state._set_status("t_proc", "processing")
-        _mk(threads_root, "t_queued"); state._set_status("t_queued", "queued")
+        _mk(threads_root, "t_urgent")
+        state._URGENT.add("t_urgent")
+        _mk(threads_root, "t_new")
+        state._UNSEEN.add("t_new")
+        _mk(threads_root, "t_proc")
+        state._set_status("t_proc", "processing")
+        _mk(threads_root, "t_queued")
+        state._set_status("t_queued", "queued")
         html = render_index("")
         pos = _positions(html, ["t_urgent", "t_proc", "t_queued", "t_new", "t_else"])
         assert pos == sorted(pos), f"not in status order: {pos}"
 
     def test_age_tiebreak_within_band(self, threads_root):
-        _mk(threads_root, "t_old"); _mk(threads_root, "t_new2")
+        _mk(threads_root, "t_old")
+        _mk(threads_root, "t_new2")
         os.utime(threads_root / "t_old", (1000, 1000))
         os.utime(threads_root / "t_new2", (2000, 2000))  # newer -> first within the else band
         html = render_index("")
@@ -51,7 +61,8 @@ class TestThreadListOrdering:
     def test_merge_status_has_no_bearing(self, threads_root, monkeypatch):
         monkeypatch.setattr("manage.web.threads._has_unmerged_changes",
                             lambda tid: tid == "t_unmerged")
-        _mk(threads_root, "t_unmerged"); _mk(threads_root, "t_urgent")
+        _mk(threads_root, "t_unmerged")
+        _mk(threads_root, "t_urgent")
         state._URGENT.add("t_urgent")
         os.utime(threads_root / "t_unmerged", (2000, 2000))  # newer, but else band
         os.utime(threads_root / "t_urgent", (1000, 1000))    # older, but urgent -> still first


### PR DESCRIPTION
Orders the thread list by **status band first**, then last-message age (newest first) within each band:

1. urgent
2. processing / starting
3. queued / waiting
4. new (an unopened response)
5. everything else (ready / error / unmerged / idle)

Merge status has **no bearing** (unmerged sorts into 'everything else'). Independent of the search/research work — branched off main.

`_thread_status_rank()` is the single rank map; `render_index` sorts by rank with Python's *stable* sort over `MANAGER.list()`'s existing mtime-descending order, so the age tiebreak comes for free. +3 tests (band order, age tiebreak, merge-irrelevance); 61 web tests green.

(The client-only as-you-type search from the same queued item is a separate follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)