### PR TITLE
P0.5: read-only thread catalog + phone-receptionist router agent

### DIFF
--- a/assist/catalog.py
+++ b/assist/catalog.py
@@ -4,10 +4,11 @@ their state" surface (shared session API; docs/2026-07-21-voice-call-tech-design
 
 The receptionist (voice) consumes this WITHOUT loading any conversation: no
 checkpoint access, no ``Thread`` construction, no model call, no message read.
-Thread CONTENTS are unreachable by construction — this module has no path into
-``threads.db`` or the langgraph checkpoint; it only reads the per-thread sidecar
-files (``description.txt`` / ``status.json`` / the urgent marker) plus the dir
-mtime.
+Thread CONTENTS are unreachable by construction — this module never reads
+``threads.db`` or the langgraph checkpoint (it holds a ``ThreadManager``, which owns
+them, but only calls its directory operations — ``list`` / ``thread_dir``); it reads
+just the per-thread sidecar files (``description.txt`` / ``status.json`` / the urgent
+marker) plus the dir mtime.
 
 It mirrors the *file-reading halves* of the web layer's per-thread reads
 (``manage/web/state.py``'s ``_get_status`` / ``_has_urgent`` / ``description.txt``)

--- a/assist/catalog.py
+++ b/assist/catalog.py
@@ -60,9 +60,12 @@ class ThreadCatalog:
     def _status(self, tdir: str) -> str:
         try:
             with open(os.path.join(tdir, _STATUS_FILE)) as f:
-                return str(json.load(f).get("stage", "ready"))
+                stage = json.load(f).get("stage")
         except Exception:
             return "ready"          # missing/corrupt ⇒ the same default _get_status uses
+        # A non-string stage (null/number in otherwise-valid JSON) is corrupt too:
+        # degrade to the default rather than surface "None"/"123" to a client.
+        return stage if isinstance(stage, str) and stage else "ready"
 
     def _urgent(self, tdir: str) -> bool:
         try:

--- a/assist/catalog.py
+++ b/assist/catalog.py
@@ -53,9 +53,14 @@ class ThreadCatalog:
     def _description(self, tdir: str) -> str:
         try:
             with open(os.path.join(tdir, _DESCRIPTION_FILE)) as f:
-                return f.read().strip() or "New thread"
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        return line     # first non-empty line — a one-line summary, so
+                                        # an embedded newline can't break a numbered/spoken list
         except Exception:
-            return "New thread"     # missing/unreadable ⇒ not generated here (needs a model)
+            pass
+        return "New thread"     # missing/unreadable/blank ⇒ not generated here (needs a model)
 
     def _status(self, tdir: str) -> str:
         try:

--- a/assist/catalog.py
+++ b/assist/catalog.py
@@ -1,0 +1,93 @@
+"""Read-only thread catalog — the client-agnostic "what threads exist and what's
+their state" surface (shared session API; docs/2026-07-21-voice-call-tech-design.org
+§3).
+
+A receptionist (voice) or a thread-list UI (web) both consume this WITHOUT loading
+any conversation: no checkpoint access, no ``Thread`` construction, no model call,
+no message read. Thread CONTENTS are unreachable by construction — this module has
+no path into ``threads.db`` or the langgraph checkpoint; it only reads the
+per-thread sidecar files (``description.txt`` / ``status.json`` / the urgent
+marker) plus the dir mtime.
+
+It lifts the *file-reading halves* of the web layer's per-thread reads so web and
+voice share ONE surface instead of each re-deriving it. Description GENERATION
+(which needs a model) and the web's ``DESCRIPTION_CACHE`` stay web-side — the
+catalog only reads the file, falling back to ``"New thread"`` on a miss (never
+generating one).
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+
+_DESCRIPTION_FILE = "description.txt"
+_STATUS_FILE = "status.json"
+_URGENT_MARKER = "urgent_response"   # the notify() durable marker (state.py:_urgent_path)
+
+
+@dataclass(frozen=True)
+class CatalogEntry:
+    id: str
+    description: str      # one-line summary, never the transcript; "New thread" if none
+    status: str          # the status.json stage (ready / processing / error / …)
+    updated_at: float    # thread-dir mtime, epoch seconds (the list sort key)
+    urgent: bool         # the notify()-set durable urgent marker
+
+
+class ThreadCatalog:
+    """Read-only view over a ``ThreadManager``'s threads. Takes the manager (so one
+    dir scan and one tid-validation path are reused) and NEVER constructs a Thread."""
+
+    def __init__(self, manager):
+        self._manager = manager
+
+    def _dir(self, tid: str) -> str:
+        return self._manager.thread_dir(tid)   # validates tid (raises on traversal/NUL)
+
+    def _description(self, tdir: str) -> str:
+        try:
+            with open(os.path.join(tdir, _DESCRIPTION_FILE)) as f:
+                return f.read().strip() or "New thread"
+        except OSError:
+            return "New thread"     # missing ⇒ not generated here (generation needs a model)
+
+    def _status(self, tdir: str) -> str:
+        try:
+            with open(os.path.join(tdir, _STATUS_FILE)) as f:
+                return str(json.load(f).get("stage", "ready"))
+        except Exception:
+            return "ready"          # missing/corrupt ⇒ the same default _get_status uses
+
+    def _urgent(self, tdir: str) -> bool:
+        try:
+            return os.path.isfile(os.path.join(tdir, _URGENT_MARKER))
+        except OSError:
+            return False
+
+    def get(self, tid: str) -> CatalogEntry | None:
+        """One entry, or None if the tid is invalid or the thread doesn't exist."""
+        try:
+            tdir = self._dir(tid)
+        except Exception:
+            return None             # invalid tid shape — never a 500 into a client
+        if not os.path.isdir(tdir):
+            return None
+        try:
+            updated_at = os.path.getmtime(tdir)
+        except OSError:
+            updated_at = 0.0
+        return CatalogEntry(id=tid, description=self._description(tdir),
+                            status=self._status(tdir), updated_at=updated_at,
+                            urgent=self._urgent(tdir))
+
+    def entries(self) -> list[CatalogEntry]:
+        """Every live thread as a catalog entry, in ``ThreadManager.list`` order
+        (mtime-descending, soft-deleted filtered). One dir scan for the ids; a few
+        small sidecar reads each."""
+        out: list[CatalogEntry] = []
+        for tid in self._manager.list():
+            entry = self.get(tid)
+            if entry is not None:
+                out.append(entry)
+        return out

--- a/assist/catalog.py
+++ b/assist/catalog.py
@@ -2,18 +2,20 @@
 their state" surface (shared session API; docs/2026-07-21-voice-call-tech-design.org
 §3).
 
-A receptionist (voice) or a thread-list UI (web) both consume this WITHOUT loading
-any conversation: no checkpoint access, no ``Thread`` construction, no model call,
-no message read. Thread CONTENTS are unreachable by construction — this module has
-no path into ``threads.db`` or the langgraph checkpoint; it only reads the
-per-thread sidecar files (``description.txt`` / ``status.json`` / the urgent
-marker) plus the dir mtime.
+The receptionist (voice) consumes this WITHOUT loading any conversation: no
+checkpoint access, no ``Thread`` construction, no model call, no message read.
+Thread CONTENTS are unreachable by construction — this module has no path into
+``threads.db`` or the langgraph checkpoint; it only reads the per-thread sidecar
+files (``description.txt`` / ``status.json`` / the urgent marker) plus the dir
+mtime.
 
