### PR TITLE
Durable queued messages + restart recovery (design + Step 1 implementation)

### DIFF
--- a/assist/backlog.py
+++ b/assist/backlog.py
@@ -1,0 +1,99 @@
+"""Durable follow-up message backlog — messages accepted while a thread is busy.
+
+A follow-up sent to a busy thread used to live only in-memory (a parked
+BackgroundTask waiter, or the resume scheduler's queue) — a web restart silently
+dropped it. Each such message is now journaled to
+``<root_dir>/<tid>/pending_messages.json`` at submit and removed (claimed, by
+id) when its turn actually starts, so at every instant it is durable in at
+least one place: this journal while waiting, ``status.json``'s
+``pending_message`` once its turn runs. Startup recovery re-dispatches whatever
+is still journaled, in submit order. See
+``docs/2026-07-13-durable-message-queue.org``.
+
+The first message of an idle thread is NOT journaled — ``_mark_pending`` makes
+it durable in ``status.json`` before the POST returns; the journal is
+follow-ups only.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from dataclasses import dataclass, field
+
+from assist.record_store import PerThreadJsonStore, RecordNotFound
+
+logger = logging.getLogger(__name__)
+
+BACKLOG_FILE = "pending_messages.json"
+
+
+class PendingMessageNotFound(RecordNotFound):
+    """No pending message with that id on that thread (a double-claim is benign)."""
+
+
+@dataclass
+class PendingMessage:
+    """One accepted-but-not-yet-started follow-up. ``rider`` holds the four raw
+    submit-form fields (sent_at/tz/lat/lon) so recovery rebuilds the ContextRider
+    with the existing ``_build_rider``; ``sender`` is set for inbound-SMS
+    follow-ups (it decides triage on re-dispatch)."""
+    thread_id: str
+    text: str
+    sender: str | None = None
+    rider: dict | None = None
+    enqueued_at: str = ""
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+
+    def to_dict(self) -> dict:
+        return {"id": self.id, "thread_id": self.thread_id, "text": self.text,
+                "sender": self.sender, "rider": self.rider,
+                "enqueued_at": self.enqueued_at}
+
+    @staticmethod
+    def from_dict(d: dict) -> "PendingMessage":
+        return PendingMessage(
+            thread_id=str(d.get("thread_id", "")), text=str(d.get("text", "")),
+            sender=d.get("sender") or None, rider=d.get("rider") or None,
+            enqueued_at=str(d.get("enqueued_at", "")),
+            id=str(d.get("id") or uuid.uuid4().hex))
+
+
+class MessageBacklog(PerThreadJsonStore[PendingMessage]):
+    """Disk-backed follow-up journal. ``root_dir`` is the thread root
+    (``MANAGER.root_dir``), matching ScheduleStore/SubscriptionStore. Uncapped on
+    purpose: inflow is human-paced, and an over-cap behavior would mean refusing
+    a user's message."""
+
+    FILENAME = BACKLOG_FILE
+    NOTFOUND_EXC = PendingMessageNotFound
+
+    @staticmethod
+    def _from_dict(d: dict) -> PendingMessage:
+        return PendingMessage.from_dict(d)
+
+    def _read(self, tid: str) -> list[PendingMessage]:
+        """The base read swallows a parse failure to [] — here that would
+        SILENTLY drop user messages, so make it loud: atomic tmp+rename makes a
+        partial write impossible, meaning a parse failure is real disk
+        corruption. Still returns [] (recovery proceeds for other threads); the
+        file is left in place for inspection."""
+        try:
+            with open(self._path(tid)) as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            return []
+        except json.JSONDecodeError:
+            logger.error("message backlog for %s is unreadable — its queued "
+                         "messages will NOT be recovered; file left for "
+                         "inspection", tid, exc_info=True)
+            return []
+        return [self._from_dict(d) for d in data]
+
+    def claim(self, tid: str, rid: str) -> None:
+        """Remove a journaled message whose turn is now running (claim by id).
+        Idempotent — a recovery dedupe or a double-claim finds it already gone."""
+        try:
+            self.remove(tid, rid)
+        except PendingMessageNotFound:
+            pass

--- a/assist/backlog.py
+++ b/assist/backlog.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import uuid
 from dataclasses import dataclass, field
 
@@ -76,17 +77,24 @@ class MessageBacklog(PerThreadJsonStore[PendingMessage]):
         """The base read swallows a parse failure to [] — here that would
         SILENTLY drop user messages, so make it loud: atomic tmp+rename makes a
         partial write impossible, meaning a parse failure is real disk
-        corruption. Still returns [] (recovery proceeds for other threads); the
-        file is left in place for inspection."""
+        corruption. The corrupt file is moved aside to ``<name>.corrupt`` for
+        inspection (a later ``add``'s read-modify-write would otherwise replace
+        it, destroying the evidence), and [] is returned so recovery proceeds
+        for other threads."""
+        path = self._path(tid)
         try:
-            with open(self._path(tid)) as f:
+            with open(path) as f:
                 data = json.load(f)
         except FileNotFoundError:
             return []
         except json.JSONDecodeError:
             logger.error("message backlog for %s is unreadable — its queued "
-                         "messages will NOT be recovered; file left for "
-                         "inspection", tid, exc_info=True)
+                         "messages will NOT be recovered; moved to %s.corrupt "
+                         "for inspection", tid, path, exc_info=True)
+            try:
+                os.replace(path, f"{path}.corrupt")
+            except OSError:
+                pass
             return []
         return [self._from_dict(d) for d in data]
 

--- a/assist/backlog.py
+++ b/assist/backlog.py
@@ -89,12 +89,14 @@ class MessageBacklog(PerThreadJsonStore[PendingMessage]):
             return []
         except json.JSONDecodeError:
             logger.error("message backlog for %s is unreadable — its queued "
-                         "messages will NOT be recovered; moved to %s.corrupt "
-                         "for inspection", tid, path, exc_info=True)
+                         "messages will NOT be recovered", tid, exc_info=True)
             try:
                 os.replace(path, f"{path}.corrupt")
+                logger.error("corrupt backlog moved to %s.corrupt for inspection",
+                             path)
             except OSError:
-                pass
+                logger.error("corrupt backlog could NOT be moved aside; left at %s",
+                             path)
             return []
         return [self._from_dict(d) for d in data]
 

--- a/assist/checkpoint_rollback.py
+++ b/assist/checkpoint_rollback.py
@@ -122,6 +122,18 @@ def invoke_with_rollback(
                 original_history = list(
                     agent.get_state_history(current_config)
                 )
+                # Bound the walk to the CURRENT turn: get_state_history spans the
+                # whole thread, and rolling past this turn's input checkpoint
+                # lands on the PREVIOUS turn's terminal state — invoking
+                # input=None there returns immediately with the old answer, so
+                # the failing turn would silently "succeed" stale. This bites
+                # hardest on a crash-recovery resume, whose depth-0 point is
+                # often early in the turn. Truncate at (and include) the first
+                # checkpoint carrying this turn's input.
+                for i, snap in enumerate(original_history):
+                    if (snap.metadata or {}).get("source") == "input":
+                        original_history = original_history[: i + 1]
+                        break
                 logger.warning(
                     "Rollback[%s]: %s on first attempt, "
                     "%d checkpoints available (max_depth=%d, retries_per_step=%d)",

--- a/assist/record_store.py
+++ b/assist/record_store.py
@@ -1,5 +1,5 @@
-"""Per-thread JSON record store — the disk-is-truth persistence shared by schedules and
-message-event subscriptions.
+"""Per-thread JSON record store — the disk-is-truth persistence shared by schedules,
+message-event subscriptions, and the pending-message backlog.
 
 Each thread's records live in ``<root_dir>/<tid>/<FILENAME>`` (atomic tmp+rename, like
 ``status.json``), so they survive restart and die with the thread via the thread dir's

--- a/assist/sandbox_manager.py
+++ b/assist/sandbox_manager.py
@@ -404,3 +404,29 @@ class SandboxManager:
             except Exception as e:
                 logger.warning("Container cleanup failed for %s: %s", path, e)
         cls._containers.clear()
+
+    @classmethod
+    def reap_orphans(cls) -> None:
+        """Kill every ``assist.sandbox`` container by DOCKER LABEL, not the
+        in-memory registry. After a web-process crash ``_containers`` is empty,
+        but the containers survive — and a ``docker exec``'d tool command keeps
+        running inside one, mutating the host-bind-mounted /workspace that a
+        recovery resume's FRESH container mounts too, for up to the 3h backstop
+        TTL. Startup recovery calls this before dispatching any resume so a
+        zombie writer can never share a workspace with a resumed turn.
+        Best-effort: docker being down must not block recovery (turns will fail
+        fail-fast on their own if docker stays down)."""
+        try:
+            client = cls._get_docker_client()
+            orphans = client.containers.list(
+                filters={"label": "assist.sandbox=true"})
+        except Exception as e:
+            logger.warning("orphan-sandbox reap skipped (docker unavailable): %s", e)
+            return
+        for container in orphans:
+            try:
+                container.kill()
+                logger.info("Reaped orphaned sandbox %s", container.id[:12])
+            except Exception as e:
+                logger.warning("orphan reap failed for %s: %s", container.id[:12], e)
+        cls._containers.clear()

--- a/assist/sandbox_manager.py
+++ b/assist/sandbox_manager.py
@@ -406,24 +406,39 @@ class SandboxManager:
         cls._containers.clear()
 
     @classmethod
-    def reap_orphans(cls) -> None:
-        """Kill every ``assist.sandbox`` container by DOCKER LABEL, not the
-        in-memory registry. After a web-process crash ``_containers`` is empty,
-        but the containers survive — and a ``docker exec``'d tool command keeps
-        running inside one, mutating the host-bind-mounted /workspace that a
-        recovery resume's FRESH container mounts too, for up to the 3h backstop
-        TTL. Startup recovery calls this before dispatching any resume so a
-        zombie writer can never share a workspace with a resumed turn.
-        Best-effort: docker being down must not block recovery (turns will fail
-        fail-fast on their own if docker stays down)."""
+    def reap_orphans(cls, root_dir: str) -> None:
+        """Kill THIS INSTANCE's surviving sandbox containers — by docker label
+        plus workspace mount, not the in-memory registry. After a web-process
+        crash ``_containers`` is empty, but the containers survive — and a
+        ``docker exec``'d tool command keeps running inside one, mutating the
+        host-bind-mounted /workspace that a recovery resume's FRESH container
+        mounts too, for up to the 3h backstop TTL. Startup recovery calls this
+        before dispatching any resume so a zombie writer can never share a
+        workspace with a resumed turn.
+
+        Scoped to containers whose /workspace bind-mount lives under
+        ``root_dir`` (this deployment's threads root): the label alone is
+        host-global, and prod + eval/dev sandboxes share ONE docker daemon on
+        this box — a bare-label reap would kill a concurrently running eval's
+        LIVE containers mid-turn. The mount filter needs no new create-time
+        labeling, so it also covers orphans from pre-existing code. Best-effort:
+        docker being down must not block recovery (turns fail fast on their own
+        if it stays down)."""
+        root = os.path.realpath(root_dir) + os.sep
         try:
             client = cls._get_docker_client()
-            orphans = client.containers.list(
+            candidates = client.containers.list(
                 filters={"label": "assist.sandbox=true"})
         except Exception as e:
             logger.warning("orphan-sandbox reap skipped (docker unavailable): %s", e)
             return
-        for container in orphans:
+        for container in candidates:
+            mounts = (container.attrs or {}).get("Mounts", [])
+            ours = any(m.get("Destination") == "/workspace"
+                       and os.path.realpath(m.get("Source", "")).startswith(root)
+                       for m in mounts)
+            if not ours:
+                continue
             try:
                 container.kill()
                 logger.info("Reaped orphaned sandbox %s", container.id[:12])

--- a/assist/thread.py
+++ b/assist/thread.py
@@ -231,9 +231,12 @@ class Thread:
 
     def resume(self) -> str:
         """Resume this thread's in-flight turn from its durable checkpoint (``input=None``)
-        after a fair-scheduling quantum pause. Completed supersteps (incl. any mid-flight
-        sub-agent) are in the checkpoint under ``durability="sync"``, so no work is redone —
-        see ``docs/2026-07-08-fair-scheduling.org`` + ``tests/test_subagent_durable_resume.py``."""
+        — after a fair-scheduling quantum pause, or after a server restart killed the turn
+        mid-flight (startup recovery; docs/2026-07-13-durable-message-queue.org). Completed
+        supersteps (incl. any mid-flight sub-agent) are in the checkpoint under
+        ``durability="sync"``, so no completed work is redone; only the superstep in flight
+        at an uncooperative kill re-runs — see ``docs/2026-07-08-fair-scheduling.org`` +
+        ``tests/test_subagent_durable_resume.py`` + ``tests/test_restart_recovery.py``."""
         return self._run(None)
 
     def pending_reply(self) -> dict | None:

--- a/docs/2026-07-13-durable-message-queue.org
+++ b/docs/2026-07-13-durable-message-queue.org
@@ -1,0 +1,209 @@
+#+title: Durable queued/pending messages — survive a web restart
+#+date: <2026-07-13>
+#+author: design doc (for review)
+
+* Problem
+
+When a thread is busy and the user sends follow-up messages, the backlog lives
+*only in in-memory structures*. A web restart (deploy, crash, =systemd restart=)
+drops it. Two failure modes:
+
+1. A *paused* fair-scheduling turn is orphaned — its work is durable in the
+   checkpoint, but nothing re-enqueues the resume, and the startup reconcile
+   *actively flips it to =error=*.
+2. *Queued follow-up messages are silently lost* with no trace, because
+   =status.json= records only the one in-flight message.
+
+Goal: make the follow-up backlog durable and recover it (plus the paused-turn
+resume) on startup — exactly-once, in submit order — without violating
+event-loop liveness or the "fail-fast, don't heal-and-retry" rule.
+
+This is the durability half. Surfacing the backlog in the UI is a separate
+design (feature #1). This ships independently.
+
+* Current behavior — what exactly is lost (verified, file:line)
+
+- Submit =post_message= (=threads.py:1729=): =paused= → =_RESUME_SCHEDULER.submit_message=
+  → in-memory =queue.Queue= (=_ResumeScheduler._q=, :1654); else
+  =background_tasks.add_task(_process_message,…)= (:1744), where a 2nd message to a
+  =processing= thread *parks a threadpool worker in =cond.wait=* (=thread_queue.py:197=).
+  Both purely in-memory.
+- =_mark_pending= (:1377) no-ops when busy (:1411); =status.json= holds a *single*
+  =pending_message= (:1418). So 2nd/3rd follow-ups are recorded *nowhere durable*.
+- Pause (=_process_message= =except ThreadPauseRequested= :1150): enqueues an
+  in-memory =submit_resume= (:1164), writes =status="paused"= (:1166). The mid-turn
+  state IS durable (langgraph =SqliteSaver=/=threads.db=, =thread_manager.py:120=);
+  the *resume trigger* is not.
+- Startup reconcile (=state.py:595=): marks *every* =BUSY_STAGES= thread —
+  including =paused= — to =error=. So a restart converts a resumable paused turn
+  into a dead =error=.
+
+| Item | Durable today | Lost on restart |
+|------+---------------+-----------------|
+| Paused turn mid-flight state | yes (checkpoint) | orphaned (resume trigger gone; forced to =error=) |
+| Paused turn resume trigger | no (=_q=) | *lost* |
+| Follow-up to a paused thread | no (=_q=) | *lost* (silent) |
+| Follow-up(s) to a processing thread | no (parked waiter) | *lost* (silent, no trace) |
+| The in-flight (1st) message | yes (=status.pending_message=) | surfaced in =error= banner; user re-sends |
+
+*Precedent to reuse:* =PerThreadJsonStore= (=assist/record_store.py=) — lock-
+serialized, atomic tmp+rename, disk-is-truth, per-thread, =all()=-scans-every-thread,
+dies with the thread dir. Already backs =ScheduleStore= and =SubscriptionStore=.
+
+* Proposed durable data model
+
+No new infrastructure, no new DB, no =threads.db= writes on the hot path.
+
+** Follow-up backlog (new)
+Per-thread =pending_messages.json= via a =Backlog(PerThreadJsonStore)= subclass
+(mirrors =ScheduleStore= exactly). Each record:
+: { "id": <uuid>, "text": str, "sender": str|null,
+:   "rider": {"sent_at","tz","lat","lon"}|null, "enqueued_at": <iso> }
+FIFO by list order. Per-thread (dies with the thread on =hard_delete= =rmtree=,
+=thread_manager.py:222=; no eviction hook). =CAP= bounds runaway growth like
+=ScheduleStore.CAP_PER_THREAD=. =rider= stores the four raw form fields so recovery
+reconstructs the =ContextRider= via the existing =_build_rider= (:1421). Reusing
+=PerThreadJsonStore= gives lock-serialized atomic RMW, no partial file, and
+=all()= for the startup scan — deleting fragility by composing a stable block.
+
+** Paused-turn resume durability (no new file)
+Extend the existing =status="paused"= write (:1166) with the resume params
+carried only in-memory today: =accumulated_active_ms= (the =carry=, :1158), plus
+=resume_sender= / =resume_rider= (so a paused *triage* turn resumes with the right
+=send_reply= target + context). =status="paused"= + the checkpoint then fully
+describe the resume — no separate resume journal.
+
+* On-startup recovery flow
+
+1. *Change the BUSY→error reconcile* (=state.py:595=) to *exclude =paused=*. It
+   still errors the genuinely-interrupted stages
+   {=initializing=,=cloning=,=starting_sandbox=,=processing=,=queued=} (container
+   gone, not a clean boundary), carrying =pending_message= into the error banner.
+2. *Recover paused resumes.* For each =tid= with =status=="paused"=: enqueue a
+   resume job (params from the extended =status.json=; =accumulated_active_ms=
+   defaults 0, so pre-feature paused threads still resume).
+3. *Recover queued follow-ups.* Scan =BACKLOG.all()=; for each tid with a
+   non-empty backlog, enqueue its entries *in list order*, after that tid's resume
+   job (recovery controls order: resume first, then messages — preserving the
+   current "message runs after the resume" invariant).
+4. *Start the single serial worker* (the generalized =_ResumeScheduler=), which
+   drains one job at a time. Per-tid order preserved; cross-tid order irrelevant.
+
+* Exactly-once / ordering — claim-before-run
+
+The serial worker *pops* a backlog entry (=PerThreadJsonStore.remove=, under its
+lock) *before* starting the turn, not after success:
+- Crash *after claim, mid-run*: entry already gone → *not replayed* (satisfies "a
+  crash mid-processing must not replay a half-done turn"). Partial work is in the
+  checkpoint; the thread surfaces =error=/=ready=; user re-sends if needed.
+- Crash *before claim*: replayed exactly once.
+
+Single serial worker + FIFO head-claim = strict submit order per thread.
+
+* Reconciling "fail-fast / don't heal-and-retry" with durability
+
+The line is *unstarted work* vs *an interrupted turn*:
+- *Unstarted queued follow-ups* never began a turn → running them once is
+  delivering an accepted-but-unprocessed message, not a retry. *Recover.*
+- *The paused turn's resume* reached a clean, designed pause point
+  (=ThreadPauseRequested= fires only at a superstep boundary with a
+  =durability="sync"= checkpoint). =status=="paused"= is durable proof. Re-enqueuing
+  is durability of a non-terminated turn, not heal-and-retry. *Recover.*
+- *A =processing=/=starting_sandbox= turn* interrupted by the crash is NOT at a
+  clean boundary and its per-turn sandbox is gone. Auto-resuming *would* be
+  heal-and-retry. *Keep erroring it*; user re-sends. Its unstarted backlog
+  follow-ups are still recovered (independent unprocessed messages).
+
+* Event-loop safety of the durable write
+
+=post_message= runs on the single-worker loop. Two liveness-safe options;
+recommend *A*:
+- *A (recommended):* =post_message= is =async def= → append via
+  =await run_in_threadpool(BACKLOG.add, rec)=. The write + store lock run in a pool
+  thread, never on the loop, for *milliseconds* (a bounded file write) — different
+  in kind from the resume-scheduler's forbidden park-for-a-quantum pattern, so no
+  2026-06-10-class pool exhaustion. Loop stays strictly lock-free.
+- *B:* append inline on the loop like =_mark_pending='s =_set_status= write. Simpler,
+  but takes the store lock on the loop. Rejected in favor of A.
+Off-loop writers (pause path, worker claim/pop, completion drain) append directly.
+
+* Dispatch model — two shippable steps
+
+- *Step 1 — Journal (smaller blast radius, ship first):* keep today's live
+  dispatch; make the backlog a durable *journal* — append on submit, claim-pop
+  when the turn starts. Read only at startup. Fully durable + recovered; minimal
+  change to the concurrency hot path.
+- *Step 2 — Single source of truth (recommended end state):* the durable backlog
+  becomes the *only* representation of a queued follow-up — a follow-up to a busy
+  thread is appended, NOT parked as a =THREAD_QUEUE= waiter; the serial worker
+  drains the next entry at turn completion. *Deletes* the in-memory
+  park-per-follow-up fragility rather than shadowing it. One race to resolve in
+  detailed design (a follow-up appended at the instant of the terminal
+  drain-check → by-construction: submit re-checks =status= and kicks the drain if
+  idle). Full three-phase (touches the submit path + the queue).
+
+The serial worker is the existing =_ResumeScheduler= (already owns =submit_resume=
++ =submit_message=) — generalize/rename it. No new component.
+
+* Seam with feature #1 (UI surfacing)
+
+Feature #1 reads =BACKLOG.for_thread(tid)= (=record_store.py:69=) to render "N
+queued" rows, with the same event-loop-safe read discipline as =_get_status=
+(bare read, missing/corrupt → empty). This design owns no rendering.
+*Independently shippable:* without #1 the backlog is invisible but durable +
+recovered; the existing single =pending_message= bubble still renders (no
+regression, no dependency either way). Keep the record shape (=id=, =text=,
+=enqueued_at=) stable as #1's contract. (Note: feature #1 ships first on an
+in-memory mirror; when this lands, #1 re-sources its read from the backlog.)
+
+* Risks / edge cases
+
+- Restart mid-write: tmp+=os.replace= (=record_store.py:60=) is atomic — whole-old
+  or whole-new, never partial.
+- *Corrupt backlog:* =_read= degrades =JSONDecodeError= to =[]= today — that would
+  *silently drop* messages. Since atomic replace makes partial writes impossible,
+  a parse failure = real corruption; mitigation: *log at ERROR* and don't
+  overwrite the file (leave for inspection). Accepted limit.
+- Thread deleted with a backlog: =rmtree= takes the file; startup scan skips
+  =.deleted= → never replayed. No orphan.
+- Double-run: prevented by claim-before-run pop.
+- Paused *triage* turn resumed without =sender=: avoided by persisting
+  =resume_sender= (D2).
+- Runaway growth: bounded by =CAP=.
+- Two uvicorn workers: out of scope by construction (single worker, documented).
+
+* Test plan (symptom-level, un-mocked where risk lives)
+
+Real =PerThreadJsonStore= over a tmp dir + the real route/=_process_message=
+(extend =tests/test_web_process_message_e2e.py=).
+1. *Restart recovery — exactly once, in order:* enqueue 2 follow-ups, drop all
+   in-memory state, run lifespan recovery + =start_scheduler= → both process in
+   submit order; each entry popped exactly once; backlog empty at end.
+2. *No replay of a half-done turn:* backlog entry marked claimed/popped (turn
+   started), crash before completion, recover → *not* re-dispatched.
+3. *Paused resume survives restart:* =status="paused"= + params, no in-memory =_q=,
+   recover → a resume job (=input=None=) enqueued and =paused= *not* flipped to
+   =error=; a =processing= thread *is* flipped.
+4. *Ordering vs resume:* paused thread + one follow-up → resume enqueued before
+   the follow-up.
+5. *Deleted-thread backlog never replayed.*
+6. *Event-loop liveness (un-mocked):* under =PYTHONASYNCIODEBUG=1=, hold the store
+   lock in another thread and POST a follow-up → =post_message= returns promptly
+   (Option A: append is off-loop).
+7. *Durable append atomic under concurrency:* two near-simultaneous follow-ups →
+   both land (no lost update).
+8. *Corrupt backlog is loud:* truncated file → recovery logs ERROR, doesn't crash,
+   leaves the file.
+
+* Decisions to flag for Pierre
+
+- *D0 (scope):* ship Step 1 (durable journal + recovery) first; Step 2 (backlog as
+  single source of truth) as a follow-up full-three-phase change. Confirm.
+- *D1 (mid-flight policy):* recover =paused= resumes + unstarted follow-ups; keep
+  erroring =processing=-and-earlier. Sub-question: auto-run recovered follow-ups
+  behind an errored head turn (default yes), or hold them?
+- *D2 (resume params in status):* persist =accumulated_active_ms= (2h-cap
+  accounting across restart) + =resume_sender=/=resume_rider=. Confirm the rider is
+  worth persisting vs resuming with =rider=None=.
+- *D3 (append placement):* Option A (=run_in_threadpool=, recommended) vs B (inline).
+- *D4 (cap):* per-thread backlog =CAP= value + over-cap behavior.

--- a/docs/2026-07-13-durable-message-queue.org
+++ b/docs/2026-07-13-durable-message-queue.org
@@ -120,10 +120,12 @@ checkpoint, discarding its pending work):
    model call, no sandbox start; degrade to the =error= banner if unreadable).
 2. =snap.next= non-empty *or* =snap.interrupts= non-empty → *resume*
    (=input=None=, fresh sandbox — same path as a fair-scheduling resume).
-3. =next= empty *and* the latest checkpointed human message contains
-   =pending_message= → the turn actually COMPLETED before the kill (the crash
-   landed in the post-invoke bookkeeping window) → finalize: mark =ready=, no
-   re-run.
+3. =next= empty *and* the latest checkpointed human message EXACTLY equals
+   =pending_message= (as sent, or with the supersede-fold prefix the checkpoint
+   carries) → the turn actually COMPLETED before the kill (the crash landed in
+   the post-invoke bookkeeping window) → finalize: mark =ready=, no re-run.
+   Exact only — containment/suffix would misread a short pending found inside
+   the PREVIOUS turn's message as completed and silently drop it.
 4. Otherwise (message never reached the checkpoint) → *re-dispatch*
    =pending_message= as a fresh message (=domain= threads re-enter via their
    init path). Nothing ran, so this is delivering, not retrying.
@@ -266,15 +268,27 @@ in-memory mirror; when this lands, #1 re-sources its read from the backlog.)
   the odds; small fix in =checkpoint_rollback.py=).
 - Two uvicorn workers: out of scope by construction (single worker, documented).
 - Dispatch-path coverage (as-built): the SMS path (=_dispatch_event=) journals
