### PR TITLE
Render generated PNG graphs in web threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ where reliability is harder than with frontier APIs.
   - **Org-format skill** scopes editing rules to `.org` files
     (heading-body discipline, no orphaned content) without affecting
     other formats.
+  - **Web rendering skill** displays workspace files and generated PNG
+    graphs directly in the conversation.
 
 - **Resilient context handling.** Large tool results are evicted to
   disk before overflowing context, context-overflow errors are caught

--- a/assist/thread_manager.py
+++ b/assist/thread_manager.py
@@ -357,7 +357,7 @@ class ThreadManager:
     # SIBLING of the working dir (not under it, so it isn't part of the agent's
     # /workspace project tree).  Unlike the per-turn container's ephemeral /tmp,
     # this lives on the host and survives across turns — so a file the agent
-    # writes to /tmp (e.g. a .md copy of a non-showable file, to render) is still
+    # writes to /tmp (e.g. a converted copy or generated image artifact) is still
     # there next turn and is reachable by the web renderer.  Removed with the
     # thread dir on hard_delete.
     def thread_tmp_dir(self, tid: str) -> str:

--- a/assist/web_skills/render/SKILL.md
+++ b/assist/web_skills/render/SKILL.md
@@ -1,9 +1,32 @@
 ---
 name: render
-description: Rendering things in the user's web view (web UI only) beyond plain text — files AND maps. FILES — "show me fitness.org"; "open my notes"; "view the report"; "display that pdf"; "pull up the recipes file". MAPS — whenever the discussion involves mappable, real-world locations (places, addresses, businesses, routes, "near", "walking distance", "how far", "on a map"), e.g. "coffee shops near X"; "map these places"; "show the route from A to B". MUST load before responding when the user asks to SHOW/OPEN/VIEW/DISPLAY/pull up a file, OR whenever real-world places/routes are being discussed that would be clearer on a map.
+description: Rendering things in the user's web view (web UI only) beyond plain text — files, generated PNG graphs/charts, existing PNG artifacts, and maps. MUST load when the user wants to see a file in the conversation, asks for a graph or chart to be created and displayed, refers back to a PNG artifact they want displayed, names the render skill, or discusses places/routes that would be clearer on a map.
 ---
 
 # Render — show a file in the user's web view
+
+## Creating and showing graphs
+
+When the user asks to **show a graph or chart**, complete this exact sequence:
+
+1. Use `execute` with Python and matplotlib to create a PNG under persistent
+   `/tmp` (for example `/tmp/chart.png`). Matplotlib is already installed;
+   do not install packages.
+2. Verify the command succeeded and the PNG exists at that exact path.
+3. In the same response, emit a file render block naming that exact PNG:
+
+```render
+type: file
+path: /tmp/chart.png
+```
+
+The model is text-only, but that does not prevent it from displaying an image
+file it created. Do not `read_file` a PNG, replace it with an ASCII graph, create
+an HTML/markdown substitute, or merely tell the user where the PNG was saved.
+
+If the user later says **show/render the graph here**, reuse the PNG path from
+the conversation and emit the block again immediately. Do not inspect, recreate,
+or re-verify an existing PNG before emitting its block.
 
 When the user asks to **show, open, view, display, or pull up** a file, render
 it for them in the web view. Do this by emitting a **render block** — a fenced
@@ -18,7 +41,7 @@ Replace `PATH-TO-THE-FILE` with the real file — either in the user's workspace
 (e.g. `path: /workspace/fitness.org`) or under `/tmp` (e.g.
 `path: /tmp/summary.md`). **`/tmp` is a persistent scratch directory** that
 renders exactly like the workspace, so you can `write_file` a file there to show
-it (see "Showing a file that isn't .org/.md/.pdf" below).
+it (see "Showing other file types" below).
 
 ## Showing only part of a file
 
@@ -52,11 +75,11 @@ a single line or page use the same number twice, e.g. `pages: 3-3`). The range i
 the block must be numbers you resolved — never put a description like
 `lines: the backups section` in the block. Omit the range to show the whole file.
 
-## Showing a file that isn't .org / .md / .pdf
+## Showing other file types
 