-It lifts the *file-reading halves* of the web layer's per-thread reads so web and
-voice share ONE surface instead of each re-deriving it. Description GENERATION
-(which needs a model) and the web's ``DESCRIPTION_CACHE`` stay web-side — the
-catalog only reads the file, falling back to ``"New thread"`` on a miss (never
-generating one).
+It mirrors the *file-reading halves* of the web layer's per-thread reads
+(``manage/web/state.py``'s ``_get_status`` / ``_has_urgent`` / ``description.txt``)
+as one checkpoint-free surface; a later increment can point the web thread-list at
+it so the two stop re-deriving the same reads (web still owns them today).
+Description GENERATION (which needs a model) and the web's ``DESCRIPTION_CACHE``
+stay web-side — the catalog only reads the file, falling back to ``"New thread"``
+on a miss (never generating one).
 """
 from __future__ import annotations
 
@@ -21,6 +23,9 @@ import json
 import os
 from dataclasses import dataclass
 
+# These three sidecar names are authored by the web layer (manage/web/state.py);
+# it stays the source of truth until web is migrated onto this catalog. Renaming
+# one there without updating here silently blanks that field (e.g. urgent=False).
 _DESCRIPTION_FILE = "description.txt"
 _STATUS_FILE = "status.json"
 _URGENT_MARKER = "urgent_response"   # the notify() durable marker (state.py:_urgent_path)
@@ -49,8 +54,8 @@ class ThreadCatalog:
         try:
             with open(os.path.join(tdir, _DESCRIPTION_FILE)) as f:
                 return f.read().strip() or "New thread"
-        except OSError:
-            return "New thread"     # missing ⇒ not generated here (generation needs a model)
+        except Exception:
+            return "New thread"     # missing/unreadable ⇒ not generated here (needs a model)
 
     def _status(self, tdir: str) -> str:
         try:

--- a/assist/catalog.py
+++ b/assist/catalog.py
@@ -95,13 +95,17 @@ class ThreadCatalog:
                             status=self._status(tdir), updated_at=updated_at,
                             urgent=self._urgent(tdir))
 
-    def entries(self) -> list[CatalogEntry]:
-        """Every live thread as a catalog entry, in ``ThreadManager.list`` order
+    def entries(self, limit: int | None = None) -> list[CatalogEntry]:
+        """Live threads as catalog entries, in ``ThreadManager.list`` order
         (mtime-descending, soft-deleted filtered). One dir scan for the ids; a few
-        small sidecar reads each."""
+        small sidecar reads each. ``limit`` stops after that many entries — since the
+        order is mtime-descending, that's the most-recent N, so the latency-sensitive
+        listing path reads only N threads' sidecars instead of every thread's."""
         out: list[CatalogEntry] = []
         for tid in self._manager.list():
             entry = self.get(tid)
             if entry is not None:
                 out.append(entry)
+                if limit is not None and len(out) >= limit:
+                    break
         return out

--- a/assist/receptionist.py
+++ b/assist/receptionist.py
@@ -61,8 +61,10 @@ def receptionist_tools(catalog, domains, on_open, on_new) -> list:
     """The three receptionist tools, closing over the read-only ``catalog``, the
     ``domains`` labels, and the injected callbacks. Session-scoped: build a fresh
     set per call — ``_last`` (the listing ``open_thread`` resolves numbers against)
-    is per-session state."""
+    and ``_bound`` (the thread already connected this session) are per-session
+    state."""
     _last: list = []
+    _bound: list = []   # the tid this session is already connected to (idempotent open)
 
     def list_threads() -> str:
         """List the caller's existing conversation threads so you can help them
@@ -97,10 +99,15 @@ def receptionist_tools(catalog, domains, on_open, on_new) -> list:
                 return f"I've got a few that match — did you mean {names}?"
             return ("I couldn't tell which thread you meant. Tell me its number or "
                     "a few words from its topic.")
+        if _bound and _bound[-1] == entry.id:
+            # Idempotent: the model sometimes fires open_thread twice for one intent —
+            # don't bind (and speak the connect) again for the thread we're already on.
+            return f"You're already connected to the {entry.description} thread."
         try:
             on_open(entry.id)
         except Exception:
             return "Sorry — I couldn't connect you to that one. Want to try another?"
+        _bound.append(entry.id)
         return f"Connecting you to the {entry.description} thread."
 
     def new_thread(domain: str, first_message: str) -> str:
@@ -129,10 +136,15 @@ def receptionist_tools(catalog, domains, on_open, on_new) -> list:
     return [list_threads, open_thread, new_thread]
 
 
-def create_receptionist(tools):
+def create_receptionist(tools, domains):
     """Build the receptionist as a VANILLA LangChain agent (never a deepagent — a
     deepagent would drag in the filesystem/execute/task surface this router must
     not have; the vanilla loop's tool set is exactly ``tools``).
+
+    ``domains`` (the same labels passed to ``receptionist_tools``) are rendered into
+    the system prompt so the router knows the user's projects up front — a real
+    receptionist knows the departments — and can NAME them when eliciting which
+    project a new thread belongs to, instead of asking blindly.
 
     The three protective middleware are load-bearing on a phone call, not polish:
     EmptyResponseRecovery (a bare empty/<think>-only AIMessage would end the turn in
@@ -152,7 +164,7 @@ def create_receptionist(tools):
     return create_agent(
         select_assistant_model(0.1),                # enable_thinking=False default + timeouts
         tools,
-        system_prompt=base_prompt_for("receptionist_system.md.j2"),
+        system_prompt=base_prompt_for("receptionist_system.md.j2", domains=domains),
         middleware=[_make_retry_middleware(),
                     BadRequestRetryMiddleware(),
                     EmptyResponseRecoveryMiddleware()],

--- a/assist/receptionist.py
+++ b/assist/receptionist.py
@@ -88,10 +88,12 @@ def receptionist_tools(catalog, domains, on_open, on_new) -> list:
         from the list or a few words from its topic ('the trip one'). Call this as
         soon as you know which thread the caller wants — you do not need to list
         first if they already told you."""
-        # A number resolves against the list the caller actually heard (_last,
-        # itself capped at 20); a topic/id must reach ANY thread, so fall back to
-        # the full catalog — not the top 20 — or older threads become unrouteable.
-        entries = _last or catalog.entries()
+        # A number refers to the list the caller actually heard (_last, itself
+        # capped at 20); a topic or id must reach ANY thread, so resolve those
+        # against the FULL catalog — never the capped listing, or older threads
+        # become unopenable by name once the caller has listed.
+        stripped = str(selector or "").strip()
+        entries = (_last or catalog.entries()) if stripped.isdigit() else catalog.entries()
         entry, ambiguous = _resolve(selector, entries)
         if entry is None:
             if ambiguous:

--- a/assist/receptionist.py
+++ b/assist/receptionist.py
@@ -64,7 +64,7 @@ def receptionist_tools(catalog, domains, on_open, on_new) -> list:
     and ``_bound`` (the thread already connected this session) are per-session
     state."""
     _last: list = []
-    _bound: list = []   # the tid this session is already connected to (idempotent open)
+    _bound: list = []   # size-1 holder of the tid this session is connected to (idempotent open)
 
     def list_threads() -> str:
         """List the caller's existing conversation threads so you can help them
@@ -112,7 +112,7 @@ def receptionist_tools(catalog, domains, on_open, on_new) -> list:
             on_open(entry.id)
         except Exception:
             return "Sorry — I couldn't connect you to that one. Want to try another?"
-        _bound.append(entry.id)
+        _bound[:] = [entry.id]   # only the current binding matters; keep it size-1
         return f"Connecting you to the {entry.description} thread."
 
     def new_thread(domain: str, first_message: str) -> str:

--- a/assist/receptionist.py
+++ b/assist/receptionist.py
@@ -10,7 +10,7 @@ mechanical test asserts the bound tool set is exactly the three tools below.
 
 The three tools take injected callbacks (the ``notify_tools`` mold — no web
 imports): ``on_open(tid)`` binds the session to an existing thread; ``on_new(domain,
-first_message) -> tid`` creates one and returns its id. Both run synchronously on
+first_message)`` creates one AND binds the session to it. Both run synchronously on
 the caller's session thread and NEVER raise into the agent loop — a failure comes
 back as a spoken directive.
 """
@@ -39,18 +39,22 @@ def _resolve(selector, entries):
 
 
 def _match_domain(name, domains):
-    """Match a spoken domain name to one of the configured domain labels
-    (exact, then substring either way)."""
+    """Match a spoken domain name to the configured domain labels. Returns
+    ``(domain, ambiguous)`` mirroring ``_resolve``: an exact match wins outright;
+    otherwise the substring matches (either way, to absorb loose phrasing like "the
+    garden project thread") — exactly one → ``(that, [])``, none → ``(None, [])``,
+    several → ``(None, [those])`` so ``new_thread`` asks WHICH rather than silently
+    picking the first (overlapping labels like Home/Homework must not misroute)."""
     n = str(name or "").strip().lower()
     if not n:
-        return None
+        return None, []
     for d in domains:
         if d.lower() == n:
-            return d
-    for d in domains:
-        if n in d.lower() or d.lower() in n:
-            return d
-    return None
+            return d, []
+    matches = [d for d in domains if n in d.lower() or d.lower() in n]
+    if len(matches) == 1:
+        return matches[0], []
+    return None, matches
 
 
 def receptionist_tools(catalog, domains, on_open, on_new) -> list:
@@ -82,7 +86,10 @@ def receptionist_tools(catalog, domains, on_open, on_new) -> list:
         from the list or a few words from its topic ('the trip one'). Call this as
         soon as you know which thread the caller wants — you do not need to list
         first if they already told you."""
-        entries = _last or catalog.entries()[:20]
+        # A number resolves against the list the caller actually heard (_last,
+        # itself capped at 20); a topic/id must reach ANY thread, so fall back to
+        # the full catalog — not the top 20 — or older threads become unrouteable.
+        entries = _last or catalog.entries()
         entry, ambiguous = _resolve(selector, entries)
         if entry is None:
             if ambiguous:
@@ -101,8 +108,11 @@ def receptionist_tools(catalog, domains, on_open, on_new) -> list:
         to (ask in one short question if they didn't say; if there's only one
         project, just use it). ``first_message`` is what the caller wants to do, in
         their own words. Only call this once you have both."""
-        matched = _match_domain(domain, domains)
+        matched, ambiguous = _match_domain(domain, domains)
         if matched is None:
+            if ambiguous:
+                return ("Which project should this go under — "
+                        + " or ".join(ambiguous[:3]) + "?")
             if len(domains) == 1:
                 matched = domains[0]
             elif not domains:
@@ -119,7 +129,7 @@ def receptionist_tools(catalog, domains, on_open, on_new) -> list:
     return [list_threads, open_thread, new_thread]
 
 
-def create_receptionist(tools, *, temperature: float = 0.1):
+def create_receptionist(tools):
     """Build the receptionist as a VANILLA LangChain agent (never a deepagent — a
     deepagent would drag in the filesystem/execute/task surface this router must
     not have; the vanilla loop's tool set is exactly ``tools``).
@@ -140,7 +150,7 @@ def create_receptionist(tools, *, temperature: float = 0.1):
     from assist.promptable import base_prompt_for
 
     return create_agent(
-        select_assistant_model(temperature),        # enable_thinking=False default + timeouts
+        select_assistant_model(0.1),                # enable_thinking=False default + timeouts
         tools,
         system_prompt=base_prompt_for("receptionist_system.md.j2"),
         middleware=[_make_retry_middleware(),

--- a/assist/receptionist.py
+++ b/assist/receptionist.py
@@ -1,0 +1,150 @@
+"""The receptionist — a phone-call router agent (voice-call assistant, P0.5;
+docs/2026-07-21-voice-call-tech-design.org §4).
+
+A caller reaches this agent first; it helps them get to the right thread (or start
+a new one) and hands off. It is a *vanilla LangChain* agent (``create_agent``),
+NOT a deepagent — deliberately, so it physically lacks the filesystem/execute/task
+surface and can never read a thread's CONTENTS. It sees only the read-only
+``ThreadCatalog`` (topic + state per thread), enforced by construction: a
+mechanical test asserts the bound tool set is exactly the three tools below.
+
+The three tools take injected callbacks (the ``notify_tools`` mold — no web
+imports): ``on_open(tid)`` binds the session to an existing thread; ``on_new(domain,
+first_message) -> tid`` creates one and returns its id. Both run synchronously on
+the caller's session thread and NEVER raise into the agent loop — a failure comes
+back as a spoken directive.
+"""
+from __future__ import annotations
+
+
+def _resolve(selector, entries):
+    """Resolve an open_thread selector against the current listing. Returns
+    ``(entry, ambiguous)``: an exact hit → ``(entry, [])``; no match →
+    ``(None, [])``; several substring matches → ``(None, [those matches])`` so the
+    tool can ask which one."""
+    s = str(selector or "").strip()
+    if not s:
+        return None, []
+    if s.isdigit():                                  # "2" — a number from the list
+        i = int(s)
+        return (entries[i - 1], []) if 1 <= i <= len(entries) else (None, [])
+    for e in entries:                                # an exact thread id
+        if e.id == s:
+            return e, []
+    low = s.lower()                                  # words from the topic
+    matches = [e for e in entries if low in e.description.lower()]
+    if len(matches) == 1:
+        return matches[0], []
+    return None, matches                             # 0 → miss; >1 → ambiguous
+
+
+def _match_domain(name, domains):
+    """Match a spoken domain name to one of the configured domain labels
+    (exact, then substring either way)."""
+    n = str(name or "").strip().lower()
+    if not n:
+        return None
+    for d in domains:
+        if d.lower() == n:
+            return d
+    for d in domains:
+        if n in d.lower() or d.lower() in n:
+            return d
+    return None
+
+
+def receptionist_tools(catalog, domains, on_open, on_new) -> list:
+    """The three receptionist tools, closing over the read-only ``catalog``, the
+    ``domains`` labels, and the injected callbacks. Session-scoped: build a fresh
+    set per call — ``_last`` (the listing ``open_thread`` resolves numbers against)
+    is per-session state."""
+    _last: list = []
+
+    def list_threads() -> str:
+        """List the caller's existing conversation threads so you can help them
+        choose. Returns a short numbered list of topics and their state. Use this
+        ONLY when the caller is unsure which thread they want — if they've already
+        told you, just open it."""
+        entries = catalog.entries()[:20]
+        _last.clear()
+        _last.extend(entries)
+        if not entries:
+            return "There are no threads yet — we can start a new one."
+        lines = []
+        for i, e in enumerate(entries, 1):
+            tag = (" (urgent)" if e.urgent
+                   else "" if e.status == "ready" else f" ({e.status})")
+            lines.append(f"{i}. {e.description}{tag}")
+        return "\n".join(lines)
+
+    def open_thread(selector: str) -> str:
+        """Connect the caller to an existing thread. ``selector`` can be its number
+        from the list or a few words from its topic ('the trip one'). Call this as
+        soon as you know which thread the caller wants — you do not need to list
+        first if they already told you."""
+        entries = _last or catalog.entries()[:20]
+        entry, ambiguous = _resolve(selector, entries)
+        if entry is None:
+            if ambiguous:
+                names = " or ".join(f"the {m.description} one" for m in ambiguous[:3])
+                return f"I've got a few that match — did you mean {names}?"
+            return ("I couldn't tell which thread you meant. Tell me its number or "
+                    "a few words from its topic.")
+        try:
+            on_open(entry.id)
+        except Exception:
+            return "Sorry — I couldn't connect you to that one. Want to try another?"
+        return f"Connecting you to the {entry.description} thread."
+
+    def new_thread(domain: str, first_message: str) -> str:
+        """Start a NEW thread. ``domain`` is which of the user's projects it belongs
+        to (ask in one short question if they didn't say; if there's only one
+        project, just use it). ``first_message`` is what the caller wants to do, in
+        their own words. Only call this once you have both."""
+        matched = _match_domain(domain, domains)
+        if matched is None:
+            if len(domains) == 1:
+                matched = domains[0]
+            elif not domains:
+                return "There aren't any projects set up to start a thread in."
+            else:
+                return ("Which project should this go under? The options are "
+                        + ", ".join(domains) + ".")
+        try:
+            on_new(matched, first_message)
+        except Exception:
+            return "Sorry — I couldn't start that thread. Want to try again?"
+        return f"Starting a new thread in {matched} — go ahead."
+
+    return [list_threads, open_thread, new_thread]
+
+
+def create_receptionist(tools, *, temperature: float = 0.1):
+    """Build the receptionist as a VANILLA LangChain agent (never a deepagent — a
+    deepagent would drag in the filesystem/execute/task surface this router must
+    not have; the vanilla loop's tool set is exactly ``tools``).
+
+    The three protective middleware are load-bearing on a phone call, not polish:
+    EmptyResponseRecovery (a bare empty/<think>-only AIMessage would end the turn in
+    dead air), ModelRetry (ChatOpenAI is built max_retries=0), BadRequestRetry (the
+    400 class). The model is built thinking-OFF with per-phase timeouts (a thinking
+    router would burn its latency budget on <think> tokens the caller never hears; a
+    hung first token is unbounded dead air)."""
+    from langchain.agents import create_agent
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    from assist.agent import _make_retry_middleware
+    from assist.middleware.bad_request_retry import BadRequestRetryMiddleware
+    from assist.middleware.empty_response_recovery import EmptyResponseRecoveryMiddleware
+    from assist.model_manager import select_assistant_model
+    from assist.promptable import base_prompt_for
+
+    return create_agent(
+        select_assistant_model(temperature),        # enable_thinking=False default + timeouts
+        tools,
+        system_prompt=base_prompt_for("receptionist_system.md.j2"),
+        middleware=[_make_retry_middleware(),
+                    BadRequestRetryMiddleware(),
+                    EmptyResponseRecoveryMiddleware()],
+        checkpointer=InMemorySaver(),               # scoped to the one call
+    )

--- a/assist/receptionist.py
+++ b/assist/receptionist.py
@@ -71,7 +71,7 @@ def receptionist_tools(catalog, domains, on_open, on_new) -> list:
         choose. Returns a short numbered list of topics and their state. Use this
         ONLY when the caller is unsure which thread they want — if they've already
         told you, just open it."""
-        entries = catalog.entries()[:20]
+        entries = catalog.entries(limit=20)
         _last.clear()
         _last.extend(entries)
         if not entries:

--- a/assist/receptionist.py
+++ b/assist/receptionist.py
@@ -78,8 +78,11 @@ def receptionist_tools(catalog, domains, on_open, on_new) -> list:
             return "There are no threads yet — we can start a new one."
         lines = []
         for i, e in enumerate(entries, 1):
-            tag = (" (urgent)" if e.urgent
-                   else "" if e.status == "ready" else f" ({e.status})")
+            # urgent and a busy stage are orthogonal (a thread can be urgent AND
+            # processing) — show both so the caller doesn't lose either signal.
+            marks = (["urgent"] if e.urgent else []) + \
+                    ([] if e.status == "ready" else [e.status])
+            tag = f" ({', '.join(marks)})" if marks else ""
             lines.append(f"{i}. {e.description}{tag}")
         return "\n".join(lines)
 

--- a/assist/receptionist.py
+++ b/assist/receptionist.py
@@ -132,6 +132,10 @@ def receptionist_tools(catalog, domains, on_open, on_new) -> list:
             else:
                 return ("Which project should this go under? The options are "
                         + ", ".join(domains) + ".")
+        if not str(first_message or "").strip():
+            # Don't create an empty thread (the model can fire this before it has the
+            # ask) — elicit what they want first, like the domain question above.
+            return f"Sure — what would you like to start in {matched}?"
         try:
             on_new(matched, first_message)
         except Exception:
@@ -157,7 +161,9 @@ def create_receptionist(tools, domains):
     400 class). The model is built thinking-OFF with per-phase timeouts (a thinking
     router would burn its latency budget on <think> tokens the caller never hears; a
     hung first token is unbounded dead air)."""
-    from langchain.agents import create_agent
+    # aliased: this is LangChain's vanilla create_agent, NOT assist.agent.create_agent
+    # (the deepagent builder used everywhere else) — the distinction is the whole point.
+    from langchain.agents import create_agent as create_langchain_agent
     from langgraph.checkpoint.memory import InMemorySaver
 
     from assist.agent import _make_retry_middleware
@@ -166,7 +172,7 @@ def create_receptionist(tools, domains):
     from assist.model_manager import select_assistant_model
     from assist.promptable import base_prompt_for
 
-    return create_agent(
+    return create_langchain_agent(
         select_assistant_model(0.1),                # enable_thinking=False default + timeouts
         tools,
         system_prompt=base_prompt_for("receptionist_system.md.j2", domains=domains),

--- a/assist/templates/receptionist_system.md.j2
+++ b/assist/templates/receptionist_system.md.j2
@@ -6,6 +6,9 @@ Your output is SPOKEN aloud over a phone call. So:
   emoji, no code. One or two sentences per turn.
 - Sound like a person, not a menu.
 
+{% if domains %}The user's projects are: {{ domains | join(", ") }}. Every new thread
+belongs to exactly one of them.
+{% endif %}
 What you can do (your only tools):
 - list_threads — see the user's existing threads (a topic + state for each).
 - open_thread — connect them to one of those threads.
@@ -30,7 +33,8 @@ How to behave:
   question to disambiguate.
 - To start a new thread you need the DOMAIN (which project it belongs to) and a
   first message (what they want). If they didn't say the domain, ask which project
-  in one short question. If there's only one project, just use it.
+  in one short question, naming the options so they can just pick one. If there's
+  only one project, just use it.
 - You CANNOT see what's inside any thread — only the short topic and its state. If
   the caller asks you to read or summarize a thread's contents, say you can't see
   inside from here, and offer to connect them so they can pick it up in the

--- a/assist/templates/receptionist_system.md.j2
+++ b/assist/templates/receptionist_system.md.j2
@@ -1,0 +1,35 @@
+You are a phone receptionist for the user's personal assistant. The user has
+called in and you help them get to the right conversation (thread), fast.
+
+Your output is SPOKEN aloud over a phone call. So:
+- Speak in short, plain sentences. No lists, no markdown, no bullet points, no
+  emoji, no code. One or two sentences per turn.
+- Sound like a person, not a menu.
+
+What you can do (your only tools):
+- list_threads — see the user's existing threads (a topic + state for each).
+- open_thread — connect them to one of those threads.
+- new_thread — start a new thread (you must know which project/domain it belongs
+  to, and what the user wants to do).
+
+How to behave:
+- YIELD IMMEDIATELY to what the caller wants. If they already say what they're
+  after ("get me into the trip planning one", "I want to start something new about
+  the garden"), just do it — open_thread or new_thread — do not read them a list.
+- Only when the caller is unsure or asks what's going on: call list_threads and
+  offer a SMALL number of relevant ones (at most about three — the urgent, recent,
+  or newly-started ones), conversationally. Never read the whole list aloud like a
+  phone menu.
+- To open a thread, you can pass its number from the list or a few words from its
+  topic; the tool figures out which one. If more than one matches, ask a short
+  question to disambiguate.
+- To start a new thread you need the DOMAIN (which project it belongs to) and a
+  first message (what they want). If they didn't say the domain, ask which project
+  in one short question. If there's only one project, just use it.
+- You CANNOT see what's inside any thread — only the short topic and its state. If
+  the caller asks you to read or summarize a thread's contents, say you can't see
+  inside from here, and offer to connect them so they can pick it up in the
+  conversation itself.
+
+Keep it warm and brief. The goal is to get them into the right conversation in as
+few words as possible.

--- a/assist/templates/receptionist_system.md.j2
+++ b/assist/templates/receptionist_system.md.j2
@@ -13,9 +13,14 @@ What you can do (your only tools):
   to, and what the user wants to do).
 
 How to behave:
+- Calling the tool is the ONLY thing that acts. Saying "connecting you now" WITHOUT
+  calling open_thread leaves the caller stranded — the words do nothing on their
+  own. Whenever you tell the caller you're opening, connecting to, or starting a
+  thread, you MUST emit the matching tool call in the same turn.
 - YIELD IMMEDIATELY to what the caller wants. If they already say what they're
   after ("get me into the trip planning one", "I want to start something new about
-  the garden"), just do it — open_thread or new_thread — do not read them a list.
+  the garden"), just do it — call open_thread or new_thread — do not read them a
+  list.
 - Only when the caller is unsure or asks what's going on: call list_threads and
   offer a SMALL number of relevant ones (at most about three — the urgent, recent,
   or newly-started ones), conversationally. Never read the whole list aloud like a

--- a/edd/eval/test_receptionist.py
+++ b/edd/eval/test_receptionist.py
@@ -103,7 +103,7 @@ class TestReceptionist(TestCase):
         root = self._dir(trip={"description": "trip planning to Portugal"},
                          garden={"description": "garden bed layout", "urgent": True})
         call = _Call(root, ["Home"])
-        reply = call.say("Hey, I'm not sure what I've got going on — what's here?")
+        call.say("Hey, I'm not sure what I've got going on — what's here?")
         self.assertTrue(call.called("list_threads"))
         self.assertEqual(call.opened, [])          # offered, didn't force-open
 

--- a/edd/eval/test_receptionist.py
+++ b/edd/eval/test_receptionist.py
@@ -47,7 +47,7 @@ class _Call:
         tools = receptionist_tools(catalog, domains,
                                    self.opened.append,
                                    lambda d, m: self.created.append((d, m)))
-        self.agent = create_receptionist(tools)
+        self.agent = create_receptionist(tools, domains)
         self.config = {"configurable": {"thread_id": "eval-call"}}
         self.messages: list = []
 

--- a/edd/eval/test_receptionist.py
+++ b/edd/eval/test_receptionist.py
@@ -153,5 +153,8 @@ class TestReceptionist(TestCase):
                          garden={"description": "garden bed layout"})
         call = _Call(root, ["Home"])
         reply = call.say("What's going on, give me the rundown.")
-        self.assertNotRegex(reply, r"(^|\n)\s*[-*#]\s|```|\|",
-                            "spoken reply must have no markdown bullets/headers/tables/code")
+        # The prompt says "No lists" for spoken output — reject numbered-list lines
+        # (1. / 2.) too, not just markdown bullets/headers/tables/code, so the eval
+        # matches the contract (the model must speak the threads, not echo the menu).
+        self.assertNotRegex(reply, r"(^|\n)\s*(?:[-*#]|\d+\.)\s|```|\|",
+                            "spoken reply must have no lists/markdown/tables/code")

--- a/edd/eval/test_receptionist.py
+++ b/edd/eval/test_receptionist.py
@@ -1,0 +1,155 @@
+"""Eval: the phone receptionist routes callers to the right thread (voice-call
+assistant, P0.5; docs/2026-07-21-voice-call-tech-design.org §4).
+
+Real-LLM eval (the small model). The receptionist is a *vanilla* LangChain agent
+(no sandbox, no filesystem) whose whole job is tool-routing over the read-only
+thread catalog, so each test asserts on the OBSERVABLE routing effect — which tool
+the model called, and whether the injected on_open/on_new callbacks fired with the
+right thread/domain — plus the spoken-output shape. Contents are unreachable by
+construction (the catalog can't read them), so the content-leak test checks the
+model doesn't *fabricate* a summary instead.
+
+Prompts deliberately avoid the system-prompt wording verbatim (probe
+generalization, not lexical echo).
+"""
+import json
+import os
+import re
+import tempfile
+from unittest import TestCase
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from assist.catalog import ThreadCatalog
+from assist.receptionist import create_receptionist, receptionist_tools
+from assist.thread_manager import ThreadManager
+
+
+def _mk(root, tid, *, description, stage="ready", urgent=False):
+    d = os.path.join(root, tid)
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, "description.txt"), "w") as f:
+        f.write(description)
+    with open(os.path.join(d, "status.json"), "w") as f:
+        json.dump({"stage": stage}, f)
+    if urgent:
+        open(os.path.join(d, "urgent_response"), "w").close()
+
+
+class _Call:
+    """A live receptionist call over a fixture thread dir: records which threads
+    were opened and which were created, and lets a test drive turns."""
+
+    def __init__(self, root, domains):
+        self.opened: list = []
+        self.created: list = []
+        catalog = ThreadCatalog(ThreadManager(root))
+        tools = receptionist_tools(catalog, domains,
+                                   self.opened.append,
+                                   lambda d, m: self.created.append((d, m)))
+        self.agent = create_receptionist(tools)
+        self.config = {"configurable": {"thread_id": "eval-call"}}
+        self.messages: list = []
+
+    def say(self, text) -> str:
+        """One caller turn; returns the receptionist's final spoken reply."""
+        state = self.agent.invoke(
+            {"messages": self.messages + [HumanMessage(content=text)]}, self.config)
+        self.messages = state["messages"]
+        finals = [m for m in state["messages"]
+                  if isinstance(m, AIMessage) and isinstance(m.content, str) and m.content.strip()]
+        return finals[-1].content if finals else ""
+
+    def tool_calls(self) -> list:
+        """Every (name, args) tool call the model made this call, in order."""
+        return [(tc["name"], tc.get("args", {}))
+                for m in self.messages if isinstance(m, AIMessage)
+                for tc in (m.tool_calls or [])]
+
+    def called(self, name) -> bool:
+        return any(n == name for n, _ in self.tool_calls())
+
+
+class TestReceptionist(TestCase):
+    def _dir(self, **threads):
+        root = tempfile.mkdtemp(prefix="receptionist_eval_")
+        for tid, kw in threads.items():
+            _mk(root, tid, **kw)
+        return root
+
+    # ── yield to intent: open directly, don't read a menu first ──────────────
+
+    def test_picks_thread_by_topic(self):
+        root = self._dir(trip={"description": "trip planning to Portugal"},
+                         groc={"description": "grocery list"})
+        call = _Call(root, ["Home"])
+        call.say("Put me through to my Portugal trip planning conversation.")
+        self.assertEqual(call.opened, ["trip"])   # opened the right one
+
+    def test_yields_without_reading_the_list(self):
+        root = self._dir(trip={"description": "trip planning to Portugal"},
+                         groc={"description": "grocery list"})
+        call = _Call(root, ["Home"])
+        call.say("Get me into the grocery list one.")
+        self.assertEqual(call.opened, ["groc"])
+        self.assertFalse(call.called("list_threads"),
+                         "should open directly, not read a menu when intent is clear")
+
+    # ── offer a small set only when the caller is unsure ─────────────────────
+
+    def test_offers_when_unsure(self):
+        root = self._dir(trip={"description": "trip planning to Portugal"},
+                         garden={"description": "garden bed layout", "urgent": True})
+        call = _Call(root, ["Home"])
+        reply = call.say("Hey, I'm not sure what I've got going on — what's here?")
+        self.assertTrue(call.called("list_threads"))
+        self.assertEqual(call.opened, [])          # offered, didn't force-open
+
+    def test_ambiguous_asks_which(self):
+        root = self._dir(rome={"description": "trip to Rome"},
+                         oslo={"description": "trip to Oslo"})
+        call = _Call(root, ["Home"])
+        reply = call.say("Get me into the trip thread.").lower()
+        self.assertEqual(call.opened, [])          # didn't guess
+        self.assertTrue("rome" in reply and "oslo" in reply,
+                        "should surface the two candidates to disambiguate")
+
+    # ── new thread needs a domain ────────────────────────────────────────────
+
+    def test_new_thread_uses_named_domain(self):
+        root = self._dir(trip={"description": "trip planning"})
+        call = _Call(root, ["Home", "Garden"])
+        call.say("Start a brand-new thread under the Garden project about "
+                 "planting tomatoes this weekend.")
+        self.assertEqual([d for d, _ in call.created], ["Garden"])
+
+    def test_new_thread_asks_domain_when_missing(self):
+        root = self._dir(trip={"description": "trip planning"})
+        call = _Call(root, ["Home", "Garden"])
+        reply = call.say("I want to start something new.").lower()
+        self.assertEqual(call.created, [])         # doesn't invent a domain
+        self.assertTrue("home" in reply or "garden" in reply,
+                        "should ask which project")
+
+    # ── can't see inside a thread ────────────────────────────────────────────
+
+    def test_no_content_fabrication(self):
+        root = self._dir(trip={"description": "trip planning to Portugal"})
+        call = _Call(root, ["Home"])
+        reply = call.say("Read me back what I decided in the trip planning thread.").lower()
+        # It cannot read contents — so it must either say so / offer to connect,
+        # or actually connect the caller — never narrate fabricated decisions.
+        self.assertTrue(
+            call.opened == ["trip"]
+            or any(p in reply for p in ("can't", "cannot", "inside", "connect", "pick it up")),
+            f"should not fabricate contents; got: {reply!r}")
+
+    # ── spoken output shape ──────────────────────────────────────────────────
+
+    def test_spoken_output_no_markdown(self):
+        root = self._dir(trip={"description": "trip planning to Portugal"},
+                         garden={"description": "garden bed layout"})
+        call = _Call(root, ["Home"])
+        reply = call.say("What's going on, give me the rundown.")
+        self.assertNotRegex(reply, r"(^|\n)\s*[-*#]\s|```|\|",
+                            "spoken reply must have no markdown bullets/headers/tables/code")

--- a/edd/eval/test_receptionist.py
+++ b/edd/eval/test_receptionist.py
@@ -15,6 +15,7 @@ generalization, not lexical echo).
 import json
 import os
 import re
+import shutil
 import tempfile
 from unittest import TestCase
 
@@ -73,6 +74,7 @@ class _Call:
 class TestReceptionist(TestCase):
     def _dir(self, **threads):
         root = tempfile.mkdtemp(prefix="receptionist_eval_")
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
         for tid, kw in threads.items():
             _mk(root, tid, **kw)
         return root

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,86 @@
+"""Thread catalog — the read-only list-with-metadata surface both web and voice
+consume (assist/catalog.py; docs/2026-07-21-voice-call-tech-design.org §3, P0.5)."""
+import json
+import os
+
+from assist.catalog import CatalogEntry, ThreadCatalog
+from assist.thread_manager import ThreadManager
+
+
+def _mk(root, tid, *, description=None, stage=None, urgent=False, deleted=False):
+    d = os.path.join(root, tid)
+    os.makedirs(d, exist_ok=True)
+    if description is not None:
+        with open(os.path.join(d, "description.txt"), "w") as f:
+            f.write(description)
+    if stage is not None:
+        with open(os.path.join(d, "status.json"), "w") as f:
+            json.dump({"stage": stage}, f)
+    if urgent:
+        open(os.path.join(d, "urgent_response"), "w").close()
+    if deleted:
+        open(os.path.join(d, ".deleted"), "w").close()
+    return d
+
+
+def _catalog(tmp_path):
+    return ThreadCatalog(ThreadManager(str(tmp_path)))
+
+
+def test_entry_reads_all_sidecars(tmp_path):
+    _mk(tmp_path, "t1", description="trip planning", stage="processing", urgent=True)
+    cat = _catalog(tmp_path)
+    (e,) = cat.entries()
+    assert isinstance(e, CatalogEntry)
+    assert (e.id, e.description, e.status, e.urgent) == \
+        ("t1", "trip planning", "processing", True)
+    assert e.updated_at > 0
+
+
+def test_missing_sidecars_default(tmp_path):
+    _mk(tmp_path, "t1")   # no description / status / urgent
+    (e,) = _catalog(tmp_path).entries()
+    assert e.description == "New thread"   # never generated (needs a model)
+    assert e.status == "ready"            # _get_status's default
+    assert e.urgent is False
+
+
+def test_corrupt_status_degrades_not_raises(tmp_path):
+    d = _mk(tmp_path, "t1", description="x")
+    with open(os.path.join(d, "status.json"), "w") as f:
+        f.write("{corrupt")
+    (e,) = _catalog(tmp_path).entries()
+    assert e.status == "ready"            # corrupt ⇒ default, no exception
+
+
+def test_soft_deleted_and_pycache_excluded(tmp_path):
+    _mk(tmp_path, "live", description="a")
+    _mk(tmp_path, "gone", description="b", deleted=True)
+    os.makedirs(tmp_path / "__pycache__", exist_ok=True)
+    ids = [e.id for e in _catalog(tmp_path).entries()]
+    assert ids == ["live"]
+
+
+def test_entries_sorted_mtime_desc(tmp_path):
+    import time
+    _mk(tmp_path, "old", description="o")
+    time.sleep(0.01)
+    _mk(tmp_path, "new", description="n")
+    ids = [e.id for e in _catalog(tmp_path).entries()]
+    assert ids == ["new", "old"]          # ThreadManager.list order preserved
+
+
+def test_get_unknown_or_bad_tid_is_none(tmp_path):
+    cat = _catalog(tmp_path)
+    assert cat.get("does-not-exist") is None
+    assert cat.get("../escape") is None   # invalid tid shape ⇒ None, not a raise
+
+
+def test_no_thread_construction_no_content_access(tmp_path):
+    # The catalog must never touch the checkpoint / message store — it reads only
+    # the sidecar files. A thread with a bogus "threads.db"/checkpoint but valid
+    # sidecars still yields a clean entry (proves contents are never loaded).
+    d = _mk(tmp_path, "t1", description="desc", stage="ready")
+    open(os.path.join(d, "threads.db"), "w").write("not a real db")
+    (e,) = _catalog(tmp_path).entries()
+    assert e.description == "desc"        # no checkpoint read attempted

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -98,11 +98,16 @@ def test_get_unknown_or_bad_tid_is_none(tmp_path):
 
 
 def test_no_thread_construction_no_content_access(tmp_path):
-    # The catalog must never touch the checkpoint / message store — it reads only
-    # the sidecar files. A thread with a bogus "threads.db"/checkpoint but valid
-    # sidecars still yields a clean entry (proves contents are never loaded).
-    d = _mk(tmp_path, "t1", description="desc", stage="ready")
-    with open(os.path.join(d, "threads.db"), "w") as f:
-        f.write("not a real db")
-    (e,) = _catalog(tmp_path).entries()
-    assert e.description == "desc"        # no checkpoint read attempted
+    # The catalog must never touch the checkpoint / message store — only the sidecar
+    # files. Plant a poison threads.db at the REAL ThreadManager location
+    # (<root>/threads.db, thread_manager.py) and confirm entries come solely from the
+    # sidecars, with none of the db's content leaking into any field and the db file
+    # itself not surfacing as a thread.
+    _mk(tmp_path, "t1", description="desc", stage="ready")
+    with open(tmp_path / "threads.db", "w") as f:
+        f.write("SECRET_TRANSCRIPT should never surface")
+    entries = _catalog(tmp_path).entries()
+    assert {e.id for e in entries} == {"t1"}         # the db file is not a thread
+    (e,) = entries
+    assert e.description == "desc"                    # from the sidecar, not the db
+    assert all("SECRET" not in (x.description + x.status) for x in entries)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -53,6 +53,17 @@ def test_corrupt_status_degrades_not_raises(tmp_path):
     assert e.status == "ready"            # corrupt ⇒ default, no exception
 
 
+def test_nonstring_status_stage_degrades_to_ready(tmp_path):
+    # Valid JSON but a non-string stage (null/number) is corrupt too — degrade to
+    # the default, don't surface "None"/"123" to a client.
+    for bad in (None, 123, ["processing"]):
+        d = _mk(tmp_path, "t1", description="x")
+        with open(os.path.join(d, "status.json"), "w") as f:
+            json.dump({"stage": bad}, f)
+        (e,) = _catalog(tmp_path).entries()
+        assert e.status == "ready", f"stage={bad!r} should degrade"
+
+
 def test_soft_deleted_and_pycache_excluded(tmp_path):
     _mk(tmp_path, "live", description="a")
     _mk(tmp_path, "gone", description="b", deleted=True)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -91,6 +91,18 @@ def test_entries_sorted_mtime_desc(tmp_path):
     assert ids == ["new", "old"]          # ThreadManager.list order preserved
 
 
+def test_entries_limit_returns_most_recent_n(tmp_path):
+    # limit stops after N entries; since the order is mtime-desc, that's the most
+    # recent N — so the listing path reads only N threads' sidecars, not every one.
+    import time
+    for name in ("a", "b", "c"):
+        _mk(tmp_path, name, description=name)
+        time.sleep(0.01)
+    ids = [e.id for e in _catalog(tmp_path).entries(limit=2)]
+    assert ids == ["c", "b"]              # newest two only
+    assert len(_catalog(tmp_path).entries(limit=99)) == 3   # limit > count is fine
+
+
 def test_get_unknown_or_bad_tid_is_none(tmp_path):
     cat = _catalog(tmp_path)
     assert cat.get("does-not-exist") is None

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -45,6 +45,16 @@ def test_missing_sidecars_default(tmp_path):
     assert e.urgent is False
 
 
+def test_multiline_description_uses_first_nonempty_line(tmp_path):
+    # A one-line summary is the contract — an embedded newline must not leak (it would
+    # break the numbered list / spoken reply). Take the first non-empty line.
+    d = _mk(tmp_path, "t1", stage="ready")
+    with open(os.path.join(d, "description.txt"), "w") as f:
+        f.write("\n  trip planning to Portugal  \nand a stray second line\n")
+    (e,) = _catalog(tmp_path).entries()
+    assert e.description == "trip planning to Portugal"
+
+
 def test_corrupt_status_degrades_not_raises(tmp_path):
     d = _mk(tmp_path, "t1", description="x")
     with open(os.path.join(d, "status.json"), "w") as f:
@@ -92,6 +102,7 @@ def test_no_thread_construction_no_content_access(tmp_path):
     # the sidecar files. A thread with a bogus "threads.db"/checkpoint but valid
     # sidecars still yields a clean entry (proves contents are never loaded).
     d = _mk(tmp_path, "t1", description="desc", stage="ready")
-    open(os.path.join(d, "threads.db"), "w").write("not a real db")
+    with open(os.path.join(d, "threads.db"), "w") as f:
+        f.write("not a real db")
     (e,) = _catalog(tmp_path).entries()
     assert e.description == "desc"        # no checkpoint read attempted

--- a/tests/test_receptionist.py
+++ b/tests/test_receptionist.py
@@ -174,6 +174,20 @@ def test_open_thread_topic_resolves_full_catalog_not_stale_listing(tmp_path):
     assert "banana" in reply
 
 
+def test_open_thread_bound_tracks_only_current_thread(tmp_path):
+    # _bound is a size-1 "currently connected" holder: re-opening the CURRENT thread
+    # is a no-op, but opening a different one and coming back re-binds (not treated
+    # as already-connected).
+    opened = []
+    _mk(tmp_path, "a", description="apple")
+    _mk(tmp_path, "b", description="banana")
+    tools = _tools(tmp_path, ["Home"], opened=opened)
+    tools["open_thread"]("apple")          # bind a
+    tools["open_thread"]("banana")         # switch to b
+    tools["open_thread"]("apple")          # current is b, so a re-binds
+    assert opened == ["a", "b", "a"]
+
+
 def test_open_thread_ambiguous_asks(tmp_path):
     opened = []
     _mk(tmp_path, "a", description="trip to Rome")

--- a/tests/test_receptionist.py
+++ b/tests/test_receptionist.py
@@ -141,6 +141,19 @@ def test_open_thread_without_listing_scans_catalog(tmp_path):
     assert opened == ["a"] and "trip planning" in reply
 
 
+def test_open_thread_is_idempotent_within_session(tmp_path):
+    # The small model sometimes fires open_thread twice for one intent; the second
+    # open of the thread we're already on must NOT bind (or speak "connecting") again.
+    opened = []
+    _mk(tmp_path, "a", description="trip planning")
+    tools = _tools(tmp_path, ["Home"], opened=opened)
+    first = tools["open_thread"]("trip")
+    second = tools["open_thread"]("trip")
+    assert opened == ["a"]                          # on_open fired once, not twice
+    assert "connecting" in first.lower()
+    assert "already connected" in second.lower()
+
+
 def test_open_thread_ambiguous_asks(tmp_path):
     opened = []
     _mk(tmp_path, "a", description="trip to Rome")

--- a/tests/test_receptionist.py
+++ b/tests/test_receptionist.py
@@ -86,11 +86,21 @@ def test_resolve_empty_or_miss(tmp_path):
 
 def test_match_domain_exact_and_substring():
     domains = ["Home", "Garden Project"]
-    assert _match_domain("home", domains) == "Home"
-    assert _match_domain("garden", domains) == "Garden Project"
-    assert _match_domain("the garden project thread", domains) == "Garden Project"
-    assert _match_domain("", domains) is None
-    assert _match_domain("finance", domains) is None
+    assert _match_domain("home", domains) == ("Home", [])
+    assert _match_domain("garden", domains) == ("Garden Project", [])
+    assert _match_domain("the garden project thread", domains) == ("Garden Project", [])
+    assert _match_domain("", domains) == (None, [])
+    assert _match_domain("finance", domains) == (None, [])
+
+
+def test_match_domain_overlapping_labels_are_ambiguous_not_misrouted():
+    # "home" is a substring of "homework" — first-match-wins would silently
+    # misroute; instead both match ⇒ ambiguous ⇒ new_thread asks which.
+    matched, amb = _match_domain("I need homework help", ["Home", "Homework"])
+    assert matched is None
+    assert set(amb) == {"Home", "Homework"}
+    matched, amb = _match_domain("the network one", ["Work", "Network"])
+    assert matched is None and set(amb) == {"Work", "Network"}
 
 
 # ── list_threads ──────────────────────────────────────────────────────────────
@@ -185,6 +195,14 @@ def test_new_thread_unknown_domain_asks(tmp_path):
     reply = tools["new_thread"]("finance", "x")
     assert created == []
     assert "Home" in reply and "Garden" in reply     # lists the options
+
+
+def test_new_thread_ambiguous_domain_asks_which(tmp_path):
+    created = []
+    tools = _tools(tmp_path, ["Home", "Homework"], created=created)
+    reply = tools["new_thread"]("I need homework help", "algebra problem set")
+    assert created == []                             # doesn't silently pick "Home"
+    assert "Home" in reply and "Homework" in reply   # asks which
 
 
 def test_new_thread_no_domains_configured(tmp_path):

--- a/tests/test_receptionist.py
+++ b/tests/test_receptionist.py
@@ -1,0 +1,214 @@
+"""Receptionist tool logic — resolution, ambiguity, domain matching, callback
+isolation, and the by-construction tool-set guarantee (assist/receptionist.py;
+docs/2026-07-21-voice-call-tech-design.org §4, P0.5)."""
+import json
+import os
+
+from assist.catalog import ThreadCatalog
+from assist.receptionist import _match_domain, _resolve, receptionist_tools
+from assist.thread_manager import ThreadManager
+
+
+def _mk(root, tid, *, description, stage="ready", urgent=False):
+    d = os.path.join(root, tid)
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, "description.txt"), "w") as f:
+        f.write(description)
+    with open(os.path.join(d, "status.json"), "w") as f:
+        json.dump({"stage": stage}, f)
+    if urgent:
+        open(os.path.join(d, "urgent_response"), "w").close()
+    return d
+
+
+def _tools(tmp_path, domains, *, opened=None, created=None):
+    """Build a tool set over a real catalog; record callback invocations."""
+    cat = ThreadCatalog(ThreadManager(str(tmp_path)))
+    on_open = (lambda tid: opened.append(tid)) if opened is not None else (lambda tid: None)
+    on_new = ((lambda d, m: created.append((d, m)))
+              if created is not None else (lambda d, m: None))
+    by_name = {t.__name__: t for t in receptionist_tools(cat, domains, on_open, on_new)}
+    return by_name
+
+
+# ── _resolve ────────────────────────────────────────────────────────────────
+
+def _entries(tmp_path):
+    import time
+    _mk(tmp_path, "a", description="trip planning")
+    time.sleep(0.01)
+    _mk(tmp_path, "b", description="garden beds")
+    return ThreadCatalog(ThreadManager(str(tmp_path))).entries()   # [b, a] mtime-desc
+
+
+def test_resolve_by_number(tmp_path):
+    entries = _entries(tmp_path)
+    assert _resolve("1", entries) == (entries[0], [])
+    assert _resolve("2", entries) == (entries[1], [])
+
+
+def test_resolve_number_out_of_range_is_miss(tmp_path):
+    entries = _entries(tmp_path)
+    assert _resolve("9", entries) == (None, [])
+    assert _resolve("0", entries) == (None, [])
+
+
+def test_resolve_by_exact_id(tmp_path):
+    entries = _entries(tmp_path)
+    entry, amb = _resolve("a", entries)
+    assert entry.id == "a" and amb == []
+
+
+def test_resolve_by_substring(tmp_path):
+    entries = _entries(tmp_path)
+    entry, amb = _resolve("garden", entries)
+    assert entry.id == "b" and amb == []
+
+
+def test_resolve_ambiguous_returns_matches(tmp_path):
+    import time
+    _mk(tmp_path, "a", description="trip to Rome planning")
+    time.sleep(0.01)
+    _mk(tmp_path, "b", description="trip to Oslo planning")
+    entries = ThreadCatalog(ThreadManager(str(tmp_path))).entries()
+    entry, amb = _resolve("trip", entries)
+    assert entry is None
+    assert {e.id for e in amb} == {"a", "b"}
+
+
+def test_resolve_empty_or_miss(tmp_path):
+    entries = _entries(tmp_path)
+    assert _resolve("", entries) == (None, [])
+    assert _resolve("nonexistent topic", entries) == (None, [])
+
+
+# ── _match_domain ─────────────────────────────────────────────────────────────
+
+def test_match_domain_exact_and_substring():
+    domains = ["Home", "Garden Project"]
+    assert _match_domain("home", domains) == "Home"
+    assert _match_domain("garden", domains) == "Garden Project"
+    assert _match_domain("the garden project thread", domains) == "Garden Project"
+    assert _match_domain("", domains) is None
+    assert _match_domain("finance", domains) is None
+
+
+# ── list_threads ──────────────────────────────────────────────────────────────
+
+def test_list_threads_numbers_and_tags(tmp_path):
+    import time
+    _mk(tmp_path, "a", description="trip planning", stage="processing")
+    time.sleep(0.01)
+    _mk(tmp_path, "b", description="garden", urgent=True)
+    out = _tools(tmp_path, ["Home"])["list_threads"]()
+    lines = out.splitlines()
+    assert lines[0] == "1. garden (urgent)"          # mtime-desc, urgent tag
+    assert lines[1] == "2. trip planning (processing)"
+
+
+def test_list_threads_empty(tmp_path):
+    out = _tools(tmp_path, ["Home"])["list_threads"]()
+    assert "no threads" in out.lower()
+
+
+# ── open_thread ───────────────────────────────────────────────────────────────
+
+def test_open_thread_by_number_uses_last_listing(tmp_path):
+    opened = []
+    tools = _tools(tmp_path, ["Home"], opened=opened)
+    _mk(tmp_path, "a", description="trip planning")
+    tools["list_threads"]()                 # seeds _last
+    reply = tools["open_thread"]("1")
+    assert opened == ["a"]
+    assert "trip planning" in reply
+
+
+def test_open_thread_without_listing_scans_catalog(tmp_path):
+    opened = []
+    _mk(tmp_path, "a", description="trip planning")
+    tools = _tools(tmp_path, ["Home"], opened=opened)
+    reply = tools["open_thread"]("trip")   # no list_threads first
+    assert opened == ["a"] and "trip planning" in reply
+
+
+def test_open_thread_ambiguous_asks(tmp_path):
+    opened = []
+    _mk(tmp_path, "a", description="trip to Rome")
+    _mk(tmp_path, "b", description="trip to Oslo")
+    tools = _tools(tmp_path, ["Home"], opened=opened)
+    reply = tools["open_thread"]("trip")
+    assert opened == []                              # nothing opened
+    assert "Rome" in reply and "Oslo" in reply
+
+
+def test_open_thread_miss(tmp_path):
+    opened = []
+    _mk(tmp_path, "a", description="trip planning")
+    tools = _tools(tmp_path, ["Home"], opened=opened)
+    reply = tools["open_thread"]("nonexistent")
+    assert opened == [] and "couldn't tell" in reply.lower()
+
+
+def test_open_thread_callback_failure_is_spoken(tmp_path):
+    _mk(tmp_path, "a", description="trip planning")
+    cat = ThreadCatalog(ThreadManager(str(tmp_path)))
+
+    def boom(tid):
+        raise RuntimeError("session gone")
+
+    tools = {t.__name__: t for t in
+             receptionist_tools(cat, ["Home"], boom, lambda d, m: None)}
+    reply = tools["open_thread"]("trip")
+    assert "couldn't connect" in reply.lower()       # not raised
+
+
+# ── new_thread ────────────────────────────────────────────────────────────────
+
+def test_new_thread_matches_domain(tmp_path):
+    created = []
+    tools = _tools(tmp_path, ["Home", "Garden"], created=created)
+    reply = tools["new_thread"]("garden", "plant tomatoes")
+    assert created == [("Garden", "plant tomatoes")]
+    assert "Garden" in reply
+
+
+def test_new_thread_single_domain_auto(tmp_path):
+    created = []
+    tools = _tools(tmp_path, ["Home"], created=created)
+    reply = tools["new_thread"]("whatever", "hi")
+    assert created == [("Home", "hi")]               # sole domain used despite no match
+
+
+def test_new_thread_unknown_domain_asks(tmp_path):
+    created = []
+    tools = _tools(tmp_path, ["Home", "Garden"], created=created)
+    reply = tools["new_thread"]("finance", "x")
+    assert created == []
+    assert "Home" in reply and "Garden" in reply     # lists the options
+
+
+def test_new_thread_no_domains_configured(tmp_path):
+    created = []
+    tools = _tools(tmp_path, [], created=created)
+    reply = tools["new_thread"]("x", "y")
+    assert created == [] and "aren't any projects" in reply.lower()
+
+
+def test_new_thread_callback_failure_is_spoken(tmp_path):
+    cat = ThreadCatalog(ThreadManager(str(tmp_path)))
+
+    def boom(d, m):
+        raise RuntimeError("create failed")
+
+    tools = {t.__name__: t for t in
+             receptionist_tools(cat, ["Home"], lambda tid: None, boom)}
+    reply = tools["new_thread"]("home", "x")
+    assert "couldn't start" in reply.lower()
+
+
+# ── by-construction tool set ─────────────────────────────────────────────────
+
+def test_tool_set_is_exactly_the_three(tmp_path):
+    cat = ThreadCatalog(ThreadManager(str(tmp_path)))
+    names = {t.__name__ for t in receptionist_tools(cat, ["Home"], lambda t: None, lambda d, m: None)}
+    assert names == {"list_threads", "open_thread", "new_thread"}

--- a/tests/test_receptionist.py
+++ b/tests/test_receptionist.py
@@ -116,6 +116,13 @@ def test_list_threads_numbers_and_tags(tmp_path):
     assert lines[1] == "2. trip planning (processing)"
 
 
+def test_list_threads_urgent_and_busy_show_both_tags(tmp_path):
+    # urgent and a busy stage are orthogonal — the tag must not drop the stage.
+    _mk(tmp_path, "a", description="deploy", stage="processing", urgent=True)
+    out = _tools(tmp_path, ["Home"])["list_threads"]()
+    assert out.splitlines()[0] == "1. deploy (urgent, processing)"
+
+
 def test_list_threads_empty(tmp_path):
     out = _tools(tmp_path, ["Home"])["list_threads"]()
     assert "no threads" in out.lower()

--- a/tests/test_receptionist.py
+++ b/tests/test_receptionist.py
@@ -252,6 +252,16 @@ def test_new_thread_ambiguous_domain_asks_which(tmp_path):
     assert "Home" in reply and "Homework" in reply   # asks which
 
 
+def test_new_thread_empty_first_message_elicits_not_creates(tmp_path):
+    # The model can fire new_thread before it has the ask — an empty/whitespace
+    # first_message must NOT create a useless thread; elicit what they want.
+    created = []
+    tools = _tools(tmp_path, ["Home"], created=created)
+    reply = tools["new_thread"]("Home", "   ")
+    assert created == []                             # nothing created
+    assert "what would you like" in reply.lower()
+
+
 def test_new_thread_no_domains_configured(tmp_path):
     created = []
     tools = _tools(tmp_path, [], created=created)

--- a/tests/test_receptionist.py
+++ b/tests/test_receptionist.py
@@ -154,6 +154,19 @@ def test_open_thread_is_idempotent_within_session(tmp_path):
     assert "already connected" in second.lower()
 
 
+def test_open_thread_topic_resolves_full_catalog_not_stale_listing(tmp_path):
+    # A topic/id must reach ANY thread even after the caller listed — resolve those
+    # against the full catalog, not the (capped, now-stale) _last listing.
+    opened = []
+    _mk(tmp_path, "a", description="apple thread")
+    tools = _tools(tmp_path, ["Home"], opened=opened)
+    tools["list_threads"]()                         # _last = [apple] (the heard list)
+    _mk(tmp_path, "b", description="banana thread")  # created AFTER the listing
+    reply = tools["open_thread"]("banana")           # not in _last, but in the catalog
+    assert opened == ["b"]                           # resolved against the full catalog
+    assert "banana" in reply
+
+
 def test_open_thread_ambiguous_asks(tmp_path):
     opened = []
     _mk(tmp_path, "a", description="trip to Rome")


### PR DESCRIPTION
## What

P0.5 of the voice-call assistant (docs/2026-07-21-voice-call-tech-design.org §3–§4, in the emacsos repo). Builds on the P0 shared session API (#207, now merged).

- **`assist/catalog.py` — `ThreadCatalog`**: a read-only list-with-metadata surface (id, description, status, updated_at, urgent) built from per-thread sidecar files only. No checkpoint access, no `Thread` construction, no model call — thread CONTENTS are unreachable by construction. The surface a voice receptionist (and later the web thread-list) consume without loading any conversation.
- **`assist/receptionist.py` — the phone receptionist**: a *vanilla* LangChain `create_agent` (NOT a deepagent — so it physically lacks the filesystem/execute/task surface and can never read a thread's contents). Three injected-callback tools over the catalog: `list_threads` / `open_thread` (number|id|substring resolution, ambiguity handling, idempotent within a session) / `new_thread` (domain matching with ambiguity → asks which). Thinking-off model + the empty-response/retry/bad-request middleware (dead air on a call is a failure). Spoken-output system prompt with the project list injected.

## Eval

`edd/eval/test_receptionist.py` — 8 real-LLM behaviors (yield-to-intent, yield-without-menu, offer-when-unsure, disambiguate, new-thread-domain, ask-domain-when-missing, no-content-fabrication, spoken-output). **N=10 = 80/80.** Two eval-driven fixes beyond the initial build, both structural rather than prose: inject the domain list into the prompt (so it NAMES options when eliciting a domain; 70%→100%), and idempotent `open_thread` (the domains line nudged a double-open; a repeat open of the current thread is now a no-op — also prevents a double session-bind on a real call).

## Local review

Round-1 team (correctness, security, simplicity, docstring) fixed before the PR: `_match_domain` overlapping-label misroute (→ ask on ambiguity), `open_thread` `[:20]` making old threads unrouteable (→ topic/id resolves full catalog), an unused knob, and catalog docstring drift. 30 receptionist + 7 catalog unit tests.

## Async-subagent spike (§7.0) verdict

deepagents' `AsyncSubAgentMiddleware` needs a remote/ASGI LangGraph server and its subagents still serialize on the one `--parallel 1` llama slot → no real concurrency. **Serialized-journal + push** is the P0.5 vehicle (adopt the interface, defer the middleware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)