### PR TITLE
Mid-turn interjection: steer work in flight

### DIFF
--- a/assist/agent.py
+++ b/assist/agent.py
@@ -38,6 +38,7 @@ from assist.middleware.memory_middleware import SmallModelMemoryMiddleware
 from assist.middleware.write_collision import WriteCollisionMiddleware
 from assist.middleware.thread_queue_middleware import ThreadQueueMiddleware
 from assist.middleware.context_rider_middleware import ContextRiderMiddleware
+from assist.middleware.interjection import InterjectionMiddleware
 from assist.middleware.image_input_guard import ImageInputGuardMiddleware
 from assist.env import env_int
 
@@ -430,7 +431,11 @@ def create_agent(model: BaseChatModel,
             # line (the error/exit summary) is at the TAIL, not the head.
             ToolResultToFileMiddleware(backend, tools={"execute"}, floor_chars=8000,
                                        preview_style="head_tail", untrusted=True),
-            skills_mw, memory_mw, ContextRiderMiddleware(), logging_mw],
+            # Mid-turn interjection delivery (main agent only — deepagents
+            # never propagates this list to subagent stacks): inert unless the
+            # embedder registered callbacks (the web layer is the only one).
+            skills_mw, memory_mw, ContextRiderMiddleware(),
+            InterjectionMiddleware(), logging_mw],
         backend=backend,
         # Tool-list construction is the lever that actually moves delegation on
         # this model (prose demonstrably doesn't — 0/7 eval trials ignored both

--- a/assist/backlog.py
+++ b/assist/backlog.py
@@ -9,9 +9,13 @@ An entry is a turn that has been accepted but not yet started. Two origins:
 
 Entries live in ``<root_dir>/<tid>/pending_messages.json``, journaled before
 the accepting call returns and removed (claimed, by id) when the turn actually
-starts — so at every instant the work is durable in at least one place: this
-journal while waiting, ``status.json``'s ``pending_message`` once it runs.
-Startup recovery re-dispatches whatever is still journaled, in submit order.
+starts — or, for an ``origin=None`` entry, when the RUNNING turn consumes it
+mid-turn as an interjection (claimed only once its injected copy is durably in
+the graph checkpoint; docs/2026-07-20-mid-turn-interjection-design.org) — so
+at every instant the work is durable in at least one place: this journal while
+waiting, ``status.json``'s ``pending_message`` or the thread checkpoint once
+it runs. Startup recovery re-dispatches whatever is still journaled, in
+submit order.
 See ``docs/2026-07-13-durable-message-queue.org`` (durability/recovery) and the
 blank-slate assessment doc (this journal is the nascent job queue).
 
@@ -39,7 +43,9 @@ class PendingMessageNotFound(RecordNotFound):
 
 @dataclass
 class PendingMessage:
-    """One accepted-but-not-yet-started unit of work. ``rider`` holds the four
+    """One accepted-but-not-yet-delivered unit of work — delivered as its own
+    turn, or consumed mid-turn by the running turn (the interjection path).
+    ``rider`` holds the four
     raw submit-form fields (sent_at/tz/lat/lon) so recovery rebuilds the
     ContextRider with the existing ``_build_rider``; ``sender`` is set for
     inbound-SMS follow-ups (it decides triage on re-dispatch); ``origin`` is

--- a/assist/middleware/interjection.py
+++ b/assist/middleware/interjection.py
@@ -24,11 +24,12 @@ Mechanics (all verified empirically at design time):
   queued fallback dispatcher skip a consumed entry — exactly-once, no new
   dedup machinery. An entry the turn never consumes runs as today's follow-up
   turn: nothing is ever lost.
-- SENDER EQUALITY is the whole scoping story: inject iff
-  ``entry.sender == turn sender`` — an untrusted SMS entry can never enter a
-  full-privilege owner turn, an owner entry never lands inside a
-  reply-to-stranger triage context, and owner entries naturally steer
-  scheduled/continuation turns.
+- SCOPING is two gates: ``entry.origin is None`` (a user follow-up — an
+  agent-scheduled continuation entry is work, not steering) and
+  ``entry.sender == turn sender`` — the security posture: an untrusted SMS
+  entry can never enter a full-privilege owner turn, an owner entry never
+  lands inside a reply-to-stranger triage context, and owner entries
+  naturally steer scheduled/continuation turns.
 - CLAIM-SCAN INVARIANT (Pierre, PR #199): the journal id must be recoverable
   from the durable checkpoint at every claim site. This assumes message
   history is NON-MUTATING for kwargs: deepagents' summarization is (it
@@ -38,10 +39,11 @@ Mechanics (all verified empirically at design time):
 
 Wired like ContextRider/notify: callbacks injected by the web layer
 (``register_interjection_callbacks``); unregistered (CLI/emacsos/evals/
-subagents) ⇒ inert by construction. The web layer owns the framing text, the
-claim side effects (clear-continuations with verbatim enumeration), and the
-turn-scoped claim tracking that feeds its fate-sharing re-journal on terminal
-error.
+subagents) ⇒ inert by construction. The web layer owns the framing text (which
+for an owner entry also enumerates + snapshots the pending continuations), the
+claim side effects (clearing the snapshotted continuations — deferred to claim
+so the clear is fate-shared with the message's durability), and the turn-scoped
+claim tracking that feeds its fate-sharing re-journal on terminal error.
 """
 from __future__ import annotations
 
@@ -56,13 +58,30 @@ from assist.thread_queue import active_handle
 
 logger = logging.getLogger(__name__)
 
+# The kwargs key carrying journal ids on injected messages — THE claim-scan
+# invariant (Pierre, PR #199 note 2): every claim site recovers ids via
+# collect_interjection_ids so the scans can never drift apart.
+INTERJECTION_IDS_KEY = "interjection_ids"
+
+
+def collect_interjection_ids(msgs) -> set:
+    """Journal ids carried by messages already in (checkpointed) state."""
+    ids: set = set()
+    for m in msgs:
+        ids.update((getattr(m, "additional_kwargs", None) or {}).get(
+            INTERJECTION_IDS_KEY, []))
+    return ids
+
+
 # Set by the web layer at import time; None => middleware is inert.
 #   peek(tid) -> list of journal records (this hook runs on the turn's worker
 #                thread, so the locked read is fine)
 #   consume(tid, ids) -> None  (claim by id + turn-scoped claim tracking for
-#                               the web layer's error-exit re-journal; idempotent)
-#   frame(record) -> str  (framing + message text; owner entries also clear
-#                          pending continuations and enumerate them)
+#                               the web layer's error-exit re-journal + the
+#                               deferred continuation clear; idempotent)
+#   frame(record) -> str  (framing + message text; owner entries also
+#                          enumerate pending continuations and snapshot their
+#                          ids for the clear-at-claim)
 _CALLBACKS: dict[str, Callable] | None = None
 
 
@@ -90,13 +109,8 @@ class InterjectionMiddleware(AgentMiddleware):
             return None
         tid = handle.thread_id
         try:
-            msgs = state.get("messages", [])
             # 1. CLAIM ids already durably in state (a prior superstep).
-            in_state: set[str] = set()
-            for m in msgs:
-                for i in (getattr(m, "additional_kwargs", None) or {}).get(
-                        "interjection_ids", []):
-                    in_state.add(i)
+            in_state = collect_interjection_ids(state.get("messages", []))
             if in_state:
                 _CALLBACKS["consume"](tid, in_state)
 
@@ -111,7 +125,7 @@ class InterjectionMiddleware(AgentMiddleware):
             for rec in pending:
                 new_msgs.append(HumanMessage(
                     content=_CALLBACKS["frame"](rec),
-                    additional_kwargs={"interjection_ids": [rec.id]}))
+                    additional_kwargs={INTERJECTION_IDS_KEY: [rec.id]}))
             logger.info("interjection: injected %d message(s) into %s",
                         len(new_msgs), tid)
             return {"messages": new_msgs}
@@ -127,11 +141,14 @@ def _turn_sender(runtime: Runtime) -> str | None:
     """The running turn's sender (None = owner web/scheduled/continuation turn;
     an SMS triage turn carries it in the run config). Read via langgraph's
     get_config() — the run config is NOT on ``runtime`` in this langchain
-    (the ContextRiderMiddleware lesson)."""
+    (the ContextRiderMiddleware lesson). FAIL CLOSED: on any read failure
+    return "" — it matches no entry (the store coerces "" to None on write,
+    so no record ever carries it), degrading to inject-nothing rather than
+    treating a possibly-triage turn as owner scope."""
     try:
         from langgraph.config import get_config
         from assist.events.reply import SMS_SENDER_KEY
         cfg = get_config() or {}
         return (cfg.get("configurable") or {}).get(SMS_SENDER_KEY) or None
     except Exception:
-        return None
+        return ""

