### PR TITLE
Website file download: read_url to navigate, curl to download

### DIFF
--- a/assist/agent.py
+++ b/assist/agent.py
@@ -449,6 +449,23 @@ def create_agent(model: BaseChatModel,
             # line (the error/exit summary) is at the TAIL, not the head.
             ToolResultToFileMiddleware(backend, tools={"execute"}, floor_chars=8000,
                                        preview_style="head_tail", untrusted=True),
+            # read_url on the MAIN agent is a NAVIGATION tool: follow a known
+            # URL + the links it surfaces to find a page or downloadable file
+            # (the download itself is curl in the sandbox, egress-gated). It
+            # can't do general research — no search_internet here — so the
+            # delegation split holds: a research question still routes to the
+            # research-agent (which has search). The guards are load-bearing:
+            # UrlProvenanceMiddleware keeps read_url on URLs from the user or a
+            # link a page actually surfaced (same-host), never invented ones —
+            # so it can't flood on fabricated URLs the way raw curl did (thread
+            # …527c2a44). ReadUrlRereadBreaker caps SAME-url re-reads; the
+            # breadth crawl itself is ultimately bounded by the recursion limit,
+            # but read_url's clean extraction + the skill keep navigation to a
+            # few hops. Offload a large page like the research agent does.
+            ToolResultToFileMiddleware(backend, tools={"read_url"}, floor_chars=4000,
+                                       preview_style="head", untrusted=True,
+                                       name="ToolResultToFileMiddleware_read_url"),
+            *_read_url_guards(),
             # Mid-turn interjection delivery (main agent only — deepagents
             # never propagates this list to subagent stacks): inert unless the
             # embedder registered callbacks (the web layer is the only one).
@@ -472,7 +489,8 @@ def create_agent(model: BaseChatModel,
         # built-ins: direct deterministic real-world lookups the main agent answers
         # inline (gated by the travel / render skills), like a calculation — not web
         # research, so not on the research sub-agent.  Skip any a spec supplies (no dup).
-        tools=list(spec.tools) + [t for t in (travel, directions, map_data) if t not in spec.tools],
+        tools=list(spec.tools) + [t for t in (travel, directions, map_data, read_url)
+                                  if t not in spec.tools],
         # HITL gating (e.g. the web spec gates send_reply → approve/edit/reject); None off.
         **({"interrupt_on": spec.interrupt_on} if spec.interrupt_on else {}),
     )
@@ -544,16 +562,19 @@ def create_context_agent(model: BaseChatModel,
 
 
 def _read_url_guards():
-    """The guard pair every read_url-bearing research agent gets, in one place so the
-    two sites can't drift.
+    """The guard pair every read_url-bearing agent gets, in one place so the
+    three call sites can't drift: the research SEARCHER and FACT-CHECKER
+    sub-agents, and the MAIN agent's navigation read_url (added 2026-07-21 for
+    the explore-website flow).
 
     - UrlProvenanceMiddleware: refuse read_url on a URL absent from prior tool/user
-      messages (a fabrication). Wired on the searcher and the fact-checker — the two
-      read_url-bearing sub-agents. The orchestrator has no read_url (V2: it delegates all
-      fetching), so it needs no guard: it can't 404-loop on a guessed URL it can't fetch.
-      See docs/2026-07-08-research-reread-runaway.org.
+      messages (a fabrication), with same-host page links allowed (site
+      navigation). The research ORCHESTRATOR has no read_url (V2: it delegates
+      all fetching to the searcher), so it needs no guard: it can't 404-loop on
+      a guessed URL it can't fetch. See docs/2026-07-08-research-reread-runaway.org.
     - ReadUrlRereadBreaker: refuse re-reading the SAME url past max_reads (the 2026-07-07
-      peptides real-URL re-read shape).
+      peptides real-URL re-read shape) — this is what bounds the crawl-to-death
+      that raw curl has no guard against.
     """
     return [UrlProvenanceMiddleware(), ReadUrlRereadBreaker()]
 

--- a/assist/middleware/tool_result_to_file.py
+++ b/assist/middleware/tool_result_to_file.py
@@ -105,8 +105,15 @@ class ToolResultToFileMiddleware(AgentMiddleware):
 
     def __init__(self, backend, *, tools: frozenset[str] | set[str],
                  floor_chars: int = _DEFAULT_FLOOR_CHARS, preview_style: str = "head",
-                 untrusted: bool = False):
+                 untrusted: bool = False, name: str | None = None):
         super().__init__()
+        # langchain REJECTS duplicate middleware ``.name``s (it raises at agent
+        # construction, not silently drop one), so an agent that wants two
+        # instances (e.g. execute with a head_tail preview AND read_url with a
+        # head preview) must give the second a distinct name — the class name
+        # alone would collide and crash the build.
+        if name is not None:
+            self.name = name
         self.backend = backend
         self._tools = frozenset(tools)
         self._floor = floor_chars

--- a/assist/middleware/url_provenance.py
+++ b/assist/middleware/url_provenance.py
@@ -18,20 +18,35 @@ fabricated URL by writing it into its reasoning, then fetching it — see
 can't name an exfil URL and have a follow-up read of it pass, a read-becomes-write);
 and a ``read_file``/``grep`` of OFFLOADED untrusted content (read_url page, execute
 output), written under /large_tool_results/untrusted- — the SAME content laundered
-through a file. So a URL
-sourced only from fetched-page content, direct or offloaded, cannot be fetched; to
-reach a new page the agent re-searches. A URL sourced no other way — a pure
-fabrication, or one planted in a page — is rejected. This keeps the guard a coarse,
+through a file.
+
+SAME-HOST NAVIGATION (2026-07-21): a URL that literally appeared in fetched-page
+content is fetchable IF its host is already trusted (a user URL or search result was
+on that host). BOTH conditions are required — this is what lets ``read_url`` navigate
+WITHIN a site the user pointed at (the "explore a website, find and download a file"
+flow) without re-searching every next page, while keeping the two attacks the guard
+exists for blocked: (1) a FABRICATED same-host path (the searcher inventing
+``casio.com/products/<model>`` — the dead-URL flood) never appears on any page, so
+the page-content requirement refuses it; (2) a CROSS-HOST jump from page content
+(SSRF to 169.254.169.254 / an internal service, or a secret-bearing exfil URL to
+``evil.example/leak?d=…``) has no matching trusted host, so the same-host requirement
+refuses it — and the attacker can't statically author a link carrying the victim's
+runtime secret anyway. Only *more pages a trusted site actually links to* become
+reachable. A URL that is neither trusted-sourced nor a same-host page link is still
+rejected. This keeps the guard a coarse,
 unambiguous bound (a substring/membership check on trusted text, not a fuzzy "looks
 invented/malicious" heuristic), and it does not end the turn: it returns a corrective
 tool result so the model retries with a real URL. RESIDUAL: a model that FOLLOWS a
 multi-step injection to ``write_file`` an arbitrary URL then ``read_file`` it can
 self-launder — gated by behavioral injection-resistance, not this guard.
 
-Scope: the two ``read_url``-bearing research agents — the SEARCHER and the
-FACT-CHECKER. Each should only ever fetch a URL already trusted in its context: the
+Scope: every ``read_url``-bearing agent — the research SEARCHER and FACT-CHECKER
+sub-agents, and the MAIN agent's navigation ``read_url`` (added 2026-07-21 for the
+explore-website flow, whose trusted channel is the user's URLs plus same-host page
+links). Each should only ever fetch a URL already trusted in its context: the
 searcher's own search results; the fact-checker's cited URLs (which reach it via the
-report ``read_file``/initial message it is handed). The V2 orchestrator holds no
+report ``read_file``/initial message it is handed); the main agent's user-supplied
+URL and pages on that same host. The V2 research orchestrator holds no
 ``read_url`` (it delegates all fetching), so the guard doesn't run there — an earlier
 version guarded it after thread 20260708090812 fabricated URLs under
 search-unavailable and 404-looped ~90 min. Guidance now tells the orchestrator to STOP
@@ -92,6 +107,13 @@ _OFFLOAD_MARK = UNTRUSTED_OFFLOAD_MARK
 # The LOCATION args of read_file/grep (NOT the grep `pattern`, which is a search term):
 # a marker here means the read TARGETS offloaded content.
 _OFFLOAD_PATH_KEYS = ("path", "file_path", "glob")
+
+
+def _host_of(url: str) -> str:
+    try:
+        return (urlsplit(url.strip().rstrip(_TRAILING)).hostname or "").lower()
+    except ValueError:
+        return ""
 
 
 def normalize_url(url: str) -> str:
@@ -190,6 +212,28 @@ def _seen_urls(messages: list) -> dict[str, str]:
     return seen
 
 
+def _page_content_urls(messages: list) -> set[str]:
+    """Normalized URLs that literally appeared in FETCHED-PAGE content — the
+    untrusted read_url channel, direct or offloaded (the INVERSE of the set
+    _seen_urls trusts). These are the links a page actually surfaced; a
+    fabricated path never appears here. Same-host members are navigable (see
+    wrap_tool_call) — that admits following a real link on an already-trusted
+    site while still blocking a fabricated same-host path (the dead-URL flood)
+    and an exfil URL the model invents."""
+    calls_by_id: dict[str, dict] = {}
+    for m in messages:
+        for tc in getattr(m, "tool_calls", None) or []:
+            cid = tc.get("id")
+            if cid:
+                calls_by_id[cid] = tc
+    urls: set[str] = set()
+    for m in messages:
+        if isinstance(m, ToolMessage) and _is_untrusted_result(m, calls_by_id):
+            for raw in _URL_RE.findall(_message_text(m)):
+                urls.add(normalize_url(raw))
+    return urls
+
+
 def _display_url(raw: str) -> str:
     """The captured URL trimmed for the correction message so it's fetchable:
     drop trailing sentence punctuation, plus a trailing closing bracket ONLY when
