### PR TITLE
Add author-skill: the agent writes a new domain skill on request

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,11 @@ middleware lists every skill it finds there alongside the built-ins, and
 `load_skill(name="<skill-name>")` loads the body. (Skills are listed
 once per chat — add one and start a new chat to pick it up.)
 
+**Authoring one on request.** Ask the agent to "make a skill for X" and
+the `author-skill` built-in walks it through writing a correct
+`SKILL.md` into the domain repo's `.claude/skills/`. Press **Merge &
+Push** to land it on `main`, then a new chat discovers it.
+
 **Frontmatter — stay on the portable core.** Use only the open-standard
 keys, so the file works in every agent:
 

--- a/assist/skills/author-skill/SKILL.md
+++ b/assist/skills/author-skill/SKILL.md
@@ -39,8 +39,9 @@ Two fields between `---` fences:
 ## 4. PUBLISH
 - `read_file` the new file back and confirm the `---` fences, both fields, and the `# H1`
   first line are present.
-- Commit it: `execute("git -C /workspace add .claude/skills/<name> && git -C /workspace commit -m 'Add <name> skill'")`.
-- Tell the user the skill is written, and that to start using it they press **Merge & Push**
-  in the web UI — that lands it on `main`. You cannot push, and every new chat is cloned from
-  `main`, so the skill appears only after Merge & Push, and only in a NEW chat (this
-  conversation's skill list was fixed when it started).
+- You do NOT run git. Your file changes are committed and the thread branch is pushed for you
+  at the end of the turn.
+- Tell the user that to start using the skill they press **Merge & Push** in the web UI —
+  that lands it on `main`. You cannot push, and every new chat is cloned from `main`, so the
+  skill appears only after Merge & Push, and only in a NEW chat (this conversation's skill
+  list was fixed when it started).

--- a/assist/skills/author-skill/SKILL.md
+++ b/assist/skills/author-skill/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: author-skill
+description: Author a new agent skill — write a well-formed SKILL.md so the assistant gains a reusable capability. EXAMPLES — "make a skill for converting between currencies"; "turn the way you just did that into a reusable skill"; "add a skill that captures our release checklist". MUST load before creating or scaffolding a new skill or a .claude/skills/ folder.
+---
+
+# Author a skill — write a well-formed SKILL.md
+
+You are creating a NEW skill: a folder holding one `SKILL.md`, discovered from the working
+repository's `.claude/skills/` directory. Create it with `write_file`, then help the user
+publish it. Four phases.
+
+## 1. WHERE
+- `write_file` the file to `.claude/skills/<name>/SKILL.md` in the working repository. This
+  one file IS the skill — do not edit any prompt or template to "register" it.
+- `<name>` is lowercase letters, digits, and single hyphens (e.g. `convert-currency`); the
+  `name:` field MUST equal the folder name.
+
+## 2. FRONTMATTER
+Two fields between `---` fences:
+
+    ---
+    name: convert-currency
+    description: {one-line capability}. EXAMPLES — "…"; "…". MUST load before {trigger}.
+    ---
+
+- The description is the ONLY thing seen when deciding to load the skill — say WHEN to use it,
+  not how, and keep the trigger specific so it does not fire on another skill's requests.
+- Never put a colon-then-space (`: `) inside an unquoted description: YAML reads it as a new
+  field and the skill is silently dropped. WRONG: `Convert money: dollars to euros`.
+  RIGHT: `Convert money between currencies — dollars to euros and back`.
+
+## 3. BODY
+- The first line is a one-line `# H1` title. Then the concrete rules to follow when the skill
+  applies — numbered steps, and wrong-vs-right for anything easy to get wrong. Do NOT add a
+  "when to use" section; that is the description's job. The body is rules, not routing.
+- Reference the tools this agent has — `read_file`, `write_file`, `edit_file`, `execute`,
+  `ls` — never `Bash`, `Edit`, or `WebFetch`.
+
+## 4. PUBLISH
+- `read_file` the new file back and confirm the `---` fences, both fields, and the `# H1`
+  first line are present.
+- Commit it: `execute("git -C /workspace add .claude/skills/<name> && git -C /workspace commit -m 'Add <name> skill'")`.
+- Tell the user the skill is written, and that to start using it they press **Merge & Push**
+  in the web UI — that lands it on `main`. You cannot push, and every new chat is cloned from
+  `main`, so the skill appears only after Merge & Push, and only in a NEW chat (this
+  conversation's skill list was fixed when it started).

--- a/docs/2026-07-09-author-skill.org
+++ b/docs/2026-07-09-author-skill.org
@@ -1,0 +1,61 @@
+#+title: author-skill — a skill for authoring skills
+#+date: <2026-07-09>
+
+* Goal
+Let a user ask the assist agent to *make a new skill* ("make a skill for X",
+"turn the way you just did that into a reusable skill") and have the agent
+produce a correct, discoverable ~SKILL.md~ without a developer in the loop.
+
+* Decision — runtime domain-skill authoring
+The new built-in ~author-skill~ (=assist/skills/author-skill/SKILL.md=) loads
+when the user asks to create/modify a skill and guides the agent to write a
+domain skill into the working repository's =.claude/skills/<name>/SKILL.md=.
+
+Chosen over the two alternatives:
+- *Dev-side authoring guide for built-ins* (output into =assist/skills/=,
+  committed + deployed by us). Rejected as the primary target: it is really
+  documentation-as-skill for the maintainer, not a capability for the user.
+- *Both paths in one skill.* Rejected for now — a longer body covering two
+  destinations and their deploy mechanics, for a second destination the user
+  rarely wants. Keep the body about the one path that works end-to-end at
+  runtime; a maintainer authoring a built-in can read the same rules.
+
+* Why a skill (not a scaffold script / middleware)
+Consistent with the project's guidance-first stance: authoring a skill is a
+model behaviour (write good prose with a specific frontmatter shape), not a
+deterministic transform. There is no existing scaffold to reuse; the source
+material (=README.md= "Writing a skill", =docs/2026-05-07-skill-description-format.org=,
+the =CLAUDE.md= gotcha bullets) is exactly what the skill body distills.
+
+* The skill contract (what the body enforces)
+1. *WHERE* — one folder, =.claude/skills/<name>/SKILL.md=; nothing else edited
+   to "register" it (the four-layer model: a correct description IS the
+   registration). ~name~ lowercase/hyphen, == folder name.
+2. *FRONTMATTER* — two required fields; the description shape
+   ={capability}. EXAMPLES — "…"; "…". MUST load before {trigger}.=; and the
+   load-bearing =: = colon-space trap that silently drops a skill.
+3. *BODY* — one-line ~# H1~, concrete rules + wrong-vs-right, no "when to use"
+   section, and the agent's own tool vocabulary (~read_file~/~write_file~/
+   ~edit_file~/~execute~/~ls~), never ~Bash~/~Edit~/~WebFetch~.
+4. *PUBLISH* — ~read_file~ it back to confirm the fences/fields/H1 (no fragile
+   in-shell ~python -c~ parse — it mangled on Qwen3.6 and sent the agent off the
+   rails), commit it, then tell the user to press *Merge & Push* in the web UI to
+   land it on ~main~ — only then does a new chat (cloned from ~main~) contain it.
+
+* Known limitation — create-then-use needs Merge & Push, then a fresh chat
+Two barriers, not one. (1) The agent cannot push (=git_push_blocker=), and every
+new chat clones a fresh working copy off =origin/main= — so a skill only
+*locally* committed on this thread's branch is physically ABSENT from a new
+chat's clone until the user presses *Merge & Push* (rebase→squash→push to main).
+(2) Even in a repo that already has it, =skills_metadata= is cached per session,
+so the authoring chat won't list it. The body routes the user through Merge &
+Push and tells them it appears in a *new* chat. Not worth invalidating the
+per-session cache or granting the agent push; both boundaries are cheap + clear.
+
+* Eval
+=edd/eval/test_author_skill.py= — two-assertion bar: (1) ~author-skill~ loaded,
+(2) a written ~SKILL.md~ that would actually load — valid YAML, name==folder,
+non-empty description, ~# H1~ body. The requested capability (shopping list by
+aisle) is deliberately absent from the skill's own EXAMPLES so a pass measures
+generalization, not lexical proximity. Cadence per =CLAUDE.md= (baseline N=3 →
+post-review N=5 → stability N=10).

