### PR TITLE
Search-runaway breaker: bound a healthy-backend search loop

### DIFF
--- a/assist/agent.py
+++ b/assist/agent.py
@@ -30,6 +30,7 @@ from assist.middleware.tool_result_to_file import ToolResultToFileMiddleware
 from assist.middleware.bad_request_retry import BadRequestRetryMiddleware
 from assist.middleware.loop_detection import LoopDetectionMiddleware
 from assist.middleware.search_unavailable_breaker import SearchUnavailableBreakerMiddleware
+from assist.middleware.search_runaway_breaker import SearchRunawayBreakerMiddleware
 from assist.middleware.empty_response_recovery import EmptyResponseRecoveryMiddleware
 from assist.middleware.read_only_enforcer import ReadOnlyEnforcerMiddleware
 from assist.middleware.git_push_blocker import GitPushBlockerMiddleware
@@ -717,6 +718,13 @@ def create_research_agent(model: BaseChatModel,
                 # docstring).  Threshold env-tunable for A/B + operator tuning.
                 SearchUnavailableBreakerMiddleware(
                     threshold=env_int("ASSIST_SEARCH_UNAVAILABLE_THRESHOLD", 4)),
+                # Bound a search RUNAWAY on a HEALTHY backend: same-query repetition,
+                # empty-result hammering (the 2026-07-18 coding-toy incident: 3 obscure
+                # queries searched ~80x each, all healthy-empty — invisible to the two
+                # guards above, which key on consecutive-repeats and the unavailable
+                # constant respectively). Inert on the non-search subagents (critique,
+                # fact-check) — same uniform-stack posture as the unavailable breaker.
+                SearchRunawayBreakerMiddleware(),
                 ThreadQueueMiddleware(),
                 EmptyResponseRecoveryMiddleware()]
 

--- a/assist/middleware/loop_detection.py
+++ b/assist/middleware/loop_detection.py
@@ -141,6 +141,18 @@ def _current_turn_slice(messages: list) -> list:
     return messages
 
 