@@ -259,6 +303,23 @@ class UrlProvenanceMiddleware(AgentMiddleware):
             else getattr(state, "messages", [])
         allowed = _seen_urls(messages)
         if normalize_url(url) in allowed:
+            return handler(request)
+        # Same-host navigation: a link the fetched page ACTUALLY surfaced, on a
+        # host already trusted, is fetchable — this is what lets read_url
+        # navigate WITHIN a site the user pointed at (find a manual, follow
+        # Support → the download). BOTH conditions are load-bearing:
+        #  - in page content (not just host-matched): a fabricated same-host
+        #    path never appeared on any page, so the dead-URL flood the guard
+        #    exists to stop stays blocked — the model can only follow links a
+        #    page really emitted, not invent canonical URLs.
+        #  - same host (not just page-present): a page linking cross-host
+        #    (169.254.169.254, an internal service, evil.example/leak?d=secret)
+        #    has no matching trusted host, so SSRF + secret-bearing exfil stay
+        #    blocked — the jump to a NEW host from page content is refused.
+        nurl = normalize_url(url)
+        host = _host_of(url)
+        if (host and host in {_host_of(u) for u in allowed}
+                and nurl in _page_content_urls(messages)):
             return handler(request)
 
         self._intervention_count += 1

--- a/assist/skills/explore-website/SKILL.md
+++ b/assist/skills/explore-website/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: explore-website
+description: "Explore ONE specific website to find and download a file — a manual, PDF, spec sheet, dataset, image, export. Navigate with read_url, download with curl. EXAMPLES — 'download the user manual PDF from the fellow website'; 'get the CSV linked on this vendor dashboard page'; 'save the spec sheet from acme.com/products/x'. This is NOT general web research (that's the research agent, which searches). MUST load before fetching pages or files from a specific website with read_url or curl."
+---
+
+# Explore a website — read to navigate, curl to download
+
+You have a specific website (or a page URL) and need to find and download one
+or more files from it. The rule is simple: **`read_url` finds; `curl`
+downloads.** Never swap them.
+
+## The failure this skill exists to prevent — read this first
+
+Do **not** hunt for a file by curling page after page of a site's raw HTML.
+Modern sites (Shopify, most storefronts, docs sites) return HTML stuffed with
+dozens of asset URLs — `/cdn/…/assets/*.js`, CSS, fonts, thumbnails. If you
+`curl` a page and start following those looking for your file, you will
+follow link after link, each a dead end, and **never converge**. You will burn
+the step limit and the user gets nothing after a long wait. There is no hope
+down that path — a file is never found by crawling a site's assets.
+
+`read_url` exists precisely to avoid this: it strips the asset noise and hands
+you the page's **real links**. Use it.
+
+## Find the file — with `read_url`
+
+`read_url(url)` returns the page's readable text **plus** a "Links on this
+page:" list of real URLs (absolute). That link list is how you navigate.
+
+1. `read_url` the URL the user gave (or the site homepage).
+2. In the surfaced links, pick the one section that would hold your file —
+   Support, Downloads, Manuals, Resources, or the specific product page.
+   Ignore `/assets/`, `.js`, `.css`, font, and thumbnail links entirely.
+3. `read_url` that page. Repeat until a surfaced link **is** your file — it
+   ends in `.pdf` / `.csv` / `.zip` / `.xlsx` etc., or sits under a downloads
+   / files / CDN-files path.
+4. **Budget: 2–4 `read_url` hops.** read_url is host-side and safe. But if a
+   few hops don't surface the file, **stop** — tell the user you couldn't find
+   it and name the pages you checked. Do not keep hopping.
+
+## Download the file — with `curl`
+
+Once `read_url` gave you the file's real URL, download it in the sandbox:
+
+```
+curl -L -o /workspace/<name> "<file-url>"
+```
+
+`-L` follows redirects, `-o` writes into `/workspace`.
+
+- Downloading uses the sandbox's network, which is allowlisted. If curl gets a
+  **403 from the proxy** ("tunnel"/"proxy" in the error), the host isn't
+  approved: call `request_egress(host, port, task)`, tell the user approval is
+  waiting, and **stop** — do not retry until approved. (Load the `egress`
+  skill for that flow.)
+- **Multiple files:** `read_url` the page once, collect **all** the file URLs
+  from its surfaced links, then `curl` each. Don't re-read the page between
+  downloads.
+- After downloading, inspect it (e.g. `pdfinfo file.pdf`, `head`, `wc -l`) and
+  report what you got — filename, size, page/row count.
+
+## Do not
+
+- **Do not `curl` a page to read it.** curl returns raw asset-soup HTML;
+  `read_url` returns clean links. curl is only for downloading the file you
+  already found.
+- **Do not web-search for a file on a site you already have.** For a known
+  site, `read_url` it directly — searching hits our rate limits and isn't
+  needed. (If you genuinely don't know the site at all, **one** search to find
+  the official site is fine — then switch to `read_url`.)
+- **Do not crawl `/assets/`, `.js`, `.css`, font, or thumbnail URLs.** They
+  never contain your file.
+- **Do not loop.** Re-reading the same page or re-downloading makes no
+  progress; the reread guard will stop you. Treat that stop as a signal to
+  change approach or report failure — not to try the same URL again.
+
+## Worked example (fictional site)
+
+User: *"Download the Fathom Tide Kettle manual PDF from
+`https://www.fathomcoffee.example/`."*
+
+1. `read_url("https://www.fathomcoffee.example/")` → links include
+   `…/pages/support  (Support & manuals)`.
+2. `read_url(".../pages/support")` → links include
+   `…/pages/tide-manual  (Tide Kettle manual)`.
+3. `read_url(".../pages/tide-manual")` → link
+   `…/cdn/shop/files/Fathom_Tide_Manual_v3.pdf`.
+4. `curl -L -o /workspace/Fathom_Tide_Manual.pdf ".../Fathom_Tide_Manual_v3.pdf"`
+5. `pdfinfo /workspace/Fathom_Tide_Manual.pdf` → report the page count.
+
+Three reads, one download, zero asset crawling.
+
+## When a site needs JavaScript
+
+Some sites build their links or download buttons with JavaScript, so
+`read_url` (which runs no JS) and `curl` won't see the file. If `read_url`
+shows the page but none of its surfaced links lead to the file and you're
+confident it exists, **say so** — that page needs a headless browser, which
+isn't available yet. Don't curl-crawl trying to work around it; tell the user
+it needs browser rendering.

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -28,7 +28,7 @@ import time
 import threading
 from datetime import datetime, timezone
 from html.parser import HTMLParser
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import requests
 