--- a/assist/middleware/interjection.py
+++ b/assist/middleware/interjection.py
@@ -1,0 +1,137 @@
+"""Mid-turn interjection — deliver journaled user messages to the RUNNING turn.
+
+A message sent while a turn is running lands durably in the pending-work
+journal (=MESSAGE_BACKLOG=). This middleware's ``before_model`` hook peeks that
+journal at every main-loop model-call boundary and, when unconsumed eligible
+entries exist, appends them to graph state as individually framed
+``HumanMessage``s — the model's very next call sees them and chooses redirect /
+incorporate / defer / stop in its own voice (the four outcomes are DESCRIPTIVE,
+never an interface; docs/2026-07-20-mid-turn-interjection-design.org).
+
+This is a DELIVERY CHANNEL, not a behavior guard: no prompt can make the model
+see a message that is not in its context (the guidance-first rule's "provably
+can't" case). Everything behavioral lives in the injected framing.
+
+Mechanics (all verified empirically at design time):
+- ``before_model`` ONLY: at that boundary every prior tool call has its
+  ToolMessage in state, so the appended user message lands after complete
+  AI/Tool pairs — a sequence the live Qwen template accepts and honors.
+- CLAIM IS DEFERRED: the hook never claims what it just injected — the message
+  is only in memory until its superstep checkpoint commits. It claims entry
+  ids found in messages ALREADY IN STATE (a prior superstep ⇒ durably
+  checkpointed), via ``additional_kwargs["interjection_ids"]``; a second sweep
+  runs at the turn's terminal exits. The shipped entry-gone gate then makes the
+  queued fallback dispatcher skip a consumed entry — exactly-once, no new
+  dedup machinery. An entry the turn never consumes runs as today's follow-up
+  turn: nothing is ever lost.
+- SENDER EQUALITY is the whole scoping story: inject iff
+  ``entry.sender == turn sender`` — an untrusted SMS entry can never enter a
+  full-privilege owner turn, an owner entry never lands inside a
+  reply-to-stranger triage context, and owner entries naturally steer
+  scheduled/continuation turns.
+- CLAIM-SCAN INVARIANT (Pierre, PR #199): the journal id must be recoverable
+  from the durable checkpoint at every claim site. This assumes message
+  history is NON-MUTATING for kwargs: deepagents' summarization is (it
+  summarizes via wrap_model_call without rewriting state); langchain's own
+  SummarizationMiddleware rewrites history with RemoveMessage and would break
+  the scan — do not swap it in without redesigning the claim.
+
+Wired like ContextRider/notify: callbacks injected by the web layer
+(``register_interjection_callbacks``); unregistered (CLI/emacsos/evals/
+subagents) ⇒ inert by construction. The web layer owns the framing text, the
+claim side effects (clear-continuations with verbatim enumeration), and the
+turn-scoped claim tracking that feeds its fate-sharing re-journal on terminal
+error.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+from langchain.agents.middleware import AgentMiddleware, AgentState
+from langchain_core.messages import HumanMessage
+from langgraph.runtime import Runtime
+
+from assist.thread_queue import active_handle
+
+logger = logging.getLogger(__name__)
+
+# Set by the web layer at import time; None => middleware is inert.
+#   peek(tid) -> list of journal records (this hook runs on the turn's worker
+#                thread, so the locked read is fine)
+#   consume(tid, ids) -> None  (claim by id + turn-scoped claim tracking for
+#                               the web layer's error-exit re-journal; idempotent)
+#   frame(record) -> str  (framing + message text; owner entries also clear
+#                          pending continuations and enumerate them)
+_CALLBACKS: dict[str, Callable] | None = None
+
+
+def register_interjection_callbacks(peek, consume, frame) -> None:
+    global _CALLBACKS
+    _CALLBACKS = {"peek": peek, "consume": consume, "frame": frame}
+
+
+class InterjectionMiddleware(AgentMiddleware):
+    """Deliver + claim journaled interjections at model-call boundaries.
+
+    Claim tracking for the fate-sharing re-journal (a user's steering intent
+    must survive a failed turn — Pierre, PR #199 note 5) lives WEB-SIDE inside
+    the ``consume`` callback (a per-tid turn-scoped record list): turns
+    serialize per thread, so the web layer can clear it at turn start and read
+    it at terminal error exits without reaching into this compiled graph."""
+
+    def before_model(
+        self, state: AgentState, runtime: Runtime
+    ) -> dict[str, Any] | None:
+        if _CALLBACKS is None:
+            return None
+        handle = active_handle()
+        if handle is None:
+            return None
+        tid = handle.thread_id
+        try:
+            msgs = state.get("messages", [])
+            # 1. CLAIM ids already durably in state (a prior superstep).
+            in_state: set[str] = set()
+            for m in msgs:
+                for i in (getattr(m, "additional_kwargs", None) or {}).get(
+                        "interjection_ids", []):
+                    in_state.add(i)
+            if in_state:
+                _CALLBACKS["consume"](tid, in_state)
+
+            # 2. INJECT unconsumed, sender-eligible entries not already in state.
+            sender = _turn_sender(runtime)
+            pending = [r for r in _CALLBACKS["peek"](tid)
+                       if r.origin is None and r.sender == sender
+                       and r.id not in in_state]
+            if not pending:
+                return None
+            new_msgs = []
+            for rec in pending:
+                new_msgs.append(HumanMessage(
+                    content=_CALLBACKS["frame"](rec),
+                    additional_kwargs={"interjection_ids": [rec.id]}))
+            logger.info("interjection: injected %d message(s) into %s",
+                        len(new_msgs), tid)
+            return {"messages": new_msgs}
+        except Exception:
+            # Delivery is best-effort per boundary: a journal hiccup must never
+            # fail the running turn — the fallback follow-up path still delivers.
+            logger.error("interjection hook failed for %s (fallback delivery "
+                         "still applies)", tid, exc_info=True)
+            return None
+
+
+def _turn_sender(runtime: Runtime) -> str | None:
+    """The running turn's sender (None = owner web/scheduled/continuation turn;
+    an SMS triage turn carries it in the run config). Read via langgraph's
+    get_config() — the run config is NOT on ``runtime`` in this langchain
+    (the ContextRiderMiddleware lesson)."""
+    try:
+        from langgraph.config import get_config
+        from assist.events.reply import SMS_SENDER_KEY
+        cfg = get_config() or {}
+        return (cfg.get("configurable") or {}).get(SMS_SENDER_KEY) or None
+    except Exception:
+        return None

--- a/assist/middleware/interjection.py
+++ b/assist/middleware/interjection.py
@@ -142,9 +142,10 @@ def _turn_sender(runtime: Runtime) -> str | None:
     an SMS triage turn carries it in the run config). Read via langgraph's
     get_config() — the run config is NOT on ``runtime`` in this langchain
     (the ContextRiderMiddleware lesson). FAIL CLOSED: on any read failure
-    return "" — it matches no entry (the store coerces "" to None on write,
-    so no record ever carries it), degrading to inject-nothing rather than
-    treating a possibly-triage turn as owner scope."""
+    return "" — it matches no entry (the store coerces "" to None on every
+    read via from_dict, so no record it returns ever carries it), degrading
+    to inject-nothing rather than treating a possibly-triage turn as owner
+    scope."""
     try:
         from langgraph.config import get_config
         from assist.events.reply import SMS_SENDER_KEY

--- a/docs/2026-07-20-mid-turn-interjection-design.org
+++ b/docs/2026-07-20-mid-turn-interjection-design.org
@@ -150,16 +150,44 @@ follow-up-ran — never neither. Latency measured on the research shape.
 Regression: durable-queue + progressive-responses suites at baseline;
 anti-telegraphing phrasings. Cadence N=3 → 3 → 5 → 10.
 
-* Needs Pierre
+* Decisions (resolved 2026-07-20 — Pierre's PR #199 review)
 
-1. *Defer-as-continuation*: deferral now consumes chain-cap budget and renders
-   as a "will follow up" note — confirm that shape (it is the visible, capped,
-   honest version of "I'll get to it next").
-2. *Fate-sharing*: a claimed interjection dies with a later terminal turn
-   error like the head message (error banner; no auto re-run machinery).
-   Recommend yes (no-theoretical-code).
-3. *Web "stop" into a running triage turn*: the account-of-work reply arrives
-   as the triage turn's HITL-gated draft — confirm that surface.
-4. *#196 supersede note*: this feature ships the queued-bubble slice on the
-   durable journal; PR #196's remaining scope (its in-memory mirror design)
-   should be re-based on this or closed — your call at review time.
+1. *Four outcomes are DESCRIPTIVE, not an interface.* Redirect / incorporate /
+   defer / stop name the model's behavior for humans and evals; no downstream
+   code branches on the choice (an outcome label was rejected as machinery
+   with no consumer). Evals assert outcomes via mechanical proxies: defer ⇒ a
+   continuation entry exists; stop ⇒ no post-boundary tool calls + an account;
+   redirect/incorporate ⇒ answer content. If code ever needs the outcome, that
+   is a new design conversation, not a hidden contract.
+2. *The claim invariant is EXPLICIT and tested.* Invariant: "an interjection's
+   journal id, carried in its injected message's =additional_kwargs=, must be
+   recoverable from the durable checkpoint at every claim site." Pinned by
+   unit tests: (a) =additional_kwargs= round-trips the SqliteSaver (verified
+   empirically at design time; the test makes it permanent); (b) the
+   history-editing middleware in the stack (=tool_name_sanitization=; the
+   deepagents summarization) preserves =additional_kwargs= on HumanMessages —
+   and a comment in the middleware pins the non-mutating-history assumption
+   against a future summarizer swap (langchain's own rewrites history).
+3. *Cleared continuations are ENUMERATED to the model.* The consume callback
+   returns the cleared records, and the injected framing lists their task
+   texts verbatim ("Cleared scheduled follow-ups — recreate with
+   =continue_later= if still wanted, or revise deliberately: 1. <task> …").
+   The model recreates or intentionally drops each; nothing relies on its
+   memory of what it had planned. (Pierre's suggested shape, adopted.)
+4. *Defer via =continue_later=*: confirmed (reuse over a second mechanism).
+5. *Fate-sharing REVERSED (Pierre's push-back, adopted): claimed interjections
+   SURVIVE a terminal turn error.* Rationale: a user often interjects
+   precisely because the turn looks like it is failing — losing that steering
+   intent with the failed turn would destroy the exact message that mattered
+   most. Mechanism (symmetric with the shipped continuation cancel-sweep): the
+   turn tracks the ids it claimed (turn-scoped set); terminal error exits
+   re-journal those entries (same id, same text) and submit them to the serial
+   worker as follow-up turns. The framed copy left in the dead turn's context
+   is duplicate EXPOSURE when the follow-up runs — benign, named. The error
+   banner + the re-run follow-up together tell the honest story.
+6. *Web "stop" into a running triage turn*: confirmed — the account-of-work
+   arrives as the triage turn's HITL-gated draft; nothing external sends.
+
+Still open (not blocking implementation): PR #196's remaining scope (this
+feature ships the queued-bubble slice on the durable journal) — close as
+superseded or rebase, Pierre's call.

--- a/docs/2026-07-20-mid-turn-interjection-design.org
+++ b/docs/2026-07-20-mid-turn-interjection-design.org
@@ -13,8 +13,8 @@ eligible entries exist, appends them to graph state as *individually framed*
 injected at the same boundary = coalescing). The model's next call sees them
 and chooses redirect / incorporate / defer / stop in its own voice. The *claim*
 (journal removal) is deferred until the injected message is provably in a
-durable checkpoint — one sweep function ("claim every journal id present in
-the checkpointed messages") called at exactly two sites: the next
+durable checkpoint — the same claim discipline ("claim every journal id
+present in the checkpointed messages") at exactly two sites: the next
 =before_model=, and the terminal =ready=/=awaiting_approval= exits. The shipped
 entry-gone gate then makes the queued fallback dispatcher skip a consumed
 entry — exactly-once with zero new dedup machinery. An entry the turn never
@@ -82,20 +82,37 @@ work falls out of the same equality. The =awaiting_approval= state is
 untouched by construction (no model calls run while interrupted → the shipped
 supersede path remains the one story there).
 
-* Consume side effects (kept minimal)
+* Consume side effects (kept minimal; as-built mechanism)
 
-On claim of an owner interjection: one call to the existing
-=_clear_pending_continuations= (redirect bias — this is US-6's actual
-cancel-the-background-work mechanism, and it keeps consumed and unconsumed
-interjections consistent: an unconsumed one already clears at its follow-up
-turn's start). The framing tells the model its scheduled follow-ups were
-cleared — re-schedule what still matters (a later =continue_later= in the same
-turn journals AFTER the clear, so the new plan survives). CUT from the plan:
-the =interjection_seen= event (a write with no reader — queued/seen derive
-from journal-presence and the checkpoint marker), and the pause-handler claim
-sweep (subtle — a pause aborts the superstep, so the injection may not be
-checkpointed — and redundant: the serial resume-before-follow-up ordering
-already protects the window; residual = a transiently stale "queued" label).
+An OWNER interjection supersedes the queued plan (redirect bias — this is
+US-6's actual cancel-the-background-work mechanism), split across the two
+callback moments so nothing durable can outrun the message itself:
+- At INJECTION time the *framing* callback enumerates the pending
+  continuations verbatim (Decision 3) and snapshots their ids in the
+  turn-scoped context. Nothing is cleared yet — the framed message exists
+  only in memory until its superstep commits.
+- At CLAIM time (=_consume_interjections=) the snapshotted ids are cleared.
+  The clear thus commits iff the enumerating message reached the durable
+  checkpoint — a turn that dies pre-checkpoint leaves the follow-ups intact
+  (they were promised "cleared" only in a message that never durably
+  existed), and the entry re-runs as a follow-up turn whose =_clears_plan=
+  start does the clear with full context. Clearing by snapshotted id, not
+  clear-all, is what lets a =continue_later= the model issues in RESPONSE
+  (a fresh id, journaled before the claim) survive — the review found
+  clear-all at either moment loses one side or the other.
+CUT from the plan: the =interjection_seen= event (a write with no reader —
+queued/seen derive from journal-presence and the checkpoint marker), and the
+pause-handler claim sweep (subtle — a pause aborts the superstep, so the
+injection may not be checkpointed — and redundant: the serial
+resume-before-follow-up ordering already protects the window; residual = a
+transiently stale "queued" label).
+
+Named restart residuals (the turn-scoped context is in-memory; a restart
+between a pause and its resume loses it): pre-restart CLAIMS lose
+fate-sharing coverage (a later error can't re-journal them — the framed copy
+in the checkpoint remains the record), and enumerated-but-uncleared
+continuation snapshots are dropped (the follow-ups still run: redundant work
+in the rare case, never lost work).
 
 * Visibility (the second review blocker — a #196 slice ships HERE)
 
@@ -125,8 +142,10 @@ precedent) that ends a subagent early when an owner interjection is pending.
 * Implementation notes
 
 - =assist/middleware/interjection.py=: =before_model= hook; thread id via
-  =active_handle()= (ThreadQueueMiddleware discipline); injected callbacks
-  (peek / claim+clear) registered by the web layer; inert unregistered. A
+  =active_handle()= (ThreadQueueMiddleware discipline); three injected
+  callbacks registered by the web layer — =peek= (journal read), =consume=
+  (claim + turn-scoped tracking + the deferred continuation clear), =frame=
+  (framing text + owner enumerate-and-snapshot); inert unregistered. A
   comment PINS the assumption that message history is non-mutating (deepagents
   summarization is; langchain's own SummarizationMiddleware is not — a swap
   would break the claim scan).
@@ -139,14 +158,23 @@ precedent) that ends a subagent early when an owner interjection is pending.
   =_continuation_chain_len= tolerate injected human messages (a non-marker
   human breaks the chain run — acceptable cap reset, confirm deliberately).
 
-* Eval plan
+* Eval plan (annotated as-built)
 
-Behavior suites (stubbed research): redirect / incorporate / defer (asserts
-the =continue_later= entry exists — mechanical) / stop (no post-boundary tool
-calls + an account of completed work) / coalesce (two rapid entries, both
-addressed) / triage (same-sender steers; different-sender left queued).
-Mechanical zero-loss (un-mocked journal/queue): every trial ends claimed ∨
-follow-up-ran — never neither. Latency measured on the research shape.
+Behavior suites (stubbed research; =edd/eval/test_interjection.py=):
+redirect / incorporate / defer (mechanical: addressed-now ∨ a continuation
+journaled) / stop (≤1 post-boundary tool call + an account of completed
+work) / coalesce (two rapid entries, both addressed). As-built deviations:
+- *Triage* — moved to unit (the sender matrix in =tests/test_interjection.py=
+  pins the mechanics; the behavioral steering is the same framing minus the
+  defer clause, covered by the redirect shape). A live-phone/SMS behavioral
+  pass stays a follow-up.
+- *Mechanical zero-loss* — the presented-∨-still-journaled floor is asserted
+  per eval trial (=_assert_presented=); the unconsumed-fallback and
+  error-path halves are unit-pinned (the web layer owns them).
+- *Latency on the research shape* — structural, not wall-clock: injection
+  happens only at main-loop boundaries by construction, so the worst case IS
+  the synchronous-subagent bound named under Honesty; wall-clock measurement
+  deferred to live testing.
 Regression: durable-queue + progressive-responses suites at baseline;
 anti-telegraphing phrasings. Cadence N=3 → 3 → 5 → 10.
 
@@ -168,23 +196,33 @@ anti-telegraphing phrasings. Cadence N=3 → 3 → 5 → 10.
    deepagents summarization) preserves =additional_kwargs= on HumanMessages —
    and a comment in the middleware pins the non-mutating-history assumption
    against a future summarizer swap (langchain's own rewrites history).
-3. *Cleared continuations are ENUMERATED to the model.* The consume callback
-   returns the cleared records, and the injected framing lists their task
-   texts verbatim ("Cleared scheduled follow-ups — recreate with
-   =continue_later= if still wanted, or revise deliberately: 1. <task> …").
-   The model recreates or intentionally drops each; nothing relies on its
-   memory of what it had planned. (Pierre's suggested shape, adopted.)
+3. *Cleared continuations are ENUMERATED to the model.* The framing callback
+   enumerates the pending continuations' task texts verbatim in the injected
+   message ("cleared your scheduled follow-ups: 1. <task> … — recreate any
+   that still matter with =continue_later=, or drop them deliberately") and
+   snapshots their ids; the actual clear runs at claim time against that
+   snapshot (see Consume side effects — fate-shared with the message's
+   durability). The model recreates or intentionally drops each; nothing
+   relies on its memory of what it had planned. (Pierre's suggested shape,
+   adopted.)
 4. *Defer via =continue_later=*: confirmed (reuse over a second mechanism).
 5. *Fate-sharing REVERSED (Pierre's push-back, adopted): claimed interjections
    SURVIVE a terminal turn error.* Rationale: a user often interjects
    precisely because the turn looks like it is failing — losing that steering
    intent with the failed turn would destroy the exact message that mattered
    most. Mechanism (symmetric with the shipped continuation cancel-sweep): the
-   turn tracks the ids it claimed (turn-scoped set); terminal error exits
-   re-journal those entries (same id, same text) and submit them to the serial
-   worker as follow-up turns. The framed copy left in the dead turn's context
-   is duplicate EXPOSURE when the follow-up runs — benign, named. The error
-   banner + the re-run follow-up together tell the honest story.
+   turn tracks the records it claimed (turn-scoped); terminal error exits
+   re-journal each claimed text under a *fresh id* and submit it to the serial
+   worker as a follow-up turn. Fresh, not same-id (an amendment found in
+   review): the dead turn's framed copy keeps the old id in the thread
+   checkpoint forever, so a same-id entry would be silently re-claimed by any
+   later turn's boundary scan and the follow-up's entry-gone gate would skip
+   it — the promised retry would never run. A fresh id matches nothing stale;
+   the message is delivered exactly once, by its dispatcher or by legitimate
+   re-injection into an intervening turn. The framed copy left in the dead
+   turn's context is duplicate EXPOSURE when the follow-up runs — benign,
+   named. The error banner + the re-run follow-up together tell the honest
+   story.
 6. *Web "stop" into a running triage turn*: confirmed — the account-of-work
    arrives as the triage turn's HITL-gated draft; nothing external sends.
 

--- a/docs/2026-07-20-mid-turn-interjection-design.org
+++ b/docs/2026-07-20-mid-turn-interjection-design.org
@@ -1,0 +1,165 @@
+#+title: Design — Mid-turn interjection (v2, post design-review team)
+#+date: <2026-07-20>
+#+author: design doc — PRD: 2026-07-19-prd-mid-turn-interjection.org (decisions resolved)
+
+* Shape (one paragraph)
+
+The journal is already the interjection channel: a message to a busy thread
+lands durably in =MESSAGE_BACKLOG= (=origin=None=) before any dispatcher runs.
+One new middleware — *=InterjectionMiddleware=*, =before_model= only — peeks
+the journal at every main-loop model-call boundary and, when unconsumed
+eligible entries exist, appends them to graph state as *individually framed*
+=HumanMessage=s (a fixed redirect-biased framing per entry; all pending entries
+injected at the same boundary = coalescing). The model's next call sees them
+and chooses redirect / incorporate / defer / stop in its own voice. The *claim*
+(journal removal) is deferred until the injected message is provably in a
+durable checkpoint — one sweep function ("claim every journal id present in
+the checkpointed messages") called at exactly two sites: the next
+=before_model=, and the terminal =ready=/=awaiting_approval= exits. The shipped
+entry-gone gate then makes the queued fallback dispatcher skip a consumed
+entry — exactly-once with zero new dedup machinery. An entry the turn never
+consumes runs as today's follow-up turn: nothing is ever lost.
+
+* Verified foundations (empirical, on the deployed stack)
+
+- *Template legality*: the live Qwen3.6 =--jinja= endpoint accepts
+  =[..., assistant(tool_calls), tool, user]= (200, with and without tools
+  bound) — and the model HONORS the injection (a post-tool "give it in
+  Fahrenheit" interjection produced the converted answer).
+- *Superstep durability*: in installed langchain 1.3.1, each middleware hook is
+  its own graph node/superstep; under =durability="sync"= the injected message
+  is checkpointed BEFORE the next node runs (verified in a real SqliteSaver
+  history). The claim discipline is sound in every arrangement: no ordering
+  can produce a claimed-but-never-presented message (a crash pre-checkpoint
+  leaves the entry journaled → re-injected on resume: at-least-once
+  presentation, exactly-once claim).
+- *Fresh-id append* via the =add_messages= reducer from a hook: legal,
+  verified. *=additional_kwargs=* (the per-message claim-id tracking) survives
+  SqliteSaver round-trips intact.
+- *Wiring*: zero AgentSpec changes — the ContextRider inert-when-unconfigured
+  precedent one-for-one (injected callbacks registered by the web layer;
+  unregistered = inert on CLI/emacsos/evals). Subagent exclusion is structural
+  in deepagents (the caller's middleware list never reaches subagent stacks);
+  triage + continuation turns share the main stack via =MANAGER.get=.
+
+* Why middleware is legitimate here (guidance-first check)
+
+No prompt can make the model see a message that is not in its context — the
+message physically arrives after the turn's input was assembled. The middleware
+is a *delivery channel*, not a behavior guard: it re-does nothing, inspects
+nothing the model already has. Everything behavioral (the four-way choice)
+stays guidance, inside the injected framing, tuned eval-first.
+
+* The four outcomes (with DEFER fixed — the review's blocker)
+
+- *Redirect / incorporate*: the model adjusts in-turn; the framing's default
+  ("the user's latest word wins") carries the PRD's redirect bias.
+- *Defer — the model calls =continue_later=*. The plan's original "defer needs
+  no mechanism (the fallback delivers)" was FALSE for a consumed entry: once
+  claimed, the fallback dispatcher skips (entry-gone gate), so "I'll handle it
+  next" would be a promise with no mechanism. Never-claim-on-defer is
+  unimplementable without intent-parsing (rejected guard class). Routing defer
+  through the shipped =continue_later= closes it with zero new machinery: the
+  deferral is journaled, dispatched at the ready exit, chain-capped, VISIBLE
+  (the "↻ will follow up" note), and mechanically assertable in evals (defer ⇒
+  a continuation entry exists). Turns without the tool (triage; continuation
+  turns) get a framing without the defer option.
+- *Stop*: no keyword middleware — the framing unconditionally instructs
+  halt-future-work + a brief account of completed work (the model must author
+  the account anyway). Pre-named escalation if the stop eval underperforms: a
+  stop-emphasized framing VARIANT chosen by a cheap textual signal — still the
+  model deciding, never a turn-killing guard.
+
+* Sender scoping — one equality, not a matrix
+
+*Inject iff =entry.sender == turn.sender=.* This single comparison IS the
+security posture by construction: an untrusted (spoofable) SMS entry can never
+be injected into a full-privilege owner turn, and an owner entry never lands
+inside a reply-to-stranger triage context (its right home is its own follow-up
+turn — today's behavior, preserved). Owner entries (=sender=None=) naturally
+inject into scheduled/continuation turns too — steering/stopping background
+work falls out of the same equality. The =awaiting_approval= state is
+untouched by construction (no model calls run while interrupted → the shipped
+supersede path remains the one story there).
+
+* Consume side effects (kept minimal)
+
+On claim of an owner interjection: one call to the existing
+=_clear_pending_continuations= (redirect bias — this is US-6's actual
+cancel-the-background-work mechanism, and it keeps consumed and unconsumed
+interjections consistent: an unconsumed one already clears at its follow-up
+turn's start). The framing tells the model its scheduled follow-ups were
+cleared — re-schedule what still matters (a later =continue_later= in the same
+turn journals AFTER the clear, so the new plan survives). CUT from the plan:
+the =interjection_seen= event (a write with no reader — queued/seen derive
+from journal-presence and the checkpoint marker), and the pause-handler claim
+sweep (subtle — a pause aborts the superstep, so the injection may not be
+checkpointed — and redundant: the serial resume-before-follow-up ordering
+already protects the window; residual = a transiently stale "queued" label).
+
+* Visibility (the second review blocker — a #196 slice ships HERE)
+
+An interjection was INVISIBLE from send until consumption (the pending bubble
+belongs to the running turn; the render's journal peek showed only
+continuation entries) — fatal for a feature whose promise is "you can steer";
+the user would resend. Fix folded into v1: the render's existing lock-free
+journal peek also renders =origin=None= entries as *queued user bubbles*
+(~10 lines in the same loop). Seen-state: a claimed entry's framed message in
+the checkpoint renders as the user's bubble (framing stripped, keyed on the
+=_INTERJECTION_FRAME= prefix — the =_CONTINUATION_RIDER= render branch
+pattern) with a "seen mid-turn" badge. This is a deliberate minimal slice of
+PR #196's vocabulary, superseding that design's in-memory =_QUEUED= mirror
+with the durable journal that now exists (note on #196 at ship time).
+
+* Honesty: the latency bound
+
+Steering takes effect at MAIN-LOOP boundaries. A synchronous subagent dispatch
+(research inside a continuation turn; context-agent) is ONE main-loop tool
+call — minutes — and the middleware must not attach to subagents. So the
+PRD's flagship "skip the research" case is the WORST case: the stop lands only
+when the subagent returns. v1 states this and the eval measures the research
+case specifically (never hidden in an average). Pre-named escalation, only on
+eval evidence: a breaker-mold subagent-side check (SearchUnavailableBreaker
+precedent) that ends a subagent early when an owner interjection is pending.
+
+* Implementation notes
+
+- =assist/middleware/interjection.py=: =before_model= hook; thread id via
+  =active_handle()= (ThreadQueueMiddleware discipline); injected callbacks
+  (peek / claim+clear) registered by the web layer; inert unregistered. A
+  comment PINS the assumption that message history is non-mutating (deepagents
+  summarization is; langchain's own SummarizationMiddleware is not — a swap
+  would break the claim scan).
+- =_INTERJECTION_FRAME= beside the other markers in threads.py; framing text
+  eval-owned; per-entry framing (one HumanMessage per entry, all at one
+  boundary) so render, per-entry claims, and coalescing all work without a
+  delimiter grammar.
+- Verify at implementation: =additional_kwargs= untouched by
+  tool_name_sanitization's history edits; =_human_ordinal= + elapsed-badge +
+  =_continuation_chain_len= tolerate injected human messages (a non-marker
+  human breaks the chain run — acceptable cap reset, confirm deliberately).
+
+* Eval plan
+
+Behavior suites (stubbed research): redirect / incorporate / defer (asserts
+the =continue_later= entry exists — mechanical) / stop (no post-boundary tool
+calls + an account of completed work) / coalesce (two rapid entries, both
+addressed) / triage (same-sender steers; different-sender left queued).
+Mechanical zero-loss (un-mocked journal/queue): every trial ends claimed ∨
+follow-up-ran — never neither. Latency measured on the research shape.
+Regression: durable-queue + progressive-responses suites at baseline;
+anti-telegraphing phrasings. Cadence N=3 → 3 → 5 → 10.
+
+* Needs Pierre
+
+1. *Defer-as-continuation*: deferral now consumes chain-cap budget and renders
+   as a "will follow up" note — confirm that shape (it is the visible, capped,
+   honest version of "I'll get to it next").
+2. *Fate-sharing*: a claimed interjection dies with a later terminal turn
+   error like the head message (error banner; no auto re-run machinery).
+   Recommend yes (no-theoretical-code).
+3. *Web "stop" into a running triage turn*: the account-of-work reply arrives
+   as the triage turn's HITL-gated draft — confirm that surface.
+4. *#196 supersede note*: this feature ships the queued-bubble slice on the
+   durable journal; PR #196's remaining scope (its in-memory mirror design)
+   should be re-based on this or closed — your call at review time.

--- a/edd/eval/test_interjection.py
+++ b/edd/eval/test_interjection.py
@@ -29,7 +29,7 @@ from assist.spec import AgentSpec
 from manage.web.threads import (_INTERJECTION_FRAME, _INTERJECTION_GUIDE,
                                 _INTERJECTION_DEFER)
 
-from .utils import create_filesystem, stub_research_subagent
+from .utils import create_filesystem, final_answer, stub_research_subagent
 
 _BIKE_ORG = """* My bike — Linus Roadster
 ** Parts I still need