+def _messages_from_state(request) -> list:
+    """The message history from a ``wrap_tool_call`` request's state, tolerating both the
+    dict and object state shapes langchain may pass. Shared by every history-counting
+    tool-call guard (the search-unavailable / search-runaway / read_url-reread breakers and
+    UrlProvenanceMiddleware) so the dict-vs-object contract lives in ONE place — a copy in
+    each was load-bearing logic that had to stay in sync (the PR #138 copy-paste class)."""
+    state = request.state or {}
+    if isinstance(state, dict):
+        return state.get("messages", [])
+    return getattr(state, "messages", [])
+
+
 def _extract_events(messages: list, window: int | None = None) -> list[dict]:
     """Collect recent (AIMessage tool_call, matching ToolMessage) pairs.
 

--- a/assist/middleware/read_url_reread_breaker.py
+++ b/assist/middleware/read_url_reread_breaker.py
@@ -25,7 +25,7 @@ from langchain.tools.tool_node import ToolCallRequest
 from langchain_core.messages import ToolMessage
 from langgraph.types import Command
 
-from assist.middleware.loop_detection import _extract_events
+from assist.middleware.loop_detection import _extract_events, _messages_from_state
 from assist.middleware.url_provenance import normalize_url
 
 logger = logging.getLogger(__name__)
@@ -98,9 +98,7 @@ class ReadUrlRereadBreaker(AgentMiddleware):
             return handler(request)
         target = normalize_url(url)
 
-        state = request.state or {}
-        messages = state.get("messages", []) if isinstance(state, dict) \
-            else getattr(state, "messages", [])
+        messages = _messages_from_state(request)
         if _prior_read_count(messages, target) < self._max_reads:
             return handler(request)
 

--- a/assist/middleware/search_runaway_breaker.py
+++ b/assist/middleware/search_runaway_breaker.py
@@ -9,9 +9,11 @@ product-spec queries ~80 times each, ALL returning healthy-empty ``"[]"`` — cy
 (so consecutive-repeat detection never fired) and returning real (empty) results (so the
 unavailable breaker never fired), 346 searches in 33 min. See docs (search-runaway).
 
-Four bounds, all keyed on the tool's OWN emitted constant (``_SEARCH_EMPTY_GUIDANCE``) and
-call counts — never on result CONTENT, so injected search snippets can't forge an empty or
-reset a counter. Decision order in ``wrap_tool_call`` (first match wins), counting only
+Four bounds, keyed only on the tool's OWN emitted constant (``_SEARCH_EMPTY_GUIDANCE``,
+matched by exact string equality) and call counts — never on the ATTACKER-INFLUENCED parts
+of a result (a search snippet's title/url/content), so injected search content can't forge
+an empty or reset a counter: a real result is a list-repr string and can never equal the
+bare constant. Decision order in ``wrap_tool_call`` (first match wins), counting only
 COMPLETED ``search_internet`` events in the current turn (via ``loop_detection._extract_events``):
 
   1. total completed searches >= TOTAL_CAP        -> refuse-finalize (stop, answer now)

--- a/assist/middleware/search_runaway_breaker.py
+++ b/assist/middleware/search_runaway_breaker.py
@@ -1,0 +1,189 @@
+"""Break a ``search_internet`` RUNAWAY — repeated / empty-hammering / high-volume
+searching against a HEALTHY backend.
+
+The fourth history-counting guard on the research searcher, orthogonal to the other three:
+``loop_detection`` (consecutive exact-repeats only), ``SearchUnavailableBreaker`` (keys on
+the backend-DOWN constant), and ``ReadUrlRereadBreaker`` (read_url, not search). The gap
+this fills is the 2026-07-18 coding-toy runaway: the searcher issued THREE obscure
+product-spec queries ~80 times each, ALL returning healthy-empty ``"[]"`` — cycling A/B/C
+(so consecutive-repeat detection never fired) and returning real (empty) results (so the
+unavailable breaker never fired), 346 searches in 33 min. See docs (search-runaway).
+
+Four bounds, all keyed on the tool's OWN emitted constant (``_SEARCH_EMPTY_GUIDANCE``) and
+call counts — never on result CONTENT, so injected search snippets can't forge an empty or
+reset a counter. Decision order in ``wrap_tool_call`` (first match wins), counting only
+COMPLETED ``search_internet`` events in the current turn (via ``loop_detection._extract_events``):
+
+  1. total completed searches >= TOTAL_CAP        -> refuse-finalize (stop, answer now)
+  2. trailing run of empties >= CONSECUTIVE_EMPTY  -> refuse-finalize (nothing is landing)
+  3. same normalized query completed >= SAME_QUERY -> refuse-steer (vary the query)
+  4. this query already returned empty this turn   -> short-circuit: serve the cached empty
+                                                       guidance WITHOUT hitting the backend
+  else -> real backend call.
+
+Return-status convention (consistent with the sibling breakers): a *refused* call returns a
+``status="error"`` ToolMessage (FINALIZE-not-kill — the model is told to answer from what it
+has, not terminated with an empty stub); the *short-circuit* (4) returns a NON-error
+ToolMessage byte-identical to a real healthy-empty, so history-counting and the model's
+interpretation don't diverge from a backend empty. Both always set ``tool_call_id`` so the
+call→result pairing (and thus the counters, and the OpenAI tool-call contract) hold.
+
+Scope and honest residuals:
+  * "Turn" == one searcher-subagent dispatch (``_extract_events`` bounds to the current
+    turn); a no-op on the single-run research agents this is wired on. Cross-dispatch
+    search budget is NOT bounded here — the searcher's own recursion_limit (~25 supersteps,
+    NOT the orchestrator's 300 — deepagents doesn't forward it) is that backstop.
+  * Completed-only counting can't see the in-flight siblings of ONE concurrent batch, so
+    the first batch of identical queries is un-counted; the effective ceiling is
+    ``TOTAL_CAP + one batch width`` (observed batch width ~3), not a hard 50. From the 2nd
+    superstep on, the first batch's empties are committed, so decision 4 short-circuits the
+    repeats. (A strict in-batch bound is stateless-feasible — count same-query siblings
+    preceding this call's id in the current AIMessage — but is a deliberate v1 deferral:
+    the observed width is single-digit.)
+  * TOTAL_CAP is per-dispatch. Legit research is ~11 searches/dispatch (a broad comparison
+    is spread across many dispatches, ~11 each), so 50 has ~4.5x headroom and can't clip
+    real breadth. TOTAL_CAP is also the ONLY guard on Tavily spend for a distinct-query
+    loop against a THROTTLED backend (results come back real, dodging both empty and
+    unavailable detection).
+"""
+import logging
+from typing import Any, Callable
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain.tools.tool_node import ToolCallRequest
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
+
+from assist.middleware.loop_detection import _extract_events, _messages_from_state
+from assist.tools import _SEARCH_EMPTY_GUIDANCE
+
+logger = logging.getLogger(__name__)
+
+_SEARCH_TOOL = "search_internet"
+
+# Hardcoded like ReadUrlRereadBreaker's _DEFAULT_MAX_READS (repeat-cap sibling) — these are
+# coarse real bounds, not per-deploy dials. SAME_QUERY_CAP: identical completed queries
+# allowed before the next is refused. TOTAL_CAP: completed searches/dispatch. CONSECUTIVE_
+# EMPTY_CAP: trailing all-empty run (catches distinct-reword hammering that dodges the
+# same-query cap; a run resets on any non-empty result, so TOTAL_CAP is its real backstop).
+_SAME_QUERY_CAP = 3
+_TOTAL_CAP = 50
+_CONSECUTIVE_EMPTY_CAP = 5
+
+# Shared by the two finalize refusals (total-cap and consecutive-empty) — one string, not two
+# near-identical ones (the copy-paste-breeds-divergence lesson).
+_FINALIZE_STEER = (
+    "Stop searching now and write your answer from what you have already gathered. "
+    "Further searching this turn will not help — if you could not find something after "
+    "the searches so far, say plainly that it is not available and answer from what you have."
+)
+
+
+def _search_query(tool_call: dict) -> str:
+    """The raw ``query`` a search_internet call targets, or "" if none. ``args``-or-
+    ``arguments`` mirrors the sibling extractors (normalized AIMessage.tool_calls use
+    ``args``; the raw OpenAI shape uses ``arguments``). ``max_results`` is deliberately NOT
+    part of query identity, so varying it can't evade the same-query cap."""
+    if tool_call.get("name") != _SEARCH_TOOL:
+        return ""
+    args: Any = tool_call.get("args") or tool_call.get("arguments") or {}
+    return args.get("query", "") if isinstance(args, dict) else ""
+
+
+def _normalize_query(query: str) -> str:
+    """Query identity for the same-query cap: lowercased, stripped, internal whitespace
+    collapsed. An UNAMBIGUOUS normalizer only — no fuzzy/token-set matching, which would
+    risk clipping legitimately-distinct queries (coarse real bounds over ambiguous signals).
+    Null-safe: a malformed ``query`` of ``None`` or ``""`` normalizes to ``""`` (grouping
+    all malformed-query calls together so the caps still bound them — the small model emits
+    malformed tool args, cf. the ``glob(path="/")`` runaway). Local to this module,
+    mirroring ReadUrlRereadBreaker's local ``_read_url_arg``. American spelling (matches
+    ``normalize_url``)."""
+    return " ".join((query or "").lower().split())
+
+
+def _completed_searches(messages: list) -> list[dict]:
+    """The completed ``search_internet`` events in this turn's history (each has its
+    ToolMessage result), via the shared ``loop_detection._extract_events`` pairing —
+    completed-only so the CURRENT in-flight call (and its concurrent siblings) isn't counted."""
+    return [e for e in _extract_events(messages, window=None)
+            if e["completed"] and e["tool_name"] == _SEARCH_TOOL]
+
+
+def _trailing_empty_run(events: list[dict]) -> int:
+    """Length of the trailing run of completed searches whose result is the empty-guidance
+    constant. Distinct queries count (that's what catches reword-hammering); the run resets
+    on any non-empty result (so TOTAL_CAP is the real backstop against reset-interleaving)."""
+    n = 0
+    for e in reversed(events):
+        if e["result_content"] == _SEARCH_EMPTY_GUIDANCE:
+            n += 1
+        else:
+            break
+    return n
+
+
+class SearchRunawayBreakerMiddleware(AgentMiddleware):
+    """Bound a ``search_internet`` runaway (repetition, empty-hammering, volume) on a healthy
+    backend. Stateless across turns except an intervention counter for logging; all bounds
+    read the current turn's committed history. Named for what it does — the flat TOTAL_CAP
+    covers non-looping runaways too, so "runaway" not "loop"."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.tools = []
+        self._intervention_count = 0
+
+    def _refuse(self, request: ToolCallRequest, content: str, reason: str) -> ToolMessage:
+        self._intervention_count += 1
+        logger.warning("SearchRunawayBreaker: refused search_internet — %s (intervention #%d)",
+                       reason, self._intervention_count)
+        return ToolMessage(content=content,
+                           tool_call_id=request.tool_call.get("id", ""),
+                           name=_SEARCH_TOOL,
+                           status="error")
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], "ToolMessage | Command"],
+    ) -> "ToolMessage | Command":
+        # Gate on the tool NAME, not on a truthy query — a malformed search_internet(query="")
+        # or (query=None) must still be COUNTED (else it bypasses every bound, keyed on the
+        # empty query; the small model emits malformed args). Only a genuinely different tool
+        # passes straight through.
+        if request.tool_call.get("name") != _SEARCH_TOOL:
+            return handler(request)
+
+        query = _search_query(request.tool_call)
+        events = _completed_searches(_messages_from_state(request))
+        target = _normalize_query(query)
+        same = [e for e in events if _normalize_query(_search_query(
+            {"name": e["tool_name"], "args": e["args"]})) == target]
+
+        # 1. hard volume ceiling (per dispatch)
+        if len(events) >= _TOTAL_CAP:
+            return self._refuse(request, _FINALIZE_STEER,
+                                f"{len(events)} searches this turn >= total cap {_TOTAL_CAP}")
+        # 2. nothing is landing — a trailing run of empties (distinct queries allowed)
+        if _trailing_empty_run(events) >= _CONSECUTIVE_EMPTY_CAP:
+            return self._refuse(request, _FINALIZE_STEER,
+                                f">= {_CONSECUTIVE_EMPTY_CAP} consecutive empty searches")
+        # 3. this exact query is being repeated (any position; loop_detection catches only
+        #    the CONSECUTIVE case, so this covers the A/B/C-cycling shape it misses)
+        if len(same) >= _SAME_QUERY_CAP:
+            return self._refuse(
+                request,
+                (f"You have already run this exact search {_SAME_QUERY_CAP} times this "
+                 f"turn — re-running an identical query returns the same thing. Try a "
+                 f"distinctly different query, or answer from what you have."),
+                f"same query x{len(same)} >= cap {_SAME_QUERY_CAP}")
+        # 4. this query already came back empty — serve the cached empty, no backend hit
+        if any(e["result_content"] == _SEARCH_EMPTY_GUIDANCE for e in same):
+            self._intervention_count += 1
+            logger.warning("SearchRunawayBreaker: short-circuit search_internet(%r) — already "
+                           "empty this turn (intervention #%d)", query, self._intervention_count)
+            return ToolMessage(content=_SEARCH_EMPTY_GUIDANCE,
+                               tool_call_id=request.tool_call.get("id", ""),
+                               name=_SEARCH_TOOL)
+        return handler(request)

--- a/assist/middleware/search_runaway_breaker.py
+++ b/assist/middleware/search_runaway_breaker.py
@@ -90,16 +90,17 @@ def _search_query(tool_call: dict) -> str:
     return args.get("query", "") if isinstance(args, dict) else ""
 
 
-def _normalize_query(query: str) -> str:
+def _normalize_query(query) -> str:
     """Query identity for the same-query cap: lowercased, stripped, internal whitespace
     collapsed. An UNAMBIGUOUS normalizer only — no fuzzy/token-set matching, which would
     risk clipping legitimately-distinct queries (coarse real bounds over ambiguous signals).