@@ -128,12 +128,30 @@ class _MainContentExtractor(HTMLParser):
         self._main = 0
         self._main_text: list[str] = []
         self._body_text: list[str] = []
+        # <a href> capture: read_url strips text-only, which is useless for
+        # NAVIGATING a site (you learn a "Manual" link exists but not its
+        # URL). Collect (href, anchor-text) in document order so read_url can
+        # surface them — the difference between "find with read_url" working
+        # and the agent falling back to curl-crawling raw HTML for hrefs.
+        self._links: list[tuple[str, list[str]]] = []
+        self._in_a = 0
 
     def handle_starttag(self, tag, attrs):
         if tag in _NOISE_TAGS:
             self._noise += 1
         elif tag in _MAIN_TAGS:
             self._main += 1
+        elif tag == "a" and not self._noise:
+            href = next((v for k, v in attrs if k == "href"), None)
+            # keep only real navigable links: http(s) or relative. Drop
+            # in-page anchors and non-fetchable schemes (mailto/javascript/
+            # data/tel/…), scheme-parsed + case-insensitive so ` JavaScript:`
+            # and `data:text/html` don't slip in as noise.
+            if href and not href.lstrip().startswith("#"):
+                scheme = urlparse(href.strip()).scheme.lower()
+                if scheme in ("", "http", "https"):
+                    self._links.append((href, []))
+                    self._in_a += 1
         self._boundary()
 
     def handle_endtag(self, tag):
