### PR TITLE
Fix egress-smoke Phase 2: chmod the approvals dir (CI-only permission gap)

### DIFF
--- a/dockerfiles/test-sandbox-egress.sh
+++ b/dockerfiles/test-sandbox-egress.sh
@@ -33,6 +33,17 @@ HOST_DIR=$(mktemp -d)
 APPROVALS_DIR=$(mktemp -d)
 SANDBOX2="assist-egress-smoke-sb-$$"
 
+# Same runner-uid-vs-container-uid gap as $HOST_DIR below: `mktemp -d`
+# defaults to 0700, so the proxy container's non-root `proxy` user
+# (uid 1000, Dockerfile.egress-proxy) can't even traverse into
+# /approvals on a host where the runner's uid differs (GitHub's
+# ubuntu-latest = 1001) — every _read_small_json() call fails closed
+# with PermissionError, so approval grants silently never match. The
+# files created inside get their mode from the process umask (already
+# world-readable), so only the directory's own x-for-other bit is
+# missing.
+chmod 0755 "$APPROVALS_DIR"
+
 # Mount the real requirements.txt + pyproject.toml + assist source so
 # the positive case probes EXACTLY what dev-agent's eval install does
 # (`pip install -r requirements.txt -e .`).  Drift to a non-allowlisted


### PR DESCRIPTION
## Problem

Both PR #202 and #203 fail CI at the exact same step, and so does a plain push to `main`'s current tip: `make sandbox-smoke` fails in Phase 2 ("approval grants") with `FAIL: approved example.com not reachable (000)`. This predates and is unrelated to either PR's diff — it's a bug in `main` itself, shipped with the egress-approval-HITL feature (#200).

## Root cause

`dockerfiles/test-sandbox-egress.sh` creates `APPROVALS_DIR=$(mktemp -d)`, which defaults to mode `0700` owned by the invoking user, then bind-mounts it read-only into the egress-proxy container. That container runs as a non-root user (`proxy`, uid 1000 — `Dockerfile.egress-proxy`). On GitHub's `ubuntu-latest` runners the job's own user is uid 1001, so the proxy process can't even traverse into `/approvals` — every `_read_small_json()` call in `egress-proxy.py` hits `PermissionError` and silently returns `{}` (by design — fail-closed on any parse problem), so `client-map.json`/`approved-hosts.json` never resolve and every grant looks absent.

This exact uid-mismatch class of bug was already hit and fixed for the *other* bind-mounted dir in this same script (`$HOST_DIR`, a few lines up) — `chmod 0755 "$HOST_DIR"; chmod -R a+rX "$HOST_DIR"`, with a comment explaining the runner-uid-1001-vs-container-uid-1000 gap. `APPROVALS_DIR` was added later (for the approval-grants feature) and missed the same fix.

Confirmed directly: a throwaway container run with `--user 1234:1234` against a `0700` host dir reproduces `PermissionError(13, 'Permission denied')` on `os.listdir`; `chmod 0755` on the same dir resolves it. Also confirmed via a temporary diagnostic branch (pushed to CI, now deleted) that the real GitHub Actions failure was this exact `PermissionError`, not a client-IP mismatch or a timing race (a 10x retry loop never once succeeded).

## Fix

One `chmod 0755 "$APPROVALS_DIR"` right after `mktemp -d`, mirroring the established `$HOST_DIR` pattern. The files created inside are already world-readable (default umask), so only the directory's own traverse bit was missing — no recursive chmod needed since nothing is copied in, only written directly.

Production is unaffected: `assist/egress/client_map.py`'s `_write()` creates its directory via `os.makedirs(..., exist_ok=True)`, which is subject to the deploy host's normal umask (typically `022` → `0755`), not `mktemp -d`'s deliberately-restrictive `0700`. This is a test-harness-only bug.

## Verification

- Ran the full `dockerfiles/test-sandbox-egress.sh` locally end-to-end: all of Phase 1 + Phase 2 (probes 1–13) pass.
- Isolated repro of the exact permission gap (see above) confirms both the failure mode and the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)