--- a/docs/2026-07-09-author-skill.org
+++ b/docs/2026-07-09-author-skill.org
@@ -55,7 +55,9 @@ per-session cache or granting the agent push; both boundaries are cheap + clear.
 * Eval
 =edd/eval/test_author_skill.py= — two-assertion bar: (1) ~author-skill~ loaded,
 (2) a written ~SKILL.md~ that would actually load — valid YAML, name==folder,
-non-empty description, ~# H1~ body. The requested capability (shopping list by
-aisle) is deliberately absent from the skill's own EXAMPLES so a pass measures
-generalization, not lexical proximity. Cadence per =CLAUDE.md= (baseline N=3 →
-post-review N=5 → stability N=10).
+non-empty description, ~# H1~ body (parsed with the loader's own anchored
+frontmatter regex, so a non-loading skill can't mis-pass). The requested
+capability (write a limerick from a topic) is deliberately absent from the
+skill's own EXAMPLES AND overlaps no built-in skill, so a pass measures
+generalization, not lexical proximity or a disambiguation confound. Cadence per
+=CLAUDE.md= (baseline N=3 → post-review N=5 → stability N=10). Result: N=5 5/5.

--- a/docs/2026-07-09-author-skill.org
+++ b/docs/2026-07-09-author-skill.org
@@ -39,8 +39,10 @@ the =CLAUDE.md= gotcha bullets) is exactly what the skill body distills.
    ~edit_file~/~execute~/~ls~), never ~Bash~/~Edit~/~WebFetch~.
 4. *PUBLISH* — ~read_file~ it back to confirm the fences/fields/H1 (no fragile
    in-shell ~python -c~ parse — it mangled on Qwen3.6 and sent the agent off the
-   rails), commit it, then tell the user to press *Merge & Push* in the web UI to
-   land it on ~main~ — only then does a new chat (cloned from ~main~) contain it.
+   rails). The agent runs NO git: =DomainManager.sync= host-commits the turn's
+   writes + pushes the thread branch automatically (domain_manager.py:427). So
+   the agent just tells the user to press *Merge & Push* in the web UI to land it
+   on ~main~ — only then does a new chat (cloned from ~main~) contain it.
 
 * Known limitation — create-then-use needs Merge & Push, then a fresh chat
 Two barriers, not one. (1) The agent cannot push (=git_push_blocker=), and every