@@ -141,6 +159,8 @@ class _MainContentExtractor(HTMLParser):
             self._noise -= 1
         elif tag in _MAIN_TAGS and self._main:
             self._main -= 1
+        elif tag == "a" and self._in_a:
+            self._in_a -= 1
         self._boundary()
 
     def _boundary(self):
@@ -160,20 +180,51 @@ class _MainContentExtractor(HTMLParser):
         self._body_text.append(data)
         if self._main:
             self._main_text.append(data)
+        if self._in_a and self._links:
+            self._links[-1][1].append(data)
 
     def text(self) -> str:
         chosen = (self._main_text if any(s.strip() for s in self._main_text)
                   else self._body_text)
         return re.sub(r"\s+", " ", "".join(chosen)).strip()
 
+    def links(self) -> list[tuple[str, str]]:
+        """(href, anchor-text) for every real link, in document order, deduped
+        by href (first anchor text wins)."""
+        seen, out = set(), []
+        for href, words in self._links:
+            if href in seen:
+                continue
+            seen.add(href)
+            out.append((href, re.sub(r"\s+", " ", "".join(words)).strip()))
+        return out
 
-def _extract_main_content(html: str) -> str:
-    """Article text where the page marks one (``<article>``/``<main>``), else the
-    whole-page text with scripts/styles removed. See ``_MainContentExtractor``."""
+
+# Cap the surfaced link list: enough to navigate a page, not enough to flood
+# context on a link-farm. A page needing more than this is one to read a
+# narrower section of, not to dump wholesale.
+_MAX_SURFACED_LINKS = 40
+
+
+def _extract_main_content(html: str, base_url: str = "") -> str:
+    """Readable text (article region where marked, else whole-page minus
+    scripts/styles) followed by a compact ``Links on this page:`` list with
+    absolute URLs — so read_url can be used to NAVIGATE a site (find the page
+    or file to fetch) instead of curl-crawling raw HTML. ``base_url`` resolves
+    relative hrefs; omit it and links are listed as-written."""
     parser = _MainContentExtractor()
     parser.feed(html)
     parser.close()  # flush any token left dangling at end-of-document