@@ -95,13 +95,6 @@ class TestInterjection(TestCase):
             agent.message(ask)
         return agent, journal
 
-    def _final_answer(self, agent):
-        for m in reversed(agent.all_messages()):
-            if isinstance(m, AIMessage) and isinstance(m.content, str) \
-                    and m.content.strip():
-                return m.content
-        return ""
-
     def _tool_calls_after_injection(self, agent):
         """Tool calls the model made AFTER the injected frame message —
         the mechanical proxy for 'stop means stop'."""
@@ -138,7 +131,7 @@ class TestInterjection(TestCase):
             "for my bike for the rest of the year, month by month.",
             ["forget the plan — just list the parts I still need to buy"])
         self._assert_presented(agent, journal)
-        answer = self._final_answer(agent).lower()
+        answer = final_answer(agent).lower()
         self.assertTrue("light" in answer or "bell" in answer,
                         f"answer ignored the narrowed ask: {answer[:400]}")
         self.assertNotIn("december", answer)     # the month-by-month plan died
@@ -150,14 +143,14 @@ class TestInterjection(TestCase):
             "What parts do I still need to buy for my bike?",
             ["include what was already done recently too"])
         self._assert_presented(agent, journal)
-        answer = self._final_answer(agent).lower()
+        answer = final_answer(agent).lower()
         self.assertTrue("light" in answer or "bell" in answer,
                         f"lost the original ask: {answer[:400]}")
         self.assertTrue("saddle" in answer or "chain" in answer,
                         f"addition not incorporated: {answer[:400]}")
 
     def test_stop_halts_with_account(self):