--- a/edd/eval/test_author_skill.py
+++ b/edd/eval/test_author_skill.py
@@ -77,8 +77,8 @@ class TestAuthorSkill(TestCase):
         create_filesystem(root, {
             "README.md": "Helpers for my writing workflows.",
         })
-        # A real domain repo is version-controlled, with an identity, so the
-        # skill's commit step has somewhere to land instead of erroring mid-turn.
+        # A real domain repo is version-controlled — mirror that so the agent
+        # sees a realistic environment (the host, not the agent, commits/pushes).
         # -b main: don't inherit the machine's init.defaultBranch (may be master);
         # the domain-repo world assumes main.
         subprocess.run(["git", "init", "-q", "-b", "main"], cwd=root, check=True)

--- a/edd/eval/test_author_skill.py
+++ b/edd/eval/test_author_skill.py
@@ -1,0 +1,142 @@
+"""Author-skill eval — does the agent write a well-formed, discoverable skill?
+
+The `author-skill` built-in guides the agent to create a NEW skill: a
+`.claude/skills/<name>/SKILL.md` in the working repository. It is a runtime
+domain-skill authoring flow — the produced skill loads in a *later* chat (after
+the user merges it to main), not this one, so the test measures the ARTIFACT,
+not in-session self-use.
+
+Each test asserts the same thing twice over:
+
+1. The agent loaded the `author-skill` skill (progressive disclosure fired on
+   the user's create-a-skill request).
+2. The agent applied it — it wrote a SKILL.md that will actually load: the file
+   opens with `---`-fenced YAML frontmatter (parsed with the SAME anchored regex
+   the loader uses), `name` equals its folder, a non-empty description, and a
+   one-line H1 body. A skill that does not parse (the classic `: ` colon-space
+   trap, or leading content before the fence) is silently dropped by the loader,
+   so this is the by-construction bar for "this skill would be discoverable".
+
+The requested capability (writing a limerick from a topic) is deliberately NOT
+one of the skill description's own EXAMPLES *and* does not overlap any existing
+built-in skill, so a pass measures generalization, not lexical proximity or a
+disambiguation confound.
+"""
+import glob
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+
+from unittest import TestCase
+
+import yaml
+
+import assist
+from assist.agent import create_agent, AgentHarness
+from assist.model_manager import select_assistant_model
+
+from .utils import create_filesystem, read_file, skill_was_loaded, stub_research_subagent
+
+# The loader's own frontmatter extraction (deepagents skills middleware): the
+# file MUST start with `---`, or it is dropped. Mirror it exactly so the test
+# can't pass a skill the real loader would reject.
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+_BUILTIN_SKILLS_DIR = os.path.join(os.path.dirname(assist.__file__), "skills")
+
+
+class TestAuthorSkill(TestCase):
+    """Verifies the agent authors a well-formed, loadable skill on request."""
+
+    def setUp(self):
+        self.model = select_assistant_model(0.1)
+        # Guard against the agent escaping the tempdir and writing into the real
+        # built-in skills dir (a shell step in the wrong cwd did this once).
+        self._skills_before = set(os.listdir(_BUILTIN_SKILLS_DIR))
+
+    def tearDown(self):
+        strays = set(os.listdir(_BUILTIN_SKILLS_DIR)) - self._skills_before
+        for name in strays:
+            shutil.rmtree(os.path.join(_BUILTIN_SKILLS_DIR, name), ignore_errors=True)
+        self.assertEqual(
+            strays, set(),
+            f"Agent escaped the tempdir and wrote {strays} into the real "
+            f"built-in skills dir ({_BUILTIN_SKILLS_DIR}); cleaned up. The skill "
+            f"must create the file with write_file in the working repo, not via "
+            f"a shell command in the wrong working directory.",
+        )
+
+    def _make_agent(self):
+        root = tempfile.mkdtemp()
+        create_filesystem(root, {
+            "README.md": "Helpers for my writing workflows.",
+        })
+        # A real domain repo is version-controlled, with an identity, so the
+        # skill's commit step has somewhere to land instead of erroring mid-turn.
+        subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], cwd=root, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=root, check=True)
+        subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+        subprocess.run(["git", "commit", "-qm", "init"], cwd=root, check=True)
+        return AgentHarness(create_agent(self.model, root)), root
+
+    def _assert_valid_skill_authored(self, root: str):
+        paths = glob.glob(os.path.join(root, ".claude", "skills", "*", "SKILL.md"))
+        self.assertEqual(
+            len(paths), 1,
+            f"Expected exactly one authored .claude/skills/<name>/SKILL.md, "
+            f"found {paths}. The author-skill body says the file goes there and "
+            f"nowhere else.",
+        )
+        path = paths[0]
+        folder = os.path.basename(os.path.dirname(path))
+        raw = read_file(path)
+
+        m = _FRONTMATTER_RE.match(raw)
+        self.assertIsNotNone(
+            m,
+            "SKILL.md has no leading `---`-fenced YAML frontmatter block — the "
+            "loader would drop it (leading content or a missing opening fence).",
+        )
+        try:
+            meta = yaml.safe_load(m.group(1))
+        except yaml.YAMLError as exc:  # the `: ` colon-space trap lands here
+            self.fail(f"Frontmatter is not valid YAML (likely a colon-space in "
+                      f"the description): {exc}")
+        self.assertIsInstance(meta, dict, "Frontmatter did not parse to a mapping.")
+        # The loader only WARNS on name!=folder, but a correct skill matches; the
+        # author-skill body requires it, so hold the stronger bar here.
+        self.assertEqual(
+            meta.get("name"), folder,
+            f"`name: {meta.get('name')!r}` should equal the folder name {folder!r}.",
+        )
+        self.assertTrue(
+            (meta.get("description") or "").strip(),
+            "Skill has no description — the loader silently skips it.",
+        )
+
+        body = raw[m.end():].lstrip()
+        self.assertTrue(
+            body.startswith("# "),
+            f"Body must open with a one-line `# H1` title; got: {body[:60]!r}",
+        )
+
+    def test_explicit_skill_creation(self):
+        """The user asks, in so many words, for a new skill."""
+        agent, root = self._make_agent()
+
+        with stub_research_subagent():
+            agent.message(
+                "Please create a new skill for me: whenever I give you a topic, "
+                "write a limerick about it (the five-line AABBA form). Set it up "
+                "so it's there for next time."
+            )
+
+        self.assertTrue(
+            skill_was_loaded(agent, "author-skill"),
+            "Agent did not load /skills/author-skill/SKILL.md despite an "
+            "explicit request to create a new skill.",
+        )
+        self._assert_valid_skill_authored(root)