-    return parser.text()
+    text = parser.text()
+    links = parser.links()
+    if not links:
+        return text
+    shown = links[:_MAX_SURFACED_LINKS]
+    lines = [f"- {urljoin(base_url, href) if base_url else href}"
+             + (f"  ({label})" if label else "") for href, label in shown]
+    more = (f"\n… and {len(links) - len(shown)} more links"
+            if len(links) > len(shown) else "")
+    return f"{text}\n\nLinks on this page:\n" + "\n".join(lines) + more
 
 
 def read_url(url: str) -> str:
@@ -182,7 +233,10 @@ def read_url(url: str) -> str:
     Returns the page's main article text where the page marks one
     (``<article>``/``<main>``) so the char budget holds signal, not nav/footer
     chrome; degrades to a whole-page text strip (scripts/styles removed) when
-    the page marks no article. Returns the FULL extracted text (not truncated) —
+    the page marks no article. A compact ``Links on this page:`` list (absolute
+    URLs) follows the text, so this tool can NAVIGATE a site — find the page or
+    downloadable file to fetch — without reading raw HTML. Returns the FULL
+    extracted text (not truncated) —
     the offload middleware saves a large result to a file and hands the agent a
     preview + path to grep, so full page content stays reachable without flooding
     context. The error path returns a short ``Error fetching URL:`` string inline.
@@ -201,7 +255,7 @@ def read_url(url: str) -> str:
             timeout=15,
         )
         resp.raise_for_status()
-        return _extract_main_content(resp.text)
+        return _extract_main_content(resp.text, base_url=url)
     except Exception as e:
         return f"Error fetching URL: {e}"
 