-  follow-ups like the web path; scheduler/geo turns still call
-  =_process_message= directly with no journal (a missed schedule refires by
-  design — =next_fire_at= only advances on success — so they need none), and a
-  due schedule at startup could still race a recovery job's ORDER (the queue
-  serializes the turns themselves). Same-tid waiter clobber of the running
-  turn's status is closed via the lock-free =peek_holder= skip; the residual is
-  a direct-dispatch waiter behind a same-tid turn that is itself queued behind
-  another thread (rare double-nesting). Step 2's single-source dispatch
-  subsumes all of these.
+  follow-ups like the web path; scheduler/geo turns carry no journal entry
+  (their prompts are regenerable and mid-turn crashes are covered by head
+  recovery via =pending_message= — note the scheduler is advance-persist-THEN-
+  dispatch, so a fire crashed pre-turn is lost until the next cadence by its
+  own no-catch-up design, not refired).
+- *NAMED RESIDUAL (direct-dispatch vs recovery, Step 1):* a due schedule / geo
+  completion at startup fires as soon as =_llm_reachable= passes — the same
+  probe recovery's bounded wait polls — so it can win the recovery window on
+  the exact cold-boot-after-crash timing. If it does, its status writes REPLACE
+  the recovered thread's (=pending_message=/=sender=/=claimed_id= clobbered)
+  and the recover job then sees stage ≠ "paused" → the head decision is
+  *silently skipped*: the interrupted head turn is neither resumed nor
+  re-dispatched and no banner surfaces. Journaled follow-ups still recover
+  (the drain doesn't depend on the stage). Accepted for Step 1 as a rare,
+  compound-timing loss — named, not "fixed" — because closing it here means a
+  clobber-proof recovery marker outside status.json; Step 2's single-source
+  dispatch closes it by construction. Similarly narrowed-not-closed: the
+  same-tid waiter clobber is gated by the lock-free =peek_holder= skip and a
+  SINGLE busy sample in =post_message= (journal + status decisions can't
+  disagree), but a direct-dispatch waiter behind a same-tid turn that is
+  itself queued behind another thread still writes (rare double-nesting).
 - Ordering under a re-paused recovery resume: the drain SUBMITS follow-ups to
   the serial worker rather than running them inline, so a head resume that hits
   its quantum again re-queues ahead of them — the never-on-a-mid-flight-

--- a/docs/2026-07-13-durable-message-queue.org
+++ b/docs/2026-07-13-durable-message-queue.org
@@ -75,13 +75,31 @@ describe the resume — no separate resume journal.
 
 * On-startup recovery flow
 
-1. *Change the BUSY→error reconcile* (=state.py:595=) to *exclude =paused=*. It
-   still errors the genuinely-interrupted stages
-   {=initializing=,=cloning=,=starting_sandbox=,=processing=,=queued=} (container
-   gone, not a clean boundary), carrying =pending_message= into the error banner.
-2. *Recover paused resumes.* For each =tid= with =status=="paused"=: enqueue a
-   resume job (params from the extended =status.json=; =accumulated_active_ms=
-   defaults 0, so pre-feature paused threads still resume).
+1. *Replace the BUSY→error reconcile* (=state.py:595=) with recovery for every
+   busy stage (per Pierre's review: in-progress turns are recoverable too — the
+   checkpoint is durable at every superstep, not just at pauses). The
+   resume-vs-redispatch rule per thread is:
+   - =paused= → *resume* (=input=None=; params from the extended =status.json=;
+     =accumulated_active_ms= defaults 0, so pre-feature paused threads still resume).
+   - =processing= → *resume from the last checkpoint* — the restart killed the
+     turn mid-flight, but =durability="sync"= means every completed superstep is
+     already persisted (=thread.py:288-302=); the resume path already builds a
+     fresh sandbox (=_get_sandbox_backend= runs for =resume=True= too,
+     =threads.py:1043=), so the dead container is a non-issue — a new one is
+     created exactly as a fair-scheduling resume does. *Guard:* resume only if
+     the turn's human message is already IN the checkpoint (compare the
+     checkpoint's latest human message to =status.pending_message=). A crash
+     *before the first checkpoint* of the turn means =input=None= would re-invoke
+     on the PREVIOUS turn's final state — a spurious turn; in that case fall
+     through to re-dispatch below.
+   - =queued= / =starting_sandbox= / =initializing= / =cloning= (turn never
+     started, or pre-first-checkpoint) → *re-dispatch* =status.pending_message=
+     as a fresh message (it's durable in status.json today). Nothing ran, so
+     this is delivering, not retrying.
+   - Only a thread whose state can't support either (no pending_message, no
+     checkpoint match) falls back to the =error= banner.
+2. *Recovery jobs go onto the serial worker* in the same per-tid order rule as
+   below (resume/re-dispatch first, then backlog follow-ups).
 3. *Recover queued follow-ups.* Scan =BACKLOG.all()=; for each tid with a
    non-empty backlog, enqueue its entries *in list order*, after that tid's resume
    job (recovery controls order: resume first, then messages — preserving the
@@ -93,26 +111,41 @@ describe the resume — no separate resume journal.
 
 The serial worker *pops* a backlog entry (=PerThreadJsonStore.remove=, under its
 lock) *before* starting the turn, not after success:
-- Crash *after claim, mid-run*: entry already gone → *not replayed* (satisfies "a
-  crash mid-processing must not replay a half-done turn"). Partial work is in the
-  checkpoint; the thread surfaces =error=/=ready=; user re-sends if needed.
-- Crash *before claim*: replayed exactly once.
+- Crash *after claim, mid-run*: the backlog entry is already gone → *not
+  replayed as a fresh message*. Instead the thread's turn is by then =processing=
+  with that text in =status.pending_message=, so the in-progress recovery path
+  (resume-from-checkpoint, or re-dispatch via the first-checkpoint guard) covers
+  it — exactly one delivery path applies, never both.
+- Crash *before claim*: replayed exactly once from the backlog.
 
 Single serial worker + FIFO head-claim = strict submit order per thread.
 
 * Reconciling "fail-fast / don't heal-and-retry" with durability
 
-The line is *unstarted work* vs *an interrupted turn*:
+(Revised per Pierre's review: recover in-progress turns too.) The line is
+*infrastructure failure of OUR making* vs *a failed turn*:
 - *Unstarted queued follow-ups* never began a turn → running them once is
   delivering an accepted-but-unprocessed message, not a retry. *Recover.*
-- *The paused turn's resume* reached a clean, designed pause point
-  (=ThreadPauseRequested= fires only at a superstep boundary with a
-  =durability="sync"= checkpoint). =status=="paused"= is durable proof. Re-enqueuing
-  is durability of a non-terminated turn, not heal-and-retry. *Recover.*
-- *A =processing=/=starting_sandbox= turn* interrupted by the crash is NOT at a
-  clean boundary and its per-turn sandbox is gone. Auto-resuming *would* be
-  heal-and-retry. *Keep erroring it*; user re-sends. Its unstarted backlog
-  follow-ups are still recovered (independent unprocessed messages).
+- *The paused turn's resume* reached a clean, designed pause point with a
+  =durability="sync"= checkpoint. *Recover.*
+- *An in-progress (=processing=) turn killed by the restart*: the restart is an
+  operator/infra event, not a turn failure — the turn did nothing wrong. Every
+  completed superstep is already checkpointed (=durability="sync"=), so resuming
+  =input=None= re-runs only the superstep in flight at the kill, in a *fresh
+  sandbox* (the resume path already creates one, exactly like a fair-scheduling
+  resume). This is the same mechanism as the quantum pause — the difference is
+  only that the turn didn't get to a chosen boundary first. *Recover, with the
+  first-checkpoint guard* (a turn whose human message never reached the
+  checkpoint is re-dispatched as a fresh message instead).
+- *Named residual (honest):* the interrupted superstep re-runs on resume, so a
+  side-effectful tool call in flight at the kill (a notify, a web request)
+  executes again. In-sandbox effects are consistent by construction — the old
+  container's state is gone with it; =send_reply= is HITL-gated so a duplicate
+  SMS can't fire unattended. Accepted: restarts are rare, operator-initiated,
+  and one re-run superstep beats losing the turn.
+- The fail-fast rule still governs *turn-internal* failures (sandbox vanished
+  mid-turn, cap breach): those terminate, no heal-and-retry. Recovery here is
+  strictly about surviving a process restart.
 
 * Event-loop safety of the durable write
 
@@ -179,11 +212,17 @@ Real =PerThreadJsonStore= over a tmp dir + the real route/=_process_message=
 1. *Restart recovery — exactly once, in order:* enqueue 2 follow-ups, drop all
    in-memory state, run lifespan recovery + =start_scheduler= → both process in
    submit order; each entry popped exactly once; backlog empty at end.
-2. *No replay of a half-done turn:* backlog entry marked claimed/popped (turn
-   started), crash before completion, recover → *not* re-dispatched.
-3. *Paused resume survives restart:* =status="paused"= + params, no in-memory =_q=,
-   recover → a resume job (=input=None=) enqueued and =paused= *not* flipped to
-   =error=; a =processing= thread *is* flipped.
+2. *No double delivery of a claimed message:* backlog entry claimed/popped (turn
+   started, text now in =pending_message=), crash before completion, recover →
+   not re-dispatched from the backlog; exactly one recovery path (the in-progress
+   resume) handles it.
+3. *Busy stages survive restart:* (a) =status="paused"= + params, no in-memory
+   =_q= → a resume job (=input=None=) enqueued, not flipped to =error=. (b)
+   =status="processing"= with the turn's human message IN the checkpoint → a
+   resume job enqueued (fresh sandbox), not errored. (c) =processing= with the
+   message NOT yet checkpointed (crash pre-first-checkpoint) → re-dispatched as a
+   fresh message, not resumed (the spurious-turn guard). (d) =queued= /
+   =starting_sandbox= → re-dispatched from =pending_message=.
 4. *Ordering vs resume:* paused thread + one follow-up → resume enqueued before
    the follow-up.
 5. *Deleted-thread backlog never replayed.*
@@ -199,9 +238,16 @@ Real =PerThreadJsonStore= over a tmp dir + the real route/=_process_message=
 
 - *D0 (scope):* ship Step 1 (durable journal + recovery) first; Step 2 (backlog as
   single source of truth) as a follow-up full-three-phase change. Confirm.
-- *D1 (mid-flight policy):* recover =paused= resumes + unstarted follow-ups; keep
-  erroring =processing=-and-earlier. Sub-question: auto-run recovered follow-ups
-  behind an errored head turn (default yes), or hold them?
+- *D1 (mid-flight policy) — RESOLVED by Pierre's review:* recover in-progress
+  turns too — resume =processing= from the last checkpoint (fresh sandbox, like a
+  fair-scheduling resume), re-dispatch never-started stages from
+  =pending_message=, with the first-checkpoint guard deciding between the two.
+  Residual named: the interrupted superstep re-runs (side-effectful tool calls
+  may execute twice; =send_reply= stays HITL-gated). Remaining sub-question: the
+  2h-cap accounting for a resumed =processing= turn — its in-memory
+  =accumulated_active_ms= is lost on crash, so the resumed slice restarts the cap
+  at 0 unless we also persist the carry periodically (recommend: accept the
+  reset; a restart is rare and the cap is a runaway backstop, not billing).
 - *D2 (resume params in status):* persist =accumulated_active_ms= (2h-cap
   accounting across restart) + =resume_sender=/=resume_rider=. Confirm the rider is
   worth persisting vs resuming with =rider=None=.

--- a/docs/2026-07-13-durable-message-queue.org
+++ b/docs/2026-07-13-durable-message-queue.org
@@ -265,12 +265,27 @@ in-memory mirror; when this lands, #1 re-sources its read from the backlog.)
   =source="input"= checkpoint (pre-existing exposure, but crash resume raises
   the odds; small fix in =checkpoint_rollback.py=).
 - Two uvicorn workers: out of scope by construction (single worker, documented).
-- Scheduler/geo/SMS dispatch paths call =_process_message= directly with no
-  stage check (=threads.py:1466,1475,1628=) — a due schedule at startup could
-  race a recovery job. Accepted for Step 1 (pre-existing exposure, narrow
-  window, the queue serializes the turns themselves — worst case is turn ORDER,
-  and the stage-rewrite closes the main user-facing path); Step 2's
-  single-source dispatch subsumes it.
+- Dispatch-path coverage (as-built): the SMS path (=_dispatch_event=) journals
+  follow-ups like the web path; scheduler/geo turns still call
+  =_process_message= directly with no journal (a missed schedule refires by
+  design — =next_fire_at= only advances on success — so they need none), and a
+  due schedule at startup could still race a recovery job's ORDER (the queue
+  serializes the turns themselves). Same-tid waiter clobber of the running
+  turn's status is closed via the lock-free =peek_holder= skip; the residual is
+  a direct-dispatch waiter behind a same-tid turn that is itself queued behind
+  another thread (rare double-nesting). Step 2's single-source dispatch
+  subsumes all of these.
+- Ordering under a re-paused recovery resume: the drain SUBMITS follow-ups to
+  the serial worker rather than running them inline, so a head resume that hits
+  its quantum again re-queues ahead of them — the never-on-a-mid-flight-
+  checkpoint ordering holds through recovery. (The live round-robin path's
+  equivalent inversion — a queued message job ahead of a re-queued resume — is
+  pre-existing and unchanged; a =snap.next= guard in the message path is the
+  by-construction fix if it's ever observed. Step 2 territory.)
+- A spam caveat: the journal is uncapped and recovery faithfully replays it, so
+  a network-local spammer's backlog now SURVIVES a restart (before, a restart
+  cleared it). Same trust boundary as the rest of the auth-less web app
+  (wg/LAN); the parked-waiter pool remains the binding constraint.
 
 * Test plan (symptom-level, un-mocked where risk lives)
 

--- a/docs/2026-07-13-durable-message-queue.org
+++ b/docs/2026-07-13-durable-message-queue.org
@@ -60,65 +60,100 @@ Per-thread =pending_messages.json= via a =Backlog(PerThreadJsonStore)= subclass
 : { "id": <uuid>, "text": str, "sender": str|null,
 :   "rider": {"sent_at","tz","lat","lon"}|null, "enqueued_at": <iso> }
 FIFO by list order. Per-thread (dies with the thread on =hard_delete= =rmtree=,
-=thread_manager.py:222=; no eviction hook). =CAP= bounds runaway growth like
-=ScheduleStore.CAP_PER_THREAD=. =rider= stores the four raw form fields so recovery
-reconstructs the =ContextRider= via the existing =_build_rider= (:1421). Reusing
+=thread_manager.py:222=; no eviction hook). No =CAP= (design review: no observed
+runaway exists and inflow is human-paced — a cap is theoretical-only machinery,
+and over-cap behavior would mean 500ing a user's message). =sender= is real, not
+dead weight: the append hooks BOTH =post_message= (web) *and* =_dispatch_event=
+(inbound SMS, =threads.py:1486= — SMS follow-ups to a busy thread are equally
+lost today). =rider= stores the four raw form fields; recovery reconstructs the
+=ContextRider= via the existing =_build_rider= (:1421). Reusing
 =PerThreadJsonStore= gives lock-serialized atomic RMW, no partial file, and
-=all()= for the startup scan — deleting fragility by composing a stable block.
+=all()= for the startup scan; record =id= is required by the store's
+=remove(id)= and is what the claim keys on.
 
-** Paused-turn resume durability (no new file)
-Extend the existing =status="paused"= write (:1166) with the resume params
-carried only in-memory today: =accumulated_active_ms= (the =carry=, :1158), plus
-=resume_sender= / =resume_rider= (so a paused *triage* turn resumes with the right
-=send_reply= target + context). =status="paused"= + the checkpoint then fully
-describe the resume — no separate resume journal.
+** In-flight turn durability (uniform, every turn — not paused-only)
+(Design review found the paused-only version broken: a *triage* turn killed at
+=processing= would recover with =sender=None= → =MANAGER.get(..., triage=False)=
+→ the FULL tool surface with no HITL gate on =send_reply= — a security
+regression — and no reply target. The fix is uniformity, and it's ~2 lines:)
+carry =sender= + the rider fields in =pending_kwargs= so the FIRST busy
+=_set_status= of *every* turn persists them — every busy stage then has what
+recovery needs, paused or killed. The =paused= write additionally records
+=accumulated_active_ms= (the carry, :1158) so a clean pause keeps its 2h-cap
+accounting; a crash resets the cap for the resumed slice (accepted — it's a
+runaway backstop, not billing).
 
 * On-startup recovery flow
 
-1. *Replace the BUSY→error reconcile* (=state.py:595=) with recovery for every
-   busy stage (per Pierre's review: in-progress turns are recoverable too — the
-   checkpoint is durable at every superstep, not just at pauses). The
-   resume-vs-redispatch rule per thread is:
-   - =paused= → *resume* (=input=None=; params from the extended =status.json=;
-     =accumulated_active_ms= defaults 0, so pre-feature paused threads still resume).
-   - =processing= → *resume from the last checkpoint* — the restart killed the
-     turn mid-flight, but =durability="sync"= means every completed superstep is
-     already persisted (=thread.py:288-302=); the resume path already builds a
-     fresh sandbox (=_get_sandbox_backend= runs for =resume=True= too,
-     =threads.py:1043=), so the dead container is a non-issue — a new one is
-     created exactly as a fair-scheduling resume does. *Guard:* resume only if
-     the turn's human message is already IN the checkpoint (compare the
-     checkpoint's latest human message to =status.pending_message=). A crash
-     *before the first checkpoint* of the turn means =input=None= would re-invoke
-     on the PREVIOUS turn's final state — a spurious turn; in that case fall
-     through to re-dispatch below.
-   - =queued= / =starting_sandbox= / =initializing= / =cloning= (turn never
-     started, or pre-first-checkpoint) → *re-dispatch* =status.pending_message=
-     as a fresh message (it's durable in status.json today). Nothing ran, so
-     this is delivering, not retrying.
-   - Only a thread whose state can't support either (no pending_message, no
-     checkpoint match) falls back to the =error= banner.
-2. *Recovery jobs go onto the serial worker* in the same per-tid order rule as
-   below (resume/re-dispatch first, then backlog follow-ups).
-3. *Recover queued follow-ups.* Scan =BACKLOG.all()=; for each tid with a
-   non-empty backlog, enqueue its entries *in list order*, after that tid's resume
-   job (recovery controls order: resume first, then messages — preserving the
-   current "message runs after the resume" invariant).
-4. *Start the single serial worker* (the generalized =_ResumeScheduler=), which
-   drains one job at a time. Per-tid order preserved; cross-tid order irrelevant.
+(Revised by the design-review team: the per-stage matrix collapsed to ONE
+state-based guard decided off-loop; the lifespan does only cheap enqueues; and
+two ordering/consistency holes are closed by construction.)
 
-* Exactly-once / ordering — claim-before-run
+*Lifespan (on-loop, pre-=yield=, cheap file ops only):* replace the BUSY→error
+reconcile (=state.py:595=) with, per busy-stage tid (and any tid with a
+non-empty backlog):
+1. *Rewrite the stage to =paused=* (a bare =_set_status=, same cost as the old
+   error write). This is load-bearing, not cosmetic: =post_message= routes new
+   live messages through the serial worker ONLY when =stage=="paused"= (:1737) —
+   without the rewrite, a user message sent right after restart to a
+   still-=processing= thread would park as a THREAD_QUEUE waiter and could run
+   *before* the recovery resume, on the killed turn's mid-flight checkpoint
+   (review BLOCKER). With it, the existing routing sends live follow-ups behind
+   the recovery jobs, and the UI honestly shows "paused" instead of a dead
+   "processing".
+2. *Enqueue one =recover(tid)= job* on the serial worker (a =queue.Queue=
+   accepts puts before its thread starts). Enqueuing pre-=yield= guarantees no
+   live submit can outrun a recovery job. No checkpoint I/O here — the decision
+   runs on the worker.
 
-The serial worker *pops* a backlog entry (=PerThreadJsonStore.remove=, under its
-lock) *before* starting the turn, not after success:
-- Crash *after claim, mid-run*: the backlog entry is already gone → *not
-  replayed as a fresh message*. Instead the thread's turn is by then =processing=
-  with that text in =status.pending_message=, so the in-progress recovery path
-  (resume-from-checkpoint, or re-dispatch via the first-checkpoint guard) covers
-  it — exactly one delivery path applies, never both.
-- Crash *before claim*: replayed exactly once from the backlog.
+*Serial worker (off-loop), first once:* reap orphaned sandbox containers by
+label (=assist.sandbox=true=) before draining any job — a hard-killed web
+process reaps nothing, and a =docker exec='d tool command (e.g. a runaway
+=pytest=) keeps mutating the host-bind-mounted =/workspace= for up to the 3h TTL
+while the resumed turn's fresh container mounts the same dir (review finding).
+Then per =recover(tid)= job, decide by *graph state*, not text equality (review
+BLOCKER — text matching fails BOTH ways: a re-sent short message ("ok") matching
+an older one → false resume → the crashed turn silently dropped; the supersede
+fold prefixes the checkpointed text (:1102) → false re-dispatch onto a mid-flight
+checkpoint, discarding its pending work):
+1. Read the thread's checkpoint state (=get_state= — the graph built lazily, no
+   model call, no sandbox start; degrade to the =error= banner if unreadable).
+2. =snap.next= non-empty *or* =snap.interrupts= non-empty → *resume*
+   (=input=None=, fresh sandbox — same path as a fair-scheduling resume).
+3. =next= empty *and* the latest checkpointed human message contains
+   =pending_message= → the turn actually COMPLETED before the kill (the crash
+   landed in the post-invoke bookkeeping window) → finalize: mark =ready=, no
+   re-run.
+4. Otherwise (message never reached the checkpoint) → *re-dispatch*
+   =pending_message= as a fresh message (=domain= threads re-enter via their
+   init path). Nothing ran, so this is delivering, not retrying.
+5. Then dispatch that tid's backlog entries in list order (resume/re-dispatch
+   first, then follow-ups — preserving the "message runs after the resume"
+   invariant).
 
-Single serial worker + FIFO head-claim = strict submit order per thread.
+The worker waits (bounded) for the model endpoint to respond before draining —
+on a cold boot llamacpp loads for minutes after assist-web is up, and erroring
+every recovered thread against a still-loading model would defeat the feature.
+
+* Exactly-once / ordering — claim by id, status-first, inside the acquire
+
+(Hardened per review: head-pop and pop-early both had loss/duplication windows.)
+The claim is *by record id* (carried with the dispatch — head-pop can cross
+records: two same-tid background tasks park in unguaranteed order, so the wrong
+turn could pop the other's entry and a crash would then "recover" a message that
+already ran). Placement: *inside* =THREAD_QUEUE.acquire=, and *status-write
+first* —
+1. the turn's first busy =_set_status= lands (carrying the text in
+   =pending_message= + the claimed entry id),
+2. *then* the entry is removed from the backlog by id.
+A crash between the two leaves the entry in BOTH stores momentarily; recovery
+dedupes by the claimed id in status (the in-progress path owns that message —
+drop the matching backlog entry, apply the state guard). A crash while still
+waiting in the queue leaves the entry safely journaled → replayed. So at every
+instant the message is durable in at least one store and recovery delivers it
+via exactly one path.
+
+Single serial worker + submit-order records = strict per-thread order.
 
 * Reconciling "fail-fast / don't heal-and-retry" with durability
 