--- a/edd/eval/test_author_skill.py
+++ b/edd/eval/test_author_skill.py
@@ -59,7 +59,11 @@ class TestAuthorSkill(TestCase):
     def tearDown(self):
         strays = set(os.listdir(_BUILTIN_SKILLS_DIR)) - self._skills_before
         for name in strays:
-            shutil.rmtree(os.path.join(_BUILTIN_SKILLS_DIR, name), ignore_errors=True)
+            p = os.path.join(_BUILTIN_SKILLS_DIR, name)
+            if os.path.isdir(p):
+                shutil.rmtree(p, ignore_errors=True)
+            else:
+                os.remove(p)
         self.assertEqual(
             strays, set(),
             f"Agent escaped the tempdir and wrote {strays} into the real "
@@ -75,7 +79,9 @@ class TestAuthorSkill(TestCase):
         })
         # A real domain repo is version-controlled, with an identity, so the
         # skill's commit step has somewhere to land instead of erroring mid-turn.
-        subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+        # -b main: don't inherit the machine's init.defaultBranch (may be master);
+        # the domain-repo world assumes main.
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=root, check=True)
         subprocess.run(["git", "config", "user.email", "t@t"], cwd=root, check=True)
         subprocess.run(["git", "config", "user.name", "t"], cwd=root, check=True)
         subprocess.run(["git", "add", "-A"], cwd=root, check=True)