-`.org`, `.md`, and `.pdf` render richly (formatted). **Any other file still
-renders — as plain text.** So you CAN show a `.txt`, `.py`, `.j2`, log, config,
-or extension-less file directly:
+`.org`, `.md`, and `.pdf` render richly (formatted), and `.png` renders as an
+inline image. Other files render as plain text. So you CAN show a `.txt`, `.py`,
+`.j2`, log, config, or extension-less file directly:
 
 ```render
 type: file
@@ -125,13 +148,13 @@ confirmed — `map_data` geocodes real names, so a made-up one gives a wrong/emp
 - Emit the render block **instead of** reading the file and summarizing or
   pasting its contents. The block displays the actual file; a summary is not
   what the user asked for.
-- `.org`, `.md`, and `.pdf` render richly; any other file renders as plain text,
-  or convert it to a `/tmp/*.md` copy first (see "Showing a file that isn't
-  .org/.md/.pdf"). Either way, SHOW the file — don't fall back to summarizing.
+- `.org`, `.md`, and `.pdf` render richly; `.png` renders as an inline image;
+  other files render as plain text or a converted `/tmp/*.md` copy. Either way,
+  SHOW the file — don't fall back to summarizing.
 - If you don't know the exact path, find the file first (e.g. `glob`), then
   emit the block with its real path.
 - You may add a short sentence before the block (e.g. "Here's your file:"), but
   the render block itself must be exactly the fenced `render` block above.
-- For content you are writing yourself — tables, lists, code, formatting — just
-  use normal markdown; the chat renders it. The render block is **only** for
-  showing an existing workspace file.
+- For ordinary text content you are writing yourself — tables, lists, code,
+  formatting — use normal markdown. A generated PNG graph is a file artifact,
+  so show it with the render block after creating it.

--- a/dockerfiles/Dockerfile.sandbox
+++ b/dockerfiles/Dockerfile.sandbox
@@ -5,6 +5,8 @@ RUN pacman -Syu --noconfirm && \
     pacman -S --noconfirm \
         python \
         python-pip \
+        # deterministic graph/PNG creation for the render skill
+        python-matplotlib \
         base-devel \
         git \
         grep \

--- a/docs/2026-06-28-render-skill.org
+++ b/docs/2026-06-28-render-skill.org
@@ -2,6 +2,18 @@
 #+DATE: <2026-06-28>
 #+STATUS: built (CPU-tested + focal emission eval 3/3; live web render pending deploy)
 
+* 2026-07-23 follow-up: PNG graphs
+The original v1 scope below deliberately deferred images and graphs. That
+limitation is superseded by =docs/2026-07-23-png-graph-render.org=: the same
+=type: file= block now displays PNG files inline, the sandbox provides
+matplotlib for deterministic graph creation, and the render skill teaches the
+create-PNG → verify → emit-block sequence. The generic text fallback remains for
+non-PNG file types.
+
+=_SHOWABLE_EXTS= was removed in that follow-up. It had become a stale tuple after
+the route gained its any-extension escaped-text fallback, not a real allow-list or
+source of truth.
+
 * Decision + design-review outcome (2026-06-28)
 Reviewed by the design-review team (simplicity, agentic/framework-fit,
 user-intention, clean-interfaces). The split was block-from-skill vs keeping a
@@ -24,7 +36,8 @@ Review fixes folded in (as built):
 - ~type~+~path~ "always a workspace file" is a **deliberate kept constraint** —
   no inline-payload escape hatch, so the security boundary stays singular.
 - =_RENDER_DISPATCH= is the single source of truth for known types.
-- =_SHOWABLE_EXTS= moved to =manage/web/threads.py= (its only remaining consumers).
+- =_SHOWABLE_EXTS= moved to =manage/web/threads.py= in v1, then removed by the
+  2026-07-23 PNG follow-up after the route accepted every extension.
 - Factual correction: show_file was *already* web-scoped via ~_WEB_TOOLS~; only
   the *prompt steering* leaked into the shared template — that's the real wart,
   now fixed by the web-only skill. The web app token-stream concern is moot (the
@@ -110,21 +123,23 @@ lazy-loads on matching requests and never reaches emacsos/eval agents.
 - *Moved:* the show/open/view steering — out of the shared =general_instructions.md.j2=
   and into the web render ~SKILL.md~.
 - *Reused unchanged:* ~/thread/{tid}/show~, ~_safe_workspace_file~, ~_org_to_html~,
-  the CSP + sandbox iframe, ~_SHOWABLE_EXTS~.
+  and the CSP + sandbox iframe. (The PNG follow-up extends the show route and adds
+  an image branch alongside the iframe.)
 
-* Extensibility (out of scope now — build ready for it)
+* Extensibility (original v1 scope; PNG follow-up implemented 2026-07-23)
 The growth path Pierre named is **rendering visualizations / graphs**. The design
 is ready for it WITHOUT format change:
 - The block stays ~type~ + ~path~. A future ~type: chart~ points ~path~ at a
   workspace spec file (e.g. a vega-lite JSON the agent wrote); a ~chart~ renderer
-  in ~_RENDER_DISPATCH~ reads that file and renders the visualization. Same for
-  ~type: image~ (serve a workspace png through the /show route).
+  in ~_RENDER_DISPATCH~ reads that file and renders the visualization.
 - So adding a render type = one entry in the dispatch registry + one renderer +
   its own security review (each new content type is a new surface — e.g. a chart
   spec is untrusted model/agent output; render it in the sandboxed iframe / via a
   vetted lib, never eval it — same lesson as the org-RCE fix).
-- *Not built now* (no speculative code): images, charts/graphs. v1 is file-embed
-  (org/md/pdf) only.
+- *Superseded:* the original idea of a separate ~type: image~. The observed graph
+  failure justified PNG display + sandbox graph creation, but PNG remains a
+  ~type: file~ artifact; see the follow-up named above. Interactive chart specs
+  remain unbuilt.
 
 * Decisions / trade-offs
 - *Skill (guidance) vs tool (structured).* The risk: a tool call's args are a
@@ -190,7 +205,8 @@ is ready for it WITHOUT format change:
 - New: =assist/web_skills/render/SKILL.md= (web skill), =docs/2026-06-28-render-skill.org=,
   =edd/eval/test_render_agent.py=.
 - Edit: =manage/web/threads.py= (parse render blocks + ~_RENDER_DISPATCH~ +
-  ~_render_assistant_content~ + the file embed; ~_SHOWABLE_EXTS~ moved here),
+  ~_render_assistant_content~ + the file embed; v1 moved ~_SHOWABLE_EXTS~ here,
+  and the PNG follow-up later removed it),
   =assist/thread.py= (~_messages_to_dicts~ — drop the show_file branch; no block
   parsing here, that's web-only in render_thread), =assist/thread_manager.py=
   (drop ~_WEB_TOOLS~; register the web skill via ~skill_sources~), =assist/tools.py=

--- a/docs/2026-07-23-png-graph-render.org
+++ b/docs/2026-07-23-png-graph-render.org
@@ -1,0 +1,145 @@
+#+TITLE: Render generated PNG graphs in the web conversation
+#+DATE: <2026-07-23>
+#+STATUS: implemented, locally reviewed, and eval-stable; not deployed
+
+* Incident
+In thread =20260511093139-e1d2173d= the user asked to see a graph of two months of
+weight data. The agent eventually generated =/tmp/weight_chart.png=, then tried to
+=read_file= the binary and summarized the result. On the next turn, "Please render
+the graph here", it claimed that a text-only model could not render the PNG and
+substituted ASCII. When explicitly told to check the render skill, it searched for
+and read =/render-skill/render/SKILL.md= instead of calling =load_skill("render")=.
+It finally emitted a file render block, but the web route decoded PNG bytes through
+the generic plain-text fallback rather than serving an image.
+
+* Behavioral baseline
+The regressions were added to =edd/eval/test_render_agent.py= before any production
+behavior changed and run as separate real-Qwen trials:
+
+| case | baseline |
+|------+----------|
+| first-turn "show me a graph of how my weight changed" | 0/3 rendered (the render skill loaded, but no block was emitted) |
+| self-contained "render the graph" with the PNG path | 3/3 |
+| self-contained named-skill correction with the PNG path | 3/3 |
+
+The corrected, Docker-backed graph creation case was 0/3: the agent loaded the
+render skill every time but created/rendered markdown or HTML instead of PNG. The
+faithful production sequence was also 0/3: "Please render the graph
+here" never called =load_skill("render")= (twice it made no tool call; once it
+wrote another markdown graph), and the named correction therefore could not make
+the sequence pass. The passing self-contained cases show that terse follow-ups and
+conversation state, not just skill availability, are part of the failure.
+
+After review added unrelated wording, the old skill failed the existing-PNG
+generality case 0/3 while its explicitly named case remained 3/3. This separates
+semantic selection from the already-working direct named-skill path.
+
+The isolated implementation then passed 3/3 for each of the first-turn graph,
+unrelated existing-PNG, explicitly named-skill, and faithful follow-up sequence
+cases. Review subsequently strengthened the artifact and tool-call assertions;
+the post-review cadence below tests that final contract.
+
+* Decision
+Keep the existing stable =type: file= block. A PNG is a file artifact; a new
+=image= or =chart= render type would add model vocabulary and parser surface without
+adding capability. Extend the file representation in two places:
+
+1. The render skill says that requested graphs/charts are written as PNG files in
+   persistent =/tmp= and then shown with a file render block. Its description names
+   graph, chart, image, PNG, and the verb render so the small model selects it on
+   the observed requests.
+2. The web file renderer emits an =<img>= for PNG and the sync =/show= route serves
+   the original bytes as =image/png=. Org/markdown remain HTML, PDF remains the
+   browser viewer, and other extensions remain escaped plain text.
+3. The sandbox image installs Arch's =python-matplotlib= package. This makes graph
+   creation available before the turn starts, instead of asking the agent to mutate
+   an externally-managed Python installation at runtime. The skill gives Qwen the
+   checkable sequence: create the =/tmp/*.png= with Python/matplotlib, verify that
+   path exists, then emit the file block for that exact path.
+
+A standalone explicit request to use the render skill must go through =load_skill=.
+The render-specific description and body own this behavior; no shared framework
+change is justified unless a reachable failing eval requires it.
+
+That condition occurred in the first post-review N=5 gate. Graph creation,
+unrelated existing-PNG display, and the standalone named request were each 5/5,
+but a then-three-turn experiment was 4/5: one correction turn tried to =read_file= a
+hallucinated =/workspace/.claude/skills/render/SKILL.md= instead of calling
+=load_skill=. Review found that this turn followed an already-successful render
+and was unreachable in the repaired flow. A proposed shared prompt change and
+divergent calculate regression were therefore removed as theoretical code.
+
+* Threat model
+The render block and PNG are agent-authored, untrusted input. The path continues
+through =_safe_workspace_file=, including symlink resolution and separate
+=/workspace= and =/tmp= roots. The server chooses =image/png= from the supported
+extension and sends =X-Content-Type-Options: nosniff=; it does not derive HTML or a
+MIME type from file contents, decode the PNG as text, or place bytes in a data URL.
+The browser consumes the bytes through an escaped, URL-encoded same-origin =src=.
+
+No image parser, plotting engine, subprocess, or package installation is added to
+the host render path. The =/show= route stays a synchronous FastAPI handler, so file
+I/O remains in the threadpool and does not block the single-worker event loop.
+Matplotlib exists only inside the already-contained per-turn sandbox; it never
+parses or executes agent-authored content on the host render path.
+
+* Validation contract
+- Unit symptom: rendering a PNG block produces an actual =<img>= in the conversation;
+  GETting that exact =src= returns byte-identical PNG data with =image/png= and
+  =nosniff=. It must not produce an iframe, code fence, or decoded binary text.
+- Behavioral: an initial graph request and a standalone explicitly named skill
+  request must call =load_skill(name="render")=, not merely read a =SKILL.md= path.
+  Follow-ups in a thread where render is already loaded may reuse the body in
+  conversation history, but must emit a new =type: file= PNG block and must not
+  detour through filesystem skill discovery. The emitted path must name a real
+  artifact with the PNG signature. Multi-turn assertions inspect only messages
+  emitted after each turn boundary, never cumulative history.
+- Cadence: N=3 baseline, N=3 after the isolated implementation, local review to
+  convergence, N=5 after review fixes, then N=10 stability. No deployment.
+
+* Planned files
+- =assist/web_skills/render/SKILL.md=: graph/image selection and PNG recipe.
+- =manage/web/threads.py=: PNG =<img>= embed and binary response.
+- =dockerfiles/Dockerfile.sandbox=: install the sandbox plotting dependency.
+- =tests/test_render.py=: browser-visible HTML and byte-response symptom test.
+- =edd/eval/test_render_agent.py=: production-shaped behavior contracts.
+- =docs/2026-06-28-render-skill.org=: reconcile the earlier "images not built" scope.
+
+* As-built reconciliation
+The implementation retains =type: file= and adds one PNG branch to the web
+renderer: an inline =<img>= whose same-origin =/show= URL returns original bytes
+as =image/png= with =nosniff=. The sync route and existing safe-path chokepoint are
+unchanged. The sandbox image installs =python-matplotlib=, and the render skill
+now gives the small model a concrete create, verify, and emit sequence. The stale
+=_SHOWABLE_EXTS= tuple was removed because every extension already reaches the
+escaped-text fallback.
+
+The render recipe says that an already-created PNG is re-emitted immediately,
+without a redundant filesystem verification that can derail the follow-up turn.
+The sequence eval stops when that render follow-up succeeds; continuing with
+"try again" after success manufactured a turn the repaired user flow cannot reach.
+The standalone named-skill case owns the correction contract instead.
+
+The evals use a real Docker sandbox for graph creation, validate each emitted
+artifact independently by existence and PNG signature, use a decodable PNG for
+existing-file cases, inspect only the current turn in the follow-up sequence,
+and reject filesystem reads/searches for the mounted skill. Baseline and
+post-implementation N=3 results are recorded above. The first post-review N=5
+gate experiment is recorded above but did not describe a reachable flow. The four
+final contracts passed the final N=5 gate; the final-prompt N=10 stability result
+passed 40/40 individual real-model trials. Nothing was deployed.
+
+* Design-review reconciliation
+The simplicity, agentic/framework, user-flow, security, and liveness reviewers
+agreed on the =type: file= / =<img>= design but blocked the first draft on two test
+proxies: it accepted a named =.png= path without a real artifact, and the sequence
+test could accept a block from an earlier turn. Both were corrected before the
+production baseline: graph evals now use the real Docker sandbox, validate PNG
+signature bytes at the emitted path, and slice messages at each turn boundary.
+
+The review also found that =_SHOWABLE_EXTS= is stale: the route already accepts all
+extensions through its escaped-text fallback, so the tuple is not an allow-list or
+source of truth. Remove it and its misleading drift test rather than adding PNG to
+it. Reconcile every absolute "all other files are text" statement in the skill,
+renderer docstrings/comments, tests, and the original render design. Preserve the
+caption/open link and give the inline image meaningful escaped alt text.

--- a/edd/eval/test_render_agent.py
+++ b/edd/eval/test_render_agent.py
@@ -14,6 +14,7 @@ skill over keeping a tool.)
 """
 import os
 import re
+import shutil
 import tempfile
 from textwrap import dedent
 from unittest import TestCase
@@ -22,6 +23,7 @@ from deepagents.backends import FilesystemBackend
 
 from assist.agent import create_agent, AgentHarness
 from assist.model_manager import select_assistant_model
+from assist.sandbox_manager import SandboxManager
 from assist.spec import AgentSpec
 
 from .utils import create_filesystem
@@ -33,6 +35,14 @@ _RENDER_SKILLS_DIR = os.path.join(
 # A render block: a fenced ```render whose body has type: file and the path.
 _RENDER_BLOCK = re.compile(r"```render\b(.*?)```", re.S | re.I)
 
+# Complete 1x1 transparent PNG used when the graph already exists. Keeping a
+# real image here prevents routing evals from accepting a broken browser image.
+_ONE_PIXEL_PNG = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489"
+    "0000000d49444154789c6360606060000000050001a5f645400000000049454e44"
+    "ae426082"
+)
+
 
 def _personal_workspace() -> dict:
     return {
@@ -42,7 +52,12 @@ def _personal_workspace() -> dict:
             ** 2026
             | date | dist (yd) | time | weight |
             |------+-----------+------+--------|
-            | 1/5  |      2600 | 1h   |  168.4 |
+            | 6/1  |      3200 | 1h10m |  169.4 |
+            | 6/8  |      3400 | 1h12m |  168.6 |
+            | 6/15 |      3300 | 1h10m |  167.4 |
+            | 6/24 |      3500 | 1h15m |  166.4 |
+            | 7/1  |      3600 | 1h15m |  167.4 |
+            | 7/23 |      3700 | 1h20m |  166.6 |
             """),
         "swim-workouts.org": "* Swim Workouts\n** 6/9/26 Mixed Stroke (~3000 yd)\n",
         "health.org": "* Wellness visits\n| Test | 2024 |\n|------+------|\n| LDL | 129 |\n",
@@ -66,17 +81,72 @@ class TestRenderAgent(TestCase):
         return AgentHarness(create_agent(self.model, root,
                                          spec=AgentSpec(skill_sources=skills)))
 
-    def _render_block_paths(self, agent) -> list:
+    def create_sandbox_agent(self, filesystem: dict):
+        """Production-shaped agent: real Docker execute + persistent sibling /tmp."""
+        thread_root = tempfile.mkdtemp(prefix="render_graph_eval_")
+        workspace = os.path.join(thread_root, "domain")
+        os.mkdir(workspace)
+        create_filesystem(workspace, filesystem)
+        sandbox = SandboxManager.get_sandbox_backend(workspace)
+        if sandbox is None:
+            shutil.rmtree(thread_root)
+            self.skipTest("Docker sandbox unavailable — is assist-sandbox built?")
+        self.addCleanup(shutil.rmtree, thread_root, True)
+        self.addCleanup(SandboxManager.cleanup, workspace)
+        skills = {"/render-skill/": FilesystemBackend(root_dir=_RENDER_SKILLS_DIR,
+                                                      virtual_mode=True)}
+        agent = AgentHarness(create_agent(
+            self.model, workspace, sandbox_backend=sandbox,
+            spec=AgentSpec(skill_sources=skills)))
+        return agent, thread_root
+
+    def _render_block_paths(self, agent, message_count: int = 0) -> list[str]:
         """Bodies of render blocks the AGENT emitted — only AIMessage content, so
         the loaded skill's own example blocks (a ToolMessage) don't count."""
         from langchain_core.messages import AIMessage
         bodies = []
-        for m in agent.all_messages():
+        for m in agent.all_messages()[message_count:]:
             if not isinstance(m, AIMessage):
                 continue
             content = m.content if isinstance(m.content, str) else ""
             bodies.extend(b for b in _RENDER_BLOCK.findall(content) if "type:" in b.lower())
         return bodies
+
+    def _png_path(self, blocks: list[str], thread_root: str) -> str | None:
+        """Host path named by the last PNG file render block."""
+        for body in reversed(blocks):
+            match = re.search(r"(?mi)^path:\s*(.+?\.png)\s*$", body)
+            if not match:
+                continue
+            path = match.group(1)
+            if path.startswith("/tmp/"):
+                return os.path.join(thread_root, "tmp", path.removeprefix("/tmp/"))
+            if path.startswith("/workspace/"):
+                return os.path.join(thread_root, "domain",
+                                    path.removeprefix("/workspace/"))
+        return None
+
+    def _assert_no_skill_file_detour(self, calls: list[dict]):
+        """The named skill tool replaces filesystem discovery of SKILL.md."""
+        detours = [
+            call for call in calls
+            if call.get("name") != "load_skill"
+            and any(marker in str(call.get("args") or {}).lower()
+                    for marker in ("skill.md", "/render-skill"))
+        ]
+        self.assertFalse(detours, f"render skill read as an ordinary file: {detours}")
+
+    def _put_png_in_workspace(self, thread_root: str, name: str):
+        path = os.path.join(thread_root, "domain", name)
+        with open(path, "wb") as image:
+            image.write(_ONE_PIXEL_PNG)
+
+    def _assert_valid_png(self, blocks: list[str], thread_root: str):
+        path = self._png_path(blocks, thread_root)
+        self.assertIsNotNone(path, f"no PNG path in render blocks: {blocks}")
+        self.assertTrue(os.path.isfile(path), f"rendered PNG does not exist: {path}")
+        with open(path, "rb") as image:
+            self.assertEqual(image.read(8), b"\x89PNG\r\n\x1a\n")
 
     def test_emits_render_block_for_named_file(self):
         """Example-thread shape: 'show me <named file>' in a realistic workspace
@@ -144,6 +214,102 @@ class TestRenderAgent(TestCase):
                         if p:
                             paths.append(str(p))
         return paths
+
+    def _tool_calls(self, agent) -> list[dict]:
+        """Every structured tool call emitted by the agent."""
+        from langchain_core.messages import AIMessage
+        return [
+            call
+            for message in agent.all_messages()
+            if isinstance(message, AIMessage)
+            for call in (getattr(message, "tool_calls", None) or [])
+        ]
+
+    def _render_skill_was_loaded(self, agent) -> bool:
+        """True only for the load_skill tool contract, never a SKILL.md path read."""
+        return any(
+            call.get("name") == "load_skill"
+            and (call.get("args") or {}).get("name") == "render"
+            for call in self._tool_calls(agent)
+        )
+
+    def test_creates_and_renders_requested_graph(self):
+        """Production regression: asking to SEE a graph should load the web render
+        skill and finish with an image render block, not create a PNG and summarize
+        it or claim that a text-only model cannot display it."""
+        agent, thread_root = self.create_sandbox_agent(_personal_workspace())
+        agent.message("Can you show me a graph of how my weight has changed over the last 2 months?")
+        blocks = self._render_block_paths(agent)
+        self.assertTrue(self._render_skill_was_loaded(agent), "render skill should load")
+        self.assertTrue(
+            any("type: file" in b.lower() and ".png" in b.lower() for b in blocks),
+            f"expected a file render block naming a PNG; render blocks: {blocks}",
+        )
+        self._assert_valid_png(blocks, thread_root)
+
+    def test_render_existing_graph_followup_loads_skill(self):
+        """Generality: an unrelated existing visual is placed in the conversation."""
+        fs = dict(_personal_workspace())
+        agent, thread_root = self.create_sandbox_agent(fs)
+        self._put_png_in_workspace(thread_root, "weekly_laps.png")
+        agent.message("Put the picture at /workspace/weekly_laps.png in this conversation.")
+        blocks = self._render_block_paths(agent)
+        self.assertTrue(self._render_skill_was_loaded(agent), "render skill should load")
+        self.assertTrue(
+            any("type: file" in b.lower() and "weekly_laps.png" in b for b in blocks),
+            f"expected a file render block for weekly_laps.png; render blocks: {blocks}",
+        )
+        self._assert_valid_png(blocks, thread_root)
+
+    def test_named_render_skill_request_uses_load_skill(self):
+        """An explicit named-skill correction must call load_skill, not search for
+        and read the mounted SKILL.md as an ordinary workspace file."""
+        fs = dict(_personal_workspace())
+        agent, thread_root = self.create_sandbox_agent(fs)
+        self._put_png_in_workspace(thread_root, "pace_trend.png")
+        before = len(self._tool_calls(agent))
+        agent.message("Use the render skill to put /workspace/pace_trend.png in the conversation.")
+        calls = self._tool_calls(agent)[before:]
+        blocks = self._render_block_paths(agent)
+        self.assertTrue(self._render_skill_was_loaded(agent), "render skill should load")
+        self._assert_no_skill_file_detour(calls)
+        self.assertTrue(
+            any("type: file" in b.lower() and "pace_trend.png" in b for b in blocks),
+            f"expected a file render block for pace_trend.png; render blocks: {blocks}",
+        )
+        self._assert_valid_png(blocks, thread_root)
+
+    def test_graph_render_followup_sequence(self):
+        """Production flow through resolution: create/show graph, then the terse
+        render follow-up that originally failed. Stop once the request succeeds;
+        standalone named-skill coverage pins the separate correction contract."""
+        agent, thread_root = self.create_sandbox_agent(_personal_workspace())
+        before_graph = len(agent.all_messages())
+        agent.message("Can you show me a graph of how my weight has changed over the last 2 months?")
+        graph_calls = self._tool_calls(agent)
+        graph_blocks = self._render_block_paths(agent, before_graph)
+
+        before_render = len(agent.all_messages())
+        agent.message("Please render the graph here.")
+        render_followup_calls = self._tool_calls(agent)[len(graph_calls):]
+        blocks_after_render = self._render_block_paths(agent, before_render)
+
+        loaded_initially = any(
+            call.get("name") == "load_skill"
+            and (call.get("args") or {}).get("name") == "render"
+            for call in graph_calls
+        )
+        self.assertTrue(loaded_initially,
+                        f"initial graph request did not load render: {graph_calls}")
+        self.assertTrue(
+            any("type: file" in block.lower() and ".png" in block.lower()
+                for block in blocks_after_render),
+            f"render follow-up emitted no new PNG block; calls: "
+            f"{render_followup_calls}; blocks: {blocks_after_render}",
+        )
+        self._assert_no_skill_file_detour(render_followup_calls)
+        self._assert_valid_png(graph_blocks, thread_root)
+        self._assert_valid_png(blocks_after_render, thread_root)
 
     def test_shows_unsupported_file_instead_of_summarizing(self):
         """The 2026-07-08 regression: asked to SHOW a file whose extension isn't

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -189,12 +189,6 @@ async def _invalid_thread_id(request, exc):
 
 _MD_EXTENSIONS = ["fenced_code", "tables"]
 
-# Extensions the /show route + the render-block file embed can display.  Single
-# source of truth (the route dispatches md/org/pdf; _render_file_block gates on
-# this; test_route_renders_every_showable_ext pins route coverage).
-_SHOWABLE_EXTS = (".org", ".md", ".pdf")
-
-
 # Thread-list ordering rank (lower sorts first). Per Pierre: STATUS first — urgent,
 # then any busy stage except queued (processing / paused / initializing / cloning /
 # starting_sandbox), then queued (waiting for a slot), then "new" (an unopened
@@ -930,9 +924,10 @@ def render_thread(
           .msg.tools > .content {{ font-size: .82rem; color: #6b7280; margin: .15rem 0 .15rem .3rem;
               padding: .3rem .55rem; border-left: 2px solid #e5e7eb; }}
           /* A file embed lifted from a ```render block, shown inline in the
-             assistant bubble (org/md rendered page, or pdf viewer). */
+             assistant bubble (image, rendered document/text, or pdf viewer). */
           .show-embed {{ margin: .5rem 0; }}
           .show-file {{ width: 100%; height: 65vh; border: 1px solid #e5e7eb; border-radius: 6px; background: #fff; }}
+          .show-file-image {{ height: auto; max-height: 65vh; object-fit: contain; }}
           .show-map {{ width: 100%; height: 55vh; border: 1px solid #e5e7eb; border-radius: 6px; background: #fff; }}
           /* Pseudo-fullscreen (no Fullscreen API — reliable for a null-origin
              sandboxed iframe): fill the viewport, caption bar stays visible to exit. */
@@ -2758,7 +2753,7 @@ def _existing_thread_dir(tid: str) -> str:
     return tdir
 
 
-# ---- render skill: embed a workspace file (org/md/pdf) in the web UI ----
+# ---- render skill: embed a workspace file in the web UI ----
 
 _SHOW_PAGE_CSS = (
     "body{font-family:sans-serif;max-width:780px;margin:1rem auto;padding:0 1rem;"
@@ -2952,13 +2947,17 @@ def _show_src(tid: str, path: str, lines: str = "", pages: str = "") -> str:
 
 
 def _file_embed_html(tid: str, path: str, lines: str = "", pages: str = "") -> str:
-    """Inline embed for a workspace file: pdf in the browser viewer, md/org as a
-    sandboxed iframe over the /show route, plus a caption link to open it on its
-    own page.  An optional line/page range is carried into BOTH the embed src and
-    the caption link, so inline and full-page show the same section."""
+    """Inline workspace file: PNG image, PDF viewer, or sandboxed document/text
+    iframe over the /show route, plus a caption link to open it on its own page.
+    An optional line/page range is carried into BOTH the embed src and caption
+    link, so inline and full-page show the same section."""
     src = _show_src(tid, path, lines, pages)
     label = html.escape(path)
-    if os.path.splitext(path)[1].lower() == ".pdf":
+    ext = os.path.splitext(path)[1].lower()
+    if ext == ".png":
+        viewer = (f'<img class="show-file show-file-image" src="{src}" alt="Graph or image: '
+                  f'{label}" loading="lazy" />')
+    elif ext == ".pdf":
         viewer = f'<embed class="show-file" type="application/pdf" src="{src}" />'
     else:
         # sandbox WITHOUT allow-scripts: the embedded md/org page is static, so
@@ -2987,10 +2986,9 @@ def _scalar(value):
 def _render_file_block(tid: str, block: dict) -> str | None:
     """``type: file`` renderer.  Embeds a workspace/tmp file, or None when the
     path is missing (the block is then left to show as a normal code block).
-    ``.org``/``.md``/``.pdf`` render richly; ANY other file falls back to plain
-    text (the /show route escapes it) — so "show me this .j2/.py/.txt" works
-    instead of silently degrading to a raw code block.  An optional
-    ``lines:``/``pages:`` range is carried into the embed."""
+    PNG renders as an image; org/markdown/PDF render as documents; other files
+    fall back to escaped plain text. An optional ``lines:``/``pages:`` range is
+    carried into the embed."""
     path = _scalar(block.get("path", ""))
     if not path:
         return None
@@ -3310,10 +3308,10 @@ def _extract_pdf_pages(fpath: str, pages: str) -> bytes | None:
 
 @app.get("/thread/{tid}/show")
 def show_file_view(tid: str, path: str, lines: str = "", pages: str = ""):
-    """Render a file from the thread's agent workspace for embedding: pdf as
-    bytes (browser viewer), md/org as a styled HTML page.  Optional section range
-    — ``lines=N-M`` (md/org) or ``pages=N-M`` (pdf, extracted); the key not
-    matching the file type is simply unread, a malformed range shows the whole file.
+    """Render a thread workspace file: PNG/PDF as bytes, md/org as styled HTML,
+    and other files as escaped text. Optional section range — ``lines=N-M``
+    (md/org/text) or ``pages=N-M`` (pdf, extracted); the key not matching the file
+    type is unread, and a malformed range shows the whole file.
 
     Declared SYNC (not ``async def``) on purpose: the file read, the markdown/org
     conversion, and pdf extraction are blocking CPU/IO and a shown file can be
@@ -3324,6 +3322,11 @@ def show_file_view(tid: str, path: str, lines: str = "", pages: str = ""):
     if fpath is None or not os.path.isfile(fpath):
         raise HTTPException(status_code=404, detail="file not found")
     ext = os.path.splitext(fpath)[1].lower()
+    if ext == ".png":
+        return FileResponse(
+            fpath, media_type="image/png",
+            headers={"X-Content-Type-Options": "nosniff"},
+        )
     if ext == ".pdf":
         pdf_headers = {"X-Content-Type-Options": "nosniff"}
         if pages:
@@ -3344,7 +3347,7 @@ def show_file_view(tid: str, path: str, lines: str = "", pages: str = ""):
     elif ext == ".org":
         body = _org_to_html(src)
     else:
-        # Text fallback: any other file (.txt, .py, .j2, no extension, …) shows as
+        # Text fallback: other files (.txt, .py, .j2, no extension, …) show as
         # escaped plain text in a <pre>.  html.escape neutralises any markup, so an
         # agent-generated file can't inject HTML/JS (same guarantee as the org
         # renderer); binary content degrades to replacement chars, not a crash.
@@ -3464,4 +3467,3 @@ def merge_thread(tid: str):
             # Unexpected error
             logging.error(f"Merge & Push failed for thread {tid}: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Merge & Push failed: {str(e)}")
-

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -19,7 +19,6 @@ from manage.web.threads import (
     _show_src,
     _extract_pdf_pages,
     _RENDER_DISPATCH,
-    _SHOWABLE_EXTS,
 )
 
 
@@ -81,6 +80,13 @@ class TestFileEmbed:
         # sandbox WITHOUT allow-scripts so embedded content can't run JS.
         assert "sandbox=" in h and "allow-scripts" not in h
 
+    def test_png_uses_inline_image(self):
+        h = _file_embed_html("t1", "/tmp/weight_chart.png")
+        assert '<img class="show-file show-file-image"' in h
+        assert "/thread/t1/show?path=%2Ftmp%2Fweight_chart.png" in h
+        assert 'alt="Graph or image: /tmp/weight_chart.png"' in h
+        assert "<iframe" not in h and "<embed" not in h
+
     def test_path_is_url_quoted(self):
         assert "my%20report.org" in _file_embed_html("t1", "my report.org")
 
@@ -96,10 +102,10 @@ class TestFileEmbed:
     def test_render_file_block_renders_showable(self):
         assert "<iframe" in _render_file_block("t1", {"path": "/workspace/r.org"})
 
-    @pytest.mark.parametrize("name", ["a.org", "a.md", "a.pdf"])
+    @pytest.mark.parametrize("name", ["a.org", "a.md", "a.pdf", "a.png"])
     def test_every_embed_has_a_fullpage_link(self, name):
         # The full-page "view on its own page" affordance: every embed branch
-        # (md/org iframe + pdf embed) must carry a caption href to the /show page.
+        # (md/org iframe + PDF embed + PNG image) must carry a caption href to /show.
         h = _file_embed_html("t1", name)
         assert 'class="show-cap"' in h and "<a href=" in h
 
@@ -131,6 +137,13 @@ class TestRenderAssistantContent:
         out = _render_assistant_content("t1", raw)
         assert "show-embed" in out and "/thread/t1/show?path=" in out
         assert "```render" not in out
+
+    def test_png_render_block_becomes_inline_image(self):
+        raw = "```render\ntype: file\npath: /tmp/weight_chart.png\n```"
+        out = _render_assistant_content("t1", raw)
+        assert '<img class="show-file show-file-image"' in out
+        assert "/thread/t1/show?path=%2Ftmp%2Fweight_chart.png" in out
+        assert "<iframe" not in out and "```render" not in out
 
     def test_plain_markdown_untouched(self):
         out = _render_assistant_content("t1", "# Hi\n\n| a | b |\n|---|---|\n| 1 | 2 |\n")
@@ -235,6 +248,30 @@ class TestShowRoute:
         assert r.headers["content-type"] == "application/pdf"
         assert r.content == b"%PDF-1.4 fake bytes"
 
+    def test_tmp_png_block_renders_inline_and_serves_original_bytes(self, workspace):
+        # Complete, decodable 1x1 transparent PNG: the browser-visible contract
+        # is an image, not merely arbitrary bytes carrying a .png suffix.
+        png = bytes.fromhex(
+            "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489"
+            "0000000d49444154789c6360606060000000050001a5f645400000000049454e44"
+            "ae426082"
+        )
+        tmp = workspace.parent / "tmp"
+        tmp.mkdir()
+        (tmp / "weight_chart.png").write_bytes(png)
+
+        rendered = _render_assistant_content(
+            "t1", "```render\ntype: file\npath: /tmp/weight_chart.png\n```")
+        assert '<img class="show-file show-file-image"' in rendered
+        assert "<iframe" not in rendered and "```render" not in rendered
+
+        response = TestClient(web.app).get(
+            "/thread/t1/show", params={"path": "/tmp/weight_chart.png"})
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "image/png"
+        assert response.headers["x-content-type-options"] == "nosniff"
+        assert response.content == png
+
     def test_missing_file_404(self, workspace):
         r = TestClient(web.app, raise_server_exceptions=False).get(
             "/thread/t1/show", params={"path": "nope.md"})
@@ -264,18 +301,6 @@ class TestShowRoute:
         r = TestClient(web.app, raise_server_exceptions=False).get(
             "/thread/t1/show", params={"path": "/tmp/summary.md"})
         assert r.status_code == 200 and "<h1>Summary</h1>" in r.text
-
-    def test_route_renders_every_showable_ext(self, workspace):
-        # Drift guard: _SHOWABLE_EXTS is the allow-list for the file embed AND
-        # this route; if the set lists an ext the route can't handle it would 415
-        # inside the embed. Assert the route renders (never 415s) each member.
-        for ext in _SHOWABLE_EXTS:
-            name = f"drift{ext}"
-            (workspace / name).write_text("# hi\n" if ext != ".pdf" else "%PDF-1.4 x")
-            r = TestClient(web.app, raise_server_exceptions=False).get(
-                "/thread/t1/show", params={"path": name})
-            assert r.status_code != 415, f"{ext} -> {r.status_code}"
-
 
 class TestOrgRender:
     """Pure-Python org renderer (no emacs — see the security note in threads.py)."""


### PR DESCRIPTION
## What changed

- render PNG files inline in web conversations and serve their original bytes as `image/png`
- install Matplotlib in the turn sandbox so the agent can create requested graphs
- teach the web render skill to create, verify, and immediately display persistent PNG artifacts
- add browser-visible unit coverage and real-Qwen behavioral regressions

## Why

A graph request could create a PNG but then try to read the binary, substitute ASCII, or emit a file block that the web route decoded as text. Follow-up requests to show the graph did not reliably reuse the existing artifact.

The fix keeps the existing `type: file` render contract. PNG is now one supported file representation, and the render skill gives the small model a concrete create, verify, and emit sequence.

## Validation

- baseline captured before behavior changes: graph creation and follow-up flows 0/3
- final real-model stability: 40/40 across four behavior contracts
- unit suite: 1,294 passed
- local sandbox image built successfully with Matplotlib 3.11.0
- multi-lens local review converged cleanly

No deployment was performed.