@@ -137,28 +172,34 @@ Single serial worker + FIFO head-claim = strict submit order per thread.
   only that the turn didn't get to a chosen boundary first. *Recover, with the
   first-checkpoint guard* (a turn whose human message never reached the
   checkpoint is re-dispatched as a fresh message instead).
-- *Named residual (honest):* the interrupted superstep re-runs on resume, so a
-  side-effectful tool call in flight at the kill (a notify, a web request)
-  executes again. In-sandbox effects are consistent by construction — the old
-  container's state is gone with it; =send_reply= is HITL-gated so a duplicate
-  SMS can't fire unattended. Accepted: restarts are rare, operator-initiated,
-  and one re-run superstep beats losing the turn.
+- *Named residual (honest, broadened per review):* on resume, ANY tool call of
+  the interrupted superstep whose writes hadn't flushed re-runs — not just the
+  one in flight: per-task writes go through a background executor even under
+  =durability="sync"= (which gates the superstep checkpoint put, not the task-
+  write flush), so a completed-but-unflushed tool's effects repeat too. State
+  stays consistent (the writes never landed). In-sandbox effects are consistent
+  because recovery *reaps the orphaned container by label first* (it is NOT
+  automatically gone — see the recovery flow); =send_reply= is HITL-gated so a
+  duplicate SMS can't fire unattended. Accepted: restarts are rare,
+  operator-initiated, and re-running one superstep beats losing the turn.
 - The fail-fast rule still governs *turn-internal* failures (sandbox vanished
   mid-turn, cap breach): those terminate, no heal-and-retry. Recovery here is
   strictly about surviving a process restart.
 
 * Event-loop safety of the durable write
 
-=post_message= runs on the single-worker loop. Two liveness-safe options;
-recommend *A*:
-- *A (recommended):* =post_message= is =async def= → append via
-  =await run_in_threadpool(BACKLOG.add, rec)=. The write + store lock run in a pool
-  thread, never on the loop, for *milliseconds* (a bounded file write) — different
-  in kind from the resume-scheduler's forbidden park-for-a-quantum pattern, so no
-  2026-06-10-class pool exhaustion. Loop stays strictly lock-free.
-- *B:* append inline on the loop like =_mark_pending='s =_set_status= write. Simpler,
-  but takes the store lock on the loop. Rejected in favor of A.
-Off-loop writers (pause path, worker claim/pop, completion drain) append directly.
+=post_message= runs on the single-worker loop. The append runs off-loop — but
+NOT via the shared threadpool (review IMPORTANT): =run_in_threadpool= draws from
+the same 40-token anyio pool that Step 1's live dispatch saturates (every
+follow-up to a =processing= thread parks a pool worker in =cond.wait= for up to
+4h), so under exactly the backlog-heavy load this feature exists for, the
+durability write could starve behind the parkers — the POST hangs pre-303 and a
+restart in that window loses the message. Fix is one line:
+=anyio.to_thread.run_sync(BACKLOG.add, rec, limiter=<private CapacityLimiter>)=
+— a dedicated limiter, immune to pool exhaustion. The loop itself stays strictly
+lock-free either way. (Step 2 deletes the parking and dissolves the contention.)
+Off-loop writers (=_dispatch_event= append, worker claim/pop, pause-path status)
+run directly on their own threads.
 
 * Dispatch model — two shippable steps
 
@@ -172,16 +213,24 @@ Off-loop writers (pause path, worker claim/pop, completion drain) append directl
   drains the next entry at turn completion. *Deletes* the in-memory
   park-per-follow-up fragility rather than shadowing it. One race to resolve in
   detailed design (a follow-up appended at the instant of the terminal
-  drain-check → by-construction: submit re-checks =status= and kicks the drain if
-  idle). Full three-phase (touches the submit path + the queue).
+  drain-check) — sound ONLY with this exact order (review NIT): drain side
+  *write =ready= → check backlog*; submit side *append → check status*. That
+  makes the stranded interleaving a contradiction; either pair inverted strands
+  an entry until the next restart. Full three-phase (touches the submit path +
+  the queue).
 
 The serial worker is the existing =_ResumeScheduler= (already owns =submit_resume=
-+ =submit_message=) — generalize/rename it. No new component.
++ =submit_message=); a =recover= job is one more small method. No rename in
+Step 1 (churn without payoff — revisit in Step 2 if it earns it).
 
 * Seam with feature #1 (UI surfacing)
 
-Feature #1 reads =BACKLOG.for_thread(tid)= (=record_store.py:69=) to render "N
-queued" rows, with the same event-loop-safe read discipline as =_get_status=
+Feature #1 reads the backlog to render "N queued" rows — via a *lock-free bare
+read* (mirroring =peek_holder='s discipline), NOT =for_thread= (review
+IMPORTANT: =for_thread=/=all()= take the process-wide store lock — =all()= holds
+it while scanning every thread dir — and a lock acquire on the loop thread is
+the bright-line liveness rule; since =_write= is atomic tmp+rename, a reader
+needs no lock at all). Same read discipline as =_get_status=
 (bare read, missing/corrupt → empty). This design owns no rendering.
 *Independently shippable:* without #1 the backlog is invisible but durable +
 recovered; the existing single =pending_message= bubble still renders (no
@@ -199,11 +248,29 @@ in-memory mirror; when this lands, #1 re-sources its read from the backlog.)
   overwrite the file (leave for inspection). Accepted limit.
 - Thread deleted with a backlog: =rmtree= takes the file; startup scan skips
   =.deleted= → never replayed. No orphan.
-- Double-run: prevented by claim-before-run pop.
-- Paused *triage* turn resumed without =sender=: avoided by persisting
-  =resume_sender= (D2).
-- Runaway growth: bounded by =CAP=.
+- Double-run: prevented by the by-id, status-first claim.
+- *Triage* turn (any busy stage) recovered without =sender=: avoided by carrying
+  =sender=/rider in EVERY turn's first busy status write (see data model) — the
+  paused-only version left the =processing=-crash path resuming full-privilege.
+- *=awaiting_approval= (HITL):* not in =BUSY_STAGES= → recovery correctly skips
+  it (the interrupt is durable; =reply_decision= works after restart). The
+  kill-between-invoke-and-status-write window leaves stage =processing= with a
+  durable pending interrupt — the state guard resumes it, the interrupt
+  re-fires, and the resume path re-checks =pending_reply()= → converges (given
+  the uniform sender persistence above).
+- *=invoke_with_rollback= on a crash resume:* its =BadRequestError= rollback
+  walks =get_state_history= across TURNS — from an early-turn resume point it
+  can land in the PREVIOUS turn, whose terminal checkpoint returns immediately →
+  the turn silently "succeeds" stale. Bound the rollback at the current turn's
+  =source="input"= checkpoint (pre-existing exposure, but crash resume raises
+  the odds; small fix in =checkpoint_rollback.py=).
 - Two uvicorn workers: out of scope by construction (single worker, documented).
+- Scheduler/geo/SMS dispatch paths call =_process_message= directly with no
+  stage check (=threads.py:1466,1475,1628=) — a due schedule at startup could
+  race a recovery job. Accepted for Step 1 (pre-existing exposure, narrow
+  window, the queue serializes the turns themselves — worst case is turn ORDER,
+  and the stage-rewrite closes the main user-facing path); Step 2's
+  single-source dispatch subsumes it.
 
 * Test plan (symptom-level, un-mocked where risk lives)
 
@@ -216,13 +283,22 @@ Real =PerThreadJsonStore= over a tmp dir + the real route/=_process_message=
    started, text now in =pending_message=), crash before completion, recover →
    not re-dispatched from the backlog; exactly one recovery path (the in-progress
    resume) handles it.