-    Null-safe: a malformed ``query`` of ``None`` or ``""`` normalizes to ``""`` (grouping
-    all malformed-query calls together so the caps still bound them — the small model emits
-    malformed tool args, cf. the ``glob(path="/")`` runaway). Local to this module,
-    mirroring ReadUrlRereadBreaker's local ``_read_url_arg``. American spelling (matches
-    ``normalize_url``)."""
-    return " ".join((query or "").lower().split())
+    Type-safe: ANY non-string ``query`` (``None``, a ``list``, an ``int`` — the small model
+    emits malformed tool args, cf. the ``glob(path="/")`` runaway) normalizes to ``""``, so
+    malformed calls group together and the caps still bound them instead of the normalizer
+    crashing on ``.lower()``. Local to this module, mirroring ReadUrlRereadBreaker's local
+    ``_read_url_arg``. American spelling (matches ``normalize_url``)."""
+    q = query if isinstance(query, str) else ""
+    return " ".join(q.lower().split())
 
 
 def _completed_searches(messages: list) -> list[dict]:

--- a/assist/middleware/search_unavailable_breaker.py
+++ b/assist/middleware/search_unavailable_breaker.py
@@ -54,7 +54,7 @@ from assist.tools import _SEARCH_UNAVAILABLE_MESSAGE
 # Share loop detection's per-turn event extraction (windowless here — we want
 # the cumulative full-turn count).  Same import precedent as
 # empty_response_recovery importing `_last_successful_artifact`.
-from assist.middleware.loop_detection import _extract_events
+from assist.middleware.loop_detection import _extract_events, _messages_from_state
 
 logger = logging.getLogger(__name__)
 
@@ -69,8 +69,8 @@ def _count_search_unavailable(messages: list) -> int:
     state; a windowed count could let heavy read_url interleaving push earlier
     unavailable searches out of view and undercount).  Exact-equality: the
     constant is returned verbatim from one code path, so a genuine empty result
-    (``[]``) or any other content is NOT counted.  Pending calls (no result
-    yet) have ``completed=False`` and are not counted."""
+    (the ``_SEARCH_EMPTY_GUIDANCE`` steer) or any other content is NOT counted.
+    Pending calls (no result yet) have ``completed=False`` and are not counted."""
     return sum(
         1 for e in _extract_events(messages, window=None)
         if e["completed"]
@@ -141,9 +141,7 @@ class SearchUnavailableBreakerMiddleware(AgentMiddleware):
         if request.tool_call.get("name", "") != _SEARCH_TOOL:
             return handler(request)
 
-        state = request.state or {}
-        messages = state.get("messages", []) if isinstance(state, dict) \
-            else getattr(state, "messages", [])
+        messages = _messages_from_state(request)
         if _count_search_unavailable(messages) < self.threshold:
             return handler(request)
 

--- a/assist/middleware/tool_name_sanitization.py
+++ b/assist/middleware/tool_name_sanitization.py
@@ -2,8 +2,8 @@
 
 Small models (e.g. vLLM-served Ministral) sometimes hallucinate tool calls
 with names that violate the OpenAI function-name spec (a-zA-Z0-9_- , max 64
-chars).  For example, when search results return ``[]`` the model may emit a
-tool call whose name is literally ``[]``.
+chars).  For example, when a tool returns ``[]`` (an empty list result) the
+model may emit a tool call whose name is literally ``[]``.
 
 This causes two problems:
 1. LangGraph's tool node fails with "[] is not a valid tool".

--- a/assist/middleware/url_provenance.py
+++ b/assist/middleware/url_provenance.py
@@ -63,6 +63,7 @@ from langchain.tools.tool_node import ToolCallRequest
 from langchain_core.messages import HumanMessage, ToolMessage
 from langgraph.types import Command
 
+from assist.middleware.loop_detection import _messages_from_state
 from assist.middleware.tool_result_to_file import UNTRUSTED_OFFLOAD_MARK
 
 logger = logging.getLogger(__name__)
@@ -298,9 +299,7 @@ class UrlProvenanceMiddleware(AgentMiddleware):
         if not url:
             return handler(request)
 
-        state = request.state or {}
-        messages = state.get("messages", []) if isinstance(state, dict) \
-            else getattr(state, "messages", [])
+        messages = _messages_from_state(request)
         allowed = _seen_urls(messages)
         if normalize_url(url) in allowed:
             return handler(request)

--- a/assist/templates/deepagents/sub_research.txt.j2
+++ b/assist/templates/deepagents/sub_research.txt.j2
@@ -5,6 +5,8 @@ Current date/time: {{ current_datetime() }}
 ## How to search: start broad, then narrow
 Your FIRST search should be a short, broad query (a few words). Long, over-specific queries return few results — the most common mistake is to open with a narrow query and get nothing back. See what the broad search returns, then run a narrower query to close the specific gap. After each search, take a beat: what did I learn, what's still missing, what should the next query be.
 
+If a search returns NO results, do NOT re-run it or a lightly-reworded version — a reworded empty query almost always comes back empty too. Change the *angle*: broaden it, drop a constraint, or try adjacent terms. If two or three different angles for the same specific thing all come back empty, treat that thing as not findable — say so plainly and move on; do not keep searching for it.
+
 Read a page with `read_url` only when a search snippet isn't enough to state a finding precisely. Most findings come straight from the snippets — you usually don't need to open the page.
 
 ## When to stop (stop at the FIRST of these — you do NOT need exhaustive coverage)