--- a/edd/eval/test_website_download.py
+++ b/edd/eval/test_website_download.py
@@ -1,0 +1,174 @@
+"""Explore a specific website and download a file — the runaway this pins.
+
+Live 2026-07-21 (thread …527c2a44): with egress granted, the agent tried to
+find the Fellow Espress manual PDF by crawling the Shopify site with raw
+`curl` in the sandbox — following asset URL after asset URL
+(`/cdn/shop/t/…/assets/lit-element.js`, …) until it hit the 500-step
+recursion limit. `curl` returns raw asset-soup HTML with no dedup guard; the
+`read_url` reread-breaker (and clean extraction) never applied because the
+MAIN agent HAD no `read_url` (it was on the research subagent only); this
+change adds it, guarded, plus the explore-website skill.
+
+This eval reproduces that shape against a FULLY MOCKED fictional site (no
+real network — good citizens): the sandbox `curl` is stubbed to serve raw
+asset-heavy HTML, and `read_url`'s host-side fetch is mocked to serve the
+same site. The goal test asserts a BOUNDED download (find the file, fetch it
+once, never crawl assets); it fails on the pre-fix agent (curl-only, no
+skill) and passes once the agent has `read_url` + the explore-website skill.
+"""
+import re
+import tempfile
+from unittest import TestCase, mock
+
+from deepagents.backends.filesystem import FilesystemBackend
+from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
+
+from assist.agent import create_agent, AgentHarness
+from assist.checkpoint_rollback import invoke_with_rollback
+from assist.model_manager import select_assistant_model
+from assist.spec import AgentSpec
+
+from .utils import create_filesystem, skill_was_loaded, stub_research_subagent
+
+# --- the fictional site (clearly not real; .example is reserved) --------------
+_BASE = "https://www.fathomcoffee.example"
+_PDF = "/cdn/shop/files/Fathom_Tide_Manual_v3.pdf"
+
+# Shopify-style asset soup — the crawl trap. The real thread followed dozens
+# of these dead-end JS chunks.
+_ASSETS = "".join(
+    f'<script src="/cdn/shop/t/1284/assets/{n}.js"></script>'
+    for n in ("lit-element", "custom-element", "property.CoOl", "directive-helpers",
+              "preload-helper", "BaseElement", "cart-drawer", "predictive-search"))
+_HEAD = f'<html><head>{_ASSETS}</head><body>'
+_FOOT = ('<footer><a href="/pages/warranty">Warranty</a>'
+         '<a href="/collections/kettles">Shop kettles</a></footer></body></html>')
+
+# raw HTML the SANDBOX `curl` returns (asset soup + real hrefs). The manual is
+# NOT on the landing page — it's two navigation hops deep, like the real site.
+_RAW = {
+    f"{_BASE}/": _HEAD + (
+        '<main><h1>Fathom Coffee</h1>'
+        '<p>Precision pour-over gear.</p>'
+        '<nav><a href="/pages/support">Support &amp; manuals</a>'
+        '<a href="/collections/kettles">Kettles</a>'
+        '<a href="/pages/warranty">Warranty</a></nav></main>') + _FOOT,
+    f"{_BASE}/pages/support": _HEAD + (
+        '<main><h1>Support</h1>'
+        '<p>Guides and manuals for your Fathom gear.</p>'
+        '<ul><li><a href="/pages/tide-manual">Tide Kettle manual</a></li>'
+        '<li><a href="/pages/faq">FAQ</a></li></ul></main>') + _FOOT,
+    f"{_BASE}/pages/tide-manual": _HEAD + (
+        '<main><h1>Tide Kettle manual</h1>'
+        '<p>Download the full user manual (PDF):</p>'
+        f'<a href="{_PDF}">Fathom Tide Kettle — User Manual (v3, PDF)</a>'
+        '</main>') + _FOOT,
+    f"{_BASE}/pages/faq": _HEAD + '<main><h1>FAQ</h1><p>Common questions.</p></main>' + _FOOT,
+    f"{_BASE}/collections/kettles": _HEAD + '<main><h1>Kettles</h1></main>' + _FOOT,
+    f"{_BASE}/pages/warranty": _HEAD + '<main><h1>Warranty</h1></main>' + _FOOT,
+}
+# asset URLs return JS junk with no links — the crawl dead-ends
+_ASSET_JS = "console.log('shopify chunk');// bundled module, no content\n"
+
+
+def _url_in(command: str) -> str | None:
+    m = re.search(r"https?://[^\s'\"]+", command)
+    return m.group(0).rstrip("'\"") if m else None
+
+
+class _MockSiteBackend(FilesystemBackend, SandboxBackendProtocol):
+    """Sandbox stub that serves the fictional site over `curl` and records
+    what the agent fetched, so the test can see a crawl."""
+
+    def __init__(self, root_dir):
+        super().__init__(root_dir=root_dir, virtual_mode=False)
+        self.work_dir = root_dir
+        self.page_fetches: list[str] = []     # curl GETs of a page (the crawl signal)
+        self.asset_hits: list[str] = []       # curl GETs of /assets/ dead-ends
+        self.downloads: list[str] = []        # curl -o of a file
+
+    def execute(self, command, timeout=None):
+        url = _url_in(command)
+        if url and "curl" in command:
+            is_download = bool(re.search(r"-[oO]\b", command))
+            if url.startswith(_BASE) and url.endswith(".pdf"):
+                if is_download:
+                    self.downloads.append(url)
+                    return ExecuteResponse(
+                        output="  % Total    % Received\n100 2411k  100 2411k\n",
+                        exit_code=0)
+                return ExecuteResponse(output="%PDF-1.5 (binary)", exit_code=0)
+            if "/assets/" in url:
+                self.asset_hits.append(url)
+                return ExecuteResponse(output=_ASSET_JS, exit_code=0)
+            page = _RAW.get(url.split("#")[0].rstrip("/") if url != f"{_BASE}/"
+                            else url) or _RAW.get(url)
+            if page is not None:
+                self.page_fetches.append(url)
+                return ExecuteResponse(output=page, exit_code=0)
+            return ExecuteResponse(output="curl: (22) 404 Not Found", exit_code=22)
+        if command.strip().startswith("pdfinfo"):
+            if self.downloads:
+                return ExecuteResponse(output="Pages: 24\nFile size: 2411234 bytes",
+                                       exit_code=0)
+            return ExecuteResponse(output="pdfinfo: file not found", exit_code=1)
+        return ExecuteResponse(output="", exit_code=0)
+
+
+class _FakeResp:
+    def __init__(self, text): self.text, self.status_code = text, 200
+    def raise_for_status(self): pass
+
+
+def _mock_requests_get(url, **kwargs):
+    """read_url's host-side fetch → the same site (page HTML, so extraction +
+    the link surfacing see real hrefs). Assets/PDF aren't read_url targets."""
+    body = _RAW.get(url.split("#")[0]) or _RAW.get(url.rstrip("/"))
+    return _FakeResp(body if body is not None else "<html><body>Not found</body></html>")
+
+
+class TestWebsiteDownload(TestCase):
+    def setUp(self):
+        self.model = select_assistant_model(0.1)
+
+    def _run(self, prompt):
+        root = tempfile.mkdtemp()
+        create_filesystem(root, {})
+        backend = _MockSiteBackend(root)
+        with mock.patch("assist.tools.requests.get", _mock_requests_get), \
+             stub_research_subagent():
+            agent = create_agent(self.model, root, sandbox_backend=backend,
+                                 spec=AgentSpec())
+            harness = AgentHarness(agent, thread_id="eval-web-dl")
+            # 220 = headroom for a legit ~5-tool-call navigation through the
+            # deep middleware stack (each model turn is many supersteps), still
+            # far below a real crawl-to-death (prod's backstop is 500). The
+            # crawl is caught by the metric assertions below (asset_hits /
+            # over-fetch / no download), not by this limit — a regression that
+            # crawls trips those long before 220.
+            invoke_with_rollback(
+                agent, {"messages": [{"role": "user", "content": prompt}]},
+                {"configurable": {"thread_id": "eval-web-dl"},
+                 "recursion_limit": 220})
+            return harness, backend
+
+    def test_download_converges_without_crawling(self):
+        """Find the manual (2 nav hops deep on an asset-heavy site) and
+        download it — WITHOUT crawling asset URLs to death."""
+        agent, backend = self._run(
+            "Download the Fathom Tide Kettle user manual PDF from "
+            f"{_BASE}/ and save it to /workspace. Tell me its page count.")
+        self.assertTrue(backend.downloads,
+                        f"never downloaded the manual; page fetches="
+                        f"{len(backend.page_fetches)}, asset hits="
+                        f"{len(backend.asset_hits)}")
+        self.assertTrue(any(_PDF in d for d in backend.downloads),
+                        f"downloaded the wrong URL: {backend.downloads}")
+        self.assertEqual(backend.asset_hits, [],
+                         f"crawled asset dead-ends (the runaway): "
+                         f"{backend.asset_hits[:8]}")
+        self.assertLessEqual(len(backend.page_fetches), 3,
+                             f"over-fetched pages via curl (should navigate "
+                             f"with read_url): {backend.page_fetches}")
+        self.assertTrue(skill_was_loaded(agent, "explore-website"),
+                        "did not load the explore-website skill")

