### PR TITLE
Remove the auto-added general-purpose subagent

### DIFF
--- a/assist/agent.py
+++ b/assist/agent.py
@@ -2,7 +2,9 @@ import os
 import uuid
 import logging
 
-from deepagents import create_deep_agent, CompiledSubAgent
+from deepagents import (create_deep_agent, CompiledSubAgent,
+                        GeneralPurposeSubagentProfile, HarnessProfile,
+                        register_harness_profile)
 from deepagents.backends.protocol import BackendProtocol
 from langchain.messages import AIMessage, AnyMessage, HumanMessage
 from langchain_core.runnables import RunnableLambda
@@ -44,6 +46,22 @@ from assist.env import env_int
 
 
 logger = logging.getLogger(__name__)
+
+# No auto-added `general-purpose` subagent, anywhere assist builds a deep
+# agent. Evidence (prod logs, 2026-07-21): every observed general-purpose
+# dispatch was misrouted work belonging to a NAMED agent — context-agent
+# exploration, critique-agent report reviews, and "fact-check" requests that
+# GP cannot actually perform (it inherits the orchestrator's tools, which
+# deliberately carry no read_url/search — so a GP "fact-check" pattern-matches
+# plausibility while LOOKING like verification). Removing the target is the
+# repo's structural-lever pattern (don't register what shouldn't be invoked):
+# a habitual task(general-purpose) call now gets the corrective error listing
+# the real agents, which the model observably follows. Registered
+# provider-wide ("openai" is every assist model's provider) so the main
+# graph, the research pipeline, and the eval harness all agree.
+register_harness_profile("openai", HarnessProfile(
+    general_purpose_subagent=GeneralPurposeSubagentProfile(enabled=False)))
+
 
 def _has_domain_skills(backend: BackendProtocol) -> bool:
     """True iff the domain repo defines skills at ``/.claude/skills/``.

--- a/assist/spec.py
+++ b/assist/spec.py
@@ -48,8 +48,10 @@ class AgentSpec:
 
     # ADDITIVE to assist's built-in tool surface (filesystem, execute,
     # task, ...) — () means "no extra tools", not "no tools".  Reaches
-    # the main agent and the auto-injected general-purpose subagent;
-    # the bespoke context/research/critique subagents do not see these
+    # the MAIN agent only (deepagents' auto-injected general-purpose
+    # subagent — which used to inherit these — is disabled harness-wide;
+    # see the profile registration in ``assist.agent``); the bespoke
+    # context/research/critique subagents do not see these
     # (see ``create_agent``).
     tools: tuple[BaseTool | Callable | dict[str, Any], ...] = ()
 

--- a/docs/2026-06-11-embedder-contract.org
+++ b/docs/2026-06-11-embedder-contract.org
@@ -138,7 +138,11 @@ asymmetry dies with the adapter at the legacy-kwarg removal step.
   one-field change the day a client actually deviates.  When it comes
   back, settle: naming (spec names vs the registered
   =*-agent= names), the empty-set semantics against deepagents'
-  auto-injected general-purpose subagent + =task= tool, and prompt
+  auto-injected general-purpose subagent + =task= tool (update
+  2026-07-21: the auto-injected general-purpose subagent is now
+  DISABLED harness-wide — see the profile registration in
+  =assist/agent.py= — so only the =task= tool half of that question
+  remains), and prompt
   sections that advertise subagents (=general_instructions.md.j2=
   references the research workflow — a gated subagent set must gate
   the prompt too).  Container should be =tuple[str, ...]= (ordered,


### PR DESCRIPTION
Per Pierre's fork ("remove GP altogether vs give it subagents") + the eval-gated experiment he requested.

**Evidence** (prod logs): every observed `general-purpose` dispatch was misrouted work belonging to a named agent — context-agent exploration, critique-agent report reviews, and "fact-check" requests GP cannot actually perform (it inherits the orchestrator's tools — no `read_url`, no search — so a GP "fact-check" pattern-matches plausibility while *looking* like verification). ~128 GP dispatches vs ~540 context / ~300 critique in recent logs.

**Rejected alternative**: giving GP the context/research subagents would make it a nested orchestrator and reopen the sync-research bypass that the door config exists to close (#198's eval-proven lever).

**Change**: one provider-wide harness-profile registration (`GeneralPurposeSubagentProfile(enabled=False)`). Spy-verified: GP gone from both the main graph (context/research|door/critique unchanged) and the research pipeline (critique/research/fact-check unchanged); the `task` tool remains.

**Experiment**: baseline (main, GP on): 15/15 across `test_context_agent` + `test_progressive_responses`. Branch (GP off), N=3: 44/45 — the one failure re-passed 3/3 isolated (stochastic flake; zero GP dispatches occurred in any trial, so the eval shapes never exercise the habit). 1150 unit tests green.

**Residual, named**: the GP-dispatch habit only shows in real threads (evals never triggered it), so the real gate is live testing — a habitual `task(general-purpose)` in prod now costs one corrective-error boundary before the model re-routes (the T-Mobile trace shows it reads and follows that error).

**Deploy note**: prod currently runs the `interjection-design` branch (#199, unmerged, live-testing). Deploying this branch would replace it — sequencing is your call (merge #199 first, then this rebases trivially).

🤖 Generated with [Claude Code](https://claude.com/claude-code)