-        """US-6: stop means stop — no further tool calls past the boundary,
+        """US-6: stop means stop — at most one further tool call past the boundary,
         and the reply accounts for what already happened (never silent)."""
         agent, journal = self._run(
             {"bike.org": _BIKE_ORG},
@@ -167,7 +160,7 @@ class TestInterjection(TestCase):
         self._assert_presented(agent, journal)
         self.assertLessEqual(self._tool_calls_after_injection(agent), 1,
                              "kept working after being told to stop")
-        answer = self._final_answer(agent)
+        answer = final_answer(agent)
         self.assertTrue(answer.strip(), "stop must still produce an account")
 
     def test_coalesce_two_rapid_interjections(self):
@@ -178,7 +171,7 @@ class TestInterjection(TestCase):
             ["only cover what still needs buying",
              "and mention where the bell comes from"])
         self._assert_presented(agent, journal)
-        answer = self._final_answer(agent).lower()
+        answer = final_answer(agent).lower()
         self.assertTrue("light" in answer or "bell" in answer,
                         f"first interjection lost: {answer[:400]}")
         self.assertIn("valencia", answer,
@@ -194,7 +187,7 @@ class TestInterjection(TestCase):
             "List the parts my bike still needs.",
             ["afterwards, find out what each of those roughly costs these days"])
         self._assert_presented(agent, journal)
-        answer = self._final_answer(agent).lower()
+        answer = final_answer(agent).lower()
         addressed_now = "cost" in answer or "price" in answer or "$" in answer
         deferred = len(self.journaled) > 0
         self.assertTrue(addressed_now or deferred,

--- a/edd/eval/test_interjection.py
+++ b/edd/eval/test_interjection.py
@@ -1,0 +1,202 @@
+"""Mid-turn interjection — does the model actually steer? (real-LLM eval)
+
+The mechanics (deferred claim, sender scoping, fate-sharing, render) are
+unit-pinned in tests/test_interjection.py; THIS suite evals the behavioral
+contract: an interjection injected at a model-call boundary produces a
+redirect / incorporate / defer / stop in the model's own voice (outcomes are
+descriptive, asserted via mechanical proxies — design doc, Pierre note 1).
+
+Harness: callbacks registered directly on the middleware with an in-memory
+journal; entries become visible only from the SECOND before_model boundary
+(the gate), so the model commits to the original ask first — a true mid-turn
+arrival, not a two-message prompt. active_handle is patched because the eval
+harness runs outside THREAD_QUEUE.acquire (production sets it per turn).
+Research is stubbed per the mocking rule. Prompts avoid the guide's own
+vocabulary ("redirect", "fold", "mid-turn") to probe steering, not echo.
+"""
+import tempfile
+import uuid
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from assist.agent import create_agent, AgentHarness
+from assist.backlog import PendingMessage
+from assist.events.continuations import continuation_tools
+from assist.model_manager import select_assistant_model
+from assist.spec import AgentSpec
+from manage.web.threads import (_INTERJECTION_FRAME, _INTERJECTION_GUIDE,
+                                _INTERJECTION_DEFER)
+
+from .utils import create_filesystem, stub_research_subagent
+
+_BIKE_ORG = """* My bike — Linus Roadster
+** Parts I still need
+- Front light — the Black MR clamp mount version
+- Bell (the brass one from the shop on Valencia)
+** Done
+- New saddle installed in March
+- Chain replaced
+"""
+
+
+class _Journal:
+    """In-memory stand-in for MESSAGE_BACKLOG with the arrival gate: entries
+    stay invisible until the second before_model boundary, so injection is
+    genuinely mid-turn."""
+
+    def __init__(self, defer_available=True):
+        self.entries: list[PendingMessage] = []
+        self.consumed: list[str] = []
+        self.boundaries = 0
+        self.defer = defer_available
+
+    def peek(self, tid):
+        self.boundaries += 1
+        return list(self.entries) if self.boundaries > 1 else []
+
+    def consume(self, tid, ids):
+        self.consumed.extend(ids)
+        self.entries = [r for r in self.entries if r.id not in ids]
+
+    def frame(self, rec):
+        return (_INTERJECTION_FRAME + rec.text + _INTERJECTION_GUIDE
+                + (_INTERJECTION_DEFER if self.defer else "") + ")")
+
+    def add(self, text):
+        rec = PendingMessage(thread_id="eval", text=text, id=uuid.uuid4().hex)
+        self.entries.append(rec)
+        return rec
+
+
+class TestInterjection(TestCase):
+    def setUp(self):
+        self.model = select_assistant_model(0.1)
+        self.journaled = []          # continue_later's captured tasks
+
+    def _run(self, files, ask, interjections, defer_available=True):
+        journal = _Journal(defer_available)
+        for t in interjections:
+            journal.add(t)
+        root = tempfile.mkdtemp()
+        create_filesystem(root, files)
+        tools = continuation_tools(
+            lambda tid, task: self.journaled.append(task), lambda tid: 0)
+        with mock.patch("assist.middleware.interjection.active_handle",
+                        lambda: SimpleNamespace(thread_id="eval")), \
+             mock.patch("assist.middleware.interjection._CALLBACKS",
+                        {"peek": journal.peek, "consume": journal.consume,
+                         "frame": journal.frame}), \
+             stub_research_subagent():
+            # agent built INSIDE the stub context (the research-mocking rule)
+            agent = AgentHarness(create_agent(self.model, root,
+                                              spec=AgentSpec(tools=tools)))
+            agent.message(ask)
+        return agent, journal
+
+    def _final_answer(self, agent):
+        for m in reversed(agent.all_messages()):
+            if isinstance(m, AIMessage) and isinstance(m.content, str) \
+                    and m.content.strip():
+                return m.content
+        return ""
+
+    def _tool_calls_after_injection(self, agent):
+        """Tool calls the model made AFTER the injected frame message —
+        the mechanical proxy for 'stop means stop'."""
+        seen_frame = False
+        n = 0
+        for m in agent.all_messages():
+            if isinstance(m, HumanMessage) and isinstance(m.content, str) \
+                    and m.content.startswith(_INTERJECTION_FRAME):
+                seen_frame = True
+                continue
+            if seen_frame and isinstance(m, AIMessage) and m.tool_calls:
+                n += len(m.tool_calls)
+        return n
+
+    def _assert_presented(self, agent, journal):
+        """Zero-loss floor: every seeded entry reached the model — its framed
+        message is in graph state (consume may lag: it runs at the NEXT
+        boundary or the web layer's terminal sweep, neither guaranteed in this
+        harness when the injection boundary is the turn's last)."""
+        in_state = set()
+        for m in agent.all_messages():
+            in_state.update((getattr(m, "additional_kwargs", None) or {}).get(
+                "interjection_ids", []))
+        missing = [r.text for r in journal.entries if r.id not in in_state]
+        self.assertEqual(missing, [],
+                         f"interjection never presented: {missing}")
+
+    def test_redirect_mid_turn(self):
+        """US-1: the interjection narrows the request; the final answer follows
+        the interjection, not the original ask."""
+        agent, journal = self._run(
+            {"bike.org": _BIKE_ORG},
+            "Look through my files and give me a complete maintenance plan "
+            "for my bike for the rest of the year, month by month.",
+            ["forget the plan — just list the parts I still need to buy"])
+        self._assert_presented(agent, journal)
+        answer = self._final_answer(agent).lower()
+        self.assertTrue("light" in answer or "bell" in answer,
+                        f"answer ignored the narrowed ask: {answer[:400]}")
+        self.assertNotIn("december", answer)     # the month-by-month plan died
+
+    def test_incorporate_addition(self):
+        """US-2: an additive interjection folds into one coherent answer."""
+        agent, journal = self._run(
+            {"bike.org": _BIKE_ORG},
+            "What parts do I still need to buy for my bike?",
+            ["include what was already done recently too"])
+        self._assert_presented(agent, journal)
+        answer = self._final_answer(agent).lower()
+        self.assertTrue("light" in answer or "bell" in answer,
+                        f"lost the original ask: {answer[:400]}")
+        self.assertTrue("saddle" in answer or "chain" in answer,
+                        f"addition not incorporated: {answer[:400]}")
+
+    def test_stop_halts_with_account(self):
+        """US-6: stop means stop — no further tool calls past the boundary,
+        and the reply accounts for what already happened (never silent)."""
+        agent, journal = self._run(
+            {"bike.org": _BIKE_ORG},
+            "Write a detailed file for each part my bike still needs, with a "
+            "shopping checklist inside each.",
+            ["never mind, don't do any of that"])
+        self._assert_presented(agent, journal)
+        self.assertLessEqual(self._tool_calls_after_injection(agent), 1,
+                             "kept working after being told to stop")
+        answer = self._final_answer(agent)
+        self.assertTrue(answer.strip(), "stop must still produce an account")
+
+    def test_coalesce_two_rapid_interjections(self):
+        """Both entries land at one boundary; both are addressed."""
+        agent, journal = self._run(
+            {"bike.org": _BIKE_ORG},
+            "Summarize the state of my bike.",
+            ["only cover what still needs buying",
+             "and mention where the bell comes from"])
+        self._assert_presented(agent, journal)
+        answer = self._final_answer(agent).lower()
+        self.assertTrue("light" in answer or "bell" in answer,
+                        f"first interjection lost: {answer[:400]}")
+        self.assertIn("valencia", answer,
+                      f"second interjection lost: {answer[:400]}")
+
+    def test_defer_via_continue_later(self):
+        """US-3: a big new ask mid-flight may be deferred — mechanically, defer
+        ⇒ a continuation entry exists (design: continue_later IS the defer
+        mechanism). Redirect-in-place also passes (the bias is redirect); what
+        must never happen is the addition vanishing."""
+        agent, journal = self._run(
+            {"bike.org": _BIKE_ORG},
+            "List the parts my bike still needs.",
+            ["afterwards, find out what each of those roughly costs these days"])
+        self._assert_presented(agent, journal)
+        answer = self._final_answer(agent).lower()
+        addressed_now = "cost" in answer or "price" in answer or "$" in answer
+        deferred = len(self.journaled) > 0
+        self.assertTrue(addressed_now or deferred,
+                        f"the cost ask vanished: journaled={self.journaled}, "
+                        f"answer={answer[:400]}")

--- a/edd/eval/test_progressive_responses.py
+++ b/edd/eval/test_progressive_responses.py
@@ -23,7 +23,7 @@ from assist.events.continuations import continuation_tools
 from assist.model_manager import select_assistant_model
 from assist.spec import AgentSpec
 
-from .utils import create_filesystem, stub_research_subagent
+from .utils import create_filesystem, final_answer, stub_research_subagent
 
 _BIKE_ORG = """* My bike — Linus Roadster
 ** Parts I still need
@@ -66,13 +66,6 @@ class TestProgressiveSplit(TestCase):
                             n += 1
         return n
 
-    def _final_answer(self, agent):
-        from langchain_core.messages import AIMessage
-        for m in reversed(agent.all_messages()):
-            if isinstance(m, AIMessage) and isinstance(m.content, str) and m.content.strip():
-                return m.content
-        return ""
-
     def test_files_plus_research_shape_splits(self):
         """Local files answer part; the rest is research-worthy → answer from
         the files now, journal the rest, do NOT run research in this turn."""
@@ -80,7 +73,7 @@ class TestProgressiveSplit(TestCase):
             agent = self._agent({"bike.org": _BIKE_ORG})
             agent.message("Is there anything I still need to get for my bike, "
                           "and what would each roughly cost these days?")
-        answer = self._final_answer(agent)
+        answer = final_answer(agent)
         # the fast half: the from-your-files answer is in the FIRST response
         self.assertTrue("light" in answer.lower() or "bell" in answer.lower(),
                         f"answer didn't use the local file: {answer[:400]}")

--- a/edd/eval/utils.py
+++ b/edd/eval/utils.py
@@ -194,6 +194,16 @@ class AgentTestMixin:
         return agent
 
 
+def final_answer(agent) -> str:
+    """The last non-empty AI text message — the answer the user would read."""
+    from langchain_core.messages import AIMessage
+    for m in reversed(agent.all_messages()):
+        if isinstance(m, AIMessage) and isinstance(m.content, str) \
+                and m.content.strip():
+            return m.content
+    return ""
+
+
 def assertToolCall(test_case, agent, tool_name: str, msg: str = None):
     """
     Assert that a specific tool was called by the agent.

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -48,6 +48,7 @@ import anyio.to_thread
 from langchain_core.messages import HumanMessage
 
 from assist.backlog import PendingMessage
+from assist.middleware.interjection import register_interjection_callbacks
 from assist.events.continuations import CHAIN_CAP
 from assist.events.thread_log import append_event
 from assist.context_rider import ContextRider, CONTEXT_RIDER_KEY
@@ -644,6 +645,22 @@ def render_thread(
                       f'{task_txt}</div></div>')
             rendered.append(bubble)
             continue
+        elif role == "user" and raw.startswith(_INTERJECTION_FRAME):
+            # A consumed interjection: the durable copy carries the frame +
+            # steering guidance; show only the USER's words, badged so they can
+            # see the running turn saw it (US-4). rfind: the real guide is the
+            # appended one, even if the user's text quotes the guide string.
+            inner = raw[len(_INTERJECTION_FRAME):]
+            cut = inner.rfind(_INTERJECTION_GUIDE)
+            user_txt = inner[:cut] if cut != -1 else inner
+            bubble = (f'<div class="msg user"><div class="role">user'
+                      f'<span style="margin-left:.5rem; color:#9ca3af; '
+                      f'font-size:.75rem; font-weight:normal;">seen mid-turn'
+                      f'</span></div><div class="content">'
+                      f'{html.escape(user_txt).replace(chr(10), "<br/>")}'
+                      f'</div></div>')
+            rendered.append(bubble)
+            continue
         else:
             # Human/user content is plain text with basic escaping
             content_html = html.escape(raw).replace("\n", "<br/>")
@@ -673,6 +690,19 @@ def render_thread(
             '<div class="content"><span class="dots"><span>.</span><span>.</span><span>.</span></span></div>'
             '</div>',
         )
+    # Journaled-but-unconsumed user messages (origin=None) render as QUEUED
+    # user bubbles above the running turn's placeholder — visible from the
+    # moment of send (the design's visibility blocker: an invisible
+    # interjection gets resent). One lock-free peek, reused by the
+    # continuation note below (same discipline as documented there). Oldest
+    # first + insert(0) ⇒ newest ends up topmost, matching the page order.
+    _journal_entries = MESSAGE_BACKLOG.peek(tid)
+    for r in [r for r in _journal_entries if r.origin is None]:
+        rendered.insert(0, (
+            '<div class="msg user" style="opacity:.8;"><div class="role">user'
+            '<span style="margin-left:.5rem; color:#9ca3af; font-size:.75rem;'
+            'font-weight:normal;">queued</span></div><div class="content">'
+            f'{html.escape(r.text).replace(chr(10), "<br/>")}</div></div>'))
     body = "\n".join(rendered) or "<p><em>No messages yet.</em></p>"
 
     # Status banner (in-thread: keeps the fuller STAGE_LABELS sentence). While busy, a live
@@ -735,8 +765,7 @@ def render_thread(
     # the _get_status discipline — the locking for_thread() must never run on the
     # event loop, and the corrupt-file move-aside belongs to locked readers only).
     continuation_note = ""
-    pending_conts = [r for r in MESSAGE_BACKLOG.peek(tid)
-                     if r.origin == "continuation"]
+    pending_conts = [r for r in _journal_entries if r.origin == "continuation"]
     if pending_conts:
         items = "".join(
             f'<div>↻ will follow up: {html.escape(" ".join(r.text.split())[:200])}</div>'
@@ -1045,6 +1074,33 @@ _SUPERSEDE_RIDER = (
 # fidelity (the _SUPERSEDE_RIDER pattern).
 _CONTINUATION_RIDER = "[Continuing my earlier work — background follow-up] "
 
+# Mid-turn interjection framing (design: docs/2026-07-20-mid-turn-interjection-design.org).
+# The FRAME prefixes the user's text in the injected HumanMessage — it is the
+# durable render key (strip-and-badge, like the rider above) and the model's
+# attribution. The GUIDE carries ALL steering (the middleware is only a
+# delivery channel); eval-owned wording. DEFER is appended only when the turn's
+# tool surface has continue_later (triage + continuation turns don't).
+_INTERJECTION_FRAME = "[Mid-turn message from the user — sent while you were working] "
+_INTERJECTION_GUIDE = (
+    "\n\n(This message arrived mid-turn. The user's latest word wins: if it "
+    "changes what they want, redirect your remaining work now; if it adds "
+    "scope, fold it in. If it asks you to stop, do no further work and reply "
+    "with a brief account of what you already completed.")
+_INTERJECTION_DEFER = (
+    " Only if changing course would clearly waste nearly-finished work, "
+    "finish that first and call continue_later to handle this message right "
+    "after.")
+
+# Per-running-turn interjection context, keyed by tid: "claimed" holds the
+# records this turn consumed (the fate-sharing re-journal reads it at terminal
+# error exits — Pierre, PR #199 note 5), "defer" whether the turn's tool
+# surface carries continue_later (picks the framing variant). Turns serialize
+# per thread (THREAD_QUEUE), so each key has a single writer. Created at turn
+# start; a RESUMED slice reuses the live entry so claims made before a pause
+# keep coverage (a restart in between loses the in-memory list — accepted
+# residual, named in the design doc).
+_TURN_INTERJECTION: dict[str, dict] = {}
+
 
 def _continuation_chain_len(tid: str) -> int:
     """Current chain length for the continue_later cap: trailing continuation
@@ -1140,6 +1196,103 @@ def _cancel_this_turns_continuations(tid: str, pre_turn_ids: set) -> int:
     return n
 
 
+def _consume_interjections(tid: str, ids: set) -> None:
+    """The interjection claim: remove each id from the journal (the entry-gone
+    gate then makes the queued fallback dispatcher skip it — exactly-once) and
+    remember the record in the turn-scoped context for the fate-sharing
+    re-journal. Called from the middleware's next-boundary claim and from the
+    terminal sweep below; idempotent (a claimed id is simply no longer found)."""
+    ctx = _TURN_INTERJECTION.setdefault(tid, {"claimed": [], "defer": False})
+    for rec in MESSAGE_BACKLOG.for_thread(tid):
+        if rec.id in ids:
+            MESSAGE_BACKLOG.claim(tid, rec.id)
+            ctx["claimed"].append(rec)
+
+
+def _frame_interjection(rec: "PendingMessage") -> str:
+    """Build the injected message: frame + the user's text + the behavioral
+    guidance. An OWNER interjection supersedes the agent's queued plan
+    (redirect bias — this IS the cancel-the-background-work mechanism): pending
+    continuations are cleared HERE, at injection time, not at claim time — a
+    continue_later the model issues in RESPONSE journals after this clear but
+    before the next-boundary claim, so clearing at claim would wipe the model's
+    new plan. The cleared tasks are enumerated verbatim so the model recreates
+    or deliberately drops each, relying on nothing it remembers (Pierre,
+    PR #199 note 3). An interjection that instead runs as a follow-up turn
+    clears the same way at its turn start — consistent either path."""
+    guide = _INTERJECTION_GUIDE
+    ctx = _TURN_INTERJECTION.get(rec.thread_id) or {}
+    if ctx.get("defer"):
+        guide += _INTERJECTION_DEFER
+    if rec.sender is None:
+        cleared = [r.text for r in MESSAGE_BACKLOG.for_thread(rec.thread_id)
+                   if r.origin == "continuation"]
+        if cleared:
+            _clear_pending_continuations(rec.thread_id)
+            guide += (" This message also cleared your scheduled follow-ups: "
+                      + " ".join(f"{i}. {t}" for i, t in enumerate(cleared, 1))
+                      + (" — recreate any that still matter with "
+                         "continue_later, or drop them deliberately."
+                         if ctx.get("defer") else
+                         " — mention in your reply anything dropped that "
+                         "still matters."))
+    return _INTERJECTION_FRAME + rec.text + guide + ")"
+
+
+def _claim_seen_interjections(tid: str, chat) -> None:
+    """The SECOND claim site (the design's terminal sweep): claim any
+    interjection whose injected message reached the durable checkpoint but
+    whose next before_model boundary never came (the injection superstep was
+    the turn's last). Best-effort — a failed read leaves the entry journaled
+    and it runs as a follow-up turn (at-least-once presentation, never lost)."""
+    try:
+        ids: set = set()
+        for m in chat.get_raw_messages():
+            ids.update((getattr(m, "additional_kwargs", None) or {}).get(
+                "interjection_ids", []))
+        if ids:
+            _consume_interjections(tid, ids)
+    except Exception:
+        logging.error("interjection terminal claim sweep failed for %s "
+                      "(unclaimed entries run as follow-up turns)", tid,
+                      exc_info=True)
+
+
+def _rejournal_claimed_interjections(tid: str, rider) -> int:
+    """Fate-sharing REVERSED (Pierre, PR #199 note 5): a user often interjects
+    precisely because the turn looks like it is failing, so an interjection a
+    now-dead turn had claimed must not die with it. Re-add each claimed record
+    (same id, same text — the store preserves ids) and submit it to the serial
+    worker as its own follow-up turn. The framed copy left in the dead turn's
+    context is duplicate EXPOSURE when the follow-up runs — benign, named in
+    the design. Returns how many, so the error text can say so. BEST-EFFORT by
+    contract: runs inside turn error handlers (a raise would mask the original
+    failure and strand the thread busy)."""
+    n = 0
+    try:
+        claimed = (_TURN_INTERJECTION.pop(tid, None) or {}).get("claimed", [])
+        for rec in claimed:
+            MESSAGE_BACKLOG.add(rec)
+            _RESUME_SCHEDULER.submit_message(
+                tid, rec.text,
+                _build_rider(datetime.now(timezone.utc).isoformat(),
+                             rider.tz if rider else None),
+                rec.sender, rec.id)
+            n += 1
+    except Exception:
+        logging.error("interjection re-journal failed for %s (original turn "
+                      "error still surfaces)", tid, exc_info=True)
+    return n
+
+
+# The interjection middleware is inert until the embedder registers callbacks;
+# the web layer is the only embedder that does (CLI/emacsos/evals keep today's
+# behavior by construction). The journal read is the locked one — the
+# middleware hook runs on the turn's worker thread, never the event loop.
+register_interjection_callbacks(
+    MESSAGE_BACKLOG.for_thread, _consume_interjections, _frame_interjection)
+
+
 def _process_message(tid: str, text: str | None, rider: ContextRider | None = None,
                      sender: str | None = None, resume_decision: dict | None = None,
                      resume: bool = False, accumulated_active_ms: float = 0.0,
@@ -1174,6 +1327,12 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
         # pasting/quoting it) must not be misattributed as an agent note or count
         # toward the chain run — a leading space breaks the startswith keying
         # while leaving the visible text effectively unchanged.
+        text = " " + text
+    if text and text.startswith(_INTERJECTION_FRAME):
+        # Injected interjections never pass through here (the middleware appends
+        # them to graph state directly), so frame-prefixed text is always
+        # user-authored — same misattribution break as the rider above (it
+        # would otherwise render stripped + "seen mid-turn"-badged).
         text = " " + text
     # A genuine OWNER message (web/review — NOT an untrusted inbound SMS: a
     # spoofable sender must not be able to cancel promised work, and a
@@ -1261,6 +1420,15 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
             # pre-existing entries, which have live dispatchers of their own.
             _pre_turn_conts.update(r.id for r in MESSAGE_BACKLOG.for_thread(tid)
                                    if r.origin == "continuation")
+            # Turn-scoped interjection context (see _TURN_INTERJECTION): fresh
+            # for a new turn; a RESUMED slice reuses the live one so entries
+            # claimed before the pause keep fate-sharing coverage. "defer"
+            # mirrors the tool surface — triage and continuation turns have no
+            # continue_later, so their framing omits the defer option.
+            if not resume or tid not in _TURN_INTERJECTION:
+                _TURN_INTERJECTION[tid] = {
+                    "claimed": [],
+                    "defer": sender is None and origin != "continuation"}
             if origin == "continuation" and not resume and resume_decision is None:
                 # A HITL reply awaiting approval: the supersede flow below exists
                 # for a NEWER USER message and would silently REJECT the pending
@@ -1408,6 +1576,12 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
                            (_now_ms() - started_at) / 1000.0)
         except Exception as e:
             logging.warning("turn-timing record failed for %s: %s", tid, e)
+        # Second interjection claim site (terminal): claim anything injected
+        # after the last before_model boundary, then END fate-sharing coverage
+        # — the answer is committed, so a later bookkeeping error must not
+        # re-journal an already-answered interjection.
+        _claim_seen_interjections(tid, chat)
+        _TURN_INTERJECTION.pop(tid, None)
         pending = chat.pending_reply()
         if pending:
             # Preserve started_at so the HITL approve/reject resume reuses the original
@@ -1468,13 +1642,16 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
         # re-checks cleanly instead of poking at the corpse of the old one.
         DOMAIN_MANAGERS.pop(tid, None)
         _cancelled = _cancel_this_turns_continuations(tid, _pre_turn_conts)
+        _rejournaled = _rejournal_claimed_interjections(tid, rider)
         _set_status(
             tid, "error",
             error=("The sandbox container for this thread was lost mid-run. "
                    "Your last message was not completed. Send the message "
                    "again to retry in a fresh sandbox."
                    + (" A follow-up this turn had scheduled was cancelled."
-                      if _cancelled else "")),
+                      if _cancelled else "")
+                   + (" Your mid-turn message will be retried as its own turn."
+                      if _rejournaled else "")),
             **pending_kwargs,
         )
     except GraphRecursionError as e:
@@ -1484,18 +1661,22 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
         # again — so suggest narrowing/splitting, NOT "send again to retry".
         logging.warning("Recursion limit hit for thread %s: %s", tid, e)
         _cancelled = _cancel_this_turns_continuations(tid, _pre_turn_conts)
+        _rejournaled = _rejournal_claimed_interjections(tid, rider)
         _set_status(
             tid, "error",
             error=("This request grew too large to complete — it hit the internal "
                    "step limit and was stopped. Try narrowing it or splitting it "
                    "into smaller parts."
                    + (" A follow-up this turn had scheduled was cancelled."
-                      if _cancelled else "")),
+                      if _cancelled else "")
+                   + (" Your mid-turn message will be retried as its own turn."
+                      if _rejournaled else "")),
             **pending_kwargs,
         )
     except Exception as e:
         logging.error("Message processing failed for thread %s: %s", tid, e, exc_info=True)
         _cancelled = _cancel_this_turns_continuations(tid, _pre_turn_conts)
+        _rejournaled = _rejournal_claimed_interjections(tid, rider)
         if origin == "continuation":
             # Origin-aware failure (US-3: silence is not an outcome): the generic
             # banner would misattribute ("Couldn't process your message" — the
@@ -1504,7 +1685,9 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
             # the thread list, not sunk to the bottom band.
             _set_status(tid, "error",
                         error=("The background follow-up I promised couldn't be "
-                               "completed. Ask me to retry it."),
+                               "completed. Ask me to retry it."
+                               + (" Your mid-turn message will be retried as "
+                                  "its own turn." if _rejournaled else "")),
                         **pending_kwargs)
             append_event(MANAGER.thread_dir(tid), "continuation_failed",
                          id=backlog_id or "", error=str(e)[:300])
@@ -1512,7 +1695,9 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
         else:
             _set_status(tid, "error",
                         error=str(e) + (" A follow-up this turn had scheduled "
-                                        "was cancelled." if _cancelled else ""),
+                                        "was cancelled." if _cancelled else "")
+                        + (" Your mid-turn message will be retried as its own "
+                           "turn." if _rejournaled else ""),
                         **pending_kwargs)
     finally:
         # Drain this turn's persisted active-hold on any TERMINAL exit (success/error)

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -694,10 +694,11 @@ def render_thread(
             '</div>',
         )
     # Journaled-but-unconsumed user messages (origin=None) render as QUEUED
-    # user bubbles above the running turn's placeholder — visible from the
-    # moment of send (the design's visibility blocker: an invisible
-    # interjection gets resent). One lock-free peek, reused by the
-    # continuation note below (same discipline as documented there). Oldest
+    # user bubbles at the top of the page (above the running turn's
+    # placeholder when one is shown; a ready thread's not-yet-dispatched
+    # entries render the same way) — visible from the moment of send (the
+    # design's visibility blocker: an invisible interjection gets resent).
+    # One lock-free peek, reused by the continuation note below. Oldest
     # first + insert(0) ⇒ newest ends up topmost, matching the page order.
     # Seen wins over queued: an injected entry is checkpointed (its "seen
     # mid-turn" bubble above) a full superstep before the claim removes its

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -1434,13 +1434,19 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
         # A waiter behind a SAME-TID turn writes NOTHING: that running turn owns
         # status.json (its text/sender/rider must stay durable there for crash
         # recovery — clobbering the sender would resume a crashed triage turn
-        # full-privilege). A journaled follow-up (backlog_id set) never writes —
-        # it is durable in MESSAGE_BACKLOG; a direct-dispatch waiter (scheduled/
-        # geo/SMS turn) is covered by the lock-free peek_holder check, the same
-        # discipline _mark_pending uses. (Residual: a direct-dispatch waiter
-        # behind a same-tid turn that is ITSELF queued behind another thread
-        # still writes — rare double-nesting, dissolved by Step 2.)
-        if (stage == "queued" and backlog_id is None
+        # full-privilege). A journaled follow-up (backlog_id set, not resume)
+        # never writes — it is durable in MESSAGE_BACKLOG. A RESUME never
+        # writes regardless of backlog_id (a resume's durable home is its
+        # `paused` status record: overwriting it with "queued" would misroute
+        # a follow-up arriving in the wait window off the serial scheduler and
+        # onto the mid-flight checkpoint — the ordering hazard the paused
+        # routing exists to prevent — and would drop the carried active-hold
+        # on a crash). A direct-dispatch waiter (scheduled/geo/SMS turn) is
+        # covered by the lock-free peek_holder check, the same discipline
+        # _mark_pending uses. (Residual: a direct-dispatch waiter behind a
+        # same-tid turn that is ITSELF queued behind another thread still
+        # writes — rare double-nesting, dissolved by Step 2.)
+        if (stage == "queued" and backlog_id is None and not resume
                 and THREAD_QUEUE.peek_holder() != tid):
             _set_status(tid, "queued", **pending_kwargs)
 

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -1316,10 +1316,15 @@ def _rejournal_claimed_interjections(tid: str, rider) -> int:
             fresh = MESSAGE_BACKLOG.add(PendingMessage(
                 thread_id=rec.thread_id, text=rec.text, sender=rec.sender,
                 rider=rec.rider, enqueued_at=rec.enqueued_at))
+            # The retried turn keeps the ORIGINAL message's context rider
+            # (sent_at/tz/lat/lon from the journal entry — recovery fidelity,
+            # like the restart drain); fall back to a fresh rider with the
+            # dead turn's tz only when the entry never carried one.
             _RESUME_SCHEDULER.submit_message(
                 tid, fresh.text,
-                _build_rider(datetime.now(timezone.utc).isoformat(),
-                             rider.tz if rider else None),
+                _rider_from_fields(fresh.rider)
+                or _build_rider(datetime.now(timezone.utc).isoformat(),
+                                rider.tz if rider else None),
                 fresh.sender, fresh.id)
             n += 1
     except Exception:

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -48,7 +48,8 @@ import anyio.to_thread
 from langchain_core.messages import HumanMessage
 
 from assist.backlog import PendingMessage
-from assist.middleware.interjection import register_interjection_callbacks
+from assist.middleware.interjection import (collect_interjection_ids,
+                                            register_interjection_callbacks)
 from assist.events.continuations import CHAIN_CAP
 from assist.events.thread_log import append_event
 from assist.context_rider import ContextRider, CONTEXT_RIDER_KEY
@@ -618,6 +619,7 @@ def render_thread(
         """
 
     rendered = []
+    seen_interjections: set = set()
     for _i in range(len(msgs) - 1, -1, -1):
         m = msgs[_i]
         role = html.escape(m.get("role", ""))
@@ -653,6 +655,7 @@ def render_thread(
             inner = raw[len(_INTERJECTION_FRAME):]
             cut = inner.rfind(_INTERJECTION_GUIDE)
             user_txt = inner[:cut] if cut != -1 else inner
+            seen_interjections.add(user_txt)
             bubble = (f'<div class="msg user"><div class="role">user'
                       f'<span style="margin-left:.5rem; color:#9ca3af; '
                       f'font-size:.75rem; font-weight:normal;">seen mid-turn'
@@ -696,8 +699,15 @@ def render_thread(
     # interjection gets resent). One lock-free peek, reused by the
     # continuation note below (same discipline as documented there). Oldest
     # first + insert(0) ⇒ newest ends up topmost, matching the page order.
+    # Seen wins over queued: an injected entry is checkpointed (its "seen
+    # mid-turn" bubble above) a full superstep before the claim removes its
+    # journal entry — suppress the queued copy by text so the message never
+    # shows twice with contradicting badges. (Residual: an identical text
+    # sent again while the first is on screen hides its queued bubble until
+    # the first is claimed — cosmetic, self-resolving.)
     _journal_entries = MESSAGE_BACKLOG.peek(tid)
-    for r in [r for r in _journal_entries if r.origin is None]:
+    for r in [r for r in _journal_entries
+              if r.origin is None and r.text not in seen_interjections]:
         rendered.insert(0, (
             '<div class="msg user" style="opacity:.8;"><div class="role">user'
             '<span style="margin-left:.5rem; color:#9ca3af; font-size:.75rem;'
@@ -1090,15 +1100,22 @@ _INTERJECTION_DEFER = (
     " Only if changing course would clearly waste nearly-finished work, "
     "finish that first and call continue_later to handle this message right "
     "after.")
+# One string, four error exits — the interjection unit test greps it, so the
+# copies would be sync-load-bearing if inlined.
+_REJOURNAL_NOTE = " Your mid-turn message will be retried as its own turn."
 
 # Per-running-turn interjection context, keyed by tid: "claimed" holds the
 # records this turn consumed (the fate-sharing re-journal reads it at terminal
 # error exits — Pierre, PR #199 note 5), "defer" whether the turn's tool
-# surface carries continue_later (picks the framing variant). Turns serialize
-# per thread (THREAD_QUEUE), so each key has a single writer. Created at turn
-# start; a RESUMED slice reuses the live entry so claims made before a pause
-# keep coverage (a restart in between loses the in-memory list — accepted
-# residual, named in the design doc).
+# surface carries continue_later (picks the framing variant), "cleared_ids"
+# the continuation entries the framing enumerated — cleared only at claim
+# time, so the clear commits iff the enumerating message did (fate-shared by
+# construction). Turns serialize per thread (THREAD_QUEUE), so each key has a
+# single writer. Created at turn start; a RESUMED slice reuses the live entry
+# so claims made before a pause keep coverage (a restart in between loses the
+# in-memory sets — accepted residuals, named in the design doc: a later error
+# can't re-journal pre-restart claims, and enumerated-but-uncleared
+# continuations still run — redundant work, never lost work).
 _TURN_INTERJECTION: dict[str, dict] = {}
 
 
@@ -1200,37 +1217,59 @@ def _consume_interjections(tid: str, ids: set) -> None:
     """The interjection claim: remove each id from the journal (the entry-gone
     gate then makes the queued fallback dispatcher skip it — exactly-once) and
     remember the record in the turn-scoped context for the fate-sharing
-    re-journal. Called from the middleware's next-boundary claim and from the
-    terminal sweep below; idempotent (a claimed id is simply no longer found)."""
-    ctx = _TURN_INTERJECTION.setdefault(tid, {"claimed": [], "defer": False})
+    re-journal. A successful claim also drains the framing's continuation
+    snapshot ("cleared_ids"): the clear is deferred to HERE so it commits iff
+    the enumerating message reached the durable checkpoint — a turn that dies
+    pre-checkpoint leaves the scheduled follow-ups intact (they were promised
+    "cleared" only in a message that never durably existed). Clearing by
+    snapshotted id, not clear-all, is what lets a continue_later the model
+    issues in RESPONSE (a fresh id, journaled before this claim) survive.
+    Called from the middleware's next-boundary claim and from the terminal
+    sweep below; idempotent (a claimed id is simply no longer found)."""
+    ctx = _TURN_INTERJECTION.setdefault(
+        tid, {"claimed": [], "defer": False, "cleared_ids": set()})
+    claimed_any = False
     for rec in MESSAGE_BACKLOG.for_thread(tid):
         if rec.id in ids:
             MESSAGE_BACKLOG.claim(tid, rec.id)
             ctx["claimed"].append(rec)
+            claimed_any = True
+    if claimed_any and ctx.get("cleared_ids"):
+        snapshot = ctx["cleared_ids"]
+        ctx["cleared_ids"] = set()
+        for rec in MESSAGE_BACKLOG.for_thread(tid):
+            if rec.id in snapshot and rec.origin == "continuation":
+                MESSAGE_BACKLOG.claim(tid, rec.id)
+                append_event(MANAGER.thread_dir(tid),
+                             "continuation_cancelled", id=rec.id,
+                             reason="superseded by a mid-turn user message")
 
 
 def _frame_interjection(rec: "PendingMessage") -> str:
     """Build the injected message: frame + the user's text + the behavioral
     guidance. An OWNER interjection supersedes the agent's queued plan
-    (redirect bias — this IS the cancel-the-background-work mechanism): pending
-    continuations are cleared HERE, at injection time, not at claim time — a
-    continue_later the model issues in RESPONSE journals after this clear but
-    before the next-boundary claim, so clearing at claim would wipe the model's
-    new plan. The cleared tasks are enumerated verbatim so the model recreates
-    or deliberately drops each, relying on nothing it remembers (Pierre,
-    PR #199 note 3). An interjection that instead runs as a follow-up turn
-    clears the same way at its turn start — consistent either path."""
+    (redirect bias — this IS the cancel-the-background-work mechanism): the
+    framing enumerates the pending continuations verbatim so the model
+    recreates or deliberately drops each, relying on nothing it remembers
+    (Pierre, PR #199 note 3), and SNAPSHOTS their ids for the clear — which
+    runs at claim time (_consume_interjections), fate-shared with this
+    message's durability. Every frame call re-enumerates all still-pending
+    continuations (idempotent snapshot union): coalesced entries repeat the
+    list — benign — and a framing discarded by the hook's best-effort catch
+    costs nothing durable. An interjection that instead runs as a follow-up
+    turn clears via _clears_plan at its turn start — consistent either path."""
     guide = _INTERJECTION_GUIDE
     ctx = _TURN_INTERJECTION.get(rec.thread_id) or {}
     if ctx.get("defer"):
         guide += _INTERJECTION_DEFER
     if rec.sender is None:
-        cleared = [r.text for r in MESSAGE_BACKLOG.for_thread(rec.thread_id)
+        pending = [r for r in MESSAGE_BACKLOG.for_thread(rec.thread_id)
                    if r.origin == "continuation"]
-        if cleared:
-            _clear_pending_continuations(rec.thread_id)
+        if pending:
+            ctx.setdefault("cleared_ids", set()).update(r.id for r in pending)
             guide += (" This message also cleared your scheduled follow-ups: "
-                      + " ".join(f"{i}. {t}" for i, t in enumerate(cleared, 1))
+                      + " ".join(f"{i}. {r.text}"
+                                 for i, r in enumerate(pending, 1))
                       + (" — recreate any that still matter with "
                          "continue_later, or drop them deliberately."
                          if ctx.get("defer") else
@@ -1246,10 +1285,7 @@ def _claim_seen_interjections(tid: str, chat) -> None:
     the turn's last). Best-effort — a failed read leaves the entry journaled
     and it runs as a follow-up turn (at-least-once presentation, never lost)."""
     try:
-        ids: set = set()
-        for m in chat.get_raw_messages():
-            ids.update((getattr(m, "additional_kwargs", None) or {}).get(
-                "interjection_ids", []))
+        ids = collect_interjection_ids(chat.get_raw_messages())
         if ids:
             _consume_interjections(tid, ids)
     except Exception:
@@ -1261,23 +1297,30 @@ def _claim_seen_interjections(tid: str, chat) -> None:
 def _rejournal_claimed_interjections(tid: str, rider) -> int:
     """Fate-sharing REVERSED (Pierre, PR #199 note 5): a user often interjects
     precisely because the turn looks like it is failing, so an interjection a
-    now-dead turn had claimed must not die with it. Re-add each claimed record
-    (same id, same text — the store preserves ids) and submit it to the serial
-    worker as its own follow-up turn. The framed copy left in the dead turn's
-    context is duplicate EXPOSURE when the follow-up runs — benign, named in
-    the design. Returns how many, so the error text can say so. BEST-EFFORT by
-    contract: runs inside turn error handlers (a raise would mask the original
-    failure and strand the thread busy)."""
+    now-dead turn had claimed must not die with it. Re-journal each claimed
+    record's text under a FRESH id and submit it to the serial worker as its
+    own follow-up turn. Fresh, not same-id: the dead turn's framed copy keeps
+    the old id in the thread checkpoint forever, so any later turn's boundary
+    claim scan would silently re-claim a same-id entry and the follow-up's
+    entry-gone gate would then skip it — the promised retry would never run.
+    A fresh id matches nothing stale: the entry is delivered exactly once, by
+    its dispatcher or by legitimate re-injection into an intervening turn.
+    The dead framed copy itself is duplicate EXPOSURE when the follow-up runs
+    — benign, named in the design. Returns how many, so the error text can
+    say so. BEST-EFFORT by contract: runs inside turn error handlers (a raise
+    would mask the original failure and strand the thread busy)."""
     n = 0
     try:
         claimed = (_TURN_INTERJECTION.pop(tid, None) or {}).get("claimed", [])
         for rec in claimed:
-            MESSAGE_BACKLOG.add(rec)
+            fresh = MESSAGE_BACKLOG.add(PendingMessage(
+                thread_id=rec.thread_id, text=rec.text, sender=rec.sender,
+                rider=rec.rider, enqueued_at=rec.enqueued_at))
             _RESUME_SCHEDULER.submit_message(
-                tid, rec.text,
+                tid, fresh.text,
                 _build_rider(datetime.now(timezone.utc).isoformat(),
                              rider.tz if rider else None),
-                rec.sender, rec.id)
+                fresh.sender, fresh.id)
             n += 1
     except Exception:
         logging.error("interjection re-journal failed for %s (original turn "
@@ -1427,7 +1470,7 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
             # continue_later, so their framing omits the defer option.
             if not resume or tid not in _TURN_INTERJECTION:
                 _TURN_INTERJECTION[tid] = {
-                    "claimed": [],
+                    "claimed": [], "cleared_ids": set(),
                     "defer": sender is None and origin != "continuation"}
             if origin == "continuation" and not resume and resume_decision is None:
                 # A HITL reply awaiting approval: the supersede flow below exists
@@ -1650,8 +1693,7 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
                    "again to retry in a fresh sandbox."
                    + (" A follow-up this turn had scheduled was cancelled."
                       if _cancelled else "")
-                   + (" Your mid-turn message will be retried as its own turn."
-                      if _rejournaled else "")),
+                   + (_REJOURNAL_NOTE if _rejournaled else "")),
             **pending_kwargs,
         )
     except GraphRecursionError as e:
@@ -1669,8 +1711,7 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
                    "into smaller parts."
                    + (" A follow-up this turn had scheduled was cancelled."
                       if _cancelled else "")
-                   + (" Your mid-turn message will be retried as its own turn."
-                      if _rejournaled else "")),
+                   + (_REJOURNAL_NOTE if _rejournaled else "")),
             **pending_kwargs,
         )
     except Exception as e:
@@ -1686,8 +1727,7 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
             _set_status(tid, "error",
                         error=("The background follow-up I promised couldn't be "
                                "completed. Ask me to retry it."
-                               + (" Your mid-turn message will be retried as "
-                                  "its own turn." if _rejournaled else "")),
+                               + (_REJOURNAL_NOTE if _rejournaled else "")),
                         **pending_kwargs)
             append_event(MANAGER.thread_dir(tid), "continuation_failed",
                          id=backlog_id or "", error=str(e)[:300])
@@ -1696,8 +1736,7 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
             _set_status(tid, "error",
                         error=str(e) + (" A follow-up this turn had scheduled "
                                         "was cancelled." if _cancelled else "")
-                        + (" Your mid-turn message will be retried as its own "
-                           "turn." if _rejournaled else ""),
+                        + (_REJOURNAL_NOTE if _rejournaled else ""),
                         **pending_kwargs)
     finally:
         # Drain this turn's persisted active-hold on any TERMINAL exit (success/error)
@@ -2003,8 +2042,9 @@ def _dispatch_event(sender: str, text: str) -> None:
     if stage in BUSY_STAGES or THREAD_QUEUE.peek_holder() == sub.thread_id:
         # A follow-up to a busy thread (busy status, or holding the slot with no
         # busy status written yet) — journal it (runs off-loop here, so a direct
-        # add) so a restart can't drop it; the turn claims the entry when it
-        # starts, exactly like a web follow-up.
+        # add) so a restart can't drop it; its turn claims the entry when it
+        # starts — or a running SAME-sender triage turn consumes it mid-turn
+        # via the interjection middleware — exactly like a web follow-up.
         rec = MESSAGE_BACKLOG.add(PendingMessage(
             thread_id=sub.thread_id, text=rendered, sender=sender,
             enqueued_at=datetime.now(timezone.utc).isoformat()))

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -1497,7 +1497,7 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
                     logging.info("continuation on %s deferred: a reply is awaiting "
                                  "approval", tid)
                     return
-            if backlog_id:
+            if backlog_id and not resume:
                 # Exactly-once gate: the journal entry is the run ticket. A message can
                 # acquire TWO dispatchers — its live-submitted job/task plus a recovery
                 # drain job — and whichever runs second must find the entry gone and
@@ -1507,6 +1507,12 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
                 # backlog_id, but that head turn is delivered by RECOVERY, not by a
                 # backlog_id dispatcher — so gone-entry here always means already
                 # delivered.
+                #
+                # `not resume`: a fair-sched RESUME is not a dispatch — it carries the
+                # ORIGINAL turn's backlog_id only so its terminal events keep their id,
+                # and that entry was rightly claimed at the original turn start. Gating
+                # a resume on it silently swallowed the resume and stranded the thread
+                # paused forever (live thread 2026-07-21; the symptom test pins this).
                 if not any(r.id == backlog_id
                            for r in MESSAGE_BACKLOG.for_thread(tid)):
                     logging.info("follow-up %s on %s not in the journal (already "

--- a/tests/test_interjection.py
+++ b/tests/test_interjection.py
@@ -1,0 +1,327 @@
+"""Mid-turn interjection — the delivery middleware, deferred claim, sender
+scoping, framing, fate-sharing re-journal, and render surfaces
+(docs/2026-07-20-mid-turn-interjection-design.org). LLM-judgment behaviors
+(does the model redirect/defer/stop well) live in edd/eval; everything
+mechanical is pinned here.
+"""
+import contextlib
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from manage import web
+from manage.web import threads
+from manage.web.state import MESSAGE_BACKLOG, _get_status, _set_status
+from assist.backlog import PendingMessage
+from assist.middleware import interjection as ij
+from assist.middleware.interjection import InterjectionMiddleware
+
+
+@pytest.fixture
+def wired(tmp_path, monkeypatch):
+    tid = "t-inter"
+    (tmp_path / tid).mkdir()
+    monkeypatch.setattr(web.MANAGER, "root_dir", str(tmp_path))
+    monkeypatch.setattr(web.MANAGER, "thread_dir", lambda t: str(tmp_path / t))
+    monkeypatch.setattr(MESSAGE_BACKLOG, "_root", str(tmp_path))
+    monkeypatch.setattr(web.MANAGER, "thread_default_working_dir",
+                        lambda t: str(tmp_path / t))
+    monkeypatch.setattr(web.MANAGER, "touch", lambda t: None)
+    monkeypatch.setattr("manage.web.threads._get_sandbox_backend",
+                        lambda t, tz=None: None)
+    monkeypatch.setattr("manage.web.threads._get_domain_manager", lambda t: None)
+    monkeypatch.setattr("manage.web.threads.get_cached_description",
+                        lambda t: "real description")
+    monkeypatch.setattr("manage.web.state.get_cached_description",
+                        lambda t: "real description")
+    monkeypatch.setattr("manage.web.threads.SandboxManager.cleanup", lambda wd: None)
+    threads._TURN_INTERJECTION.pop(tid, None)
+    with contextlib.suppress(Exception):
+        while True:
+            threads._RESUME_SCHEDULER._q.get_nowait()
+    return tid, tmp_path
+
+
+def _hook(monkeypatch, tid, sender=None):
+    """A middleware instance whose active_handle/turn-sender resolve to this
+    test's thread + turn sender (outside a real graph both would be None)."""
+    from types import SimpleNamespace
+    monkeypatch.setattr(ij, "active_handle",
+                        lambda: SimpleNamespace(thread_id=tid))
+    monkeypatch.setattr(ij, "_turn_sender", lambda runtime: sender)
+    return InterjectionMiddleware()
+
+
+def _journal(tid, text, sender=None, origin=None):
+    return MESSAGE_BACKLOG.add(PendingMessage(
+        thread_id=tid, text=text, sender=sender, origin=origin))
+
+
+# --- injection at the boundary ------------------------------------------------
+
+def test_owner_entry_injected_framed_with_claim_id(wired, monkeypatch):
+    tid, _ = wired
+    rec = _journal(tid, "actually only road bikes")
+    out = _hook(monkeypatch, tid).before_model({"messages": []}, None)
+    (m,) = out["messages"]
+    assert isinstance(m, HumanMessage)
+    assert m.content.startswith(threads._INTERJECTION_FRAME + "actually only road bikes")
+    assert threads._INTERJECTION_GUIDE in m.content
+    assert m.additional_kwargs["interjection_ids"] == [rec.id]
+    # injection does NOT claim — the entry is only in memory until checkpointed
+    assert [r.id for r in MESSAGE_BACKLOG.for_thread(tid)] == [rec.id]
+
+
+def test_coalesce_all_pending_at_one_boundary(wired, monkeypatch):
+    tid, _ = wired
+    a, b = _journal(tid, "first"), _journal(tid, "second")
+    out = _hook(monkeypatch, tid).before_model({"messages": []}, None)
+    ids = [m.additional_kwargs["interjection_ids"][0] for m in out["messages"]]
+    assert ids == [a.id, b.id]
+
+
+def test_sender_scoping_matrix(wired, monkeypatch):
+    """Inject iff entry.sender == turn.sender — the whole security posture."""
+    tid, _ = wired
+    _journal(tid, "sms text", sender="+15550001111")
+    _journal(tid, "cont task", origin="continuation")
+    # owner turn: the SMS entry and the continuation entry both stay out
+    assert _hook(monkeypatch, tid).before_model({"messages": []}, None) is None
+    # matching triage turn: the SMS entry injects
+    out = _hook(monkeypatch, tid, sender="+15550001111").before_model(
+        {"messages": []}, None)
+    assert len(out["messages"]) == 1
+    assert "sms text" in out["messages"][0].content
+    # mismatched triage turn: nothing
+    assert _hook(monkeypatch, tid, sender="+15559999999").before_model(
+        {"messages": []}, None) is None
+
+
+def test_next_boundary_claims_checkpointed_ids(wired, monkeypatch):
+    tid, _ = wired
+    rec = _journal(tid, "steer me")
+    threads._TURN_INTERJECTION[tid] = {"claimed": [], "defer": True}
+    in_state = HumanMessage(content="framed", additional_kwargs={
+        "interjection_ids": [rec.id]})
+    out = _hook(monkeypatch, tid).before_model({"messages": [in_state]}, None)
+    assert out is None                       # claimed, not re-injected
+    assert MESSAGE_BACKLOG.for_thread(tid) == []
+    assert [r.id for r in threads._TURN_INTERJECTION[tid]["claimed"]] == [rec.id]
+
+
+def test_inert_without_callbacks_and_safe_on_error(wired, monkeypatch):
+    tid, _ = wired
+    _journal(tid, "pending")
+    mw = _hook(monkeypatch, tid)
+    monkeypatch.setattr(ij, "_CALLBACKS", None)
+    assert mw.before_model({"messages": []}, None) is None
+    # a raising callback must never fail the turn — best-effort per boundary
+    monkeypatch.setattr(ij, "_CALLBACKS", {
+        "peek": lambda t: (_ for _ in ()).throw(RuntimeError("disk")),
+        "consume": lambda t, i: None, "frame": lambda r: ""})
+    assert mw.before_model({"messages": []}, None) is None
+
+
+# --- framing variants ---------------------------------------------------------
+
+def test_defer_variant_follows_tool_surface(wired):
+    tid, _ = wired
+    rec = _journal(tid, "also check tires")
+    threads._TURN_INTERJECTION[tid] = {"claimed": [], "defer": True}
+    assert "continue_later" in threads._frame_interjection(rec)
+    threads._TURN_INTERJECTION[tid] = {"claimed": [], "defer": False}
+    assert "continue_later" not in threads._frame_interjection(rec)
+
+
+def test_owner_interjection_clears_and_enumerates_continuations(wired):
+    """Pierre PR #199 note 3: cleared tasks are enumerated verbatim, and the
+    clear happens at INJECTION time so a continue_later issued in response
+    (journaled before the next-boundary claim) survives."""
+    tid, _ = wired
+    _journal(tid, "find tire sizes", origin="continuation")
+    _journal(tid, "check tubeless", origin="continuation")
+    rec = _journal(tid, "stop all that")
+    threads._TURN_INTERJECTION[tid] = {"claimed": [], "defer": True}
+    frame = threads._frame_interjection(rec)
+    assert "1. find tire sizes" in frame and "2. check tubeless" in frame
+    assert [r.origin for r in MESSAGE_BACKLOG.for_thread(tid)] == [None]
+    # an SMS interjection must NOT clear the owner's plan (spoofable sender)
+    _journal(tid, "again", origin="continuation")
+    sms = _journal(tid, "sms steer", sender="+15550001111")
+    threads._frame_interjection(sms)
+    assert any(r.origin == "continuation" for r in MESSAGE_BACKLOG.for_thread(tid))
+
+
+# --- terminal sweep + fate-sharing --------------------------------------------
+
+def test_terminal_sweep_claims_ids_left_in_checkpoint(wired):
+    tid, _ = wired
+    rec = _journal(tid, "late steer")
+
+    class _Chat:
+        def get_raw_messages(self):
+            return [AIMessage(content="working"),
+                    HumanMessage(content="framed", additional_kwargs={
+                        "interjection_ids": [rec.id]})]
+    threads._claim_seen_interjections(tid, _Chat())
+    assert MESSAGE_BACKLOG.for_thread(tid) == []
+
+
+def test_error_exit_rejournals_claimed_interjections(wired, monkeypatch):
+    """Fate-sharing REVERSED (Pierre PR #199 note 5): a claimed interjection
+    survives a terminal turn error — re-journaled same-id and re-submitted."""
+    tid, _ = wired
+    rec = PendingMessage(thread_id=tid, text="the rescue steer")
+    threads._TURN_INTERJECTION[tid] = {"claimed": [rec], "defer": True}
+    submitted = []
+    monkeypatch.setattr(threads._RESUME_SCHEDULER, "submit_message",
+                        lambda *a, **k: submitted.append(a))
+    n = threads._rejournal_claimed_interjections(tid, None)
+    assert n == 1
+    assert [r.id for r in MESSAGE_BACKLOG.for_thread(tid)] == [rec.id]
+    assert submitted[0][0] == tid and submitted[0][1] == "the rescue steer"
+    assert tid not in threads._TURN_INTERJECTION      # coverage ended with the pop
+    # best-effort: idempotent-empty second call, and never raises
+    assert threads._rejournal_claimed_interjections(tid, None) == 0
+
+
+def test_failed_turn_surfaces_rejournal_in_error_text(wired, monkeypatch):
+    tid, _ = wired
+    rec = _journal(tid, "steer the failing turn")
+
+    class _Boom:
+        def pending_reply(self):
+            return None
+
+        def message(self, text):
+            # the running turn consumed the interjection, then died
+            threads._consume_interjections(tid, {rec.id})
+            raise RuntimeError("model exploded")
+    monkeypatch.setattr(web.MANAGER, "get",
+                        lambda t, sandbox_backend=None, **k: _Boom())
+    submitted = []
+    monkeypatch.setattr(threads._RESUME_SCHEDULER, "submit_message",
+                        lambda *a, **k: submitted.append(a))
+    threads._process_message(tid, "original ask")
+    st = _get_status(tid)
+    assert st["stage"] == "error"
+    assert "mid-turn message will be retried" in st["error"]
+    assert [r.id for r in MESSAGE_BACKLOG.for_thread(tid)] == [rec.id]
+    assert submitted and submitted[0][1] == "steer the failing turn"
+
+
+def test_successful_turn_ends_fate_sharing(wired, monkeypatch):
+    """Once the answer is committed, a claimed interjection was ANSWERED — a
+    later bookkeeping error must not re-journal it (no duplicate delivery)."""
+    tid, _ = wired
+    rec = _journal(tid, "answered steer")
+
+    class _Chat:
+        def pending_reply(self):
+            return None
+
+        def message(self, text):
+            threads._consume_interjections(tid, {rec.id})
+            return "done, redirected"
+
+        def get_messages(self):
+            return []
+
+        def get_raw_messages(self):
+            return []
+    monkeypatch.setattr(web.MANAGER, "get",
+                        lambda t, sandbox_backend=None, **k: _Chat())
+    threads._process_message(tid, "original ask")
+    assert _get_status(tid)["stage"] == "ready"
+    assert MESSAGE_BACKLOG.for_thread(tid) == []
+    assert tid not in threads._TURN_INTERJECTION
+
+
+# --- claim invariant (Pierre PR #199 note 2) ----------------------------------
+
+def test_interjection_ids_survive_checkpoint_serde():
+    """The journal id must be recoverable from the durable checkpoint at every
+    claim site — pin the serializer layer (verified empirically against a real
+    SqliteSaver at design time; this makes it permanent)."""
+    from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+    serde = JsonPlusSerializer()
+    m = HumanMessage(content=threads._INTERJECTION_FRAME + "steer",
+                     additional_kwargs={"interjection_ids": ["abc123"]})
+    back = serde.loads_typed(serde.dumps_typed(m))
+    assert back.additional_kwargs["interjection_ids"] == ["abc123"]
+
+
+def test_history_editing_middleware_preserves_human_kwargs():
+    """The one history-editing middleware in the stack only rewrites the last
+    AIMessage's tool calls — an injected HumanMessage's claim ids pass through
+    untouched (the non-mutating-history assumption the middleware pins)."""
+    from assist.middleware.tool_name_sanitization import (
+        ToolNameSanitizationMiddleware)
+    human = HumanMessage(content="framed", id="human-1", additional_kwargs={
+        "interjection_ids": ["abc123"]})
+    bad_ai = AIMessage(content="", tool_calls=[
+        {"name": "no spaces allowed!", "args": {}, "id": "c1"}])
+    out = ToolNameSanitizationMiddleware().after_model(
+        {"messages": [human, bad_ai]}, None)
+    assert human.additional_kwargs["interjection_ids"] == ["abc123"]
+    # the returned edit rewrites only the AI message, never the human one
+    assert all(m.id != "human-1" for m in (out or {}).get("messages", []))
+
+
+# --- render surfaces + neutralization ----------------------------------------
+
+def test_queued_interjection_renders_as_queued_bubble(wired, monkeypatch):
+    from fastapi.testclient import TestClient
+    tid, _ = wired
+    monkeypatch.setattr(
+        web.MANAGER, "get", lambda t, sandbox_backend=None, **k:
+        type("C", (), {"get_messages": lambda s: [],
+                       "pending_reply": lambda s: None})())
+    _set_status(tid, "processing", pending_message="original ask")
+    _journal(tid, "actually only road bikes")
+    html_out = TestClient(web.app).get(f"/thread/{tid}").text
+    assert "actually only road bikes" in html_out
+    assert ">queued</span>" in html_out
+
+
+def test_consumed_interjection_renders_stripped_with_seen_badge(wired, monkeypatch):
+    from fastapi.testclient import TestClient
+    tid, _ = wired
+    F, G = threads._INTERJECTION_FRAME, threads._INTERJECTION_GUIDE
+    persisted = F + "skip the research" + G + threads._INTERJECTION_DEFER + ")"
+    monkeypatch.setattr(
+        web.MANAGER, "get", lambda t, sandbox_backend=None, **k:
+        type("C", (), {"get_messages": lambda s: [
+            {"role": "user", "content": "original ask"},
+            {"role": "user", "content": persisted},
+            {"role": "assistant", "content": "redirected answer"}],
+            "pending_reply": lambda s: None})())
+    _set_status(tid, "ready")
+    html_out = TestClient(web.app).get(f"/thread/{tid}").text
+    assert "skip the research" in html_out
+    assert "seen mid-turn" in html_out
+    assert "latest word wins" not in html_out    # guidance never renders
+
+
+def test_user_text_starting_with_frame_is_neutralized(wired, monkeypatch):
+    tid, _ = wired
+    seen = []
+
+    class _Chat:
+        def pending_reply(self):
+            return None
+
+        def message(self, text):
+            seen.append(text)
+            return "ok"
+
+        def get_messages(self):
+            return []
+
+        def get_raw_messages(self):
+            return []
+    monkeypatch.setattr(web.MANAGER, "get",
+                        lambda t, sandbox_backend=None, **k: _Chat())
+    raw = threads._INTERJECTION_FRAME + "pasted text"
+    threads._process_message(tid, raw)
+    assert seen == [" " + raw]

--- a/tests/test_interjection.py
+++ b/tests/test_interjection.py
@@ -81,7 +81,8 @@ def test_coalesce_all_pending_at_one_boundary(wired, monkeypatch):
 
 
 def test_sender_scoping_matrix(wired, monkeypatch):
-    """Inject iff entry.sender == turn.sender — the whole security posture."""
+    """Inject iff entry.origin is None AND entry.sender == turn.sender —
+    origin gates work vs steering; sender equality is the security posture."""
     tid, _ = wired
     _journal(tid, "sms text", sender="+15550001111")
     _journal(tid, "cont task", origin="continuation")

--- a/tests/test_interjection.py
+++ b/tests/test_interjection.py
@@ -148,8 +148,8 @@ def test_owner_interjection_enumerates_then_clears_at_claim(wired):
     threads._TURN_INTERJECTION[tid] = ctx
     frame = threads._frame_interjection(rec)
     assert "1. find tire sizes" in frame and "2. check tubeless" in frame
-    # framing alone clears NOTHING (a turn dying pre-checkpoint must leave
-    # the promised follow-ups intact)
+    # framing only snapshots ids — it removes nothing from the journal (a
+    # turn dying pre-checkpoint must leave the promised follow-ups intact)
     assert ctx["cleared_ids"] == {c1.id, c2.id}
     assert sum(1 for r in MESSAGE_BACKLOG.for_thread(tid)
                if r.origin == "continuation") == 2

--- a/tests/test_interjection.py
+++ b/tests/test_interjection.py
@@ -133,23 +133,36 @@ def test_defer_variant_follows_tool_surface(wired):
     assert "continue_later" not in threads._frame_interjection(rec)
 
 
-def test_owner_interjection_clears_and_enumerates_continuations(wired):
-    """Pierre PR #199 note 3: cleared tasks are enumerated verbatim, and the
-    clear happens at INJECTION time so a continue_later issued in response
-    (journaled before the next-boundary claim) survives."""
+def test_owner_interjection_enumerates_then_clears_at_claim(wired):
+    """Pierre PR #199 note 3: pending tasks are enumerated verbatim in the
+    framing, which SNAPSHOTS their ids; the clear runs at claim time against
+    the snapshot — fate-shared with the message's durability — and a
+    continue_later issued in response (a fresh id, journaled before the
+    claim) survives the drain."""
     tid, _ = wired
-    _journal(tid, "find tire sizes", origin="continuation")
-    _journal(tid, "check tubeless", origin="continuation")
+    c1 = _journal(tid, "find tire sizes", origin="continuation")
+    c2 = _journal(tid, "check tubeless", origin="continuation")
     rec = _journal(tid, "stop all that")
-    threads._TURN_INTERJECTION[tid] = {"claimed": [], "defer": True}
+    ctx = {"claimed": [], "defer": True, "cleared_ids": set()}
+    threads._TURN_INTERJECTION[tid] = ctx
     frame = threads._frame_interjection(rec)
     assert "1. find tire sizes" in frame and "2. check tubeless" in frame
-    assert [r.origin for r in MESSAGE_BACKLOG.for_thread(tid)] == [None]
-    # an SMS interjection must NOT clear the owner's plan (spoofable sender)
-    _journal(tid, "again", origin="continuation")
+    # framing alone clears NOTHING (a turn dying pre-checkpoint must leave
+    # the promised follow-ups intact)
+    assert ctx["cleared_ids"] == {c1.id, c2.id}
+    assert sum(1 for r in MESSAGE_BACKLOG.for_thread(tid)
+               if r.origin == "continuation") == 2
+    # the model responds with a NEW continue_later before the claim...
+    c3 = _journal(tid, "compare brands instead", origin="continuation")
+    # ...then the claim drains only the snapshot: c1/c2 gone, c3 survives
+    threads._consume_interjections(tid, {rec.id})
+    left = [r.id for r in MESSAGE_BACKLOG.for_thread(tid)
+            if r.origin == "continuation"]
+    assert left == [c3.id]
+    # an SMS interjection must NOT snapshot the owner's plan (spoofable sender)
     sms = _journal(tid, "sms steer", sender="+15550001111")
     threads._frame_interjection(sms)
-    assert any(r.origin == "continuation" for r in MESSAGE_BACKLOG.for_thread(tid))
+    assert ctx["cleared_ids"] == set()
 
 
 # --- terminal sweep + fate-sharing --------------------------------------------
@@ -169,7 +182,9 @@ def test_terminal_sweep_claims_ids_left_in_checkpoint(wired):
 
 def test_error_exit_rejournals_claimed_interjections(wired, monkeypatch):
     """Fate-sharing REVERSED (Pierre PR #199 note 5): a claimed interjection
-    survives a terminal turn error — re-journaled same-id and re-submitted."""
+    survives a terminal turn error — re-journaled under a FRESH id (a same-id
+    entry would be silently re-claimed by a later turn's boundary scan of the
+    dead framed copy, and the follow-up's entry-gone gate would skip it)."""
     tid, _ = wired
     rec = PendingMessage(thread_id=tid, text="the rescue steer")
     threads._TURN_INTERJECTION[tid] = {"claimed": [rec], "defer": True}
@@ -178,8 +193,10 @@ def test_error_exit_rejournals_claimed_interjections(wired, monkeypatch):
                         lambda *a, **k: submitted.append(a))
     n = threads._rejournal_claimed_interjections(tid, None)
     assert n == 1
-    assert [r.id for r in MESSAGE_BACKLOG.for_thread(tid)] == [rec.id]
+    (entry,) = MESSAGE_BACKLOG.for_thread(tid)
+    assert entry.text == "the rescue steer" and entry.id != rec.id
     assert submitted[0][0] == tid and submitted[0][1] == "the rescue steer"
+    assert submitted[0][4] == entry.id        # dispatched under the fresh id
     assert tid not in threads._TURN_INTERJECTION      # coverage ended with the pop
     # best-effort: idempotent-empty second call, and never raises
     assert threads._rejournal_claimed_interjections(tid, None) == 0
@@ -205,8 +222,9 @@ def test_failed_turn_surfaces_rejournal_in_error_text(wired, monkeypatch):
     threads._process_message(tid, "original ask")
     st = _get_status(tid)
     assert st["stage"] == "error"
-    assert "mid-turn message will be retried" in st["error"]
-    assert [r.id for r in MESSAGE_BACKLOG.for_thread(tid)] == [rec.id]
+    assert threads._REJOURNAL_NOTE.strip() in st["error"]
+    (entry,) = MESSAGE_BACKLOG.for_thread(tid)
+    assert entry.text == "steer the failing turn" and entry.id != rec.id
     assert submitted and submitted[0][1] == "steer the failing turn"
 
 
@@ -252,20 +270,28 @@ def test_interjection_ids_survive_checkpoint_serde():
 
 
 def test_history_editing_middleware_preserves_human_kwargs():
-    """The one history-editing middleware in the stack only rewrites the last
-    AIMessage's tool calls — an injected HumanMessage's claim ids pass through
-    untouched (the non-mutating-history assumption the middleware pins)."""
+    """The history-editing middleware in the stack (tool_name_sanitization)
+    has two hooks: after_model rewrites only the last AIMessage, and
+    before_model rebuilds the WHOLE message list — both must pass an injected
+    HumanMessage's claim ids through untouched (the non-mutating-history
+    assumption the interjection middleware pins)."""
     from assist.middleware.tool_name_sanitization import (
         ToolNameSanitizationMiddleware)
+    mw = ToolNameSanitizationMiddleware()
     human = HumanMessage(content="framed", id="human-1", additional_kwargs={
         "interjection_ids": ["abc123"]})
-    bad_ai = AIMessage(content="", tool_calls=[
+    bad_ai = AIMessage(content="", id="ai-1", tool_calls=[
         {"name": "no spaces allowed!", "args": {}, "id": "c1"}])
-    out = ToolNameSanitizationMiddleware().after_model(
-        {"messages": [human, bad_ai]}, None)
+    out = mw.after_model({"messages": [human, bad_ai]}, None)
     assert human.additional_kwargs["interjection_ids"] == ["abc123"]
     # the returned edit rewrites only the AI message, never the human one
     assert all(m.id != "human-1" for m in (out or {}).get("messages", []))
+    # before_model: a historical bad tool call forces the full-history
+    # rewrite; the human message must come through with its kwargs intact
+    out2 = mw.before_model({"messages": [bad_ai, human]}, None)
+    if out2:                       # a rewrite happened — find the human copy
+        kept = [m for m in out2["messages"] if getattr(m, "id", None) == "human-1"]
+        assert kept and kept[0].additional_kwargs["interjection_ids"] == ["abc123"]
 
 
 # --- render surfaces + neutralization ----------------------------------------
@@ -301,6 +327,27 @@ def test_consumed_interjection_renders_stripped_with_seen_badge(wired, monkeypat
     assert "skip the research" in html_out
     assert "seen mid-turn" in html_out
     assert "latest word wins" not in html_out    # guidance never renders
+
+
+def test_seen_interjection_suppresses_its_queued_bubble(wired, monkeypatch):
+    """Injection is checkpointed a full superstep before the claim removes the
+    journal entry — in that window the same text must not render twice with
+    contradicting badges (seen wins over queued)."""
+    from fastapi.testclient import TestClient
+    tid, _ = wired
+    persisted = (threads._INTERJECTION_FRAME + "skip the research"
+                 + threads._INTERJECTION_GUIDE + ")")
+    monkeypatch.setattr(
+        web.MANAGER, "get", lambda t, sandbox_backend=None, **k:
+        type("C", (), {"get_messages": lambda s: [
+            {"role": "user", "content": "original ask"},
+            {"role": "user", "content": persisted}],
+            "pending_reply": lambda s: None})())
+    _set_status(tid, "processing", pending_message="original ask")
+    _journal(tid, "skip the research")     # not yet claimed
+    html_out = TestClient(web.app).get(f"/thread/{tid}").text
+    assert "seen mid-turn" in html_out
+    assert ">queued</span>" not in html_out
 
 
 def test_user_text_starting_with_frame_is_neutralized(wired, monkeypatch):

--- a/tests/test_progressive_responses.py
+++ b/tests/test_progressive_responses.py
@@ -394,3 +394,41 @@ def test_resume_of_journal_dispatched_turn_passes_the_gate(wired, monkeypatch):
                              origin="continuation", backlog_id="claimed-long-ago")
     assert ("resume",) in calls, "the resume was swallowed by the entry-gone gate"
     assert _get_status(tid)["stage"] == "ready"
+
+
+def test_waiting_resume_keeps_paused_status(wired, monkeypatch):
+    """Same seam as the gate fix, un-mocked: a RESUME waiting behind another
+    thread's turn must NOT overwrite its `paused` status with "queued" — the
+    paused record is the resume's durable home, and follow-up routing keys on
+    it (a "queued" stage misroutes a follow-up off the serial scheduler and
+    onto the mid-flight checkpoint)."""
+    import threading as _threading
+    import time as _time
+    from assist.thread_queue import THREAD_QUEUE
+    tid, _ = wired
+    calls = []
+    _wire_chat(monkeypatch, tid, calls)
+    _set_status(tid, "paused", accumulated_active_ms=1234.0,
+                pending_message="mid-flight message")
+    release = _threading.Event()
+    held = _threading.Event()
+
+    def _holder():
+        with THREAD_QUEUE.acquire("t-other-holder"):
+            held.set()
+            release.wait(timeout=10)
+    h = _threading.Thread(target=_holder, daemon=True)
+    h.start()
+    assert held.wait(timeout=5)
+    w = _threading.Thread(target=threads._process_message,
+                          args=(tid, None), kwargs={"resume": True}, daemon=True)
+    w.start()
+    deadline = _time.time() + 2.0
+    while _time.time() < deadline:      # the whole wait window: never "queued"
+        assert _get_status(tid)["stage"] == "paused"
+        _time.sleep(0.05)
+    release.set()
+    w.join(timeout=10)
+    h.join(timeout=10)
+    assert ("resume",) in calls
+    assert _get_status(tid)["stage"] == "ready"

--- a/tests/test_progressive_responses.py
+++ b/tests/test_progressive_responses.py
@@ -373,3 +373,24 @@ def test_user_message_with_marker_prefix_is_neutralized(wired, monkeypatch):
     R = threads._CONTINUATION_RIDER
     threads._process_message(tid, R + "just quoting you", origin=None)
     assert calls == [("message", " " + R + "just quoting you")]
+
+
+def test_resume_of_journal_dispatched_turn_passes_the_gate(wired, monkeypatch):
+    """THE SYMPTOM of the 2026-07-21 stuck-paused thread: a fair-sched resume
+    carries the original turn's backlog_id (for event-id fidelity), whose
+    journal entry was claimed at the ORIGINAL turn start — the exactly-once
+    gate must not treat the gone entry as "already delivered" and silently
+    swallow the resume, stranding the thread paused forever. A resume is not
+    a dispatch: its ticket was already consumed; the gate applies only to
+    fresh backlog_id dispatches."""
+    tid, _ = wired
+    calls = []
+    _wire_chat(monkeypatch, tid, calls)
+    # the journal entry is GONE (claimed by the original turn start)
+    assert MESSAGE_BACKLOG.for_thread(tid) == []
+    _set_status(tid, "paused", origin="continuation",
+                pending_message="[Continuing my earlier work — background follow-up] x")
+    threads._process_message(tid, None, resume=True,
+                             origin="continuation", backlog_id="claimed-long-ago")
+    assert ("resume",) in calls, "the resume was swallowed by the entry-gone gate"
+    assert _get_status(tid)["stage"] == "ready"


### PR DESCRIPTION
Feature 2 of the natural-turn-interaction PRDs — **now implemented** (this PR started design-only; your six review notes are folded into the doc's "Decisions" section and the implementation follows it).

## What ships
A message sent during a running turn is **seen at the next model-call boundary**: `InterjectionMiddleware` (`before_model` only, main agent only — subagents structurally excluded) peeks the durable journal and injects unconsumed entries as individually framed messages; the model chooses redirect / incorporate / defer / stop in its own voice (outcomes are descriptive, never an interface — decision 1). Claim is deferred until the injected copy is provably checkpointed (`additional_kwargs` ids; the claim invariant is explicit and test-pinned — decision 2); the shipped entry-gone gate keeps everything exactly-once. An entry the turn never consumes runs as today's follow-up turn — nothing can be lost.

- **Scoping**: inject iff `entry.origin is None` and `entry.sender == turn sender` — an SMS entry can never enter an owner turn; owner messages steer scheduled/continuation turns too.
- **Defer = `continue_later`** (decision 4): journaled, chain-capped, visible as "↻ will follow up".
- **Redirect bias**: an owner interjection's framing enumerates the pending continuations verbatim (decision 3) and snapshots their ids; the actual clear runs at claim time against the snapshot — fate-shared with the message's durability, and a `continue_later` the model issues in response survives.
- **Fate-sharing reversed** (decision 5): terminal error exits re-journal claimed interjections and resubmit them as follow-up turns. **One amendment from local review**: re-journal under a *fresh id*, not same-id — the dead turn's framed copy keeps the old id in the checkpoint forever, so a same-id entry would be silently re-claimed by any later turn's boundary scan and the promised retry would never run.
- **Visibility** (the design blocker): queued user bubbles from the journal peek; a consumed interjection renders stripped with a "seen mid-turn" badge; seen suppresses queued (they overlap for a full superstep).
- **Web "stop" into a triage turn** surfaces as the HITL-gated draft (decision 6).

## Verification
- **Unit**: 17 new tests (injection/coalesce/sender+origin matrix, deferred-claim invariant incl. serde round-trip + history-rewrite preservation, enumerate-then-clear-at-claim, fresh-id re-journal + error-text surfacing, render + neutralization + double-render suppression). Full suite 1167 green.
- **Evals** (`edd/eval/test_interjection.py`, mid-turn arrival via a boundary gate): redirect / incorporate / stop / coalesce / defer — **25/25 across 5 trials**.
- **Local review**: 4-lens round 1 (1 blocker + 3 important, all fixed: fresh-id re-journal, clear-at-claim snapshot, double-render suppression, fail-closed sender read) + round 2 clean.
- Deployed and smoke-tested; live for your testing now.

## Known limitations (named in the doc)
Steering lands at main-loop boundaries — the worst case is a full synchronous subagent run (the PRD's "skip the research" case); escalation pre-named, on eval evidence only. Restart residuals: pre-restart claims lose fate-sharing coverage; enumerated-but-uncleared continuations still run (redundant work, never lost work).

## Still open (your call, non-blocking)
PR #196's remaining scope — this ships the queued-bubble slice on the durable journal; close #196 as superseded or rebase what's left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