--- a/tests/test_create_agent_spec.py
+++ b/tests/test_create_agent_spec.py
@@ -42,17 +42,18 @@ class _CreateAgentHarness:
 class TestSpecWiring(_CreateAgentHarness):
     """The spec's fields reach create_deep_agent."""
 
-    def test_default_spec_has_only_builtin_travel_tools(self):
-        # `travel` + `directions` are built-ins always on the main agent; a default
-        # spec adds nothing else.
-        from assist.tools import directions, map_data, travel
-        assert self._build()["tools"] == [travel, directions, map_data]
-        assert self._build(spec=AgentSpec())["tools"] == [travel, directions, map_data]
+    def test_default_spec_has_only_builtin_tools(self):
+        # travel/directions/map_data (real-world lookups) + read_url
+        # (site navigation → download; guarded by the reread-breaker) are the
+        # main agent's built-ins; a default spec adds nothing else.
+        from assist.tools import directions, map_data, read_url, travel
+        assert self._build()["tools"] == [travel, directions, map_data, read_url]
+        assert self._build(spec=AgentSpec())["tools"] == [travel, directions, map_data, read_url]
 
     def test_spec_tools_reach_create_deep_agent(self):
-        from assist.tools import directions, map_data, travel
+        from assist.tools import directions, map_data, read_url, travel
         kwargs = self._build(spec=AgentSpec(tools=(_tool_a, _tool_b)))
-        assert kwargs["tools"] == [_tool_a, _tool_b, travel, directions, map_data]
+        assert kwargs["tools"] == [_tool_a, _tool_b, travel, directions, map_data, read_url]
 
     def test_spec_skill_sources_reach_middleware(self):
         from assist.middleware.skills_middleware import SmallModelSkillsMiddleware

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -466,3 +466,21 @@ class TestReadUrlExtraction:
         assert tools._extract_main_content(
             "<article><p>just this</p></article><footer>not this</footer>"
         ) == "just this"
+
+    def test_extract_surfaces_links_absolute_and_deduped(self):
+        html = ('<main><p>Manuals</p>'
+                '<a href="/pages/manual">Manual</a>'
+                '<a href="/pages/manual">dup</a>'          # deduped by href
+                '<a href="#top">skip anchor</a>'           # in-page anchor dropped
+                '<a href="mailto:x@y.z">skip mail</a>'
+                '<script src="/cdn/assets/x.js"></script>' # script href never a link
+                '</main>')
+        out = tools._extract_main_content(html, base_url="https://s.example/pages/support")
+        assert "Links on this page:" in out
+        assert "https://s.example/pages/manual  (Manual)" in out
+        assert out.count("/pages/manual") == 1             # deduped
+        assert "#top" not in out and "mailto" not in out and "/cdn/assets/" not in out
+
+    def test_extract_no_links_section_when_none(self):
+        assert "Links on this page" not in tools._extract_main_content(
+            "<main><p>text only</p></main>", base_url="https://s.example/")

--- a/tests/test_url_provenance.py
+++ b/tests/test_url_provenance.py
@@ -85,6 +85,59 @@ class TestUrlProvenanceMiddleware(TestCase):
                           "a URL seen only in a fetched page must be refused (exfil channel)")
         self.assertEqual(result.status, "error")
 