-3. *Busy stages survive restart:* (a) =status="paused"= + params, no in-memory
-   =_q= → a resume job (=input=None=) enqueued, not flipped to =error=. (b)
-   =status="processing"= with the turn's human message IN the checkpoint → a
-   resume job enqueued (fresh sandbox), not errored. (c) =processing= with the
-   message NOT yet checkpointed (crash pre-first-checkpoint) → re-dispatched as a
-   fresh message, not resumed (the spurious-turn guard). (d) =queued= /
-   =starting_sandbox= → re-dispatched from =pending_message=.
+3. *Busy stages survive restart (the state guard, all four windows):* (a)
+   =status="paused"= + params, no in-memory =_q= → resume (=input=None=), not
+   =error=. (b) =processing= with =snap.next= non-empty → resume (fresh
+   sandbox). (c) =processing=, =next= empty, message never checkpointed →
+   re-dispatched as a fresh message (spurious-turn guard). (d) =processing=,
+   =next= empty, latest human matches =pending_message= (turn completed in the
+   bookkeeping window) → finalized =ready=, NOT re-run. Plus: a re-sent
+   duplicate text ("ok" twice in history) must not fool the guard (state-based,
+   not text-equality).
+3b. *Kill-shaped resume (un-mocked):* abandon a real graph mid-superstep
+   (don't raise a cooperative exception — drop the loop), reopen the SqliteSaver
+   in a fresh "process", resume =input=None= → completed-superstep work is
+   preserved, the turn finishes. Pins the crash shape, not just the pause shape.
+3c. *Triage recovery keeps triage:* a triage turn (sender set) killed at
+   =processing= → recovery resumes with =triage=True= + the sender in
+   configurable (assert the reduced tool surface + HITL gate).
 4. *Ordering vs resume:* paused thread + one follow-up → resume enqueued before
    the follow-up.
 5. *Deleted-thread backlog never replayed.*
@@ -234,22 +310,39 @@ Real =PerThreadJsonStore= over a tmp dir + the real route/=_process_message=
 8. *Corrupt backlog is loud:* truncated file → recovery logs ERROR, doesn't crash,
    leaves the file.
 
-* Decisions to flag for Pierre
+* Decisions (resolved 2026-07-17 — Pierre's go-ahead + design-review team)
 
-- *D0 (scope):* ship Step 1 (durable journal + recovery) first; Step 2 (backlog as
-  single source of truth) as a follow-up full-three-phase change. Confirm.
-- *D1 (mid-flight policy) — RESOLVED by Pierre's review:* recover in-progress
-  turns too — resume =processing= from the last checkpoint (fresh sandbox, like a
-  fair-scheduling resume), re-dispatch never-started stages from
-  =pending_message=, with the first-checkpoint guard deciding between the two.
-  Residual named: the interrupted superstep re-runs (side-effectful tool calls
-  may execute twice; =send_reply= stays HITL-gated). Remaining sub-question: the
-  2h-cap accounting for a resumed =processing= turn — its in-memory
-  =accumulated_active_ms= is lost on crash, so the resumed slice restarts the cap
-  at 0 unless we also persist the carry periodically (recommend: accept the
-  reset; a restart is rare and the cap is a runaway backstop, not billing).
-- *D2 (resume params in status):* persist =accumulated_active_ms= (2h-cap
-  accounting across restart) + =resume_sender=/=resume_rider=. Confirm the rider is
-  worth persisting vs resuming with =rider=None=.
-- *D3 (append placement):* Option A (=run_in_threadpool=, recommended) vs B (inline).
-- *D4 (cap):* per-thread backlog =CAP= value + over-cap behavior.
+- *D0 (scope):* CONFIRMED — Step 1 (durable journal + recovery) now; Step 2
+  (backlog as single source of truth) as a follow-up full-three-phase change.
+- *D1 (mid-flight policy):* RESOLVED (Pierre) — recover in-progress turns via
+  resume-from-last-checkpoint. Refined by the design-review team: the per-stage
+  matrix collapsed to ONE graph-state guard (=snap.next=/=interrupts= → resume;
+  turn-completed → finalize; else re-dispatch), decided on the worker. 2h-cap
+  carry: accept the reset on crash (the clean-pause path still persists its
+  carry in the =paused= status).
+- *D2 (resume params):* RESOLVED — persist =sender= + rider fields in EVERY
+  turn's first busy status write (uniform; the paused-only version was a
+  security hole for crashed triage turns). =accumulated_active_ms= on the
+  =paused= write only.
+- *D3 (append placement):* RESOLVED — off-loop via a *private
+  =CapacityLimiter=* (=anyio.to_thread.run_sync=), not the shared threadpool
+  (which Step 1's parked waiters can saturate).
+- *D4 (cap):* RESOLVED — no cap (theoretical-only; inflow is human-paced; the
+  store default is uncapped).
+
+* Design-review round (2026-07-17) — summary
+
+Three lenses (event-loop liveness, langgraph checkpoint/resume fit, simplicity)
+on the post-Pierre-review design. 3 BLOCKERs found and folded in: (1) recovered
+=processing= threads bypassed the paused-only serial routing → live messages
+could run on a mid-flight checkpoint (fix: stage-rewrite to =paused= at scan);
+(2) the text-equality first-checkpoint guard failed both directions (fix:
+graph-state guard); (3) crashed triage turns resumed full-privilege (fix:
+uniform sender/rider persistence). Majors: private limiter for the append;
+by-id status-first claim inside the acquire; lifespan-enqueue/worker-decide
+split; orphaned-container reap-by-label; =invoke_with_rollback= current-turn
+bound; lock-free feature-#1 read. Simplifications: stage matrix → one guard;
+CAP/D4 cut; rider decision made uniform; no scheduler rename. The core
+mechanism (journal + claim + state-based resume) was verified against the
+deployed langgraph source: =input=None= resume is checkpoint-consistent for an
+arbitrary kill, identical to the proven cooperative-pause path.

--- a/manage/web/review.py
+++ b/manage/web/review.py
@@ -406,8 +406,8 @@ async def post_review(tid: str, background_tasks: BackgroundTasks, payload: str 
     # submitted to a BUSY thread is a follow-up — journal it durably (off-loop,
     # private limiter) and skip the status write (the running turn owns
     # status.json); the turn claims the entry when it starts.
-    busy = (_get_status(tid).get("stage") in BUSY_STAGES
-            or THREAD_QUEUE.peek_holder() == tid)
+    prior_stage = _get_status(tid).get("stage")
+    busy = prior_stage in BUSY_STAGES or THREAD_QUEUE.peek_holder() == tid
     _threads._mark_pending(tid, message, busy)
     backlog_id = None
     if busy:
@@ -417,6 +417,14 @@ async def post_review(tid: str, background_tasks: BackgroundTasks, payload: str 
                            enqueued_at=datetime.now(timezone.utc).isoformat()),
             limiter=_threads._get_backlog_limiter())
         backlog_id = rec.id
-    background_tasks.add_task(_threads._process_message, tid, message,
-                              backlog_id=backlog_id)
+    if prior_stage == "paused":
+        # A paused thread has RELEASED the slot, so a BackgroundTask waiter would
+        # acquire immediately and run on the mid-flight checkpoint. Route through
+        # the serial worker so it runs AFTER the queued resume/recovery — same as
+        # post_message.
+        _threads._RESUME_SCHEDULER.submit_message(tid, message, None, None,
+                                                  backlog_id)
+    else:
+        background_tasks.add_task(_threads._process_message, tid, message,
+                                  backlog_id=backlog_id)
     return RedirectResponse(url=f"/thread/{tid}?reviewed=1", status_code=303)

--- a/manage/web/review.py
+++ b/manage/web/review.py
@@ -14,12 +14,16 @@ from __future__ import annotations
 import html
 import json
 import os
+from datetime import datetime, timezone
 
+import anyio.to_thread
 from fastapi import BackgroundTasks, Form, HTTPException
 from fastapi.responses import HTMLResponse, RedirectResponse
 
+from assist.backlog import PendingMessage
 from assist.domain_manager import Change
 from assist.thread import Thread
+from assist.thread_queue import THREAD_QUEUE
 
 from manage.web import threads as _threads
 from manage.web.app import app
@@ -27,6 +31,7 @@ from manage.web.diff import _DIFF_CSS, _rename_pair, render_file_diff
 from manage.web.state import (
     BUSY_STAGES,
     MANAGER,
+    MESSAGE_BACKLOG,
     _get_domain_manager,
     _get_status,
     _thread_title,
@@ -395,9 +400,23 @@ async def post_review(tid: str, background_tasks: BackgroundTasks, payload: str 
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    # Set a busy+pending status synchronously (same race fix as the
-    # /message route) so the redirect render shows the submission instead of
-    # losing it to the background task.
-    _threads._mark_pending(tid, message)
-    background_tasks.add_task(_threads._process_message, tid, message)
+    # Set a busy+pending status synchronously (same race fix as the /message
+    # route) so the redirect render shows the submission instead of losing it to
+    # the background task. Same single busy sample as post_message: a review
+    # submitted to a BUSY thread is a follow-up — journal it durably (off-loop,
+    # private limiter) and skip the status write (the running turn owns
+    # status.json); the turn claims the entry when it starts.
+    busy = (_get_status(tid).get("stage") in BUSY_STAGES
+            or THREAD_QUEUE.peek_holder() == tid)
+    _threads._mark_pending(tid, message, busy)
+    backlog_id = None
+    if busy:
+        rec = await anyio.to_thread.run_sync(
+            MESSAGE_BACKLOG.add,
+            PendingMessage(thread_id=tid, text=message,
+                           enqueued_at=datetime.now(timezone.utc).isoformat()),
+            limiter=_threads._get_backlog_limiter())
+        backlog_id = rec.id
+    background_tasks.add_task(_threads._process_message, tid, message,
+                              backlog_id=backlog_id)
     return RedirectResponse(url=f"/thread/{tid}?reviewed=1", status_code=303)

--- a/manage/web/state.py
+++ b/manage/web/state.py
@@ -345,8 +345,10 @@ def _evict_caches(tid: str) -> None:
 #   ready             - idle, accepting input
 #   error             - something failed; see status["error"]
 INIT_STAGES = {"initializing", "cloning", "starting_sandbox"}
-# `paused` is BUSY (not INIT): the turn is mid-flight and will resume, so the page
-# renders history + keeps input enabled, and _mark_pending won't clobber it.
+# `paused` is BUSY (not INIT): the turn is mid-flight and will resume — yielded at
+# its fair-scheduling quantum, OR awaiting restart recovery (the lifespan rewrites
+# every interrupted busy thread to `paused`) — so the page renders history + keeps
+# input enabled, and _mark_pending won't clobber it.
 BUSY_STAGES = INIT_STAGES | {"processing", "queued", "paused"}
 
 STAGE_LABELS = {
@@ -355,7 +357,7 @@ STAGE_LABELS = {
     "starting_sandbox": "Starting sandbox container...",
     "queued": "Waiting for another thread to finish...",
     "processing": "Processing your message...",
-    "paused": "Paused for a quicker turn — will resume...",
+    "paused": "Paused — will resume...",
 }
 
 # Single-word variants for the compact thread-LIST page only. The in-thread banner
@@ -589,26 +591,25 @@ def set_description(tid: str, description: str) -> None:
     DESCRIPTION_CACHE[tid] = description
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    # Ensure thread root exists at startup
-    os.makedirs(ROOT, exist_ok=True)
+def _recover_interrupted_threads() -> None:
+    """Startup recovery scan (runs on the loop, pre-yield — cheap file ops only):
+    every turn's work is durable (the checkpoint at each superstep, the message in
+    status.json / the backlog journal), so instead of erroring busy threads,
+    rewrite each to "paused" and enqueue a recover job; the checkpoint read + the
+    resume-vs-redispatch decision run on the serial worker (threads.py
+    _recover_thread).
 
-    # Recover threads a previous server run left busy, instead of erroring them:
-    # every turn's work is durable (the checkpoint at each superstep, the message
-    # in status.json / the backlog journal), so the serial worker can resume or
-    # re-dispatch it. Here on the loop we do only cheap file ops — rewrite the
-    # stage and enqueue a recover job; the checkpoint read + resume-vs-redispatch
-    # decision runs on the worker thread (see _recover_thread in threads.py).
-    #
-    # The stage-rewrite to "paused" is load-bearing, not cosmetic: post_message
-    # routes a new live message through the serial worker ONLY when the stage is
-    # "paused" — without the rewrite, a message sent right after restart to a
-    # still-"processing" thread would park as a THREAD_QUEUE waiter and could run
-    # BEFORE the recovery resume, on the killed turn's mid-flight checkpoint.
-    # Enqueuing pre-yield (the worker queue accepts puts before its thread
-    # starts) guarantees no live submit can outrun a recovery job.
-    from manage.web.threads import start_scheduler, stop_scheduler, submit_recovery
+    The stage-rewrite to "paused" is load-bearing, not cosmetic: post_message
+    routes a new live message through the serial worker ONLY when the stage is
+    "paused" — without the rewrite, a message sent right after restart to a
+    still-"processing" thread would park as a THREAD_QUEUE waiter and could run
+    BEFORE the recovery resume, on the killed turn's mid-flight checkpoint. It is
+    also _recover_thread's marker for "this thread has an interrupted HEAD turn"
+    (a journal-only recovery must not touch the head — e.g. a durable HITL
+    interrupt awaiting approval). Enqueuing pre-yield (the worker queue accepts
+    puts before its thread starts) guarantees no live submit can outrun a
+    recovery job."""
+    from manage.web.threads import submit_recovery
     for tid in MANAGER.list():
         status = _get_status(tid)
         if status.get("stage") in BUSY_STAGES:
@@ -619,6 +620,17 @@ async def lifespan(app: FastAPI):
             # Not busy, but journaled follow-ups survive (e.g. a crash after the
             # head turn finished but before its follow-ups started).
             submit_recovery(tid)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Ensure thread root exists at startup
+    os.makedirs(ROOT, exist_ok=True)
+
+    # Recover threads a previous server run left busy, instead of erroring them
+    # (extracted so the test pins the REAL scan, not a copy).
+    from manage.web.threads import start_scheduler, stop_scheduler
+    _recover_interrupted_threads()
 
     # Populate description cache at startup
     for tid in MANAGER.list():

--- a/manage/web/state.py
+++ b/manage/web/state.py
@@ -33,6 +33,7 @@ from assist.events.tools import subscription_tools
 from assist.events.reply import reply_tools, REPLY_INTERRUPT_ON
 from assist.events.notify import notify_tools
 from assist.events.inbound import InboundLog
+from assist.backlog import MessageBacklog
 from assist.geo.catalog import Catalog
 from assist.geo.proposals import ProposalStore
 from assist.geo.registry import RegionRegistry
@@ -106,6 +107,10 @@ SCHEDULE_STORE = ScheduleStore(ROOT)
 SUBSCRIPTION_STORE = SubscriptionStore(ROOT)
 # Durable inbound-message log (records before the 200; dedup by content-hash message_id).
 INBOUND_LOG = InboundLog(ROOT)
+# Durable follow-up journal: a message accepted while its thread is busy is journaled
+# here at submit and claimed (removed by id) when its turn starts, so a restart can't
+# silently drop it — startup recovery re-dispatches whatever is still journaled.
+MESSAGE_BACKLOG = MessageBacklog(ROOT)
 # Normal turns get the config tools (schedule + subscription). A TRIAGE turn (untrusted
 # inbound SMS) gets ONLY send_reply, HITL-gated — never the host-effect config tools — so an
 # injected text can't plant/delete a subscription or schedule (MANAGER.get(triage=True)).
@@ -589,18 +594,31 @@ async def lifespan(app: FastAPI):
     # Ensure thread root exists at startup
     os.makedirs(ROOT, exist_ok=True)
 
-    # Recover any threads left mid-init by a previous server crash.
-    # Their background task is no longer running, so mark them errored
-    # so the user gets feedback instead of a forever-spinning page.
+    # Recover threads a previous server run left busy, instead of erroring them:
+    # every turn's work is durable (the checkpoint at each superstep, the message
+    # in status.json / the backlog journal), so the serial worker can resume or
+    # re-dispatch it. Here on the loop we do only cheap file ops — rewrite the
+    # stage and enqueue a recover job; the checkpoint read + resume-vs-redispatch
+    # decision runs on the worker thread (see _recover_thread in threads.py).
+    #
+    # The stage-rewrite to "paused" is load-bearing, not cosmetic: post_message
+    # routes a new live message through the serial worker ONLY when the stage is
+    # "paused" — without the rewrite, a message sent right after restart to a
+    # still-"processing" thread would park as a THREAD_QUEUE waiter and could run
+    # BEFORE the recovery resume, on the killed turn's mid-flight checkpoint.
+    # Enqueuing pre-yield (the worker queue accepts puts before its thread
+    # starts) guarantees no live submit can outrun a recovery job.
+    from manage.web.threads import start_scheduler, stop_scheduler, submit_recovery
     for tid in MANAGER.list():
         status = _get_status(tid)
         if status.get("stage") in BUSY_STAGES:
-            _set_status(
-                tid,
-                "error",
-                error="Server restarted while this thread was being set up.",
-                pending_message=status.get("pending_message", ""),
-            )
+            _set_status(tid, "paused",
+                        **{k: v for k, v in status.items() if k != "stage"})
+            submit_recovery(tid)
+        elif MESSAGE_BACKLOG.for_thread(tid):
+            # Not busy, but journaled follow-ups survive (e.g. a crash after the
+            # head turn finished but before its follow-ups started).
+            submit_recovery(tid)
 
     # Populate description cache at startup
     for tid in MANAGER.list():
@@ -609,8 +627,7 @@ async def lifespan(app: FastAPI):
     # scheduled/SMS response's badge survives a restart.
     load_unseen_cache()
     load_urgent_cache()
-    # Start the schedule poll loop (local import breaks the state<->threads cycle).
-    from manage.web.threads import start_scheduler, stop_scheduler
+    # Start the schedule poll loop + the serial worker that drains recovery jobs.
     start_scheduler()
     try:
         yield

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -1080,8 +1080,9 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
                 # delivered.
                 if not any(r.id == backlog_id
                            for r in MESSAGE_BACKLOG.for_thread(tid)):
-                    logging.info("follow-up %s on %s already delivered; skipping "
-                                 "duplicate dispatch", backlog_id, tid)
+                    logging.info("follow-up %s on %s not in the journal (already "
+                                 "delivered, or the journal was unreadable); "
+                                 "skipping this dispatch", backlog_id, tid)
                     return
                 # This journaled follow-up now OWNS the slot: take over status.json
                 # (its text/sender/rider + the claimed entry id), THEN pop the journal
@@ -1436,7 +1437,7 @@ async def thread_status(tid: str):
     return JSONResponse(_get_status(tid))
 
 
-def _mark_pending(tid: str, text: str) -> None:
+def _mark_pending(tid: str, text: str, busy: bool) -> None:
     """Record an inbound message as busy+pending *synchronously*, before the
     POST handler returns its redirect.
 
@@ -1461,9 +1462,12 @@ def _mark_pending(tid: str, text: str) -> None:
     input — which is wrong for a thread that's just received a follow-up
     message.
 
-    No-op when this thread is already busy, so a second message to a mid-turn
-    thread doesn't clobber the in-flight turn's status — that follow-up is made
-    durable by the caller instead (post_message journals it in MESSAGE_BACKLOG).
+    No-op when ``busy`` — the CALLER's single busy sample (status stage OR
+    holder==tid), which also drives its journal decision — so a second message
+    to a mid-turn thread doesn't clobber the in-flight turn's status; that
+    follow-up is made durable in MESSAGE_BACKLOG instead. One shared sample
+    keeps the two decisions consistent (independent samples could straddle a
+    turn's acquire: journal skipped AND status skipped = durable nowhere).
 
     Runs on the asyncio event-loop thread, so it must never block: it uses
     ``THREAD_QUEUE.peek_holder()`` (a lock-free read), NOT ``current_handle()``
@@ -1471,14 +1475,15 @@ def _mark_pending(tid: str, text: str) -> None:
     the queue and freeze the whole server whenever that lock is held by a
     long-running turn.
     """
-    holder_tid = THREAD_QUEUE.peek_holder()
-    # Busy = a busy status OR this tid already holding the LLM slot: a
-    # direct-dispatch turn (scheduled/geo/SMS) acquires the queue BEFORE its
-    # first busy status write, and writing our pending here in that gap would
-    # be clobbered by that turn's writes — while the caller, seeing "not busy",
-    # would also skip journaling. Treat holder==tid as busy (lock-free read).
-    if _get_status(tid).get("stage") in BUSY_STAGES or holder_tid == tid:
+    if busy:
+        # The caller's single busy sample (status stage OR holder==tid) decided
+        # this message is a journaled follow-up — write nothing: the running
+        # turn owns status.json, and a write here would be clobbered by its
+        # writes while the journal already holds this message durably. One
+        # sample drives BOTH the journal decision and this skip, so they can't
+        # disagree (two samples could straddle a turn's acquire).
         return
+    holder_tid = THREAD_QUEUE.peek_holder()
     stage = "queued" if (holder_tid is not None and holder_tid != tid) else "processing"
     # Stamp the turn-start origin at submit (this is the idle→busy edge — the guard above
     # returns for an already-busy thread, so we never reset a mid-turn turn's clock).
@@ -1719,8 +1724,9 @@ _PROVISIONER = (
 
 def _recovery_prep(q: "queue.Queue") -> None:
     """One-time worker-thread prep before draining recovery jobs (no-op cost when
-    none are queued). (a) Reap orphaned sandbox containers BY LABEL: a killed web
-    process reaps nothing, and a ``docker exec``'d tool command keeps mutating the
+    none are queued). (a) Reap THIS deployment's orphaned sandbox containers (by
+    label + /workspace-mount scope — see ``reap_orphans``): a killed web process
+    reaps nothing, and a ``docker exec``'d tool command keeps mutating the
     host-bind-mounted /workspace for up to the 3h TTL — a resumed turn's fresh
     container must never share a workspace with a zombie writer. (b) Wait
     (bounded) for the model endpoint: on a cold boot llamacpp loads for minutes
@@ -1766,10 +1772,12 @@ def _recovery_decision(tid: str, pending_message: str) -> str:
     text compare in both directions):
     - ``snap.next`` or ``snap.interrupts`` non-empty → the turn is mid-flight in
       the checkpoint → "resume" (input=None re-runs only the unpersisted work).
-    - otherwise, if the latest checkpointed human message contains
-      ``pending_message`` → the turn COMPLETED before the kill (the crash landed
-      in post-invoke bookkeeping) → "finalize" (containment, not equality: the
-      supersede fold prefixes the checkpointed copy).
+    - otherwise, if the latest checkpointed human message EXACTLY equals
+      ``pending_message`` (as sent, or as the supersede fold checkpoints it —
+      ``_SUPERSEDE_RIDER`` + text) → the turn COMPLETED before the kill (the
+      crash landed in post-invoke bookkeeping) → "finalize". Exact only:
+      containment/suffix would misread a short pending found inside the
+      PREVIOUS turn's message as completed and silently drop it.
     - otherwise the message never reached the checkpoint → "redispatch" it fresh.
     A failed state read returns "error" (the caller surfaces the restart-error
     banner rather than guessing). Built without a sandbox and without any model
@@ -2001,7 +2009,7 @@ async def post_message(tid: str, background_tasks: BackgroundTasks,
     # its task parks behind that turn (peek_holder is the lock-free read).
     prior_stage = _get_status(tid).get("stage")
     busy = prior_stage in BUSY_STAGES or THREAD_QUEUE.peek_holder() == tid
-    _mark_pending(tid, text)
+    _mark_pending(tid, text, busy)   # the ONE busy sample drives both decisions
     rider = _build_rider(sent_at, tz, lat, lon)
     backlog_id = None
     if busy:

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -41,6 +41,11 @@ from assist.domain_manager import (
     OriginAdvancedError,
 )
 from langgraph.errors import GraphRecursionError
+import anyio
+import anyio.to_thread
+from langchain_core.messages import HumanMessage
+
+from assist.backlog import PendingMessage
 from assist.context_rider import ContextRider, CONTEXT_RIDER_KEY
 from assist.events.reply import SMS_SENDER_KEY
 from assist.schedule.scheduler import Scheduler
@@ -70,6 +75,7 @@ from manage.web.state import (
     INIT_STAGES,
     MANAGER,
     MERGE_LOCK,
+    MESSAGE_BACKLOG,
     SCHEDULE_STORE,
     SUBSCRIPTION_STORE,
     _mark_urgent,
@@ -981,7 +987,8 @@ _SUPERSEDE_RIDER = (
 def _process_message(tid: str, text: str | None, rider: ContextRider | None = None,
                      sender: str | None = None, resume_decision: dict | None = None,
                      resume: bool = False, accumulated_active_ms: float = 0.0,
-                     pending_text: str | None = None) -> None:
+                     pending_text: str | None = None,
+                     backlog_id: str | None = None) -> None:
     # `sender` (set only for an inbound-message triage turn) rides the run config as
     # ``sms_sender`` so send_reply knows who to reply to; a normal turn passes None.
     # `resume_decision` (set only when approving/rejecting a pending send_reply) resumes the
@@ -994,8 +1001,23 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
     # placeholder bubble while processing (cleared once status==ready). On a resume
     # (text=None) the original message is carried via `pending_text` so the bubble
     # survives the pause window instead of vanishing until the turn completes.
+    # `backlog_id` (set only for a journaled follow-up) names this turn's entry in the
+    # durable MESSAGE_BACKLOG; it is claimed (removed) after the first busy status write
+    # inside the queue acquire — see the claim below.
     _pending_msg = text if text else pending_text
     pending_kwargs = {"pending_message": _pending_msg} if _pending_msg else {}
+    # Persist the turn's sender + rider in EVERY busy status write, so a restart can
+    # recover this turn faithfully whatever stage it dies at: a triage (inbound-SMS)
+    # turn resumed without its sender would rebuild as a FULL-privilege non-triage
+    # agent with no reply target — the sender is what keeps the reduced tool surface
+    # + HITL gate on recovery. The rider's raw fields let recovery rebuild it via
+    # _build_rider.
+    if sender:
+        pending_kwargs["sender"] = sender
+    if rider is not None:
+        pending_kwargs["rider"] = {
+            "sent_at": rider.sent_at.isoformat() if rider.sent_at else None,
+            "tz": rider.tz, "lat": rider.lat, "lon": rider.lon}
     # Turn-start origin for the elapsed badge + live WIP timer: reuse the started_at already
     # in status (a queued/paused/resumed turn keeps the original submit time, so elapsed
     # spans the queue wait + any pause) or stamp now for turns with no upstream setter
@@ -1016,7 +1038,13 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
         # flow below sets the more specific "starting_sandbox" →
         # "processing" statuses itself, so the "running" callback is
         # intentionally ignored.
-        if stage == "queued":
+        #
+        # A journaled follow-up (backlog_id set) writes NOTHING while it waits:
+        # the same-tid turn it waits behind owns status.json (its text/sender/
+        # rider must stay durable there for crash recovery), and the follow-up
+        # itself is durable in MESSAGE_BACKLOG. Writing here would clobber the
+        # running turn's recovery info with the waiter's.
+        if stage == "queued" and backlog_id is None:
             _set_status(tid, "queued", **pending_kwargs)
 
     try:
@@ -1035,7 +1063,17 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
         # double-callback.
         with THREAD_QUEUE.acquire(tid, on_state_change=on_queue_wait,
                                   accumulated_active_ms=accumulated_active_ms):
-            _set_status(tid, "starting_sandbox", **pending_kwargs)
+            if backlog_id:
+                # This journaled follow-up now OWNS the slot: take over status.json
+                # (its text/sender/rider + the claimed entry id), THEN pop the journal
+                # entry — status-first, so the message is durable in at least one store
+                # at every instant. A crash between the two leaves it in both; recovery
+                # dedupes by claimed_id. claim() is idempotent.
+                _set_status(tid, "starting_sandbox", claimed_id=backlog_id,
+                            **pending_kwargs)
+                MESSAGE_BACKLOG.claim(tid, backlog_id)
+            else:
+                _set_status(tid, "starting_sandbox", **pending_kwargs)
             try:
                 # Inside the try so the `finally` reaps even if sandbox
                 # creation registers a container and then raises — cleanup
@@ -1163,7 +1201,12 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
         # and sees `paused` is routed onto this scheduler strictly AFTER the resume.
         _RESUME_SCHEDULER.submit_resume(
             tid, rider, sender, carry, pending_kwargs.get("pending_message"))
-        _set_status(tid, "paused", **pending_kwargs)
+        # accumulated_active_ms rides the status write so a restart-recovered resume
+        # keeps its 2h-cap accounting (the in-memory submit_resume above is lost with
+        # the process; sender/rider are already in pending_kwargs). A crash of a
+        # PROCESSING turn has no carry to persist — its resumed slice restarts the
+        # cap at 0, accepted (the cap is a runaway backstop, not billing).
+        _set_status(tid, "paused", accumulated_active_ms=carry, **pending_kwargs)
         return
     except SandboxContainerLostError as e:
         # Distinct status message: a dead container is recoverable —
@@ -1400,7 +1443,8 @@ def _mark_pending(tid: str, text: str) -> None:
     message.
 
     No-op when this thread is already busy, so a second message to a mid-turn
-    thread doesn't clobber the in-flight turn's status.
+    thread doesn't clobber the in-flight turn's status — that follow-up is made
+    durable by the caller instead (post_message journals it in MESSAGE_BACKLOG).
 
     Runs on the asyncio event-loop thread, so it must never block: it uses
     ``THREAD_QUEUE.peek_holder()`` (a lock-free read), NOT ``current_handle()``
@@ -1483,7 +1527,17 @@ def _dispatch_event(sender: str, text: str) -> None:
     if sub is None:
         logging.info("inbound message from %s matched no subscription; recorded only", sender)
         return
-    _process_message(sub.thread_id, sub.render(sender, text), sender=sender)
+    rendered = sub.render(sender, text)
+    if _get_status(sub.thread_id).get("stage") in BUSY_STAGES:
+        # A follow-up to a busy thread — journal it (runs off-loop here, so a
+        # direct add) so a restart can't drop it; the turn claims the entry when
+        # it starts, exactly like a web follow-up.
+        rec = MESSAGE_BACKLOG.add(PendingMessage(
+            thread_id=sub.thread_id, text=rendered, sender=sender,
+            enqueued_at=datetime.now(timezone.utc).isoformat()))
+        _process_message(sub.thread_id, rendered, sender=sender, backlog_id=rec.id)
+    else:
+        _process_message(sub.thread_id, rendered, sender=sender)
 
 
 def _sms_secret_state(provided: str | None):
@@ -1637,8 +1691,125 @@ _PROVISIONER = (
     if GEO_REGISTRY is not None else None)
 
 
+def _recovery_prep(q: "queue.Queue") -> None:
+    """One-time worker-thread prep before draining recovery jobs (no-op cost when
+    none are queued). (a) Reap orphaned sandbox containers BY LABEL: a killed web
+    process reaps nothing, and a ``docker exec``'d tool command keeps mutating the
+    host-bind-mounted /workspace for up to the 3h TTL — a resumed turn's fresh
+    container must never share a workspace with a zombie writer. (b) Wait
+    (bounded) for the model endpoint: on a cold boot llamacpp loads for minutes
+    after assist-web is up, and erroring every recovered thread against a
+    still-loading model would defeat recovery."""
+    if q.empty():
+        return
+    SandboxManager.reap_orphans()
+    base = os.getenv("ASSIST_MODEL_URL")
+    if not base:
+        return
+    deadline = time.time() + 600
+    while time.time() < deadline:
+        try:
+            requests.get(f"{base.rstrip('/')}/models", timeout=3)
+            return
+        except requests.RequestException:
+            time.sleep(10)
+    logging.warning("recovery: model endpoint still unreachable after bounded wait; "
+                    "proceeding (recovered turns fail fast if it stays down)")
+
+
+def _rider_from_fields(fields: dict | None) -> ContextRider | None:
+    """Rebuild a turn's ContextRider from the raw fields persisted in status.json /
+    a journal entry (the same four the submit form carries)."""
+    if not fields:
+        return None
+    return _build_rider(fields.get("sent_at"), fields.get("tz"),
+                        fields.get("lat"), fields.get("lon"))
+
+
+def _recovery_decision(tid: str, pending_message: str) -> str:
+    """Resume-vs-redispatch for one recovered thread, decided by GRAPH STATE (not
+    text equality — a re-sent duplicate text or the supersede prefix would fool a
+    text compare in both directions):
+    - ``snap.next`` or ``snap.interrupts`` non-empty → the turn is mid-flight in
+      the checkpoint → "resume" (input=None re-runs only the unpersisted work).
+    - otherwise, if the latest checkpointed human message contains
+      ``pending_message`` → the turn COMPLETED before the kill (the crash landed
+      in post-invoke bookkeeping) → "finalize" (containment, not equality: the
+      supersede fold prefixes the checkpointed copy).
+    - otherwise the message never reached the checkpoint → "redispatch" it fresh.
+    Built without a sandbox and without any model call (lazy graph build — the
+    same shape as the pending_reply read)."""
+    try:
+        chat = MANAGER.get(tid, sandbox_backend=None)
+        snap = chat.agent.get_state(chat.runconfig)
+    except Exception:
+        logging.error("recovery: state read failed for %s", tid, exc_info=True)
+        return "error"
+    if (getattr(snap, "next", None) or ()) or (getattr(snap, "interrupts", None) or ()):
+        return "resume"
+    latest_human = ""
+    for m in reversed((snap.values or {}).get("messages", [])):
+        if isinstance(m, HumanMessage):
+            latest_human = m.content if isinstance(m.content, str) else str(m.content)
+            break
+    if pending_message and pending_message in latest_human:
+        return "finalize"
+    return "redispatch"
+
+
+def _recover_thread(tid: str) -> None:
+    """Serial-worker recovery of one thread after a restart. Order: dedupe the
+    claimed journal entry (if the crash landed between the status-claim write and
+    the pop, the entry is in both stores — status owns it), decide by graph
+    state, run the head turn (resume / finalize / re-dispatch), then dispatch the
+    thread's remaining journaled follow-ups in submit order."""
+    status = _get_status(tid)
+    pending = status.get("pending_message") or ""
+    sender = status.get("sender") or None
+    rider = _rider_from_fields(status.get("rider"))
+    claimed = status.get("claimed_id")
+    if claimed:
+        MESSAGE_BACKLOG.claim(tid, claimed)
+
+    decision = _recovery_decision(tid, pending)
+    logging.info("recovery: %s -> %s", tid, decision)
+    if decision == "resume":
+        _process_message(
+            tid, None, rider=rider, sender=sender, resume=True,
+            accumulated_active_ms=float(status.get("accumulated_active_ms") or 0.0),
+            pending_text=pending or None)
+    elif decision == "finalize":
+        _set_status(tid, "ready")
+    elif decision == "redispatch" and pending:
+        # Skip when a journal entry carries this same text — the on_queue_wait skip
+        # keeps status owned by the running turn, but a legacy/edge write could
+        # leave a follow-up's text here while its entry is still journaled; the
+        # journal dispatch below delivers it exactly once.
+        if any(r.text == pending for r in MESSAGE_BACKLOG.for_thread(tid)):
+            _set_status(tid, "ready")
+        else:
+            _process_message(tid, pending, rider=rider, sender=sender)
+    else:
+        _set_status(tid, "error",
+                    error=("Server restarted and this thread's turn could not be "
+                           "recovered. Send the message again."),
+                    pending_message=pending)
+
+    for rec in MESSAGE_BACKLOG.for_thread(tid):
+        _process_message(tid, rec.text, rider=_rider_from_fields(rec.rider),
+                         sender=rec.sender, backlog_id=rec.id)
+
+
+def submit_recovery(tid: str) -> None:
+    """Lifespan entry point: enqueue a thread's post-restart recovery on the serial
+    worker (a cheap queue.put — safe on the event loop, and accepted before the
+    worker thread starts)."""
+    _RESUME_SCHEDULER.submit_recover(tid)
+
+
 class _ResumeScheduler:
-    """One dedicated thread that dispatches fair-scheduling resumes SERIALLY.
+    """One dedicated thread that dispatches fair-scheduling resumes — and, at
+    startup, post-restart RECOVERY jobs — SERIALLY.
 
     A paused turn resumes by re-running ``_process_message(..., resume=True)``, which
     re-acquires the LLM slot and parks in the queue's ``cond.wait`` until its turn comes
@@ -1648,7 +1819,11 @@ class _ResumeScheduler:
     starve the pool and stall request handling (a 2026-06-10-class outage). This thread
     owns the parking instead, consuming ZERO pool tokens. Serial is correct: the LLM slot
     is ``--parallel 1``, so only one resume can run at a time anyway. A resume that pauses
-    again simply re-submits itself here (round-robin, back of the queue)."""
+    again simply re-submits itself here (round-robin, back of the queue).
+
+    Recovery jobs (``submit_recover``, enqueued by the lifespan BEFORE serving
+    starts) ride the same queue, so a live submit can never outrun a thread's
+    recovery — see ``_recover_thread`` and docs/2026-07-13-durable-message-queue.org."""
 
     def __init__(self) -> None:
         self._q: "queue.Queue[dict]" = queue.Queue()
@@ -1664,23 +1839,41 @@ class _ResumeScheduler:
     def submit_resume(self, tid: str, rider, sender, accumulated_active_ms: float,
                       pending_text: str | None) -> None:
         """Continue a paused turn from its checkpoint (input=None)."""
-        self._q.put({"tid": tid, "text": None, "rider": rider, "sender": sender,
-                     "resume": True, "acc": accumulated_active_ms, "pending": pending_text})
+        self._q.put({"kind": "turn", "tid": tid, "text": None, "rider": rider,
+                     "sender": sender, "resume": True, "acc": accumulated_active_ms,
+                     "pending": pending_text, "backlog_id": None})
 
-    def submit_message(self, tid: str, text: str, rider, sender) -> None:
+    def submit_message(self, tid: str, text: str, rider, sender,
+                       backlog_id: str | None = None) -> None:
         """Run a NEW message for a tid that has an in-flight (paused) turn — routed here
         so it runs AFTER the resume on this serial thread, never on the paused turn's
-        mid-flight checkpoint (fix-by-construction ordering; no priority needed)."""
-        self._q.put({"tid": tid, "text": text, "rider": rider, "sender": sender,
-                     "resume": False, "acc": 0.0, "pending": None})
+        mid-flight checkpoint (fix-by-construction ordering; no priority needed).
+        ``backlog_id`` names the message's durable journal entry (claimed when the
+        turn starts)."""
+        self._q.put({"kind": "turn", "tid": tid, "text": text, "rider": rider,
+                     "sender": sender, "resume": False, "acc": 0.0, "pending": None,
+                     "backlog_id": backlog_id})
+
+    def submit_recover(self, tid: str) -> None:
+        """Recover one thread after a restart: decide resume-vs-redispatch from the
+        durable checkpoint state, run it, then drain the thread's journaled
+        follow-ups — all serially on this worker (the lifespan enqueues these
+        BEFORE serving starts, so no live submit can outrun them)."""
+        self._q.put({"kind": "recover", "tid": tid})
 
     def _loop(self) -> None:
+        _recovery_prep(self._q)
         while True:
             it = self._q.get()
             try:
-                _process_message(it["tid"], it["text"], rider=it["rider"],
-                                 sender=it["sender"], resume=it["resume"],
-                                 accumulated_active_ms=it["acc"], pending_text=it["pending"])
+                if it.get("kind") == "recover":
+                    _recover_thread(it["tid"])
+                else:
+                    _process_message(it["tid"], it["text"], rider=it["rider"],
+                                     sender=it["sender"], resume=it["resume"],
+                                     accumulated_active_ms=it["acc"],
+                                     pending_text=it["pending"],
+                                     backlog_id=it.get("backlog_id"))
             except Exception:
                 logging.error("fair-scheduling dispatch failed for %s", it["tid"],
                               exc_info=True)
@@ -1726,20 +1919,54 @@ def stop_scheduler() -> None:
     _SCHEDULER.stop()
 
 
+# Private capacity for the backlog append — NOT the shared threadpool: every follow-up
+# to a processing thread parks a shared-pool worker in cond.wait (up to wait_timeout),
+# so under exactly the backlog-heavy load this journal exists for, a run_in_threadpool
+# append could starve behind the parkers and the POST would hang pre-303 with the
+# message not yet durable. A dedicated limiter is immune to that. Created lazily —
+# anyio primitives must be constructed inside a running loop.
+_backlog_limiter: anyio.CapacityLimiter | None = None
+
+
+def _get_backlog_limiter() -> anyio.CapacityLimiter:
+    global _backlog_limiter
+    if _backlog_limiter is None:
+        _backlog_limiter = anyio.CapacityLimiter(4)
+    return _backlog_limiter
+
+
 @app.post("/thread/{tid}/message")
 async def post_message(tid: str, background_tasks: BackgroundTasks,
                        text: str = Form(...),
                        sent_at: str | None = Form(None), tz: str | None = Form(None),
                        lat: str | None = Form(None), lon: str | None = Form(None)):
     _existing_thread_dir(tid)  # validates tid (404 on traversal/NUL) + existence
+    # Read the stage BEFORE _mark_pending: for an idle thread _mark_pending flips it
+    # busy (that first message is durable via status.pending_message); a message to an
+    # ALREADY-busy thread is a follow-up, journaled below so a restart can't drop it.
+    prior_stage = _get_status(tid).get("stage")
     _mark_pending(tid, text)
     rider = _build_rider(sent_at, tz, lat, lon)
-    if _get_status(tid).get("stage") == "paused":
-        # A turn is paused mid-flight (its resume is already queued on the scheduler).
-        # Route this new message through the SAME serial scheduler so it runs AFTER the
-        # resume — never on the paused turn's mid-flight checkpoint. This only sets the
-        # flag off-loop-safely (a plain queue.put); the loop stays lock-free.
-        _RESUME_SCHEDULER.submit_message(tid, text, rider, None)
+    if prior_stage in BUSY_STAGES:
+        rec = PendingMessage(
+            thread_id=tid, text=text,
+            rider=({"sent_at": sent_at, "tz": tz, "lat": lat, "lon": lon}
+                   if (sent_at or tz or lat or lon) else None),
+            enqueued_at=datetime.now(timezone.utc).isoformat())
+        # Durable BEFORE the 303 — off-loop (file write + store lock never on the
+        # event loop), on the private limiter (see above).
+        await anyio.to_thread.run_sync(MESSAGE_BACKLOG.add, rec,
+                                       limiter=_get_backlog_limiter())
+        if prior_stage == "paused":
+            # A turn is paused mid-flight (its resume is already queued on the
+            # scheduler). Route this new message through the SAME serial scheduler so
+            # it runs AFTER the resume — never on the paused turn's mid-flight
+            # checkpoint. This only sets the flag off-loop-safely (a plain queue.put);
+            # the loop stays lock-free.
+            _RESUME_SCHEDULER.submit_message(tid, text, rider, None, rec.id)
+        else:
+            background_tasks.add_task(_process_message, tid, text, rider,
+                                      backlog_id=rec.id)
     else:
         background_tasks.add_task(_process_message, tid, text, rider)
     return RedirectResponse(url=f"/thread/{tid}", status_code=303)

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -1557,8 +1557,8 @@ def _dispatch_event(sender: str, text: str) -> None:
         logging.info("inbound message from %s matched no subscription; recorded only", sender)
         return
     rendered = sub.render(sender, text)
-    if (_get_status(sub.thread_id).get("stage") in BUSY_STAGES
-            or THREAD_QUEUE.peek_holder() == sub.thread_id):
+    stage = _get_status(sub.thread_id).get("stage")
+    if stage in BUSY_STAGES or THREAD_QUEUE.peek_holder() == sub.thread_id:
         # A follow-up to a busy thread (busy status, or holding the slot with no
         # busy status written yet) — journal it (runs off-loop here, so a direct
         # add) so a restart can't drop it; the turn claims the entry when it
@@ -1566,7 +1566,16 @@ def _dispatch_event(sender: str, text: str) -> None:
         rec = MESSAGE_BACKLOG.add(PendingMessage(
             thread_id=sub.thread_id, text=rendered, sender=sender,
             enqueued_at=datetime.now(timezone.utc).isoformat()))
-        _process_message(sub.thread_id, rendered, sender=sender, backlog_id=rec.id)
+        if stage == "paused":
+            # A paused thread has RELEASED the slot — dispatching directly would
+            # acquire immediately and run on the mid-flight checkpoint. Route
+            # through the serial worker, behind the queued resume/recovery
+            # (same as post_message).
+            _RESUME_SCHEDULER.submit_message(sub.thread_id, rendered, None,
+                                             sender, rec.id)
+        else:
+            _process_message(sub.thread_id, rendered, sender=sender,
+                             backlog_id=rec.id)
     else:
         _process_message(sub.thread_id, rendered, sender=sender)
 

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -1,7 +1,9 @@
 """Index + thread page rendering and the routes that drive them.
 
-Owns ``_process_message`` (the synchronous worker spawned as a
-``BackgroundTask`` for both ``/message`` and ``/review`` submissions),
+Owns ``_process_message`` (the synchronous per-turn worker — spawned as a
+``BackgroundTask`` for ``/message``/``/review`` submissions and SMS/scheduled
+dispatch, or run on the ``_ResumeScheduler`` serial worker for fair-scheduling
+resumes, paused-thread follow-ups, and restart recovery),
 ``_initialize_thread`` (first-turn clone + sandbox boot), and
 ``_capture_conversation`` (capture-this-thread side-quest).
 """
@@ -1015,9 +1017,7 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
     if sender:
         pending_kwargs["sender"] = sender
     if rider is not None:
-        pending_kwargs["rider"] = {
-            "sent_at": rider.sent_at.isoformat() if rider.sent_at else None,
-            "tz": rider.tz, "lat": rider.lat, "lon": rider.lon}
+        pending_kwargs["rider"] = _rider_to_fields(rider)
     # Turn-start origin for the elapsed badge + live WIP timer: reuse the started_at already
     # in status (a queued/paused/resumed turn keeps the original submit time, so elapsed
     # spans the queue wait + any pause) or stamp now for turns with no upstream setter
@@ -1039,12 +1039,17 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
         # "processing" statuses itself, so the "running" callback is
         # intentionally ignored.
         #
-        # A journaled follow-up (backlog_id set) writes NOTHING while it waits:
-        # the same-tid turn it waits behind owns status.json (its text/sender/
-        # rider must stay durable there for crash recovery), and the follow-up
-        # itself is durable in MESSAGE_BACKLOG. Writing here would clobber the
-        # running turn's recovery info with the waiter's.
-        if stage == "queued" and backlog_id is None:
+        # A waiter behind a SAME-TID turn writes NOTHING: that running turn owns
+        # status.json (its text/sender/rider must stay durable there for crash
+        # recovery — clobbering the sender would resume a crashed triage turn
+        # full-privilege). A journaled follow-up (backlog_id set) never writes —
+        # it is durable in MESSAGE_BACKLOG; a direct-dispatch waiter (scheduled/
+        # geo/SMS turn) is covered by the lock-free peek_holder check, the same
+        # discipline _mark_pending uses. (Residual: a direct-dispatch waiter
+        # behind a same-tid turn that is ITSELF queued behind another thread
+        # still writes — rare double-nesting, dissolved by Step 2.)
+        if (stage == "queued" and backlog_id is None
+                and THREAD_QUEUE.peek_holder() != tid):
             _set_status(tid, "queued", **pending_kwargs)
 
     try:
@@ -1064,11 +1069,25 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
         with THREAD_QUEUE.acquire(tid, on_state_change=on_queue_wait,
                                   accumulated_active_ms=accumulated_active_ms):
             if backlog_id:
+                # Exactly-once gate: the journal entry is the run ticket. A message can
+                # acquire TWO dispatchers — its live-submitted job/task plus a recovery
+                # drain job — and whichever runs second must find the entry gone and
+                # SKIP, not re-run the turn (claim() alone is idempotent-silent, which
+                # would deliver twice). The one state where "entry gone" still means
+                # "run" is the crash window below: status carries claimed_id ==
+                # backlog_id, but that head turn is delivered by RECOVERY, not by a
+                # backlog_id dispatcher — so gone-entry here always means already
+                # delivered.
+                if not any(r.id == backlog_id
+                           for r in MESSAGE_BACKLOG.for_thread(tid)):
+                    logging.info("follow-up %s on %s already delivered; skipping "
+                                 "duplicate dispatch", backlog_id, tid)
+                    return
                 # This journaled follow-up now OWNS the slot: take over status.json
                 # (its text/sender/rider + the claimed entry id), THEN pop the journal
                 # entry — status-first, so the message is durable in at least one store
                 # at every instant. A crash between the two leaves it in both; recovery
-                # dedupes by claimed_id. claim() is idempotent.
+                # dedupes by claimed_id.
                 _set_status(tid, "starting_sandbox", claimed_id=backlog_id,
                             **pending_kwargs)
                 MESSAGE_BACKLOG.claim(tid, backlog_id)
@@ -1452,9 +1471,14 @@ def _mark_pending(tid: str, text: str) -> None:
     the queue and freeze the whole server whenever that lock is held by a
     long-running turn.
     """
-    if _get_status(tid).get("stage") in BUSY_STAGES:
-        return
     holder_tid = THREAD_QUEUE.peek_holder()
+    # Busy = a busy status OR this tid already holding the LLM slot: a
+    # direct-dispatch turn (scheduled/geo/SMS) acquires the queue BEFORE its
+    # first busy status write, and writing our pending here in that gap would
+    # be clobbered by that turn's writes — while the caller, seeing "not busy",
+    # would also skip journaling. Treat holder==tid as busy (lock-free read).
+    if _get_status(tid).get("stage") in BUSY_STAGES or holder_tid == tid:
+        return
     stage = "queued" if (holder_tid is not None and holder_tid != tid) else "processing"
     # Stamp the turn-start origin at submit (this is the idle→busy edge — the guard above
     # returns for an already-busy thread, so we never reset a mid-turn turn's clock).
@@ -1528,10 +1552,12 @@ def _dispatch_event(sender: str, text: str) -> None:
         logging.info("inbound message from %s matched no subscription; recorded only", sender)
         return
     rendered = sub.render(sender, text)
-    if _get_status(sub.thread_id).get("stage") in BUSY_STAGES:
-        # A follow-up to a busy thread — journal it (runs off-loop here, so a
-        # direct add) so a restart can't drop it; the turn claims the entry when
-        # it starts, exactly like a web follow-up.
+    if (_get_status(sub.thread_id).get("stage") in BUSY_STAGES
+            or THREAD_QUEUE.peek_holder() == sub.thread_id):
+        # A follow-up to a busy thread (busy status, or holding the slot with no
+        # busy status written yet) — journal it (runs off-loop here, so a direct
+        # add) so a restart can't drop it; the turn claims the entry when it
+        # starts, exactly like a web follow-up.
         rec = MESSAGE_BACKLOG.add(PendingMessage(
             thread_id=sub.thread_id, text=rendered, sender=sender,
             enqueued_at=datetime.now(timezone.utc).isoformat()))
@@ -1702,17 +1728,17 @@ def _recovery_prep(q: "queue.Queue") -> None:
     still-loading model would defeat recovery."""
     if q.empty():
         return
-    SandboxManager.reap_orphans()
-    base = os.getenv("ASSIST_MODEL_URL")
-    if not base:
+    SandboxManager.reap_orphans(MANAGER.root_dir)
+    if not os.getenv("ASSIST_MODEL_URL"):
         return
+    # _llm_reachable requires a 200 — llama-server binds its port immediately on a
+    # cold boot and answers 503 for minutes while the GGUF loads, so an
+    # any-response probe would return in exactly the window this wait targets.
     deadline = time.time() + 600
     while time.time() < deadline:
-        try:
-            requests.get(f"{base.rstrip('/')}/models", timeout=3)
+        if _llm_reachable():
             return
-        except requests.RequestException:
-            time.sleep(10)
+        time.sleep(10)
     logging.warning("recovery: model endpoint still unreachable after bounded wait; "
                     "proceeding (recovered turns fail fast if it stays down)")
 
@@ -1726,6 +1752,14 @@ def _rider_from_fields(fields: dict | None) -> ContextRider | None:
                         fields.get("lat"), fields.get("lon"))
 
 
+def _rider_to_fields(rider: ContextRider) -> dict:
+    """Serialize a rider to the four raw fields ``_rider_from_fields`` reads —
+    the one place the persisted key set is defined (the submit paths persist the
+    raw form fields with the same keys)."""
+    return {"sent_at": rider.sent_at.isoformat() if rider.sent_at else None,
+            "tz": rider.tz, "lat": rider.lat, "lon": rider.lon}
+
+
 def _recovery_decision(tid: str, pending_message: str) -> str:
     """Resume-vs-redispatch for one recovered thread, decided by GRAPH STATE (not
     text equality — a re-sent duplicate text or the supersede prefix would fool a
@@ -1737,8 +1771,9 @@ def _recovery_decision(tid: str, pending_message: str) -> str:
       in post-invoke bookkeeping) → "finalize" (containment, not equality: the
       supersede fold prefixes the checkpointed copy).
     - otherwise the message never reached the checkpoint → "redispatch" it fresh.
-    Built without a sandbox and without any model call (lazy graph build — the
-    same shape as the pending_reply read)."""
+    A failed state read returns "error" (the caller surfaces the restart-error
+    banner rather than guessing). Built without a sandbox and without any model
+    call (lazy graph build — the same shape as the pending_reply read)."""
     try:
         chat = MANAGER.get(tid, sandbox_backend=None)
         snap = chat.agent.get_state(chat.runconfig)
@@ -1752,52 +1787,67 @@ def _recovery_decision(tid: str, pending_message: str) -> str:
         if isinstance(m, HumanMessage):
             latest_human = m.content if isinstance(m.content, str) else str(m.content)
             break
-    if pending_message and pending_message in latest_human:
+    # EXACT match only — against the message as sent, or as the supersede fold
+    # checkpoints it (_SUPERSEDE_RIDER + text; status keeps the unfolded text).
+    # Anything looser silently drops messages: containment/suffix would read a
+    # short pending ("ok" / "book it") found inside or at the end of the
+    # PREVIOUS turn's message (here after a crash pre-input-checkpoint) as "this
+    # turn completed" and finalize it away.
+    if pending_message and latest_human in (pending_message,
+                                            _SUPERSEDE_RIDER + pending_message):
         return "finalize"
     return "redispatch"
 
 
 def _recover_thread(tid: str) -> None:
-    """Serial-worker recovery of one thread after a restart. Order: dedupe the
-    claimed journal entry (if the crash landed between the status-claim write and
-    the pop, the entry is in both stores — status owns it), decide by graph
-    state, run the head turn (resume / finalize / re-dispatch), then dispatch the
-    thread's remaining journaled follow-ups in submit order."""
+    """Serial-worker recovery of one thread after a restart.
+
+    HEAD turn — only when the pre-restart stage was busy (the lifespan rewrote
+    every such thread to "paused", so that stage IS the marker; a journal-only
+    recovery — a ready/awaiting_approval thread with surviving follow-ups — has
+    no interrupted head turn and must not touch it, esp. a durable HITL
+    interrupt awaiting approval): dedupe the claimed journal entry (a crash
+    between the status-claim write and the pop leaves it in both stores —
+    status owns it), then decide by graph state — "resume" / "finalize" /
+    "redispatch", or "error" when the state is unreadable (surfaced as the
+    restart-error banner).
+
+    FOLLOW-UPS — always: submit each journaled entry to the serial worker (NOT
+    inline). If the head resume paused again mid-recovery, its re-queued resume
+    job is already ahead of these submissions, preserving the never-on-a-
+    mid-flight-checkpoint ordering; and if a live dispatcher for the same entry
+    is also queued, whichever runs second finds the entry claimed and skips
+    (the exactly-once gate in _process_message)."""
     status = _get_status(tid)
     pending = status.get("pending_message") or ""
     sender = status.get("sender") or None
     rider = _rider_from_fields(status.get("rider"))
-    claimed = status.get("claimed_id")
-    if claimed:
-        MESSAGE_BACKLOG.claim(tid, claimed)
 
-    decision = _recovery_decision(tid, pending)
-    logging.info("recovery: %s -> %s", tid, decision)
-    if decision == "resume":
-        _process_message(
-            tid, None, rider=rider, sender=sender, resume=True,
-            accumulated_active_ms=float(status.get("accumulated_active_ms") or 0.0),
-            pending_text=pending or None)
-    elif decision == "finalize":
-        _set_status(tid, "ready")
-    elif decision == "redispatch" and pending:
-        # Skip when a journal entry carries this same text — the on_queue_wait skip
-        # keeps status owned by the running turn, but a legacy/edge write could
-        # leave a follow-up's text here while its entry is still journaled; the
-        # journal dispatch below delivers it exactly once.
-        if any(r.text == pending for r in MESSAGE_BACKLOG.for_thread(tid)):
+    if status.get("stage") == "paused":
+        claimed = status.get("claimed_id")
+        if claimed:
+            MESSAGE_BACKLOG.claim(tid, claimed)
+        decision = _recovery_decision(tid, pending)
+        logging.info("recovery: %s -> %s", tid, decision)
+        if decision == "resume":
+            _process_message(
+                tid, None, rider=rider, sender=sender, resume=True,
+                accumulated_active_ms=float(
+                    status.get("accumulated_active_ms") or 0.0),
+                pending_text=pending or None)
+        elif decision == "finalize":
             _set_status(tid, "ready")
-        else:
+        elif decision == "redispatch" and pending:
             _process_message(tid, pending, rider=rider, sender=sender)
-    else:
-        _set_status(tid, "error",
-                    error=("Server restarted and this thread's turn could not be "
-                           "recovered. Send the message again."),
-                    pending_message=pending)
+        else:
+            _set_status(tid, "error",
+                        error=("Server restarted and this thread's turn could "
+                               "not be recovered. Send the message again."),
+                        pending_message=pending)
 
     for rec in MESSAGE_BACKLOG.for_thread(tid):
-        _process_message(tid, rec.text, rider=_rider_from_fields(rec.rider),
-                         sender=rec.sender, backlog_id=rec.id)
+        _RESUME_SCHEDULER.submit_message(
+            tid, rec.text, _rider_from_fields(rec.rider), rec.sender, rec.id)
 
 
 def submit_recovery(tid: str) -> None:
@@ -1845,11 +1895,12 @@ class _ResumeScheduler:
 
     def submit_message(self, tid: str, text: str, rider, sender,
                        backlog_id: str | None = None) -> None:
-        """Run a NEW message for a tid that has an in-flight (paused) turn — routed here
-        so it runs AFTER the resume on this serial thread, never on the paused turn's
-        mid-flight checkpoint (fix-by-construction ordering; no priority needed).
-        ``backlog_id`` names the message's durable journal entry (claimed when the
-        turn starts)."""
+        """Run a NEW message for a tid with an in-flight (paused) turn or a pending
+        restart recovery — routed here so it runs AFTER the resume/recovery job on
+        this serial thread, never on a mid-flight checkpoint (fix-by-construction
+        ordering; no priority needed). ``backlog_id`` names the message's durable
+        journal entry (claimed when the turn starts; a duplicate dispatcher for the
+        same entry skips via the exactly-once gate)."""
         self._q.put({"kind": "turn", "tid": tid, "text": text, "rider": rider,
                      "sender": sender, "resume": False, "acc": 0.0, "pending": None,
                      "backlog_id": backlog_id})
@@ -1941,13 +1992,19 @@ async def post_message(tid: str, background_tasks: BackgroundTasks,
                        sent_at: str | None = Form(None), tz: str | None = Form(None),
                        lat: str | None = Form(None), lon: str | None = Form(None)):
     _existing_thread_dir(tid)  # validates tid (404 on traversal/NUL) + existence
-    # Read the stage BEFORE _mark_pending: for an idle thread _mark_pending flips it
-    # busy (that first message is durable via status.pending_message); a message to an
-    # ALREADY-busy thread is a follow-up, journaled below so a restart can't drop it.
+    # Read the busy state BEFORE _mark_pending: for an idle thread _mark_pending
+    # flips it busy (that first message is durable via status.pending_message); a
+    # message to an ALREADY-busy thread is a follow-up, journaled below so a restart
+    # can't drop it. "Busy" includes this tid holding the LLM slot with no busy
+    # status yet (a direct-dispatch scheduled/geo/SMS turn writes its first status
+    # only after acquiring) — otherwise the follow-up would be durable NOWHERE while
+    # its task parks behind that turn (peek_holder is the lock-free read).
     prior_stage = _get_status(tid).get("stage")
+    busy = prior_stage in BUSY_STAGES or THREAD_QUEUE.peek_holder() == tid
     _mark_pending(tid, text)
     rider = _build_rider(sent_at, tz, lat, lon)
-    if prior_stage in BUSY_STAGES:
+    backlog_id = None
+    if busy:
         rec = PendingMessage(
             thread_id=tid, text=text,
             rider=({"sent_at": sent_at, "tz": tz, "lat": lat, "lon": lon}
@@ -1957,18 +2014,17 @@ async def post_message(tid: str, background_tasks: BackgroundTasks,
         # event loop), on the private limiter (see above).
         await anyio.to_thread.run_sync(MESSAGE_BACKLOG.add, rec,
                                        limiter=_get_backlog_limiter())
-        if prior_stage == "paused":
-            # A turn is paused mid-flight (its resume is already queued on the
-            # scheduler). Route this new message through the SAME serial scheduler so
-            # it runs AFTER the resume — never on the paused turn's mid-flight
-            # checkpoint. This only sets the flag off-loop-safely (a plain queue.put);
-            # the loop stays lock-free.
-            _RESUME_SCHEDULER.submit_message(tid, text, rider, None, rec.id)
-        else:
-            background_tasks.add_task(_process_message, tid, text, rider,
-                                      backlog_id=rec.id)
+        backlog_id = rec.id
+    if prior_stage == "paused":
+        # A turn is paused mid-flight (its resume is already queued on the
+        # scheduler). Route this new message through the SAME serial scheduler so it
+        # runs AFTER the resume — never on the paused turn's mid-flight checkpoint.
+        # This only sets the flag off-loop-safely (a plain queue.put); the loop
+        # stays lock-free.
+        _RESUME_SCHEDULER.submit_message(tid, text, rider, None, backlog_id)
     else:
-        background_tasks.add_task(_process_message, tid, text, rider)
+        background_tasks.add_task(_process_message, tid, text, rider,
+                                  backlog_id=backlog_id)
     return RedirectResponse(url=f"/thread/{tid}", status_code=303)
 
 

--- a/tests/test_fair_scheduling_integration.py
+++ b/tests/test_fair_scheduling_integration.py
@@ -51,6 +51,10 @@ def wired(tmp_path, monkeypatch):
 
     monkeypatch.setattr(web.MANAGER, "root_dir", str(tmp_path))
     monkeypatch.setattr(web.MANAGER, "thread_dir", lambda t: str(tmp_path / t))
+    # The follow-up journal lives under the thread root — repoint it with MANAGER
+    # (post_message journals a message to a busy thread before dispatching it).
+    from manage.web.state import MESSAGE_BACKLOG
+    monkeypatch.setattr(MESSAGE_BACKLOG, "_root", str(tmp_path))
     monkeypatch.setattr(web.MANAGER, "thread_default_working_dir",
                         lambda t: str(tmp_path / t))
     monkeypatch.setattr(web.MANAGER, "touch", lambda t: None)
@@ -104,8 +108,10 @@ def test_new_message_while_paused_routes_through_scheduler(wired, monkeypatch):
     _set_status(tid, "paused", pending_message="hello")
 
     submitted = []
-    monkeypatch.setattr(threads._RESUME_SCHEDULER, "submit_message",
-                        lambda t, text, rider, sender: submitted.append((t, text)))
+    monkeypatch.setattr(
+        threads._RESUME_SCHEDULER, "submit_message",
+        lambda t, text, rider, sender, backlog_id=None:
+            submitted.append((t, text, backlog_id)))
     spawned = []
     monkeypatch.setattr(threads.BackgroundTasks, "add_task",
                         lambda self, fn, *a, **k: spawned.append(fn))
@@ -115,6 +121,11 @@ def test_new_message_while_paused_routes_through_scheduler(wired, monkeypatch):
                              follow_redirects=False)
 
     # The new message was routed to the serial scheduler (runs AFTER the resume),
-    # NOT spawned as a competing BackgroundTask onto a mid-flight checkpoint.
-    assert submitted == [(tid, "follow-up")]
+    # NOT spawned as a competing BackgroundTask onto a mid-flight checkpoint —
+    # and it was journaled first (durable follow-up), with its entry id carried
+    # so the turn claims it when it starts.
+    from manage.web.state import MESSAGE_BACKLOG
+    recs = MESSAGE_BACKLOG.for_thread(tid)
+    assert [r.text for r in recs] == ["follow-up"]
+    assert submitted == [(tid, "follow-up", recs[0].id)]
     assert threads._process_message not in spawned

--- a/tests/test_restart_recovery.py
+++ b/tests/test_restart_recovery.py
@@ -3,9 +3,10 @@
 Pins the contracts of docs/2026-07-13-durable-message-queue.org (Step 1): a
 message accepted while its thread is busy is journaled durably BEFORE the POST
 returns; the turn claims (removes) its entry status-first when it starts; and
-startup recovery delivers every journaled message exactly once and resumes /
-re-dispatches / finalizes the interrupted head turn by GRAPH STATE, not text
-equality. The kill-shaped test exercises a real langgraph SqliteSaver abandoned
+startup recovery delivers every journaled message exactly once and handles the
+interrupted head turn — resume-vs-rest decided by GRAPH STATE, with "finalize"
+requiring an EXACT match of the checkpointed message (as sent, or with the
+supersede prefix). The kill-shaped test exercises a real langgraph SqliteSaver abandoned
 mid-run and reopened in a fresh "process" — the crash shape, not the cooperative
 pause shape.
 """
@@ -443,34 +444,47 @@ def test_event_loop_stays_live_while_store_lock_is_held(wired, monkeypatch):
     it): hold the journal store's lock in another thread while a busy-thread POST
     is in flight. The POST's append must run OFF the event loop (private
     CapacityLimiter), so the loop stays live — a concurrent GET completes promptly
-    while the POST is still blocked on the lock."""
+    while the POST is still blocked on the lock.
+
+    The client MUST be context-managed: only ``__enter__`` pins ONE portal (one
+    event loop) shared by both requests — the no-ctx form spins a fresh loop per
+    request, which would pass even if the append regressed to running inline on
+    the loop (a vacuous test). The lifespan that entering runs is neutralized
+    (recovery scan / scheduler / manager close are process-level, not under test)."""
     import threading as _threading
     import time as _time
     from fastapi.testclient import TestClient
+    from manage.web import state as st_mod
 
     tid, _ = wired
     _set_status(tid, "processing", pending_message="head")
     monkeypatch.setattr(threads.BackgroundTasks, "add_task",
                         lambda self, fn, *a, **k: None)
+    monkeypatch.setattr(st_mod, "_recover_interrupted_threads", lambda: None)
+    monkeypatch.setattr(threads, "start_scheduler", lambda: None)
+    monkeypatch.setattr(threads, "stop_scheduler", lambda: None)
+    monkeypatch.setattr(web.MANAGER, "close", lambda: None)
 
-    client = TestClient(web.app)      # one portal = one event loop for both requests
-    MESSAGE_BACKLOG._lock.acquire()
-    post_done = _threading.Event()
-    try:
-        t = _threading.Thread(
-            target=lambda: (client.post(f"/thread/{tid}/message",
-                                        data={"text": "follow-up"},
-                                        follow_redirects=False),
-                            post_done.set()),
-            daemon=True)
-        t.start()
-        _time.sleep(0.3)
-        assert not post_done.is_set(), "POST should be blocked on the held store lock"
-        start = _time.monotonic()
-        status = client.get(f"/thread/{tid}/status")
-        elapsed = _time.monotonic() - start
-        assert status.status_code == 200
-        assert elapsed < 2.0, f"loop blocked: GET took {elapsed:.1f}s under a held store lock"
-    finally:
-        MESSAGE_BACKLOG._lock.release()
-    assert post_done.wait(5.0), "POST must complete once the lock is released"
+    with TestClient(web.app) as client:   # ctx-managed: ONE portal/loop for both
+        MESSAGE_BACKLOG._lock.acquire()
+        post_done = _threading.Event()
+        try:
+            t = _threading.Thread(
+                target=lambda: (client.post(f"/thread/{tid}/message",
+                                            data={"text": "follow-up"},
+                                            follow_redirects=False),
+                                post_done.set()),
+                daemon=True)
+            t.start()
+            _time.sleep(0.3)
+            assert not post_done.is_set(), \
+                "POST should be blocked on the held store lock"
+            start = _time.monotonic()
+            status = client.get(f"/thread/{tid}/status")
+            elapsed = _time.monotonic() - start
+            assert status.status_code == 200
+            assert elapsed < 2.0, \
+                f"loop blocked: GET took {elapsed:.1f}s under a held store lock"
+        finally:
+            MESSAGE_BACKLOG._lock.release()
+        assert post_done.wait(5.0), "POST must complete once the lock is released"

--- a/tests/test_restart_recovery.py
+++ b/tests/test_restart_recovery.py
@@ -1,0 +1,375 @@
+"""Restart recovery — durable follow-up journal + resume-from-checkpoint.
+
+Pins the contracts of docs/2026-07-13-durable-message-queue.org (Step 1): a
+message accepted while its thread is busy is journaled durably BEFORE the POST
+returns; the turn claims (removes) its entry status-first when it starts; and
+startup recovery delivers every journaled message exactly once and resumes /
+re-dispatches / finalizes the interrupted head turn by GRAPH STATE, not text
+equality. The kill-shaped test exercises a real langgraph SqliteSaver abandoned
+mid-run and reopened in a fresh "process" — the crash shape, not the cooperative
+pause shape.
+"""
+import contextlib
+import json
+import os
+import sqlite3
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from manage import web
+from manage.web import threads
+from manage.web.state import MESSAGE_BACKLOG, _get_status, _set_status
+from assist.backlog import MessageBacklog, PendingMessage
+
+
+@pytest.fixture
+def wired(tmp_path, monkeypatch):
+    """A thread dir + repointed MANAGER/backlog, with the agent machinery stubbed
+    (same shape as test_fair_scheduling_integration's fixture)."""
+    tid = "t-recover"
+    (tmp_path / tid).mkdir()
+
+    monkeypatch.setattr(web.MANAGER, "root_dir", str(tmp_path))
+    monkeypatch.setattr(web.MANAGER, "thread_dir", lambda t: str(tmp_path / t))
+    monkeypatch.setattr(MESSAGE_BACKLOG, "_root", str(tmp_path))
+    monkeypatch.setattr(web.MANAGER, "thread_default_working_dir",
+                        lambda t: str(tmp_path / t))
+    monkeypatch.setattr(web.MANAGER, "touch", lambda t: None)
+    monkeypatch.setattr("manage.web.threads._get_sandbox_backend",
+                        lambda t, tz=None: None)
+    monkeypatch.setattr("manage.web.threads._get_domain_manager", lambda t: None)
+    monkeypatch.setattr("manage.web.threads.get_cached_description", lambda t: "stub")
+    monkeypatch.setattr("manage.web.threads.SandboxManager.cleanup", lambda wd: None)
+    with contextlib.suppress(Exception):
+        while True:
+            threads._RESUME_SCHEDULER._q.get_nowait()
+    return tid, tmp_path
+
+
+class _Chat:
+    """Minimal Thread stand-in that records how it was run."""
+
+    def __init__(self, tid, calls):
+        self.thread_id = tid
+        self._calls = calls
+
+    def message(self, text):
+        self._calls.append(("message", text))
+        return "done"
+
+    def resume(self):
+        self._calls.append(("resume",))
+        return "resumed"
+
+    def pending_reply(self):
+        return None
+
+    def get_messages(self):
+        return []
+
+
+def _wire_chat(monkeypatch, tid, calls, triage_seen=None):
+    def get(t, sandbox_backend=None, on_queue_state=None, configurable=None,
+            triage=False):
+        if triage_seen is not None:
+            triage_seen.append((triage, (configurable or {})))
+        return _Chat(t, calls)
+    monkeypatch.setattr(web.MANAGER, "get", get)
+
+
+# --- the journal: durable before dispatch, claimed at turn start ---------------
+
+def test_follow_up_to_busy_thread_is_journaled_durably(wired, monkeypatch):
+    tid, tmp_path = wired
+    _set_status(tid, "processing", pending_message="head turn")
+    spawned = []
+    monkeypatch.setattr(threads.BackgroundTasks, "add_task",
+                        lambda self, fn, *a, **k: spawned.append((fn, a, k)))
+
+    from fastapi.testclient import TestClient
+    TestClient(web.app).post(f"/thread/{tid}/message", data={"text": "follow-up"},
+                             follow_redirects=False)
+
+    # Durable on disk before the redirect returned, and the dispatch carries the
+    # entry id so the turn claims it when it starts.
+    on_disk = json.loads((tmp_path / tid / "pending_messages.json").read_text())
+    assert [r["text"] for r in on_disk] == ["follow-up"]
+    assert spawned and spawned[0][2].get("backlog_id") == on_disk[0]["id"]
+    # The running head turn's status was NOT clobbered by the follow-up.
+    assert _get_status(tid).get("pending_message") == "head turn"
+
+
+def test_idle_thread_first_message_is_not_journaled(wired, monkeypatch):
+    tid, tmp_path = wired
+    _set_status(tid, "ready")
+    monkeypatch.setattr(threads.BackgroundTasks, "add_task",
+                        lambda self, fn, *a, **k: None)
+    from fastapi.testclient import TestClient
+    TestClient(web.app).post(f"/thread/{tid}/message", data={"text": "first"},
+                             follow_redirects=False)
+    # The first message is durable via status.pending_message — the journal is
+    # follow-ups only.
+    assert not (tmp_path / tid / "pending_messages.json").exists()
+    assert _get_status(tid).get("pending_message") == "first"
+
+
+def test_turn_claims_its_entry_status_first(wired, monkeypatch):
+    """When a journaled follow-up's turn starts: status takes ownership (text +
+    claimed_id) and THEN the journal entry is popped — the message is durable in
+    at least one store at every instant."""
+    tid, _ = wired
+    calls = []
+    _wire_chat(monkeypatch, tid, calls)
+    rec = MESSAGE_BACKLOG.add(PendingMessage(thread_id=tid, text="follow-up"))
+
+    statuses = []
+    real_set = threads._set_status
+
+    def spy_set(t, stage, **kw):
+        statuses.append((stage, kw.get("claimed_id"),
+                         bool(MESSAGE_BACKLOG.for_thread(tid))))
+        real_set(t, stage, **kw)
+    monkeypatch.setattr(threads, "_set_status", spy_set)
+
+    threads._process_message(tid, "follow-up", backlog_id=rec.id)
+
+    # The starting_sandbox write carried the claim id while the entry was STILL
+    # journaled; the pop happened after.
+    claim_writes = [s for s in statuses if s[0] == "starting_sandbox"]
+    assert claim_writes == [("starting_sandbox", rec.id, True)]
+    assert MESSAGE_BACKLOG.for_thread(tid) == []       # claimed after
+    assert calls == [("message", "follow-up")]
+
+
+# --- the recovery decision: graph state, not text -----------------------------
+
+def _snap(next_=(), interrupts=(), messages=()):
+    return SimpleNamespace(next=next_, interrupts=interrupts,
+                           values={"messages": list(messages)})
+
+
+def test_recovery_decision_matrix(wired, monkeypatch):
+    from langchain_core.messages import AIMessage, HumanMessage
+    tid, _ = wired
+    snap_holder = {}
+
+    class _StateChat:
+        thread_id = tid
+        agent = property(lambda self: SimpleNamespace(
+            get_state=lambda cfg: snap_holder["snap"]))
+        runconfig = {}
+    monkeypatch.setattr(web.MANAGER, "get",
+                        lambda t, sandbox_backend=None, **k: _StateChat())
+
+    # Mid-flight (pending superstep) -> resume.
+    snap_holder["snap"] = _snap(next_=("agent",))
+    assert threads._recovery_decision(tid, "hello") == "resume"
+    # Durable HITL interrupt -> resume (it re-fires).
+    snap_holder["snap"] = _snap(interrupts=(object(),))
+    assert threads._recovery_decision(tid, "hello") == "resume"
+    # Turn completed before the kill -> finalize (containment: supersede prefix).
+    snap_holder["snap"] = _snap(messages=[HumanMessage("PREFIX hello"), AIMessage("hi")])
+    assert threads._recovery_decision(tid, "hello") == "finalize"
+    # Message never reached the checkpoint -> redispatch. The duplicate-text trap:
+    # an OLDER "ok" in history must NOT read as this turn's — but state decides
+    # first: with no pending superstep and no match on the LATEST human, redispatch.
+    snap_holder["snap"] = _snap(messages=[HumanMessage("ok"), AIMessage("done"),
+                                          HumanMessage("different")])
+    assert threads._recovery_decision(tid, "ok") == "redispatch"
+    # Unreadable state -> error (degrade loudly, don't guess).
+    monkeypatch.setattr(web.MANAGER, "get",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    assert threads._recovery_decision(tid, "hello") == "error"
+
+
+# --- _recover_thread: exactly-once end-to-end ---------------------------------
+
+def test_recover_redispatches_head_and_drains_backlog_in_order(wired, monkeypatch):
+    tid, _ = wired
+    calls = []
+    _wire_chat(monkeypatch, tid, calls)
+    monkeypatch.setattr(threads, "_recovery_decision", lambda t, p: "redispatch")
+    _set_status(tid, "paused", pending_message="head")
+    MESSAGE_BACKLOG.add(PendingMessage(thread_id=tid, text="f1"))
+    MESSAGE_BACKLOG.add(PendingMessage(thread_id=tid, text="f2"))
+
+    threads._recover_thread(tid)
+
+    assert calls == [("message", "head"), ("message", "f1"), ("message", "f2")]
+    assert MESSAGE_BACKLOG.for_thread(tid) == []   # each entry claimed exactly once
+
+
+def test_recover_resumes_and_preserves_triage_sender(wired, monkeypatch):
+    """A triage (inbound-SMS) turn killed mid-processing resumes AS a triage turn:
+    the sender persisted in the busy status write drives triage=True + the reply
+    target — without it the recovery would rebuild a full-privilege agent."""
+    tid, _ = wired
+    calls, triage_seen = [], []
+    _wire_chat(monkeypatch, tid, calls, triage_seen)
+    monkeypatch.setattr(threads, "_recovery_decision", lambda t, p: "resume")
+    _set_status(tid, "paused", pending_message="sms text", sender="+15550001111",
+                accumulated_active_ms=1234.0)
+
+    threads._recover_thread(tid)
+
+    assert calls == [("resume",)]
+    assert triage_seen and triage_seen[0][0] is True          # triage preserved
+    assert triage_seen[0][1].get(threads.SMS_SENDER_KEY) == "+15550001111"
+
+
+def test_recover_dedupes_claimed_entry(wired, monkeypatch):
+    """Crash between the status-claim write and the journal pop: the entry is in
+    BOTH stores. Recovery removes the claimed entry (status owns that message) and
+    delivers it via exactly one path — the head resume."""
+    tid, _ = wired
+    calls = []
+    _wire_chat(monkeypatch, tid, calls)
+    monkeypatch.setattr(threads, "_recovery_decision", lambda t, p: "resume")
+    rec = MESSAGE_BACKLOG.add(PendingMessage(thread_id=tid, text="claimed msg"))
+    _set_status(tid, "paused", pending_message="claimed msg", claimed_id=rec.id)
+
+    threads._recover_thread(tid)
+
+    assert calls == [("resume",)]                    # one delivery path
+    assert MESSAGE_BACKLOG.for_thread(tid) == []     # deduped, not re-dispatched
+
+
+def test_recover_finalizes_completed_turn(wired, monkeypatch):
+    tid, _ = wired
+    calls = []
+    _wire_chat(monkeypatch, tid, calls)
+    monkeypatch.setattr(threads, "_recovery_decision", lambda t, p: "finalize")
+    _set_status(tid, "paused", pending_message="already answered")
+
+    threads._recover_thread(tid)
+
+    assert calls == []                               # nothing re-run
+    assert _get_status(tid)["stage"] == "ready"
+
+
+def test_recover_unrecoverable_errors_with_message_surfaced(wired, monkeypatch):
+    tid, _ = wired
+    calls = []
+    _wire_chat(monkeypatch, tid, calls)
+    monkeypatch.setattr(threads, "_recovery_decision", lambda t, p: "error")
+    _set_status(tid, "paused", pending_message="lost?")
+
+    threads._recover_thread(tid)
+
+    st = _get_status(tid)
+    assert st["stage"] == "error" and st.get("pending_message") == "lost?"
+    assert calls == []
+
+
+# --- lifespan wiring: rewrite-to-paused + enqueue -----------------------------
+
+def test_lifespan_rewrites_busy_to_paused_and_enqueues_recovery(wired, monkeypatch):
+    """The stage-rewrite is load-bearing: post_message routes live messages through
+    the serial worker only for stage=='paused', so a recovered thread must not sit
+    at 'processing' where a new message could race the recovery resume."""
+    tid, _ = wired
+    _set_status(tid, "processing", pending_message="mid-flight",
+                sender="+15550001111")
+    recovered = []
+    monkeypatch.setattr(threads._RESUME_SCHEDULER, "submit_recover",
+                        lambda t: recovered.append(t))
+
+    # The lifespan's recovery block, run directly (the full lifespan needs the app).
+    from manage.web import state as st_mod
+    for t in web.MANAGER.list():
+        status = _get_status(t)
+        if status.get("stage") in st_mod.BUSY_STAGES:
+            _set_status(t, "paused",
+                        **{k: v for k, v in status.items() if k != "stage"})
+            threads.submit_recovery(t)
+
+    st = _get_status(tid)
+    assert st["stage"] == "paused"
+    assert st.get("pending_message") == "mid-flight"    # carried through
+    assert st.get("sender") == "+15550001111"           # triage info survives
+    assert recovered == [tid]
+
+
+# --- kill-shaped resume: a real graph, a real SqliteSaver, a hard abandon -----
+
+def test_kill_shaped_resume_from_reopened_checkpointer(tmp_path):
+    """The crash shape un-mocked: run a real 2-node langgraph under a SqliteSaver
+    with durability='sync', ABANDON it mid-run (node B raises — but unlike a
+    cooperative pause we then throw the whole graph object away), reopen the
+    saver as a fresh 'process', and resume input=None. Node A's completed work
+    must be preserved (not re-run) and the turn must finish."""
+    from langgraph.graph import StateGraph, START, END
+    from langgraph.checkpoint.sqlite import SqliteSaver
+    from typing_extensions import TypedDict
+
+    db = str(tmp_path / "ckpt.db")
+    runs = {"a": 0, "b": 0}
+
+    class S(TypedDict):
+        log: list
+
+    def node_a(state):
+        runs["a"] += 1
+        return {"log": state["log"] + ["a"]}
+
+    crash = {"on": True}
+
+    def node_b(state):
+        runs["b"] += 1
+        if crash["on"]:
+            raise RuntimeError("hard kill mid-superstep")
+        return {"log": state["log"] + ["b"]}
+
+    def build(conn):
+        g = StateGraph(S)
+        g.add_node("a", node_a)
+        g.add_node("b", node_b)
+        g.add_edge(START, "a")
+        g.add_edge("a", "b")
+        g.add_edge("b", END)
+        return g.compile(checkpointer=SqliteSaver(conn))
+
+    cfg = {"configurable": {"thread_id": "t1"}}
+    conn1 = sqlite3.connect(db, check_same_thread=False)
+    graph1 = build(conn1)
+    with pytest.raises(RuntimeError):
+        graph1.invoke({"log": []}, cfg, durability="sync")
+    conn1.close()          # the "process" dies; nothing cooperative ran
+
+    # Fresh process: reopen the saver, resume from the durable checkpoint.
+    crash["on"] = False
+    conn2 = sqlite3.connect(db, check_same_thread=False)
+    graph2 = build(conn2)
+    snap = graph2.get_state(cfg)
+    assert snap.next, "mid-flight turn must show a pending superstep"
+    result = graph2.invoke(None, cfg, durability="sync")
+    conn2.close()
+
+    assert result["log"] == ["a", "b"]
+    assert runs["a"] == 1, "completed superstep must NOT re-run on resume"
+    assert runs["b"] == 2   # the interrupted superstep re-runs (the named residual)
+
+
+# --- the journal store itself -------------------------------------------------
+
+def test_corrupt_backlog_is_loud_not_silent(tmp_path, caplog):
+    store = MessageBacklog(str(tmp_path))
+    (tmp_path / "t1").mkdir()
+    (tmp_path / "t1" / "pending_messages.json").write_text('[{"truncated')
+    import logging as _logging
+    with caplog.at_level(_logging.ERROR):
+        assert store.for_thread("t1") == []
+    assert any("unreadable" in r.message for r in caplog.records)
+    # left for inspection, not overwritten
+    assert (tmp_path / "t1" / "pending_messages.json").read_text() == '[{"truncated'
+
+
+def test_claim_is_idempotent(tmp_path):
+    store = MessageBacklog(str(tmp_path))
+    (tmp_path / "t1").mkdir()
+    rec = store.add(PendingMessage(thread_id="t1", text="x"))
+    store.claim("t1", rec.id)
+    store.claim("t1", rec.id)          # double-claim: no raise
+    assert store.for_thread("t1") == []

--- a/tests/test_restart_recovery.py
+++ b/tests/test_restart_recovery.py
@@ -169,12 +169,19 @@ def test_recovery_decision_matrix(wired, monkeypatch):
     # Durable HITL interrupt -> resume (it re-fires).
     snap_holder["snap"] = _snap(interrupts=(object(),))
     assert threads._recovery_decision(tid, "hello") == "resume"
-    # Turn completed before the kill -> finalize (containment: supersede prefix).
-    snap_holder["snap"] = _snap(messages=[HumanMessage("PREFIX hello"), AIMessage("hi")])
+    # Turn completed before the kill -> finalize. EXACT match only — as sent, or
+    # as the supersede fold checkpoints it (_SUPERSEDE_RIDER prefix)...
+    snap_holder["snap"] = _snap(messages=[
+        HumanMessage(threads._SUPERSEDE_RIDER + "hello"), AIMessage("hi")])
     assert threads._recovery_decision(tid, "hello") == "finalize"
-    # Message never reached the checkpoint -> redispatch. The duplicate-text trap:
-    # an OLDER "ok" in history must NOT read as this turn's — but state decides
-    # first: with no pending superstep and no match on the LATEST human, redispatch.
+    # ...but a pending that merely appears inside/at-the-end of the PREVIOUS
+    # turn's message (crash pre-input-checkpoint) must NOT finalize — that would
+    # silently drop the message.
+    snap_holder["snap"] = _snap(messages=[HumanMessage("ok, book it"), AIMessage("hi")])
+    assert threads._recovery_decision(tid, "ok") == "redispatch"
+    snap_holder["snap"] = _snap(messages=[HumanMessage("can you book it"), AIMessage("hi")])
+    assert threads._recovery_decision(tid, "book it") == "redispatch"
+    # Message never reached the checkpoint at all -> redispatch.
     snap_holder["snap"] = _snap(messages=[HumanMessage("ok"), AIMessage("done"),
                                           HumanMessage("different")])
     assert threads._recovery_decision(tid, "ok") == "redispatch"
@@ -186,6 +193,22 @@ def test_recovery_decision_matrix(wired, monkeypatch):
 
 # --- _recover_thread: exactly-once end-to-end ---------------------------------
 
+def _drain_worker_queue(calls_expected_tid):
+    """Run any turn jobs the recovery submitted to the serial worker, the way
+    _ResumeScheduler._loop would (synchronously, in order)."""
+    while True:
+        try:
+            it = threads._RESUME_SCHEDULER._q.get_nowait()
+        except Exception:
+            return
+        assert it["tid"] == calls_expected_tid
+        threads._process_message(it["tid"], it["text"], rider=it["rider"],
+                                 sender=it["sender"], resume=it["resume"],
+                                 accumulated_active_ms=it["acc"],
+                                 pending_text=it["pending"],
+                                 backlog_id=it.get("backlog_id"))
+
+
 def test_recover_redispatches_head_and_drains_backlog_in_order(wired, monkeypatch):
     tid, _ = wired
     calls = []
@@ -196,9 +219,48 @@ def test_recover_redispatches_head_and_drains_backlog_in_order(wired, monkeypatc
     MESSAGE_BACKLOG.add(PendingMessage(thread_id=tid, text="f2"))
 
     threads._recover_thread(tid)
+    # The head ran inline; the follow-ups were SUBMITTED to the serial worker
+    # (behind any resume the head might have re-queued) — run them as the worker.
+    _drain_worker_queue(tid)
 
     assert calls == [("message", "head"), ("message", "f1"), ("message", "f2")]
     assert MESSAGE_BACKLOG.for_thread(tid) == []   # each entry claimed exactly once
+
+
+def test_duplicate_dispatchers_deliver_exactly_once(wired, monkeypatch):
+    """The exactly-once gate: a live job submitted during recovery and the
+    recovery drain can BOTH target the same journal entry — whichever runs second
+    must find the entry claimed and skip, not run a second turn."""
+    tid, _ = wired
+    calls = []
+    _wire_chat(monkeypatch, tid, calls)
+    rec = MESSAGE_BACKLOG.add(PendingMessage(thread_id=tid, text="once"))
+
+    threads._process_message(tid, "once", backlog_id=rec.id)   # first dispatcher
+    threads._process_message(tid, "once", backlog_id=rec.id)   # duplicate
+
+    assert calls == [("message", "once")]          # exactly one turn ran
+
+
+def test_journal_only_recovery_skips_head_and_stays_healthy(wired, monkeypatch):
+    """A ready thread with surviving follow-ups (crash after the head turn
+    finished): recovery must NOT touch the head — no resume, no spurious
+    'could not be recovered' error — just submit the journaled follow-ups."""
+    tid, _ = wired
+    calls = []
+    _wire_chat(monkeypatch, tid, calls)
+    decisions = []
+    monkeypatch.setattr(threads, "_recovery_decision",
+                        lambda t, p: decisions.append(t) or "resume")
+    _set_status(tid, "ready")
+    MESSAGE_BACKLOG.add(PendingMessage(thread_id=tid, text="leftover"))
+
+    threads._recover_thread(tid)
+
+    assert decisions == []                          # head decision never ran
+    assert _get_status(tid)["stage"] == "ready"     # no error banner
+    _drain_worker_queue(tid)
+    assert calls == [("message", "leftover")]
 
 
 def test_recover_resumes_and_preserves_triage_sender(wired, monkeypatch):
@@ -276,14 +338,9 @@ def test_lifespan_rewrites_busy_to_paused_and_enqueues_recovery(wired, monkeypat
     monkeypatch.setattr(threads._RESUME_SCHEDULER, "submit_recover",
                         lambda t: recovered.append(t))
 
-    # The lifespan's recovery block, run directly (the full lifespan needs the app).
-    from manage.web import state as st_mod
-    for t in web.MANAGER.list():
-        status = _get_status(t)
-        if status.get("stage") in st_mod.BUSY_STAGES:
-            _set_status(t, "paused",
-                        **{k: v for k, v in status.items() if k != "stage"})
-            threads.submit_recovery(t)
+    # The REAL scan the lifespan calls (extracted so this test can't drift from it).
+    from manage.web.state import _recover_interrupted_threads
+    _recover_interrupted_threads()
 
     st = _get_status(tid)
     assert st["stage"] == "paused"
@@ -362,8 +419,14 @@ def test_corrupt_backlog_is_loud_not_silent(tmp_path, caplog):
     with caplog.at_level(_logging.ERROR):
         assert store.for_thread("t1") == []
     assert any("unreadable" in r.message for r in caplog.records)
-    # left for inspection, not overwritten
-    assert (tmp_path / "t1" / "pending_messages.json").read_text() == '[{"truncated'
+    # Moved aside for inspection — a later add()'s read-modify-write would
+    # otherwise replace the corrupt file and destroy the evidence.
+    assert (tmp_path / "t1" / "pending_messages.json.corrupt").read_text() \
+        == '[{"truncated'
+    assert not (tmp_path / "t1" / "pending_messages.json").exists()
+    # And a follow-up add works cleanly after the move-aside.
+    store.add(PendingMessage(thread_id="t1", text="after"))
+    assert [r.text for r in store.for_thread("t1")] == ["after"]
 
 
 def test_claim_is_idempotent(tmp_path):
@@ -373,3 +436,41 @@ def test_claim_is_idempotent(tmp_path):
     store.claim("t1", rec.id)
     store.claim("t1", rec.id)          # double-claim: no raise
     assert store.for_thread("t1") == []
+
+
+def test_event_loop_stays_live_while_store_lock_is_held(wired, monkeypatch):
+    """The un-mocked contended-lock test (repo rule: exercise the risk, don't mock
+    it): hold the journal store's lock in another thread while a busy-thread POST
+    is in flight. The POST's append must run OFF the event loop (private
+    CapacityLimiter), so the loop stays live — a concurrent GET completes promptly
+    while the POST is still blocked on the lock."""
+    import threading as _threading
+    import time as _time
+    from fastapi.testclient import TestClient
+
+    tid, _ = wired
+    _set_status(tid, "processing", pending_message="head")
+    monkeypatch.setattr(threads.BackgroundTasks, "add_task",
+                        lambda self, fn, *a, **k: None)
+
+    client = TestClient(web.app)      # one portal = one event loop for both requests
+    MESSAGE_BACKLOG._lock.acquire()
+    post_done = _threading.Event()
+    try:
+        t = _threading.Thread(
+            target=lambda: (client.post(f"/thread/{tid}/message",
+                                        data={"text": "follow-up"},
+                                        follow_redirects=False),
+                            post_done.set()),
+            daemon=True)
+        t.start()
+        _time.sleep(0.3)
+        assert not post_done.is_set(), "POST should be blocked on the held store lock"
+        start = _time.monotonic()
+        status = client.get(f"/thread/{tid}/status")
+        elapsed = _time.monotonic() - start
+        assert status.status_code == 200
+        assert elapsed < 2.0, f"loop blocked: GET took {elapsed:.1f}s under a held store lock"
+    finally:
+        MESSAGE_BACKLOG._lock.release()
+    assert post_done.wait(5.0), "POST must complete once the lock is released"

--- a/tests/test_restart_recovery.py
+++ b/tests/test_restart_recovery.py
@@ -430,6 +430,57 @@ def test_corrupt_backlog_is_loud_not_silent(tmp_path, caplog):
     assert [r.text for r in store.for_thread("t1")] == ["after"]
 
 
+def test_sms_follow_up_to_paused_thread_routes_through_worker(wired, monkeypatch):
+    """An inbound-SMS follow-up to a PAUSED thread must go to the serial worker
+    (behind the queued resume), never dispatch directly — a paused thread has
+    released the slot, so a direct dispatch would acquire immediately and run on
+    the mid-flight checkpoint (Copilot #197 rd1)."""
+    tid, _ = wired
+    _set_status(tid, "paused", pending_message="mid-flight")
+    sub = SimpleNamespace(thread_id=tid, render=lambda s, t: f"[{s}] {t}")
+    monkeypatch.setattr(threads.SUBSCRIPTION_STORE, "route", lambda s: sub)
+    ran, submitted = [], []
+    monkeypatch.setattr(threads, "_process_message",
+                        lambda *a, **k: ran.append(a))
+    monkeypatch.setattr(threads._RESUME_SCHEDULER, "submit_message",
+                        lambda t, text, rider, sender, backlog_id=None:
+                            submitted.append((t, text, sender, backlog_id)))
+
+    threads._dispatch_event("+15550001111", "hey")
+
+    assert ran == []                                  # no direct dispatch
+    recs = MESSAGE_BACKLOG.for_thread(tid)
+    assert len(recs) == 1 and recs[0].sender == "+15550001111"
+    assert submitted == [(tid, "[+15550001111] hey", "+15550001111", recs[0].id)]
+
+
+def test_review_to_paused_thread_routes_through_worker(wired, monkeypatch):
+    """A /review submission to a PAUSED thread routes through the serial worker
+    with its journal id, mirroring post_message (Copilot #197 rd1)."""
+    import json as _json
+    from fastapi.testclient import TestClient
+    tid, _ = wired
+    _set_status(tid, "paused", pending_message="mid-flight")
+    monkeypatch.setattr("manage.web.review._get_domain_manager", lambda t: None)
+    ran, submitted = [], []
+    monkeypatch.setattr(threads.BackgroundTasks, "add_task",
+                        lambda self, fn, *a, **k: ran.append(fn))
+    monkeypatch.setattr(threads._RESUME_SCHEDULER, "submit_message",
+                        lambda t, text, rider, sender, backlog_id=None:
+                            submitted.append((t, backlog_id)))
+
+    r = TestClient(web.app).post(
+        f"/thread/{tid}/review",
+        data={"payload": _json.dumps({"overall": "LGTM", "lines": []})},
+        follow_redirects=False)
+
+    assert r.status_code == 303
+    assert threads._process_message not in ran        # no BackgroundTask dispatch
+    recs = MESSAGE_BACKLOG.for_thread(tid)
+    assert len(recs) == 1
+    assert submitted == [(tid, recs[0].id)]
+
+
 def test_claim_is_idempotent(tmp_path):
     store = MessageBacklog(str(tmp_path))
     (tmp_path / "t1").mkdir()

--- a/tests/test_web_process_message_e2e.py
+++ b/tests/test_web_process_message_e2e.py
@@ -342,7 +342,7 @@ def test_post_message_writes_busy_status_synchronously(client, monkeypatch):
         threads.THREAD_QUEUE, "peek_holder", lambda: "other-thread",
     )
     monkeypatch.setattr("manage.web.threads._process_message",
-                        lambda tid, text, rider=None: None)
+                        lambda tid, text, rider=None, backlog_id=None: None)
 
     r = client.post(
         "/thread/thread-e2e/message",

--- a/tests/test_web_process_message_e2e.py
+++ b/tests/test_web_process_message_e2e.py
@@ -303,7 +303,7 @@ def test_mark_pending_sets_queued_when_another_thread_holds_slot(client, monkeyp
     monkeypatch.setattr(
         threads.THREAD_QUEUE, "peek_holder", lambda: "other-thread",
     )
-    threads._mark_pending("thread-e2e", "hello there")
+    threads._mark_pending("thread-e2e", "hello there", busy=False)
     st = _get_status("thread-e2e")
     assert st.get("stage") == "queued", st
     assert st.get("pending_message") == "hello there", st
@@ -314,7 +314,7 @@ def test_mark_pending_sets_processing_when_slot_free(client, monkeypatch):
     # thread's history and input must stay visible on the redirect render.
     from manage.web.state import INIT_STAGES
     monkeypatch.setattr(threads.THREAD_QUEUE, "peek_holder", lambda: None)
-    threads._mark_pending("thread-e2e", "hello")
+    threads._mark_pending("thread-e2e", "hello", busy=False)
     st = _get_status("thread-e2e")
     assert st.get("stage") == "processing", st
     assert st.get("stage") not in INIT_STAGES, st
@@ -322,12 +322,11 @@ def test_mark_pending_sets_processing_when_slot_free(client, monkeypatch):
 
 
 def test_mark_pending_noop_when_thread_already_busy(client, monkeypatch):
-    # An in-flight turn must not be clobbered by a second submission.
+    # An in-flight turn must not be clobbered by a second submission: the
+    # caller's busy sample (True here — the same sample that journals the
+    # follow-up) makes this a no-op.
     _set_status("thread-e2e", "processing", pending_message="first turn")
-    monkeypatch.setattr(
-        threads.THREAD_QUEUE, "peek_holder", lambda: "other-thread",
-    )
-    threads._mark_pending("thread-e2e", "second turn")
+    threads._mark_pending("thread-e2e", "second turn", busy=True)
     st = _get_status("thread-e2e")
     assert st.get("stage") == "processing", st
     assert st.get("pending_message") == "first turn", st

--- a/tests/test_web_review.py
+++ b/tests/test_web_review.py
@@ -343,7 +343,7 @@ class TestPostReviewRoute:
     def test_303_and_schedules_background_task(self, client, monkeypatch):
         scheduled: list[tuple[str, str]] = []
 
-        def fake_process(tid, text):
+        def fake_process(tid, text, backlog_id=None):
             scheduled.append((tid, text))
 
         # Patch the modules where these names are defined; route
@@ -375,7 +375,8 @@ class TestPostReviewRoute:
         from manage.web import threads
         from manage.web.state import _get_status
 
-        monkeypatch.setattr("manage.web.threads._process_message", lambda tid, text: None)
+        monkeypatch.setattr("manage.web.threads._process_message",
+                            lambda tid, text, backlog_id=None: None)
         monkeypatch.setattr("manage.web.review._get_domain_manager", lambda tid: None)
         # Another thread holds the LLM slot -> expect "queued".
         monkeypatch.setattr(


### PR DESCRIPTION
**Now contains the Step 1 implementation** (originally a design-only PR; Pierre approved moving forward, and the design's D1 was resolved per his review: in-progress turns recover from their last checkpoint).

## What it does
A message sent to a busy thread is journaled durably (`pending_messages.json` per thread, a `PerThreadJsonStore` subclass) **before the POST returns**, and claimed (by id, status-write-first, inside the queue acquire, behind an exactly-once gate) when its turn starts. On startup, instead of erroring busy threads, the lifespan rewrites them to `paused` and enqueues recovery on the serial worker, which: reaps this deployment's orphaned sandbox containers (label + /workspace-mount scoped — not other instances' on the shared daemon), waits bounded for the model (llama's cold-boot 503 handled), then per thread decides **by graph state** — `snap.next`/`interrupts` → resume from the last checkpoint (fresh sandbox, same path as a fair-scheduling resume); turn completed in the bookkeeping window (exact message match) → finalize; never checkpointed → re-dispatch — then drains journaled follow-ups via the worker (ordering preserved even if the resume re-pauses). Inbound-SMS and /review follow-ups journal identically. Sender+rider persist in every busy status write so a crashed **triage** turn recovers as triage (reduced tools + HITL gate), and `invoke_with_rollback` is bounded to the current turn.

## Process
Design → Pierre review (D1: recover in-progress) → design-review team (3 lenses; 3 blockers folded in) → implementation → code-review team (4 lenses; 2 blockers + 8 importants fixed) → verification re-review (4 more fixed, incl. a vacuous liveness test and doc-drift). 19 new tests incl. an **un-mocked kill-shaped langgraph resume** (abandon a real SqliteSaver mid-superstep, reopen, `input=None`: completed work preserved) and an un-mocked event-loop liveness test under a held store lock. 1129 unit green.

## Named residuals (design doc, "Risks")
- The interrupted superstep re-runs on resume (side-effectful tool calls may repeat; `send_reply` stays HITL-gated).
- A due schedule firing in the recovery window can clobber status and silently skip the head recovery (compound cold-boot timing; Step 2 closes it by construction).
- 2h-cap carry resets on a crash (kept on clean pauses).
- Step 2 (backlog as the single source of truth, deleting the parked-waiter pattern) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