@@ -12,7 +14,7 @@ Read a page with `read_url` only when a search snippet isn't enough to state a f
 - You have 3 or more relevant sources you actually read or confirmed (not just one broad result list), OR
 - Your last two searches returned basically the same information (you've hit diminishing returns).
 
-Search-count caps: a simple question needs 2–3 searches; a complex, multi-part one, up to 5. STOP after 5 searches no matter what and report what you have. You do not need a better source once you have a usable one.
+Search-count guide: a simple question needs 2–3 searches; a complex, multi-part one, up to about 5. You do not need a better source once you have a usable one — once you can answer, stop and write it.
 
 ## Source quality
 Prefer primary and authoritative sources — the official docs, the original publisher, an expert or academic page — over SEO content farms and aggregators. A plain authoritative page beats a slick one that just repackages it.

--- a/assist/tools.py
+++ b/assist/tools.py
@@ -63,6 +63,24 @@ def _search_unavailable(reason: str) -> str:
     logger.error("Web search unavailable: %s", reason)
     return _SEARCH_UNAVAILABLE_MESSAGE
 
+
+# What a HEALTHY-but-empty search returns (was a bare ``"[]"``, which the small
+# model read as "keep trying" and re-ran the same dead query dozens of times —
+# the 2026-07-18 coding-toy runaway: 3 obscure product queries each searched
+# ~80x, all empty).  A prose steer instead of ``"[]"`` tells the model an empty
+# is terminal for THIS query.  ``SearchRunawayBreakerMiddleware`` imports this
+# exact string as the single source of truth to detect an empty in the turn
+# history (same discipline as ``_SEARCH_UNAVAILABLE_MESSAGE``), so it must stay
+# byte-identical wherever an empty is produced (the tool here, and the
+# middleware's short-circuit of a repeated empty query).
+_SEARCH_EMPTY_GUIDANCE = (
+    "This search returned no results. Do NOT repeat this query or a lightly "
+    "reworded version — it will return nothing again. Try a distinctly "
+    "different angle: broaden it, drop a constraint, or use adjacent terms. If "
+    "a specific item isn't findable after a couple of different angles, treat "
+    "it as not findable and move on — say so and answer from what you have."
+)
+
 # --- Per-host fetch throttle ---
 _host_lock = threading.Lock()
 _host_last_call: dict[str, float] = {}
@@ -285,8 +303,9 @@ def search_internet(
     Queries ONE engine at a time in ``_ROTATION_ENGINES`` order and returns the FIRST
     engine that yields results (deterministic). Returns ``_SEARCH_UNAVAILABLE_MESSAGE``
     (logged) only if every engine is unreachable/throttled/malformed — a broken backend
-    fails LOUDLY but as a relayable tool result, not an exception. Returns ``"[]"`` when
-    the engines are healthy but genuinely have no results for this query."""
+    fails LOUDLY but as a relayable tool result, not an exception. Returns
+    ``_SEARCH_EMPTY_GUIDANCE`` (a "no results — don't repeat this query" steer) when the
+    engines are healthy but genuinely have no results for this query."""
     base_url = os.getenv("ASSIST_SEARCH_URL")
     if not base_url:
         return _search_unavailable(
@@ -314,7 +333,7 @@ def search_internet(
             f"SearXNG at {base_url}: every engine unreachable or throttled "
             f"(tried {', '.join(_ROTATION_ENGINES)}); Tavily backup unavailable/unset too"
         )
-    return "[]"
+    return _SEARCH_EMPTY_GUIDANCE
 
 
 def _query_engine(base_url: str, query: str, engine: str) -> tuple[list | None, bool]:

--- a/docs/2026-07-22-search-runaway-breaker.org
+++ b/docs/2026-07-22-search-runaway-breaker.org
@@ -104,8 +104,9 @@ unavailable breaker — active on the searcher, inert on critique/fact-check.
 - *Deterministic unit tests:* =tests/test_search_runaway_breaker_middleware.py= — every
   bound (total-cap 51st refused, consecutive-empty 6th refused, same-query 4th
   refused, empty circuit-break serves the constant with =tool_call_id= and no backend,
-  reset-on-non-empty, pass-through), 10 tests.
-- Full mocked unit suite green (1229); =tests/test_tools.py= empty-return assertions
+  reset-on-non-empty, pass-through, malformed/non-string query bounded not crashing),
+  11 tests.
+- Full mocked unit suite green (1230); =tests/test_tools.py= empty-return assertions
   updated to the guidance constant.
 
 * Design review (5 lenses) — resolutions

--- a/docs/2026-07-22-search-runaway-breaker.org
+++ b/docs/2026-07-22-search-runaway-breaker.org
@@ -1,0 +1,141 @@
+#+title: Search-runaway breaker — bound a healthy-backend search loop
+#+date: 2026-07-22
+
+* Problem (the 2026-07-18 coding-toy incident)
+
+Over 7 days the research searcher fired 668 =search_internet= calls; 346 of them
+were on ONE day (Jul 18), 73% of those (~250 calls) spent re-issuing THREE obscure
+coding-toy product-spec queries (e.g. "Tynami coding toy robot product
+specifications") ~80× each, ALL returning healthy-empty results (SearXNG up, just
+no hits), in concurrent 3-wide batches, for ~33 minutes. The user request itself
+was legitimate (compare screen-free coding toys for a child); the pathology was
+the searcher hammering a handful of unfindable products instead of concluding
+they were unfindable.
+
+Three shipped guards all missed it, by construction:
+- =LoopDetectionMiddleware= catches only CONSECUTIVE exact-repeats (A then A); the
+  three queries cycled A/B/C, so no two consecutive calls were identical.
+- =SearchUnavailableBreakerMiddleware= keys on the exact =_SEARCH_UNAVAILABLE_MESSAGE=
+  constant; a healthy-empty result was a bare ="[]"=, invisible to it.
+- The =sub_research.txt.j2= "STOP after 5 searches" cap is soft prompt guidance the
+  small model ignores.
+Only the searcher's recursion_limit (~25 supersteps — NOT the orchestrator's 300;
+deepagents doesn't forward it) eventually stopped it.
+
+Normal research is unaffected: ~11 searches/dispatch, and a legitimately broad
+comparison spreads ~116 DISTINCT queries across ~10 dispatches (~11 each). So the
+fix must bound repetition + empty-hammering + volume WITHOUT clipping distinct
+breadth.
+
+* Design
+
+Four bounds, primary lever = prompt hygiene, hard backstop = a new middleware.
+
+** Tool: healthy-empty returns guidance, not ="[]"= (=assist/tools.py=)
+=search_internet= now returns =_SEARCH_EMPTY_GUIDANCE= (a "no results — don't repeat
+this query, change the angle, conclude not-findable if it stays empty") in place of
+="[]"= for the healthy-empty case. A prose steer reads to the small model as
+"terminal for this query"; a bare ="[]"= read as "try again". The constant is the
+single source of truth the middleware imports to detect an empty in history (same
+discipline as =_SEARCH_UNAVAILABLE_MESSAGE=).
+
+** Prompt hygiene (=sub_research.txt.j2=, refocus-not-add)
+Folded a relax-on-empty rule mirroring the proven =read_url= "don't retry a variant"
+line: on empty, broaden / drop a constraint / try adjacent terms — don't reword the
+same dead query; after two-three empty angles for the same thing, conclude it's not
+findable and move on. Dropped the ineffective absolute "STOP after 5 searches no
+matter what" (the model ignores it, and it contradicts legitimate broad research —
+that ceiling is now the middleware's job). Best-practice grounding: query
+relaxation + know-when-to-stop (SIFT / CaRT / reformulation literature).
+
+** Middleware: =SearchRunawayBreakerMiddleware= (=assist/middleware/search_runaway_breaker.py=)
+A NEW sibling to the existing breakers (not a broadening of SearchUnavailable — it
+has the OPPOSITE return semantics on the empty case: short-circuit-and-CONTINUE, vs
+unavailable's finalize-and-STOP). Shares machinery: reuses
+=loop_detection._extract_events= (the completed-only, turn-bounded call→result
+pairing) and imports =_SEARCH_EMPTY_GUIDANCE=. Counts only COMPLETED
+=search_internet= events in the current turn. Decision ladder in =wrap_tool_call=
+(first match wins), thresholds hardcoded (like =ReadUrlRereadBreaker=, no env knobs):
+
+1. total completed searches >= 50  -> refuse-finalize (per-dispatch volume ceiling)
+2. trailing run of empties >= 5     -> refuse-finalize (nothing is landing; catches
+   distinct-reword hammering the same-query cap can't)
+3. same normalized query completed >= 3 -> refuse-steer (any position; loop_detection
+   only catches the consecutive case)
+4. this query already returned empty this turn -> short-circuit: serve the cached
+   empty-guidance WITHOUT a backend call
+else -> real backend call.
+
+Return shapes (consistent with the siblings): refusals are =status="error"= (FINALIZE-
+not-kill — the model answers from what it has, isn't terminated with a stub); the
+short-circuit is a NON-error ToolMessage byte-identical to a real empty (so history-
+counting and the model's reading don't diverge). Both always set =tool_call_id= so
+the call→result pairing (hence the counters and the OpenAI tool-call contract) hold.
+Query identity = normalized =query= only (lower/strip/collapse-ws), ignoring
+=max_results= so it can't be evaded; no fuzzy matching (coarse real bounds over
+ambiguous heuristics). Wired into the shared =_subagent_safety_mw()= after the
+unavailable breaker — active on the searcher, inert on critique/fact-check.
+
+* Honest residuals (named, not hidden)
+- *Concurrency lag:* completed-only counting can't see the in-flight siblings of ONE
+  concurrent batch, so the first batch of identical queries is un-counted; effective
+  ceiling ≈ 50 + one batch width (observed width ~3). From superstep 2 on, the
+  repeats short-circuit. A strict in-batch bound is stateless-feasible (count same-
+  query siblings preceding this call's id in the current AIMessage) but is a
+  deliberate v1 deferral — observed width is single-digit.
+- *Per-dispatch scope:* the caps are per searcher-dispatch (= one turn). Cross-
+  dispatch search budget is bounded only by the searcher recursion_limit (~25). The
+  incident was within one dispatch. Cross-dispatch is a v2 follow-up.
+- *Trailing-empty reset:* the consecutive-empty run resets on any non-empty result,
+  so a runaway that interleaves a result-returning query every ≤4 empties keeps the
+  run under 5 — bounded then by =total_cap=50=, the real backstop for that shape.
+- *total_cap is the only guard on Tavily spend* for a distinct-query loop against a
+  THROTTLED backend (results come back real, dodging both empty and unavailable
+  detection).
+
+* Validation
+- *Reproduction eval (before any fix, on the pre-fix ="[]"= condition):*
+  =edd/eval/test_search_runaway_loop.py= — a confined searcher (search + read only)
+  against a MOCKED healthy-empty SearXNG (=requests.get= patched; =requests.post=/Tavily
+  asserted never-called; =TAVILY_API_KEY= cleared) with a 3-obscure-product persistent
+  brief. Baseline reproduced the loop (18 empty searches). Guarded (breaker wired):
+  no query hits the backend past one 6-engine sweep, total bounded, agent still
+  answers. Regression: a healthy distinct-query run (results returned) is NOT clipped.
+- *Deterministic unit tests:* =tests/test_search_runaway_breaker_middleware.py= — every
+  bound (total-cap 51st refused, consecutive-empty 6th refused, same-query 4th
+  refused, empty circuit-break serves the constant with =tool_call_id= and no backend,
+  reset-on-non-empty, pass-through), 10 tests.
+- Full mocked unit suite green (1229); =tests/test_tools.py= empty-return assertions
+  updated to the guidance constant.
+
+* Design review (5 lenses) — resolutions
+Simplicity/agentic/clean-interfaces/threat-model (+ the reproduction data) converged
+with no design blockers. Folded: hardcode thresholds (drop env knobs/floors); rename
+=SearchRunawayBreaker= (covers the flat cap, not just loops); =_normalize_query= local
+to the module; short-circuit carries =tool_call_id=; decisions 1&2 share one finalize
+string; uniform-stack wiring (no skip-critique special case); fan-out cap deferred
+(observed batch width ~3); baseline runs on pre-fix ="[]"=; behavior assertion added
+for the cap. Rejected: broadening SearchUnavailable (SRP + opposite semantics), fuzzy
+near-duplicate matching (ambiguous, clips breadth), stateful in-flight counting
+(breaks checkpoint-safety).
+
+* Code review (4 lenses) — fixes
+Correctness/security/docstring/simplicity, all verified against the code. No blockers.
+Fixed: (security) gate =wrap_tool_call= pass-through on tool NAME not empty query — a
+malformed =search_internet(query="")= was bypassing every bound; (correctness) null-safe
+=_normalize_query= (a =query=None= history event crashed the hot path); (correctness) the
+reproduction eval now also passes when a hard runaway hits =recursion_limit= and returns
+None (assert on the surviving backend-GET counter); (simplicity) extracted
+=loop_detection._messages_from_state= — the dict-vs-object state extraction was a 4th copy
+across the breakers + =url_provenance= (PR #138 copy-paste class), now one shared helper;
+dropped the three never-overridden constructor params for the hardcoded constants; fixed
+two sibling docstrings the ="[]"=→guidance change left stale. Malformed-query and
+null-safety are pinned with unit tests.
+
+* Follow-ups (over time, separate PRs — from the best-practices comparison)
+Verification-quality guidance the prompts lack: lateral reading / triangulation
+(corroborate a load-bearing claim against a second independent source), conflicting-
+source handling, recency preference. Not loop-prevention — deferred.
+
+* Outcome
+(Branch =research-search-loop-breaker=; append PR + shipped-vs-deferred once it lands.)

--- a/edd/eval/test_search_runaway_loop.py
+++ b/edd/eval/test_search_runaway_loop.py
@@ -118,7 +118,9 @@ def _search_emissions(out):
     for m in out.get("messages", []):
         for tc in (getattr(m, "tool_calls", None) or []) if isinstance(m, AIMessage) else []:
             if tc.get("name") == "search_internet":
-                c[_normalize_query((tc.get("args") or {}).get("query", ""))] += 1
+                args = tc.get("args")
+                query = args.get("query", "") if isinstance(args, dict) else ""
+                c[_normalize_query(query)] += 1
     return c
 
 

--- a/edd/eval/test_search_runaway_loop.py
+++ b/edd/eval/test_search_runaway_loop.py
@@ -1,0 +1,206 @@
+"""Reproduce the research search RUNAWAY (2026-07-18 coding-toy incident).
+
+Symptom: the searcher issued THREE obscure product-spec queries ~80 times each, ALL
+returning healthy-empty results (SearXNG up, genuinely no hits), 346 searches in 33 min.
+loop_detection can't catch it (the three queries cycle A/B/C — non-consecutive); the
+search-unavailable breaker can't (the backend is UP, results are just empty). See the
+search-runaway design doc.
+
+To reproduce it reliably (not the stochastic full research flow) this uses a MINIMAL agent
+confined to the exact conditions: tools=[search_internet, read_url] against a MOCKED SearXNG
+that returns healthy-empty (``{"results": [], "unresponsive_engines": []}``) for the obscure
+item — so the model searches, gets nothing, and (pre-fix) re-searches the same dead query.
+
+Fully mocked + Tavily-free by construction: ``requests.get`` (SearXNG) is mocked to empty;
+healthy-empty never reaches the Tavily branch (``saw_down`` stays False), AND ``requests.post``
+(Tavily) is asserted never-called, AND TAVILY_API_KEY is cleared. Only the LLM is real, so
+runs vary (like all evals here). The BASELINE (no breaker) asserts the loop REPRODUCES; the
+GUARDED tests assert the breaker bounds it and the agent still answers (finalize-not-kill);
+the REGRESSION test asserts legit broad research (many DISTINCT result-returning queries) is
+NOT clipped.
+"""
+import os
+import uuid
+from collections import Counter
+from unittest import TestCase
+from unittest.mock import patch
+
+from deepagents import create_deep_agent
+from langgraph.checkpoint.memory import InMemorySaver
+from langchain_core.messages import AIMessage
+
+from assist.middleware.search_runaway_breaker import (
+    SearchRunawayBreakerMiddleware, _normalize_query, _SAME_QUERY_CAP, _TOTAL_CAP,
+)
+from assist.model_manager import select_assistant_model
+from assist.tools import read_url, search_internet
+from assist.checkpoint_rollback import invoke_with_rollback
+
+os.environ.setdefault("ASSIST_MODEL_URL", "http://127.0.0.1:8000/v1")
+
+# Synthetic, obscure items a healthy search genuinely can't find — no real products, no PII
+# (the incident's real items were niche coding toys). Three of them, to recreate the
+# incident's A/B/C-cycling multi-product comparison pressure that drove the runaway.
+_ITEM = "Zorblax QX-9 coding toy robot"
+_ITEMS = ("Zorblax QX-9", "Glimworks Tuktuk", "Nabbo Codepal")
+
+_get_queries: Counter = Counter()   # backend SearXNG GETs, keyed by normalized query
+_post_calls: list = []              # Tavily POSTs — must stay empty
+
+
+class _EmptyResp:
+    """Healthy SearXNG with genuinely no results (never triggers the Tavily fallback)."""
+    def json(self):
+        return {"results": [], "unresponsive_engines": []}
+
+    def raise_for_status(self):
+        pass
+
+
+class _ResultsResp:
+    def __init__(self, query):
+        self._query = query
+
+    def json(self):
+        return {"results": [
+            {"title": f"{self._query} — overview", "url": f"https://example.test/{abs(hash(self._query)) % 9999}",
+             "content": f"Reference material about {self._query}."}],
+            "unresponsive_engines": []}
+
+    def raise_for_status(self):
+        pass
+
+
+def _mock_get_empty(url, **kw):
+    _get_queries[_normalize_query(kw.get("params", {}).get("q", ""))] += 1
+    return _EmptyResp()
+
+
+def _mock_get_results(url, **kw):
+    q = kw.get("params", {}).get("q", "")
+    _get_queries[_normalize_query(q)] += 1
+    return _ResultsResp(q)
+
+
+def _mock_post(*a, **kw):  # Tavily — record any call so the test can assert it never happens
+    _post_calls.append(a)
+    raise AssertionError("Tavily (requests.post) must not be called in this eval")
+
+
+def _confined_agent(model, extra_middleware=()):
+    """Minimal searcher: search + read only, no orchestrator. extra_middleware wires the
+    breaker for the guarded tests."""
+    return create_deep_agent(
+        model=model,
+        tools=[search_internet, read_url],
+        checkpointer=InMemorySaver(),
+        system_prompt=("You are a research worker. Find the requested facts by searching the "
+                       "web. Report only what your sources say; be persistent and precise."),
+        middleware=[*extra_middleware],
+    )
+
+
+def _prompt(items):
+    names = ", ".join(f"the '{i}'" for i in items)
+    return (f"Research and compare the exact product specifications — battery type, "
+            f"dimensions, weight, and price — of these coding toys for kids: {names}. All are "
+            f"real products sold online. It is important to report PRECISE specs for each; "
+            f"search thoroughly from multiple angles and keep trying for each product before "
+            f"giving up. Report the specs you find for each.")
+
+
+def _search_emissions(out):
+    """search_internet tool_calls the model EMITTED, by normalized query (includes ones the
+    breaker short-circuited/refused — those still appear as tool_calls in history)."""
+    c: Counter = Counter()
+    if not out:
+        return c
+    for m in out.get("messages", []):
+        for tc in (getattr(m, "tool_calls", None) or []) if isinstance(m, AIMessage) else []:
+            if tc.get("name") == "search_internet":
+                c[_normalize_query((tc.get("args") or {}).get("query", ""))] += 1
+    return c
+
+
+def _final_text(out):
+    if not out or not out.get("messages"):
+        return ""
+    return str(out["messages"][-1].content or "")
+
+
+def _run(agent, mock_get, items=_ITEMS):
+    _get_queries.clear()
+    _post_calls.clear()
+    with patch("assist.tools.requests.get", mock_get), \
+         patch("assist.tools.requests.post", _mock_post), \
+         patch("assist.tools._host_throttle", lambda host: None), \
+         patch.dict(os.environ, {"ASSIST_SEARCH_URL": "http://searxng.test"}, clear=False):
+        os.environ.pop("TAVILY_API_KEY", None)
+        try:
+            return invoke_with_rollback(
+                agent,
+                {"messages": [{"role": "user", "content": _prompt(items)}]},
+                {"configurable": {"thread_id": str(uuid.uuid4())}, "recursion_limit": 70})
+        except Exception as e:  # recursion cap / LLM timeout mid-loop = a runaway signal
+            print(f"\n[search-runaway] run ended via {type(e).__name__}\n")
+            return None
+
+
+class TestSearchRunawayLoop(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = select_assistant_model(0.1)
+
+    def test_search_runaway_reproduces(self):
+        """BASELINE (no breaker): the same dead query is searched more than a few times, or
+        the searcher fires a lot of total searches — the incident shape."""
+        out = _run(_confined_agent(self.model), _mock_get_empty)
+        emitted = _search_emissions(out)
+        worst = emitted.most_common(1)[0][1] if emitted else 0
+        total = sum(emitted.values())
+        # _get_queries (backend GETs) survives even when a hard runaway hits recursion_limit
+        # and _run returns None (emissions would then read empty) — so a severe reproduction
+        # counts as a reproduction, not a false failure.
+        total_backend = sum(_get_queries.values())
+        print(f"\n[search-runaway BASELINE] emissions={dict(emitted)} worst={worst} "
+              f"total={total} backend_gets={total_backend} out_is_none={out is None}\n")
+        self.assertFalse(_post_calls, "Tavily must not be hit")
+        self.assertTrue(
+            out is None or worst > _SAME_QUERY_CAP or total > 10 or total_backend > 10,
+            f"expected a search runaway (incident: ~80x/query); got worst={worst} total={total} "
+            f"backend={total_backend}. If low, the model gave up gracefully — tune the "
+            f"prompt/item to induce the loop.")
+
+    def test_breaker_bounds_runaway_and_agent_answers(self):
+        """WITH the breaker: no single query is *backend-searched* past one sweep (circuit
+        break), total stays bounded, and the agent still answers (finalize-not-kill)."""
+        out = _run(_confined_agent(self.model, (SearchRunawayBreakerMiddleware(),)), _mock_get_empty)
+        emitted = _search_emissions(out)
+        total = sum(emitted.values())
+        # circuit break: each distinct query hits the backend at most ONE sweep (<=6 engine
+        # GETs), no matter how many times the model re-emitted it.
+        worst_backend = _get_queries.most_common(1)[0][1] if _get_queries else 0
+        print(f"\n[search-runaway GUARDED] emissions={dict(emitted)} total={total} "
+              f"backend_gets={dict(_get_queries)} worst_backend={worst_backend}\n")
+        self.assertFalse(_post_calls, "Tavily must not be hit")
+        self.assertLessEqual(worst_backend, 6,
+                             f"circuit-break failed: a query hit the backend {worst_backend} times "
+                             f"(>1 sweep of 6 engines); counts={dict(_get_queries)}")
+        self.assertLessEqual(total, _TOTAL_CAP + 6,
+                             f"total search emissions {total} exceeded cap+batch; {dict(emitted)}")
+        self.assertTrue(_final_text(out).strip(),
+                        "agent returned no answer — breaker should finalize (nudge), not kill")
+
+    def test_legit_breadth_not_clipped(self):
+        """REGRESSION: a run where searches RETURN results (distinct queries) must not trip
+        the breaker — the model researches to a real answer, no refusal/short-circuit."""
+        out = _run(_confined_agent(self.model, (SearchRunawayBreakerMiddleware(),)),
+                   _mock_get_results, items=("Acme Rover 3 educational robot",))
+        emitted = _search_emissions(out)
+        print(f"\n[search-runaway REGRESSION] emissions={dict(emitted)} "
+              f"backend_gets={dict(_get_queries)}\n")
+        # every distinct query reached the backend (nothing short-circuited), and the model
+        # produced an answer — breadth intact.
+        self.assertTrue(_final_text(out).strip(), "agent produced no answer on a healthy run")
+        self.assertLessEqual(sum(emitted.values()), _TOTAL_CAP,
+                             "a healthy distinct-query run should not approach the total cap")

--- a/edd/eval/utils.py
+++ b/edd/eval/utils.py
@@ -342,7 +342,7 @@ def create_filesystem(root_dir: str,
 def _urls_in_search_result(result_str: str) -> list[str]:
     """Extract URLs from a search_internet result string
     (``[{'title','url','content'}, ...]``). Returns [] for non-list results
-    (e.g. the unavailable message or ``"[]"``)."""
+    (e.g. the unavailable message or the empty-guidance steer — both prose)."""
     try:
         items = ast.literal_eval(result_str)
     except (ValueError, SyntaxError):

--- a/tests/test_search_runaway_breaker_middleware.py
+++ b/tests/test_search_runaway_breaker_middleware.py
@@ -99,15 +99,18 @@ def test_repeated_empty_query_hits_same_query_cap():
     assert not ran and out.status == "error" and "already run this exact search" in out.content
 
 
-def test_malformed_empty_or_null_query_is_counted_not_bypassed():
-    """A search_internet(query="") / (query=None) must flow THROUGH counting (not bypass every
-    bound keyed on the empty query) and must not crash the normalizer — both normalize to "".
-    3 prior malformed empties → the 4th malformed call does not reach the backend."""
+def test_malformed_query_is_counted_not_bypassed_and_never_crashes():
+    """A malformed search_internet query — "", None, a list, an int — must flow THROUGH
+    counting (not bypass every bound keyed on the empty query) and must not crash the
+    normalizer (`.lower()` on a non-string). All non-strings normalize to "" and group, so 3
+    prior malformed empties → the 4th malformed call does not reach the backend."""
     mw = SearchRunawayBreakerMiddleware()
+    # mixed malformed shapes, all empty-returning — including a truthy non-str (list/int)
     hist = _history([("", _SEARCH_EMPTY_GUIDANCE), (None, _SEARCH_EMPTY_GUIDANCE),
-                     ("", _SEARCH_EMPTY_GUIDANCE)])
-    out, ran = _run(mw, "", hist)
-    assert not ran and out.tool_call_id == "new"   # bounded, not passed straight to the backend
+                     (["cubetto"], _SEARCH_EMPTY_GUIDANCE)])
+    for bad in ("", None, ["cubetto"], 5):     # each must be handled without raising
+        out, ran = _run(mw, bad, hist)
+        assert not ran and out.tool_call_id == "new"   # bounded, not passed to the backend
 
 
 def test_consecutive_empty_cap_refuses_distinct_reword_hammer():

--- a/tests/test_search_runaway_breaker_middleware.py
+++ b/tests/test_search_runaway_breaker_middleware.py
@@ -1,0 +1,143 @@
+"""Unit tests for SearchRunawayBreakerMiddleware — deterministic, no LLM.
+
+Drives wrap_tool_call with hand-built search_internet histories and asserts each of the four
+bounds: total-cap, consecutive-empty, same-query cap, and the empty circuit-break — plus the
+finalize/short-circuit return shapes (status, tool_call_id pairing) the design depends on.
+"""
+from types import SimpleNamespace
+
+from langchain_core.messages import AIMessage, ToolMessage
+
+from assist.middleware.search_runaway_breaker import (
+    SearchRunawayBreakerMiddleware, _SAME_QUERY_CAP, _TOTAL_CAP, _CONSECUTIVE_EMPTY_CAP,
+    _FINALIZE_STEER,
+)
+from assist.tools import _SEARCH_EMPTY_GUIDANCE
+
+_RESULTS = "[{'title': 't', 'url': 'https://e.test/1', 'content': 'c'}]"  # a non-empty result
+
+
+def _ai(query, tcid):
+    return AIMessage(content="", tool_calls=[{"name": "search_internet",
+                                              "args": {"query": query}, "id": tcid}])
+
+
+def _history(pairs, prefix="h"):
+    """pairs = list of (query, result_content); builds AIMessage + its ToolMessage per pair
+    with unique tool_call_ids (duplicate ids can't occur in a real history and would mask a
+    pairing bug)."""
+    msgs = []
+    for i, (q, res) in enumerate(pairs):
+        tcid = f"{prefix}{i}"
+        msgs.append(_ai(q, tcid))
+        msgs.append(ToolMessage(content=res, tool_call_id=tcid, name="search_internet"))
+    return msgs
+
+
+def _run(mw, query, history, tcid="new"):
+    tool_call = {"name": "search_internet", "args": {"query": query}, "id": tcid}
+    req = SimpleNamespace(tool_call=tool_call, state={"messages": history})
+    handled = {"ran": False}
+
+    def handler(r):
+        handled["ran"] = True
+        return ToolMessage(content=_RESULTS, tool_call_id=tcid, name="search_internet")
+
+    return mw.wrap_tool_call(req, handler), handled["ran"]
+
+
+def test_first_search_passes_through():
+    out, ran = _run(SearchRunawayBreakerMiddleware(), "cubetto review", [])
+    assert ran and out.content == _RESULTS
+
+
+def test_non_search_tool_passes_through():
+    mw = SearchRunawayBreakerMiddleware()
+    tc = {"name": "read_url", "args": {"url": "https://x.test"}, "id": "n"}
+    req = SimpleNamespace(tool_call=tc, state={"messages": []})
+    ran = {"v": False}
+
+    def handler(r):
+        ran["v"] = True
+        return ToolMessage(content="page", tool_call_id="n", name="read_url")
+
+    mw.wrap_tool_call(req, handler)
+    assert ran["v"]
+
+
+def test_same_query_cap_refuses_the_fourth_identical():
+    # 3 prior identical NON-empty searches (so the empty circuit-break isn't what fires)
+    hist = _history([("cubetto specs", _RESULTS)] * _SAME_QUERY_CAP)
+    out, ran = _run(SearchRunawayBreakerMiddleware(), "Cubetto  SPECS", hist)  # normalizes equal
+    assert not ran
+    assert out.status == "error" and "already run this exact search" in out.content
+    assert out.tool_call_id == "new"
+
+
+def test_same_query_under_cap_passes():
+    hist = _history([("cubetto specs", _RESULTS)] * (_SAME_QUERY_CAP - 1))
+    out, ran = _run(SearchRunawayBreakerMiddleware(), "cubetto specs", hist)
+    assert ran
+
+
+def test_empty_query_repeat_short_circuits_without_backend():
+    # one prior EMPTY result for this query → the repeat is served from cache, no handler
+    hist = _history([("zorblax qx-9 specs", _SEARCH_EMPTY_GUIDANCE)])
+    out, ran = _run(SearchRunawayBreakerMiddleware(), "zorblax qx-9 specs", hist)
+    assert not ran                                  # backend NOT hit (circuit broken)
+    assert out.content == _SEARCH_EMPTY_GUIDANCE     # byte-identical to a real empty
+    assert out.status != "error"                     # a served empty is NOT an error
+    assert out.tool_call_id == "new"                 # pairs, so it counts toward next decision
+
+
+def test_repeated_empty_query_hits_same_query_cap():
+    """Empty results ALSO count toward the same-query cap: 3 prior empties of one query → the
+    4th is refused-steer (distinct path from the non-empty same-query test above)."""
+    q = "nabbo codepal battery"
+    hist = _history([(q, _SEARCH_EMPTY_GUIDANCE)] * _SAME_QUERY_CAP)
+    out, ran = _run(SearchRunawayBreakerMiddleware(), q, hist)
+    assert not ran and out.status == "error" and "already run this exact search" in out.content
+
+
+def test_malformed_empty_or_null_query_is_counted_not_bypassed():
+    """A search_internet(query="") / (query=None) must flow THROUGH counting (not bypass every
+    bound keyed on the empty query) and must not crash the normalizer — both normalize to "".
+    3 prior malformed empties → the 4th malformed call does not reach the backend."""
+    mw = SearchRunawayBreakerMiddleware()
+    hist = _history([("", _SEARCH_EMPTY_GUIDANCE), (None, _SEARCH_EMPTY_GUIDANCE),
+                     ("", _SEARCH_EMPTY_GUIDANCE)])
+    out, ran = _run(mw, "", hist)
+    assert not ran and out.tool_call_id == "new"   # bounded, not passed straight to the backend
+
+
+def test_consecutive_empty_cap_refuses_distinct_reword_hammer():
+    # N distinct empty queries in a trailing run → the (N+1)th DISTINCT one is refused-finalize
+    hist = _history([(f"zorblax variant {i}", _SEARCH_EMPTY_GUIDANCE)
+                     for i in range(_CONSECUTIVE_EMPTY_CAP)])
+    out, ran = _run(SearchRunawayBreakerMiddleware(), "zorblax brand new angle", hist)
+    assert not ran
+    assert out.status == "error" and out.content == _FINALIZE_STEER
+
+
+def test_consecutive_empty_run_resets_on_a_non_empty_result():
+    # 4 empties, then a NON-empty, then 3 more empties → trailing run is 3 (< cap) → passes
+    pairs = ([(f"a{i}", _SEARCH_EMPTY_GUIDANCE) for i in range(4)]
+             + [("hit", _RESULTS)]
+             + [(f"b{i}", _SEARCH_EMPTY_GUIDANCE) for i in range(3)])
+    out, ran = _run(SearchRunawayBreakerMiddleware(), "c brand new", _history(pairs))
+    assert ran  # consecutive-empty did not fire (run reset); total is well under cap
+
+
+def test_total_cap_refuses_the_fifty_first_even_when_all_distinct():
+    # TOTAL_CAP distinct NON-empty searches → the next distinct search is refused-finalize
+    hist = _history([(f"distinct query number {i}", _RESULTS) for i in range(_TOTAL_CAP)])
+    out, ran = _run(SearchRunawayBreakerMiddleware(), "one more distinct query", hist)
+    assert not ran
+    assert out.status == "error" and out.content == _FINALIZE_STEER
+    assert out.tool_call_id == "new"
+
+
+def test_total_cap_under_limit_passes():
+    hist = _history([(f"distinct query number {i}", _RESULTS) for i in range(_TOTAL_CAP - 1)])
+    out, ran = _run(SearchRunawayBreakerMiddleware(), "still under the cap", hist)
+    assert ran

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -147,13 +147,14 @@ class TestSearchInternet:
         # formatting (quotes/spacing/key order).
         assert len(ast.literal_eval(result)) == 3
 
-    def test_genuine_empty_returns_bracket(self, monkeypatch):
-        """Zero results with NO engine failures is a real 'no results' answer,
-        not a backend failure — return '[]' so the agent can pivot."""
+    def test_genuine_empty_returns_guidance(self, monkeypatch):
+        """Zero results with NO engine failures is a real 'no results' answer, not a backend
+        failure — return the empty-guidance steer (was a bare '[]', which the small model
+        re-hammered) so the agent pivots instead of re-running the dead query."""
         monkeypatch.setenv("ASSIST_SEARCH_URL", self.URL)
         with patch.object(tools, "requests") as req:
             req.get.return_value = _resp({"results": [], "unresponsive_engines": []})
-            assert tools.search_internet("obscure") == "[]"
+            assert tools.search_internet("obscure") == tools._SEARCH_EMPTY_GUIDANCE
 
     # --- Backend-failure modes: return the unavailable MESSAGE (loud, logged),
     # NOT raise.  Raising would crash the research turn; the agent must receive
@@ -272,12 +273,12 @@ class TestSearchInternet:
         assert "searxng: mojeek returned 1 results" in msgs
 
     def test_rotation_all_engines_healthy_but_empty_returns_empty(self, monkeypatch):
-        """Every engine up but genuinely no results → "[]" (a real no-results answer),
-        NOT unavailable."""
+        """Every engine up but genuinely no results → the empty-guidance steer (a real
+        no-results answer), NOT unavailable."""
         monkeypatch.setenv("ASSIST_SEARCH_URL", self.URL)
         with patch.object(tools, "requests") as req:
             req.get.return_value = _resp({"results": [], "unresponsive_engines": []})
-            assert tools.search_internet("q") == "[]"
+            assert tools.search_internet("q") == tools._SEARCH_EMPTY_GUIDANCE
 
     def test_results_present_with_some_failed_engines_returns_them_plainly(self, monkeypatch):
         """Results present + some engines throttled is the routine healthy metasearch case


### PR DESCRIPTION
## Problem — the 2026-07-18 coding-toy incident

Diagnosed from 7 days of prod logs: the research searcher fired **346 `search_internet` calls in 33 min** on Jul 18, ~73% of them **three obscure product-spec queries searched ~80× each, all returning healthy-empty** (SearXNG up, genuinely no hits), in concurrent 3-wide batches. The user request was legitimate (compare screen-free coding toys for a child); the pathology was hammering unfindable products instead of concluding they're unfindable.

Three shipped guards all missed it, by construction:
- **LoopDetection** catches only *consecutive* exact-repeats — the three queries cycled A/B/C.
- **SearchUnavailableBreaker** keys on the *unavailable* constant — a healthy-empty `"[]"` was invisible.
- The `"STOP after 5 searches"` prompt cap is soft and the small model ignores it.

Normal research is unaffected (~11 searches/dispatch; a broad comparison spreads ~116 *distinct* queries across ~10 dispatches). So the fix bounds repetition + empty-hammering + volume **without clipping distinct breadth**.

## Fix (guidance primary, middleware backstop)

- **`tools.py`**: healthy-empty `search_internet` now returns `_SEARCH_EMPTY_GUIDANCE` (a "no results — don't repeat, change the angle, conclude not-findable" steer) instead of a bare `"[]"` the model re-hammered.
- **`sub_research.txt.j2`**: folded a relax-on-empty hygiene line mirroring the proven `read_url` "don't retry a variant" rule; dropped the ineffective absolute cap.
- **`SearchRunawayBreakerMiddleware`** (new sibling, shares `loop_detection._extract_events`): per-dispatch bounds — same-query cap **3**, **empty circuit-break** (a repeat of an empty query short-circuits, no backend hit), consecutive-empty cap **5**, total cap **50**. Refusals are finalize-not-kill; the short-circuit serves a byte-identical non-error empty. Wired into the shared `_subagent_safety_mw` (active on the searcher, inert on critique/fact-check).
- Extracted `loop_detection._messages_from_state`, shared by all four history-counting guards (was a 4th copy).

## Validation

- **Reproduction eval** (`edd/eval/test_search_runaway_loop.py`) — a confined searcher against a **mocked healthy-empty SearXNG** (`requests.get` patched; Tavily `requests.post` asserted never-called; `TAVILY_API_KEY` cleared). Baseline reproduces the loop (~12–18 empty searches); guarded bounds it (~9 emitted, no query past one 6-engine sweep, agent still answers); regression proves a healthy distinct-query run is **not clipped**. **N=5 stable (15/15).**
- **11 deterministic middleware unit tests** (each bound + the malformed-query and null-safety regressions).
- Full mocked suite **1230 green**.

## Reviewed across 9 lenses (design + code)

Design: simplicity / agentic-fit / clean-interfaces / threat-model. Code: correctness / adversarial-security / docstring-alignment / simplicity. **0 blockers.** Fixed from code review: a `search_internet(query="")` bound-bypass (gate on tool *name*, not empty query), a `_normalize_query(None)` hot-path crash (null-safe), a reproduction-eval inversion on hard runaways, and the shared-helper extraction.

## Known limitations (honest residuals — see the design doc)

- **Concurrency lag**: completed-only counting can't see the in-flight siblings of one concurrent batch, so effective ceiling ≈ 50 + one batch width (observed ~3), not a hard 50. A strict in-batch bound is deferred (observed width is single-digit).
- **Per-dispatch scope**: cross-dispatch search budget is bounded only by the searcher's ~25-superstep recursion_limit (the incident was within one dispatch). v2 follow-up.
- **Trailing-empty reset**: a runaway interleaving a result-returning query every ≤4 empties keeps the consecutive-empty run under 5 — backstopped by the total cap.

Design doc: `docs/2026-07-22-search-runaway-breaker.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)