+    def test_allows_same_host_navigation_from_a_fetched_page(self):
+        # SAME-HOST NAVIGATION (2026-07-21): the user pointed at a site; a link
+        # the fetched page ACTUALLY surfaced, on THAT SAME HOST, is fetchable —
+        # so read_url can navigate the site (follow Support → the download).
+        # Requires BOTH: same host AND present in page content.
+        msgs = [HumanMessage(content="download the manual from https://shop.example/"),
+                ToolMessage(content="Support Links on this page: - https://shop.example/pages/support",
+                            name="read_url", tool_call_id="r0")]
+        _result, handler = self._call("https://shop.example/pages/support", msgs)
+        self.assertIsNotNone(handler.called_with,
+                             "same-host link from a fetched page must be navigable")
+
+    def test_blocks_fabricated_same_host_path_not_on_any_page(self):
+        # SECURITY (the dead-URL flood): a FABRICATED path on a trusted host —
+        # one no page ever surfaced — must stay blocked. Host-match alone is
+        # NOT enough; the URL must have appeared in fetched-page content, which
+        # a model-invented canonical URL never does.
+        msgs = [HumanMessage(content="explore https://shop.example/"),
+                ToolMessage(content="Home Links on this page: - https://shop.example/pages/support",
+                            name="read_url", tool_call_id="r0")]
+        result, handler = self._call("https://shop.example/products/invented-model-x", msgs)
+        self.assertIsNone(handler.called_with,
+                          "a fabricated same-host path (not on any page) must be refused")
+        self.assertEqual(result.status, "error")
+
+    def test_blocks_exfil_query_on_a_trusted_host_the_model_invents(self):
+        # SECURITY (exfil): even when the host is trusted (a search result was
+        # on it), a secret-bearing exfil URL the model fabricates — not present
+        # on any fetched page — is refused. (The attacker can't statically
+        # author a link carrying the victim's runtime secret either.)
+        msgs = [_search_result(["https://cdn.example/asset.js"]),
+                ToolMessage(content="page text, no useful links",
+                            name="read_url", tool_call_id="r0")]
+        result, handler = self._call("https://cdn.example/collect?secret=abc123", msgs)
+        self.assertIsNone(handler.called_with,
+                          "a fabricated exfil URL on a trusted host must be refused")
+        self.assertEqual(result.status, "error")
+
+    def test_still_blocks_ssrf_to_new_host_from_a_fetched_page(self):
+        # The containment that survives the same-host relaxation: a page linking
+        # to a DIFFERENT host (cloud metadata, an internal service, an exfil
+        # host) is still refused — the new host has no matching trusted URL.
+        for target in ("http://169.254.169.254/latest/meta-data/",
+                       "http://internal-admin.local/delete",
+                       "https://evil.example/leak"):
+            msgs = [HumanMessage(content="explore https://shop.example/"),
+                    ToolMessage(content=f"page Links: - {target}",
+                                name="read_url", tool_call_id="r0")]
+            result, handler = self._call(target, msgs)
+            self.assertIsNone(handler.called_with,
+                              f"cross-host jump from page content must stay blocked: {target}")
+            self.assertEqual(result.status, "error")
+
     def test_allows_same_url_when_it_comes_from_a_search_result(self):
         # Positive control for the exfil test: the exclusion is about the CHANNEL
         # (read_url page content), not the URL itself. The very same URL, sourced


### PR DESCRIPTION
Fixes the live runaway you hit in thread `…527c2a44`: with egress granted, the agent tried to fetch the Fellow manual PDF by **crawling the Shopify site with raw `curl`** — following asset URL after asset URL (`/cdn/…/assets/lit-element.js`, …) until it hit the 500-step recursion limit. The main agent had no `read_url` (it was research-subagent-only), so raw curl — asset-soup HTML, no dedup guard — was its only way to fetch a page.

## Eval-first
`edd/eval/test_website_download.py` reproduces the crawl against a **fully mocked fictional site** (`fathomcoffee.example` — no real network, good citizens): baseline hits the recursion limit; the fixed agent converges — **skill → ~3 `read_url` hops → 1 `curl` download → `pdfinfo`**, zero asset hits. N=3 green; delegation regression (progressive-responses, which must still route research to the door) **6/6**.

## The fix
- **`read_url` surfaces links** — a compact "Links on this page:" list (absolute URLs, deduped, http(s)/relative only). It stripped hrefs before, so "find with read_url" was literally impossible.
- **`read_url` on the main agent**, guarded — a *navigation* tool (follow a known URL + its links to a file), not research: there's no `search_internet` on the main agent, so the research-delegation split holds (a research question still can't be answered by read_url alone → still delegates).
- **`UrlProvenanceMiddleware` — same-host navigation** (the security-sensitive part, flagging for you): a link that **actually appeared in fetched-page content**, on an **already-trusted host**, is now fetchable. Both conditions are load-bearing — a *fabricated* same-host path (the dead-URL flood) never appears on a page → blocked; a *cross-host* jump from page content (SSRF to metadata/internal, or a secret-bearing exfil URL) has no trusted host → blocked. My first cut trusted any path on a trusted host; the local security review caught it and this is the by-construction fix (pinned by new tests: fabricated-same-host blocked, cross-host blocked, page-surfaced-same-host allowed).
- **`explore-website` skill**: read-to-navigate / curl-to-download, the failure cases (don't crawl assets — there's no hope, the user just waits), don't-search-a-known-site (rate limits), multi-file, and a headless-browser future note.
- `ToolResultToFileMiddleware` gained a `name=` param so the read_url offload coexists with the execute offload (langchain rejects duplicate middleware names).

## Verification
1225 unit green (new link-surfacing + same-host-security pins); website eval 3/3; delegation regression 6/6; 2-lens local review (security + simplicity/docs) — 1 security-important fixed (the host-granularity widening) + doc-drift, all addressed.

Not deployed — your call (prod is on the egress branch you're testing; this is a separate change to the main agent's tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)