### PR DESCRIPTION
Lets a user ask the assist agent to **make a new skill** ("make a skill for X", "turn the way you just did that into a reusable skill") and have it write a correct, discoverable `SKILL.md` without a developer in the loop.

## What
- **`assist/skills/author-skill/SKILL.md`** — a built-in skill (loads on create-a-skill requests) guiding the agent to write `.claude/skills/<name>/SKILL.md` into the working repo. Encodes the four-layer model ("the description IS the registration"), the frontmatter shape + the `: ` colon-space YAML trap, `name`==folder, a rules-not-routing body using assist's own tool vocabulary (`read_file`/`write_file`/`edit_file`/`execute`/`ls`, never `Bash`/`Edit`), and the publish path.
- **Publish path (the subtle part):** the agent can't push and every new chat clones `origin/main`, so a locally-committed domain skill is *absent* from a new chat until the user presses **Merge & Push**. The skill routes the user through that, not a bare "start a new chat."
- **`edd/eval/test_author_skill.py`** — two-assertion bar: skill loaded + a *would-actually-load* SKILL.md (parsed with the loader's own anchored frontmatter regex, so a non-loading skill can't mis-pass). Capability (limerick) is deliberately absent from the skill's EXAMPLES and overlaps no built-in, so a pass measures generalization. A tearDown guard catches/cleans any escape into the real skills dir.
- **`docs/2026-07-09-author-skill.org`** — design doc. **README** — one-liner under In-repo skills.

## Eval
N=5, **5/5**, 19–39s/trial.

## Design decision
Targets **runtime domain-skill authoring** (Pierre's call) over a dev-side built-in authoring guide; the "both destinations" variant was rejected for a longer body serving a destination users rarely want at runtime. The skill loads in a *later* chat (after Merge & Push), not the authoring one — a known, documented limitation (`skills_metadata` per-session cache + the clone-from-main boundary), not worth granting the agent push or invalidating the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)