### PR TITLE
Voice P1: add in-process speech engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ config.yml
 dist/
 build/lib/
 build/bdist.*/
+# Provisioned speech models are deploy artifacts, not source.
+/models/

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,12 @@ deploy-code:
 	@rsync -avz --delete \
 		--filter=':- .gitignore' \
 		--exclude '.git' \
+		--filter='H /.claude/' \
+		--filter='H /edd/eval-history/' \
+		--filter='H /edd/eval/cassettes/' \
+		--filter='H /edd/eval/test_shared_docs_skill.py' \
+		--filter='H /improvements/' \
+		--filter='H /roadmap.org_archive' \
 		./ $(DEPLOY_HOST):$(DEPLOY_PATH)/
 	@echo "✓ Code deployed"
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ define with-prod-env
 	fi
 endef
 
-.PHONY: eval test web smoke deploy deploy-code deploy-sandbox-build deploy-service deploy-install restart status logs setup-sudo help sandbox-build egress-proxy-build sandbox-smoke sandbox-shell pull-eval-history vacuum-now searxng-up searxng-down deploy-searxng
+.PHONY: eval test web smoke deploy deploy-code deploy-sandbox-build deploy-service deploy-install deploy-speech-models restart status logs setup-sudo help sandbox-build egress-proxy-build sandbox-smoke sandbox-shell pull-eval-history vacuum-now searxng-up searxng-down deploy-searxng
 
 eval:
 	$(call with-dev-env,./scripts/run-evals.sh)
@@ -81,7 +81,7 @@ sandbox-shell:
 
 # === Deployment Targets ===
 
-deploy: deploy-code deploy-sandbox-build deploy-searxng deploy-install restart
+deploy: deploy-code deploy-sandbox-build deploy-searxng deploy-install deploy-speech-models restart
 	@echo "✓ Deployed everything EXCEPT the systemd service."
 	@echo "  The service unit is left untouched (installing it needs interactive sudo)."
 	@echo "  To apply service/unit changes, run: make deploy-service"
@@ -175,6 +175,12 @@ deploy-install:
 		.venv/bin/pip install -e . && \
 		.venv/bin/pip install -r requirements.txt'
 	@echo "✓ Dependencies installed"
+
+deploy-speech-models:
+	@echo "→ Provisioning pinned speech models on remote server..."
+	@ssh $(DEPLOY_HOST) 'cd $(DEPLOY_PATH) && \
+		.venv/bin/python scripts/provision-speech-models.py models/voice'
+	@echo "✓ Speech models provisioned"
 
 restart:
 	@echo "→ Restarting $(SERVICE_NAME) service..."

--- a/docs/2026-07-23-voice-p1.org
+++ b/docs/2026-07-23-voice-p1.org
@@ -28,8 +28,9 @@ locks on the uvicorn loop. Inbound =close()= and outbound =abort()= atomically m
 closed, discard call-local backlog, and wake all waiters. Graceful outbound
 =close(final=hangup)= instead replaces ordinary backlog with exactly one priority
 terminal control, keeps it retrievable until the sender takes it, then makes later
-gets report closed. The WS owner awaits that terminal send before socket close;
-disconnect/failure uses =abort()=. Every teardown selects one of these idempotent
+gets report closed. The WS owner gives terminal send/socket close a 2 s grace;
+timeout or send failure falls through to =abort()= and releases the one-call slot.
+Disconnect/failure also uses =abort()=. Every teardown selects one of these idempotent
 paths, since cancelling the awaiting coroutine cannot stop its worker call.
 
 * Build sequence + PR slicing (architect-validated 2026-07-23)
@@ -118,7 +119,7 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
 | event log reconstructs the call | scripted-call boundary-sequence assertion |
 | STT WER ≤ target + no_speech_prob discriminates | test_speech.py real clip + noise clip |
 | in-process TTS API produces correct-rate PCM | test_speech.py sample-rate + peak |
-| teardown releases workers and preserves terminal control | test_wire.py empty-outbound get + full-inbound put + hangup-immediately-before-close |
+| teardown releases workers and bounds terminal control | test_wire.py empty-outbound get + full-inbound put + hangup-before-close + stalled terminal send |
 
 * Status
 - [X] Design read; architect build plan produced + reconciled; dep footprint de-risked (torch-free).

--- a/docs/2026-07-23-voice-p1.org
+++ b/docs/2026-07-23-voice-p1.org
@@ -17,13 +17,17 @@ records the build plan grounded in the real code, the reconciliations, and statu
 * Threading model (blocker-class — single-worker uvicorn)
 | Thread | Owns | May NOT |
 |--------+------+---------|
-| WS tasks (=@app.websocket("/call")=) | =ws.receive= → offloaded =inbound_q.put=; offloaded =outbound.get= → =ws.send=; handshake/secret | any lock or blocking queue operation on the event-loop thread; file I/O, model, STT/TTS, flow.py |
+| WS tasks (=@app.websocket("/call")=) | =ws.receive= → offloaded =inbound.put=; offloaded =outbound.get= → =ws.send=; handshake/secret; close both buffers in =finally= | any lock or blocking buffer operation on the event-loop thread; file I/O, model, STT/TTS, flow.py |
 | Session loop (1/call) | pull PCM → drive flow.py → STT → journal events → state machine; schedule/cancel TTS | blocking TTS synthesis; stays free during THINKING and SPEAKING |
 | TTS producer (1/call) | synthesize sentence chunks → split into 20 ms generation-tagged frames → serialized outbound accept boundary | flow.py, session state, observer callbacks |
 | Turn-runner (1/turn) | execute a committed durable Run by id; observer fires at its terminal exit | — |
-=inbound_q= is =queue.Queue=; =outbound= is a bounded generation-aware buffer. Every
-operation on either crosses the thread boundary through =run_in_threadpool=, so the
-WS tasks remain pure shuttles and never acquire their locks on the uvicorn loop.
+=inbound= is a bounded closeable buffer; =outbound= adds generation-aware audio
+invalidation. Every operation on either crosses the thread boundary through
+=run_in_threadpool=, so the WS tasks remain pure shuttles and never acquire their
+locks on the uvicorn loop. Idempotent =close()= atomically marks closed, discards the
+call-local backlog, and wakes all blocked getters/putters; every WS/session teardown
+path closes both buffers, since cancelling the awaiting coroutine cannot stop its
+already-running worker call.
 
 * Build sequence + PR slicing (architect-validated 2026-07-23)
 Dependency-ordered; each new dep enters the smallest PR that needs it.
@@ -111,6 +115,7 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
 | event log reconstructs the call | scripted-call boundary-sequence assertion |
 | STT WER ≤ target + no_speech_prob discriminates | test_speech.py real clip + noise clip |
 | in-process TTS API produces correct-rate PCM | test_speech.py sample-rate + peak |
+| disconnect releases blocked buffer workers | test_wire.py empty-outbound get + full-inbound put |
 
 * Status
 - [X] Design read; architect build plan produced + reconciled; dep footprint de-risked (torch-free).

--- a/docs/2026-07-23-voice-p1.org
+++ b/docs/2026-07-23-voice-p1.org
@@ -19,7 +19,7 @@ records the build plan grounded in the real code, the reconciliations, and statu
 |--------+------+---------|
 | WS loop (=@app.websocket("/call")=) | frame → =inbound_q.put=; =outbound_q.get_nowait= → =ws.send=; handshake/secret | any lock, file I/O, model, STT/TTS, flow.py, blocking =.get()= |
 | Session loop (1/call) | pull PCM → drive flow.py → STT → journal events → state machine; schedule/cancel TTS | blocking TTS synthesis; stays free during THINKING and SPEAKING |
-| TTS producer (1/call) | synthesize sentence chunks → =outbound_q=; cancellation stops iteration before flush | flow.py, session state, observer callbacks |
+| TTS producer (1/call) | synthesize sentence chunks tagged with the current generation → serialized outbound accept boundary | flow.py, session state, observer callbacks |
 | Turn-runner (1/turn) | execute a committed durable Run by id; observer fires at its terminal exit | — |
 =inbound_q=/=outbound_q= are =queue.Queue=. The WS loop is a pure shuttle.
 
@@ -58,7 +58,7 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
    =create_thread_with_message_core(text, domain, rider) -> tid= from its body
    plus =_initialize_thread=; route becomes a thin Form adapter over it.
 4. *Receptionist signature: =receptionist_tools(catalog, domains, on_open, on_new)=*
-   (shipped, receptionist.py:60) — pass =DOMAINS= (state.py:198).
+   (shipped in =receptionist.py=) — pass =DOMAINS= from =state.py=.
 5. *VAD dep: use =onnxruntime= + the silero ONNX model, NOT the =silero-vad= pip package.*
    =pip install silero-vad= pulls =torch= + the full CUDA toolkit (torch-2.13, triton,
    nvidia-cublas/cudnn/cusparse, cuda-toolkit-13 — GB). The design says "silero-VAD
@@ -73,7 +73,10 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
    Piper blocks while producing each sentence. If the session loop synthesized directly,
    it could not drain inbound PCM into =flow.py=, making barge-in impossible during that
    interval. The session remains the sole Flow/state owner and only schedules/cancels TTS;
-   the producer emits PCM chunks and stops before the session sends =flush_uplink=.
+   the producer emits generation-tagged PCM through one serialized accept boundary. On
+   barge-in the session invalidates that generation and enqueues =flush_uplink= atomically
+   at the same boundary; a chunk returned later by an in-flight Piper =next()= is rejected.
+   The session never waits for synthesis before flushing.
 
 * Reuse map (do NOT re-derive)
 - =manage/web/threads.py=: =_create_run= + =_execute_run= (durable ordinary-turn path),
@@ -81,13 +84,14 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
   =_notify_turn_observers= (terminal callback carrying =run_id=, per-observer isolated),
   =create_thread_with_message= / =_initialize_thread=.
 - =assist/middleware/interjection.py=: barge-in delivery; voice owner turns
-  =sender=None,origin=None= pass both gates (:119-121); =register_interjection_callbacks=:88.
-- =assist/catalog.py= (=ThreadCatalog=) + =assist/receptionist.py= (=receptionist_tools=:60,
-  =create_receptionist=:148) — the ROUTER agent; not yet wired to any client (voice is first).
+  =sender=None,origin=None= pass both gates; reuse =register_interjection_callbacks=.
+- =assist/catalog.py= (=ThreadCatalog=) + =assist/receptionist.py=
+  (=receptionist_tools=, =create_receptionist=) — the ROUTER agent; not yet wired to any
+  client (voice is first).
 - =manage/web/app.py= (=app=) + =state.py= (=lifespan=, =DOMAINS=) — /call WS route +
   observer registration. Bind =0.0.0.0= in =__main__.py= — the WG/firewall deploy gate.
-- =assist/spec.py=:56 (=AgentSpec.tools= extra_tools) — =back_to_receptionist()= on the in-thread agent.
-- =assist/events/thread_log.py=:32 (=append_event=, O_APPEND/torn-line) — the call-event log.
+- =assist/spec.py= (=AgentSpec.tools= extra_tools) — =back_to_receptionist()= on the in-thread agent.
+- =assist/events/thread_log.py= (=append_event=, O_APPEND/torn-line) — the call-event log.
 
 * P1 "Done =" (§10) → test map
 | target | test |
@@ -129,4 +133,6 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
   base.en ~150MB; a Piper voice) are provisioned outside a live call and are not committed.
   Deploy needs =make deploy-install= (venv rebuild) for P1.
 - PR4 scheduling constraint from review: observers enqueue text only; TTS must not run in an
-  observer or block the session's inbound-frame drain, so barge-in remains live during synthesis.
+  observer or block the session's inbound-frame drain. Barge-in invalidates the active TTS
+  generation and enqueues the flush at one serialized boundary, so an in-flight synthesis
+  chunk cannot land after the flush.

--- a/docs/2026-07-23-voice-p1.org
+++ b/docs/2026-07-23-voice-p1.org
@@ -17,11 +17,12 @@ records the build plan grounded in the real code, the reconciliations, and statu
 * Threading model (blocker-class — single-worker uvicorn)
 | Thread | Owns | May NOT |
 |--------+------+---------|
-| WS loop (=@app.websocket("/call")=) | frame → =inbound_q.put=; =outbound_q.get_nowait= → =ws.send=; handshake/secret | any lock, file I/O, model, STT/TTS, flow.py, blocking =.get()= |
+| WS loop (=@app.websocket("/call")=) | frame → =inbound_q.put=; =outbound.get_nowait= → =ws.send=; handshake/secret | any lock, file I/O, model, STT/TTS, flow.py, blocking =.get()= |
 | Session loop (1/call) | pull PCM → drive flow.py → STT → journal events → state machine; schedule/cancel TTS | blocking TTS synthesis; stays free during THINKING and SPEAKING |
-| TTS producer (1/call) | synthesize sentence chunks tagged with the current generation → serialized outbound accept boundary | flow.py, session state, observer callbacks |
+| TTS producer (1/call) | synthesize sentence chunks → split into 20 ms generation-tagged frames → serialized outbound accept boundary | flow.py, session state, observer callbacks |
 | Turn-runner (1/turn) | execute a committed durable Run by id; observer fires at its terminal exit | — |
-=inbound_q=/=outbound_q= are =queue.Queue=. The WS loop is a pure shuttle.
+=inbound_q= is =queue.Queue=; =outbound= is a bounded generation-aware buffer with
+nonblocking =get_nowait=. The WS loop is a pure shuttle.
 
 * Build sequence + PR slicing (architect-validated 2026-07-23)
 Dependency-ordered; each new dep enters the smallest PR that needs it.
@@ -73,10 +74,13 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
    Piper blocks while producing each sentence. If the session loop synthesized directly,
    it could not drain inbound PCM into =flow.py=, making barge-in impossible during that
    interval. The session remains the sole Flow/state owner and only schedules/cancels TTS;
-   the producer emits generation-tagged PCM through one serialized accept boundary. On
-   barge-in the session invalidates that generation and enqueues =flush_uplink= atomically
-   at the same boundary; a chunk returned later by an in-flight Piper =next()= is rejected.
-   The session never waits for synthesis before flushing.
+   the producer splits each sentence result into 20 ms generation-tagged PCM frames
+   before one serialized accept boundary. Producer backpressure waits on a condition
+   that releases the boundary lock and rechecks the generation on wake. On barge-in,
+   one atomic buffer operation invalidates the generation, purges its queued PCM, and
+   inserts =flush_uplink= at the front. A frame returned later by an in-flight Piper
+   =next()= is rejected; only a frame the WS shuttle already dequeued can escape. The
+   session never waits for synthesis or buffer capacity before flushing.
 
 * Reuse map (do NOT re-derive)
 - =manage/web/threads.py=: =_create_run= + =_execute_run= (durable ordinary-turn path),
@@ -97,7 +101,7 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
 | target | test |
 |--------+------|
 | endpointing premature-cutoff/false-trigger within targets | test_flow.py labeled-WAV frame-by-frame |
-| barge-in cancels-TTS-then-flush within 1 frame w/o cancelling the turn | test_session.py via fake bridge |
+| barge-in invalidates/purges TTS then flushes within 1 frame w/o cancelling the turn | test_session.py via fake bridge |
 | Goertzel DTMF on synth tones incl. noise | test_flow.py (DONE — see status) |
 | global PIN lockout | security test, rotating caller-ids |
 | per-state detector scoping (no STT pre-auth) | test_session.py + construction spy |
@@ -131,8 +135,8 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
   The silero =silero_vad.onnx= (2.3 MB, official snakers4 repo) is committed under =manage/voice/assets/=.
 - faster-whisper + piper-tts are pinned for PR2. All torch-free. Speech models (whisper
   base.en ~150MB; a Piper voice) are provisioned outside a live call and are not committed.
-  Deploy needs =make deploy-install= (venv rebuild) for P1.
+  Deploy needs =make deploy-install= plus =make deploy-speech-models= for P1.
 - PR4 scheduling constraint from review: observers enqueue text only; TTS must not run in an
   observer or block the session's inbound-frame drain. Barge-in invalidates the active TTS
-  generation and enqueues the flush at one serialized boundary, so an in-flight synthesis
-  chunk cannot land after the flush.
+  generation, purges its queued frames, and prioritizes the flush at one serialized
+  boundary, so an in-flight synthesis frame cannot land after the flush.

--- a/docs/2026-07-23-voice-p1.org
+++ b/docs/2026-07-23-voice-p1.org
@@ -8,7 +8,8 @@ authoritative *design* is the six-lens-reviewed tech doc in the emacsos repo:
 This doc is the *assist-side P1 build/state doc* — it does NOT restate the design; it
 records the build plan grounded in the real code, the reconciliations, and status.
 
-- P0 (shared session API: =plan_turn=/=route_turn= + turn-observer seam) — DONE, merged, deployed.
+- P0 (durable Run service + turn-observer seam) — DONE, merged, deployed; PR #213 is
+  authoritative for submission, queueing, interjection, and recovery semantics.
 - P0.5 (=catalog.py= + =receptionist.py= + eval N=10=80/80) — DONE, merged, deployed.
 - *P1 (this doc)* — the voice client: a new =manage/voice/= package, validated entirely
   against a FAKE BRIDGE (no phone hardware; that is P3). All in assist.
@@ -19,7 +20,7 @@ records the build plan grounded in the real code, the reconciliations, and statu
 | WS loop (=@app.websocket("/call")=) | frame → =inbound_q.put=; =outbound_q.get_nowait= → =ws.send=; handshake/secret | any lock, file I/O, model, STT/TTS, flow.py, blocking =.get()= |
 | Session loop (1/call) | pull PCM → drive flow.py → STT → journal events → state machine; schedule/cancel TTS | blocking TTS synthesis; stays free during THINKING and SPEAKING |
 | TTS producer (1/call) | synthesize sentence chunks → =outbound_q=; cancellation stops iteration before flush | flow.py, session state, observer callbacks |
-| Turn-runner (1/turn) | run =_process_message= so the session loop can journal a mid-turn steering utterance while the turn runs; observer fires here | — |
+| Turn-runner (1/turn) | execute a committed durable Run by id; observer fires at its terminal exit | — |
 =inbound_q=/=outbound_q= are =queue.Queue=. The WS loop is a pure shuttle.
 
 * Build sequence + PR slicing (architect-validated 2026-07-23)
@@ -36,26 +37,26 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
 3. *PR3 — frame codec + =tests/voice/fake_bridge.py= + =wire.py= skeleton* — the WS
    protocol (§2) + §8 resource caps, echo-level.
 4. *PR4 — =session.py=* — the state machine + call-event log + conversational contract,
-   tying flow/speech/wire together, driving the shared session API (the big one; full
+   tying flow/speech/wire together, driving the shared Run service (the big one; full
    three-phase rigor — touches the queue/observer/hot path).
 5. *PR5 — security + full scripted-call reconstruction* (global PIN lockout,
    detector-scoping spies, caller-id handling) — or folded into PR4 if reviewable.
 
-* Reconciliations — design predates P0/P0.5 landing; the CODE wins
-1. *=submit_turn= (design) → =plan_turn= + =route_turn= (shipped, threads.py:2682/2706).*
-   Voice reuses BOTH: supplies its own =dispatch= executor (direct call on the
-   turn-runner thread) and writes its busy journal (=MESSAGE_BACKLOG.add=) *synchronously*
-   (it is off-loop already; no =anyio.to_thread=).
-2. *Double-speak filter "on origin" (design) → filter on =backlog_id=-presence.*
-   =route_turn= does not forward =origin= to =dispatch= (threads.py:2719), so =origin= is
-   =None= for both web and voice owner turns. The observer signature already carries
-   =backlog_id=: idle voice turn (=backlog_id is None=, spoken synchronously) ⇒ SUPPRESS
-   the observer speak; busy/interjection turn (=backlog_id= set, the caller's answer) ⇒
-   speak via the observer at the next safe boundary.
+* Reconciliations — PR #213 is authoritative; the CODE wins
+1. *=submit_turn= (design) → commit and execute a durable ordinary Run.*
+   Voice must use the same =_create_run= → =_execute_run= path as web turns: persist the
+   accepted turn before dispatch, carry only its id across the turn-runner boundary, and
+   inherit the Run service's queueing, interjection, pause, and recovery semantics. It must
+   not write =MESSAGE_BACKLOG= or recreate the removed =plan_turn=/=route_turn= split.
+2. *One reply-delivery source: the terminal turn observer.*
+   The observer signature is =(tid, stage, origin, reply_text, run_id)=. Voice speaks an
+   accepted turn's reply only from that callback, including an immediately runnable turn;
+   it does not also speak a synchronous executor return. This removes the old
+   =backlog_id=-based double-speak distinction while preserving exactly-once delivery.
 3. *=on_new= "wraps create_thread_with_message" (design) → that is a FastAPI route*
-   (=Form=/=BackgroundTasks=, threads.py:2004). Extract a plain
+   (=Form=/=BackgroundTasks=). Extract a plain
    =create_thread_with_message_core(text, domain, rider) -> tid= from its body
-   (:2013-2018 + =_initialize_thread=:1104); route becomes a thin Form adapter over it.
+   plus =_initialize_thread=; route becomes a thin Form adapter over it.
 4. *Receptionist signature: =receptionist_tools(catalog, domains, on_open, on_new)=*
    (shipped, receptionist.py:60) — pass =DOMAINS= (state.py:198).
 5. *VAD dep: use =onnxruntime= + the silero ONNX model, NOT the =silero-vad= pip package.*
@@ -75,15 +76,16 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
    the producer emits PCM chunks and stops before the session sends =flush_uplink=.
 
 * Reuse map (do NOT re-derive)
-- =manage/web/threads.py=: =plan_turn=:2682, =route_turn=:2706, =register_turn_observer=:1411,
-  =_notify_turn_observers=:1895 (fires after terminal =_set_status= + =pop_hold=, per-observer
-  isolated), =create_thread_with_message=:2004 / =_initialize_thread=:1104.
+- =manage/web/threads.py=: =_create_run= + =_execute_run= (durable ordinary-turn path),
+  =_dispatch_pending_after= (user-priority FIFO), =register_turn_observer= +
+  =_notify_turn_observers= (terminal callback carrying =run_id=, per-observer isolated),
+  =create_thread_with_message= / =_initialize_thread=.
 - =assist/middleware/interjection.py=: barge-in delivery; voice owner turns
   =sender=None,origin=None= pass both gates (:119-121); =register_interjection_callbacks=:88.
 - =assist/catalog.py= (=ThreadCatalog=) + =assist/receptionist.py= (=receptionist_tools=:60,
   =create_receptionist=:148) — the ROUTER agent; not yet wired to any client (voice is first).
-- =manage/web/app.py=:11 (=app=) + =state.py=:688 (=lifespan=) — /call WS route + observer
-  registration; =DOMAINS=:198. Bind =0.0.0.0= (=__main__.py=:32) — the WG/firewall deploy gate.
+- =manage/web/app.py= (=app=) + =state.py= (=lifespan=, =DOMAINS=) — /call WS route +
+  observer registration. Bind =0.0.0.0= in =__main__.py= — the WG/firewall deploy gate.
 - =assist/spec.py=:56 (=AgentSpec.tools= extra_tools) — =back_to_receptionist()= on the in-thread agent.
 - =assist/events/thread_log.py=:32 (=append_event=, O_APPEND/torn-line) — the call-event log.
 
@@ -96,7 +98,7 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
 | global PIN lockout | security test, rotating caller-ids |
 | per-state detector scoping (no STT pre-auth) | test_session.py + construction spy |
 | silence watchdog fires | test_session.py frame-count THINKING gap |
-| observer double-speak filter | test_session.py idle-turn + observer = one speak |
+| observer is the single reply source | test_session.py idle and queued turns each speak once |
 | event log reconstructs the call | scripted-call boundary-sequence assertion |
 | STT WER ≤ target + no_speech_prob discriminates | test_speech.py real clip + noise clip |
 | in-process TTS API produces correct-rate PCM | test_speech.py sample-rate + peak |
@@ -115,7 +117,7 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
       without it the VAD returned ~0 on ALL audio (would have silently detected nothing in prod).
       **flow.py PR1 is complete — 19 flow tests** (incl. the review-round DTMF gap-tolerance + DTMF-scope
       assert). Local review round 1: 1 IMPORTANT (DTMF glitch → duplicate digit) + nits fixed.
-- [ ] PR2: =manage/voice/speech.py= — independently lazy faster-whisper =base.en= CPU STT +
+- [X] PR2: =manage/voice/speech.py= — independently lazy faster-whisper =base.en= CPU STT +
       Piper TTS, synchronous/off-event-loop; raw s16le/16 kHz boundary; sentence-chunk iterator
       preserves cancellation for PR4. Unit contract complete; real Whisper + Piper model checks pass.
 - [ ] PR3–PR5 per the slicing above.

--- a/docs/2026-07-23-voice-p1.org
+++ b/docs/2026-07-23-voice-p1.org
@@ -17,7 +17,8 @@ records the build plan grounded in the real code, the reconciliations, and statu
 | Thread | Owns | May NOT |
 |--------+------+---------|
 | WS loop (=@app.websocket("/call")=) | frame → =inbound_q.put=; =outbound_q.get_nowait= → =ws.send=; handshake/secret | any lock, file I/O, model, STT/TTS, flow.py, blocking =.get()= |
-| Session loop (1/call) | pull PCM → drive flow.py → STT → journal events → state machine → enqueue TTS onto =outbound_q= | (stays free during THINKING) |
+| Session loop (1/call) | pull PCM → drive flow.py → STT → journal events → state machine; schedule/cancel TTS | blocking TTS synthesis; stays free during THINKING and SPEAKING |
+| TTS producer (1/call) | synthesize sentence chunks → =outbound_q=; cancellation stops iteration before flush | flow.py, session state, observer callbacks |
 | Turn-runner (1/turn) | run =_process_message= so the session loop can journal a mid-turn steering utterance while the turn runs; observer fires here | — |
 =inbound_q=/=outbound_q= are =queue.Queue=. The WS loop is a pure shuttle.
 
@@ -27,9 +28,11 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
    frame-in/event-out engine (VAD, endpointing, barge-in, DTMF). Zero web imports, no
    network, no threads, *no wall clock* (t derived from frame count → deterministic
    fixtures). Deps: =onnxruntime= + a bundled =silero_vad.onnx= (NOT the =silero-vad=
-   pip pkg — see Reconciliations). *← current PR.*
+   pip pkg — see Reconciliations). *DONE (PR #209).*
 2. *PR2 — =speech.py= + =tests/voice/test_speech.py=* — lazy in-proc =faster-whisper=
-   (STT) + =piper= (TTS), on the session/turn thread. Deps: faster-whisper, piper-tts.
+   (STT) + =piper= (TTS), synchronously off the event loop; PR4 owns thread scheduling.
+   Deps: faster-whisper, piper-tts.
+   *← current PR.*
 3. *PR3 — frame codec + =tests/voice/fake_bridge.py= + =wire.py= skeleton* — the WS
    protocol (§2) + §8 resource caps, echo-level.
 4. *PR4 — =session.py=* — the state machine + call-event log + conversational contract,
@@ -65,6 +68,11 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
    DTMF-only scope (=vad=False=, GREETING_PIN) never loads onnxruntime/the model, and
    scripted-prob tests never touch it. Sound improvement; the only I/O stays the model load.
    (Also: silero v5 prepends 64 samples of carried context per 512-window → 576-sample input.)
+7. *TTS on the session thread (design §5/§6) → a serialized per-call TTS producer.*
+   Piper blocks while producing each sentence. If the session loop synthesized directly,
+   it could not drain inbound PCM into =flow.py=, making barge-in impossible during that
+   interval. The session remains the sole Flow/state owner and only schedules/cancels TTS;
+   the producer emits PCM chunks and stops before the session sends =flush_uplink=.
 
 * Reuse map (do NOT re-derive)
 - =manage/web/threads.py=: =plan_turn=:2682, =route_turn=:2706, =register_turn_observer=:1411,
@@ -91,7 +99,7 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
 | observer double-speak filter | test_session.py idle-turn + observer = one speak |
 | event log reconstructs the call | scripted-call boundary-sequence assertion |
 | STT WER ≤ target + no_speech_prob discriminates | test_speech.py real clip + noise clip |
-| /tts correct-rate PCM | test_speech.py sample-rate + peak |
+| in-process TTS API produces correct-rate PCM | test_speech.py sample-rate + peak |
 
 * Status
 - [X] Design read; architect build plan produced + reconciled; dep footprint de-risked (torch-free).
@@ -107,12 +115,16 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
       without it the VAD returned ~0 on ALL audio (would have silently detected nothing in prod).
       **flow.py PR1 is complete — 19 flow tests** (incl. the review-round DTMF gap-tolerance + DTMF-scope
       assert). Local review round 1: 1 IMPORTANT (DTMF glitch → duplicate digit) + nits fixed.
-- [ ] PR2–PR5 per the slicing above. Speech deps (faster-whisper, piper-tts) are INSTALLED + round-trip
-      verified (piper→whisper transcribed verbatim) but NOT yet in requirements.txt (that's PR2).
+- [ ] PR2: =manage/voice/speech.py= — independently lazy faster-whisper =base.en= CPU STT +
+      Piper TTS, synchronous/off-event-loop; raw s16le/16 kHz boundary; sentence-chunk iterator
+      preserves cancellation for PR4. Unit contract complete; real Whisper + Piper model checks pass.
+- [ ] PR3–PR5 per the slicing above.
 
 * Notes for Pierre
 - Deps landed in =requirements.txt=: =onnxruntime==1.27.0= (+ flatbuffers, protobuf) — lean, torch-free.
   The silero =silero_vad.onnx= (2.3 MB, official snakers4 repo) is committed under =manage/voice/assets/=.
-- faster-whisper + piper-tts are installed in the venv + round-trip verified, but pinned in requirements
-  only when PR2 (=speech.py=) lands. All torch-free. Speech models (whisper base.en ~150MB; a piper voice)
-  download at runtime/deploy — not committed. Deploy needs =make deploy-install= (venv rebuild) for P1.
+- faster-whisper + piper-tts are pinned for PR2. All torch-free. Speech models (whisper
+  base.en ~150MB; a Piper voice) are provisioned outside a live call and are not committed.
+  Deploy needs =make deploy-install= (venv rebuild) for P1.
+- PR4 scheduling constraint from review: observers enqueue text only; TTS must not run in an
+  observer or block the session's inbound-frame drain, so barge-in remains live during synthesis.

--- a/docs/2026-07-23-voice-p1.org
+++ b/docs/2026-07-23-voice-p1.org
@@ -17,12 +17,13 @@ records the build plan grounded in the real code, the reconciliations, and statu
 * Threading model (blocker-class — single-worker uvicorn)
 | Thread | Owns | May NOT |
 |--------+------+---------|
-| WS loop (=@app.websocket("/call")=) | frame → =inbound_q.put=; =outbound.get_nowait= → =ws.send=; handshake/secret | any lock, file I/O, model, STT/TTS, flow.py, blocking =.get()= |
+| WS tasks (=@app.websocket("/call")=) | =ws.receive= → offloaded =inbound_q.put=; offloaded =outbound.get= → =ws.send=; handshake/secret | any lock or blocking queue operation on the event-loop thread; file I/O, model, STT/TTS, flow.py |
 | Session loop (1/call) | pull PCM → drive flow.py → STT → journal events → state machine; schedule/cancel TTS | blocking TTS synthesis; stays free during THINKING and SPEAKING |
 | TTS producer (1/call) | synthesize sentence chunks → split into 20 ms generation-tagged frames → serialized outbound accept boundary | flow.py, session state, observer callbacks |
 | Turn-runner (1/turn) | execute a committed durable Run by id; observer fires at its terminal exit | — |
-=inbound_q= is =queue.Queue=; =outbound= is a bounded generation-aware buffer with
-nonblocking =get_nowait=. The WS loop is a pure shuttle.
+=inbound_q= is =queue.Queue=; =outbound= is a bounded generation-aware buffer. Every
+operation on either crosses the thread boundary through =run_in_threadpool=, so the
+WS tasks remain pure shuttles and never acquire their locks on the uvicorn loop.
 
 * Build sequence + PR slicing (architect-validated 2026-07-23)
 Dependency-ordered; each new dep enters the smallest PR that needs it.

--- a/docs/2026-07-23-voice-p1.org
+++ b/docs/2026-07-23-voice-p1.org
@@ -17,17 +17,20 @@ records the build plan grounded in the real code, the reconciliations, and statu
 * Threading model (blocker-class — single-worker uvicorn)
 | Thread | Owns | May NOT |
 |--------+------+---------|
-| WS tasks (=@app.websocket("/call")=) | =ws.receive= → offloaded =inbound.put=; offloaded =outbound.get= → =ws.send=; handshake/secret; close both buffers in =finally= | any lock or blocking buffer operation on the event-loop thread; file I/O, model, STT/TTS, flow.py |
+| WS tasks (=@app.websocket("/call")=) | =ws.receive= → offloaded =inbound.put=; offloaded =outbound.get= → =ws.send=; handshake/secret; graceful terminal drain or abrupt abort | any lock or blocking buffer operation on the event-loop thread; file I/O, model, STT/TTS, flow.py |
 | Session loop (1/call) | pull PCM → drive flow.py → STT → journal events → state machine; schedule/cancel TTS | blocking TTS synthesis; stays free during THINKING and SPEAKING |
 | TTS producer (1/call) | synthesize sentence chunks → split into 20 ms generation-tagged frames → serialized outbound accept boundary | flow.py, session state, observer callbacks |
 | Turn-runner (1/turn) | execute a committed durable Run by id; observer fires at its terminal exit | — |
 =inbound= is a bounded closeable buffer; =outbound= adds generation-aware audio
 invalidation. Every operation on either crosses the thread boundary through
 =run_in_threadpool=, so the WS tasks remain pure shuttles and never acquire their
-locks on the uvicorn loop. Idempotent =close()= atomically marks closed, discards the
-call-local backlog, and wakes all blocked getters/putters; every WS/session teardown
-path closes both buffers, since cancelling the awaiting coroutine cannot stop its
-already-running worker call.
+locks on the uvicorn loop. Inbound =close()= and outbound =abort()= atomically mark
+closed, discard call-local backlog, and wake all waiters. Graceful outbound
+=close(final=hangup)= instead replaces ordinary backlog with exactly one priority
+terminal control, keeps it retrievable until the sender takes it, then makes later
+gets report closed. The WS owner awaits that terminal send before socket close;
+disconnect/failure uses =abort()=. Every teardown selects one of these idempotent
+paths, since cancelling the awaiting coroutine cannot stop its worker call.
 
 * Build sequence + PR slicing (architect-validated 2026-07-23)
 Dependency-ordered; each new dep enters the smallest PR that needs it.
@@ -115,7 +118,7 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
 | event log reconstructs the call | scripted-call boundary-sequence assertion |
 | STT WER ≤ target + no_speech_prob discriminates | test_speech.py real clip + noise clip |
 | in-process TTS API produces correct-rate PCM | test_speech.py sample-rate + peak |
-| disconnect releases blocked buffer workers | test_wire.py empty-outbound get + full-inbound put |
+| teardown releases workers and preserves terminal control | test_wire.py empty-outbound get + full-inbound put + hangup-immediately-before-close |
 
 * Status
 - [X] Design read; architect build plan produced + reconciled; dep footprint de-risked (torch-free).

--- a/manage/voice/__init__.py
+++ b/manage/voice/__init__.py
@@ -2,8 +2,8 @@
 run service + turn-observer seam and the receptionist
 (P0.5). See docs/2026-07-23-voice-p1.org for the build plan and threading model.
 
-This PR ships ``flow.py`` — the hermetic frame-in/event-out engine. The rest of the
-package lands in later P1 slices: ``session.py`` (per-call state machine), ``wire.py``
-(the WSS /call endpoint — the only asyncio-loop code, a pure frame-shuttle), and
-``speech.py`` (in-proc STT/TTS).
+P1 currently includes ``flow.py`` (the hermetic frame-in/event-out engine) and
+``speech.py`` (lazy in-process STT/TTS). The remaining slices add ``session.py``
+(the per-call state machine) and ``wire.py`` (the WSS /call endpoint — the only
+asyncio-loop code, a pure frame shuttle).
 """

--- a/manage/voice/speech.py
+++ b/manage/voice/speech.py
@@ -1,0 +1,97 @@
+"""In-process speech boundary for the voice-call client.
+
+``Speech`` wraps the one STT/TTS implementation selected by the design:
+faster-whisper ``base.en`` on CPU and Piper. Both models load independently on
+first use from already provisioned local artifacts. Methods are synchronous and
+must be called off the uvicorn event loop; session scheduling belongs in
+``session.py``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import gcd
+from pathlib import Path
+from typing import Iterator
+
+import numpy as np
+from faster_whisper import WhisperModel
+from piper import PiperVoice
+from scipy.signal import resample_poly
+
+from manage.voice.flow import SAMPLE_RATE
+
+
+@dataclass(frozen=True)
+class Transcription:
+    """Accepted text and Whisper's segment-level no-speech evidence.
+
+    Endpointed utterances fit in one Whisper window. All segments from that
+    window carry the same probability, so the first supplies it. If VAD removes
+    the input, Whisper emits no segment and the probability is ``None`` rather
+    than an invented model score; empty text is the discard signal.
+    """
+
+    text: str
+    no_speech_prob: float | None
+
+
+class Speech:
+    """Host-owned Whisper/Piper models for the single active voice call."""
+
+    def __init__(self, piper_model_path: str | Path,
+                 whisper_model_path: str | Path):
+        self._piper_model_path = Path(piper_model_path)
+        self._whisper_model_path = str(whisper_model_path)
+        self._whisper: WhisperModel | None = None
+        self._piper: PiperVoice | None = None
+
+    def _stt(self) -> WhisperModel:
+        if self._whisper is None:
+            self._whisper = WhisperModel(
+                self._whisper_model_path,
+                device="cpu",
+                compute_type="int8",
+                local_files_only=True,
+            )
+        return self._whisper
+
+    def _tts(self) -> PiperVoice:
+        if self._piper is None:
+            self._piper = PiperVoice.load(
+                self._piper_model_path, use_cuda=False
+            )
+        return self._piper
+
+    def transcribe(
+        self, pcm: bytes, *, initial_prompt: str | None = None
+    ) -> Transcription:
+        """Transcribe little-endian mono s16le/16 kHz PCM."""
+        if len(pcm) % 2:
+            raise ValueError("PCM must contain whole 16-bit samples")
+        audio = np.frombuffer(pcm, dtype="<i2").astype(np.float32) / 32768.0
+        segments, _ = self._stt().transcribe(
+            audio,
+            language="en",
+            vad_filter=True,
+            condition_on_previous_text=False,
+            initial_prompt=initial_prompt,
+        )
+        decoded = list(segments)
+        return Transcription(
+            text="".join(segment.text for segment in decoded).strip(),
+            no_speech_prob=decoded[0].no_speech_prob if decoded else None,
+        )
+
+    def synthesize(self, text: str) -> Iterator[bytes]:
+        """Yield Piper sentence chunks as normalized mono s16le/16 kHz PCM."""
+        for chunk in self._tts().synthesize(text):
+            audio = chunk.audio_float_array
+            if chunk.sample_rate != SAMPLE_RATE:
+                divisor = gcd(chunk.sample_rate, SAMPLE_RATE)
+                audio = resample_poly(
+                    audio,
+                    SAMPLE_RATE // divisor,
+                    chunk.sample_rate // divisor,
+                )
+            normalized = np.clip(audio, -1.0, 1.0) * (0.9 * 32767)
+            yield normalized.astype("<i2").tobytes()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "deepagents",
     "docker",
     "fastapi",
+    "faster-whisper",
     "httpx",
     "Jinja2",
     "langchain",
@@ -26,6 +27,7 @@ dependencies = [
     "langgraph-checkpoint-sqlite",
     "Markdown",
     "openai",
+    "piper-tts",
     "pydantic",
     # Host-side PDF page extraction for the render skill's `pages:` range
     # (manage/web/threads.py `_extract_pdf_pages`). Pure-Python, no system deps.
@@ -33,6 +35,7 @@ dependencies = [
     "python-dotenv",
     "python-multipart",
     "requests",
+    "scipy",
     "uvicorn",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ APScheduler==3.11.2
 astroid==4.0.3
 asttokens==3.0.1
 attrs==25.4.0
+av==18.0.0
 backoff==2.2.1
 bracex==2.6
 brotli==1.2.0
@@ -19,6 +20,7 @@ charset-normalizer==3.4.4
 click==8.3.1
 clickhouse-connect==0.10.0
 cryptography==48.0.0
+ctranslate2==4.8.1
 decorator==5.2.1
 deepagents==0.6.1
 dill==0.4.0
@@ -30,6 +32,7 @@ duckduckgo_search==8.1.1
 executing==2.2.1
 fake-useragent==2.2.0
 fastapi==0.128.0
+faster-whisper==1.2.1
 filelock==3.20.3
 filetype==1.2.0
 flake8==7.3.0
@@ -94,9 +97,11 @@ packaging==25.0
 pandas==2.3.3
 parso==0.8.5
 pathspec==1.0.3
+pathvalidate==3.3.1
 pexpect==4.9.0
 platformdirs==4.5.1
 playwright==1.58.0
+piper-tts==1.6.0
 pluggy==1.6.0
 posthog==7.5.1
 primp==0.15.0

--- a/scripts/provision-speech-models.py
+++ b/scripts/provision-speech-models.py
@@ -53,13 +53,13 @@ PIPER_FILES = {
 def _download(
     url: str, destination: Path, expected_sha256: str, expected_size: int
 ) -> None:
-    current_hash = (
-        hashlib.sha256(destination.read_bytes()).hexdigest()
-        if destination.exists()
-        else None
-    )
-    if current_hash == expected_sha256:
-        return
+    if destination.exists() and destination.stat().st_size == expected_size:
+        digest = hashlib.sha256()
+        with destination.open("rb") as existing:
+            while chunk := existing.read(1024 * 1024):
+                digest.update(chunk)
+        if digest.hexdigest() == expected_sha256:
+            return
     temporary = destination.with_suffix(destination.suffix + ".part")
     digest, size = hashlib.sha256(), 0
 

--- a/scripts/provision-speech-models.py
+++ b/scripts/provision-speech-models.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Provision the immutable local speech models used by manage.voice.speech."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+import signal
+from urllib.request import urlopen
+
+WHISPER_REVISION = "3d3d5dee26484f91867d81cb899cfcf72b96be6c"
+WHISPER_BASE_URL = (
+    "https://huggingface.co/Systran/faster-whisper-base.en/resolve/"
+    f"{WHISPER_REVISION}"
+)
+WHISPER_FILES = {
+    "config.json": (
+        "f3bc3821e9fc76a27bae538e11ae5b677dcdd352b4600429ce7951d398569aeb",
+        2_227,
+    ),
+    "model.bin": (
+        "2a166925539a16005f14ff328359f9b9adb9dc4fb631bb3b227526862e93e2ef",
+        145_216_508,
+    ),
+    "tokenizer.json": (
+        "929c5252409436dce1b38a75d1abbcb5e132d170d8e324e4e04ed915fa2d22df",
+        2_128_466,
+    ),
+    "vocabulary.txt": (
+        "ff77588746d3a2595d32ab5b69ffd7b95ce2441ac57533cb66fc3eb575a115cf",
+        422_309,
+    ),
+}
+PIPER_VOICE = "en_US-lessac-medium"
+PIPER_REVISION = "0d907f158acc877ddeebcbf827659ee13bea8bcd"
+PIPER_BASE_URL = (
+    "https://huggingface.co/rhasspy/piper-voices/resolve/"
+    f"{PIPER_REVISION}/en/en_US/lessac/medium/{PIPER_VOICE}.onnx"
+)
+PIPER_FILES = {
+    ".onnx": (
+        "5efe09e69902187827af646e1a6e9d269dee769f9877d17b16b1b46eeaaf019f",
+        63_201_294,
+    ),
+    ".onnx.json": (
+        "efe19c417bed055f2d69908248c6ba650fa135bc868b0e6abb3da181dab690a0",
+        4_885,
+    ),
+}
+
+
+def _download(
+    url: str, destination: Path, expected_sha256: str, expected_size: int
+) -> None:
+    current_hash = (
+        hashlib.sha256(destination.read_bytes()).hexdigest()
+        if destination.exists()
+        else None
+    )
+    if current_hash == expected_sha256:
+        return
+    temporary = destination.with_suffix(destination.suffix + ".part")
+    digest, size = hashlib.sha256(), 0
+
+    def timeout(_signum: int, _frame: object) -> None:
+        raise TimeoutError(f"download timed out for {destination.name}")
+
+    previous_handler = signal.signal(signal.SIGALRM, timeout)
+    signal.alarm(300)
+    try:
+        with (
+            urlopen(url, timeout=60) as response,
+            temporary.open("wb") as output,
+        ):
+            while chunk := response.read(
+                min(1024 * 1024, expected_size - size + 1)
+            ):
+                size += len(chunk)
+                if size > expected_size:
+                    raise ValueError(
+                        f"oversize download for {destination.name}"
+                    )
+                digest.update(chunk)
+                output.write(chunk)
+        if size != expected_size or digest.hexdigest() != expected_sha256:
+            raise ValueError(f"integrity mismatch for {destination.name}")
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous_handler)
+    os.replace(temporary, destination)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("model_dir", type=Path)
+    args = parser.parse_args()
+    args.model_dir.mkdir(parents=True, exist_ok=True)
+
+    whisper_dir = args.model_dir / "whisper-base.en"
+    whisper_dir.mkdir(exist_ok=True)
+    for name, (checksum, size) in WHISPER_FILES.items():
+        _download(
+            f"{WHISPER_BASE_URL}/{name}",
+            whisper_dir / name,
+            checksum,
+            size,
+        )
+    for suffix, (checksum, size) in PIPER_FILES.items():
+        _download(
+            PIPER_BASE_URL + (".json" if suffix.endswith(".json") else ""),
+            args.model_dir / f"{PIPER_VOICE}{suffix}",
+            checksum,
+            size,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/voice/test_speech.py
+++ b/tests/voice/test_speech.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import os
+from pathlib import Path
 import wave
 
 import numpy as np
@@ -10,6 +11,7 @@ from manage.voice.speech import Speech
 
 _WHISPER_TEST_MODEL = os.getenv("ASSIST_WHISPER_TEST_MODEL")
 _PIPER_TEST_MODEL = os.getenv("ASSIST_PIPER_TEST_MODEL")
+_FIXTURES = Path(__file__).with_name("fixtures")
 
 
 @dataclass
@@ -145,7 +147,7 @@ def test_synthesize_resamples_to_16k(monkeypatch, tmp_path):
 @pytest.mark.skipif(not _WHISPER_TEST_MODEL,
                     reason="ASSIST_WHISPER_TEST_MODEL is not provisioned")
 def test_real_whisper_transcribes_fixture_and_rejects_noise(tmp_path):
-    with wave.open("tests/voice/fixtures/speech_16k.wav", "rb") as wav:
+    with wave.open(str(_FIXTURES / "speech_16k.wav"), "rb") as wav:
         spoken = wav.readframes(wav.getnframes())
     speech = Speech(tmp_path / "voice.onnx", _WHISPER_TEST_MODEL)
 

--- a/tests/voice/test_speech.py
+++ b/tests/voice/test_speech.py
@@ -1,0 +1,177 @@
+from dataclasses import dataclass
+import os
+import wave
+
+import numpy as np
+import pytest
+
+from manage.voice.speech import Speech
+
+
+_WHISPER_TEST_MODEL = os.getenv("ASSIST_WHISPER_TEST_MODEL")
+_PIPER_TEST_MODEL = os.getenv("ASSIST_PIPER_TEST_MODEL")
+
+
+@dataclass
+class _Segment:
+    text: str
+    no_speech_prob: float
+
+
+class _Whisper:
+    def __init__(self, segments):
+        self.segments = segments
+        self.calls = []
+
+    def transcribe(self, audio, **kwargs):
+        self.calls.append((audio, kwargs))
+        return iter(self.segments), object()
+
+
+@dataclass
+class _Chunk:
+    audio_float_array: np.ndarray
+    sample_rate: int = 16_000
+    sample_width: int = 2
+    sample_channels: int = 1
+
+
+class _Piper:
+    def __init__(self, chunks):
+        self.chunks = chunks
+        self.calls = []
+
+    def synthesize(self, text):
+        self.calls.append(text)
+        yield from self.chunks
+
+
+def test_models_load_independently_and_lazily(monkeypatch, tmp_path):
+    loads = []
+    whisper = _Whisper([_Segment(" hello ", 0.04)])
+    piper = _Piper([_Chunk(np.array([0.5], dtype=np.float32))])
+
+    monkeypatch.setattr(
+        "manage.voice.speech.WhisperModel",
+        lambda *args, **kwargs: loads.append(("stt", args, kwargs)) or whisper,
+    )
+    monkeypatch.setattr(
+        "manage.voice.speech.PiperVoice.load",
+        lambda *args, **kwargs: loads.append(("tts", args, kwargs)) or piper,
+    )
+
+    speech = Speech(tmp_path / "voice.onnx", tmp_path / "whisper")
+    assert loads == []
+
+    assert speech.transcribe(b"\0\0" * 320).text == "hello"
+    assert [load[0] for load in loads] == ["stt"]
+
+    assert list(speech.synthesize("Hello."))
+    assert [load[0] for load in loads] == ["stt", "tts"]
+
+
+def test_transcribe_passes_the_voice_contract(monkeypatch, tmp_path):
+    whisper = _Whisper([_Segment("hello", 0.08), _Segment(" world", 0.08)])
+    monkeypatch.setattr(
+        "manage.voice.speech.WhisperModel", lambda *a, **k: whisper
+    )
+
+    result = Speech(tmp_path / "voice.onnx", tmp_path / "whisper").transcribe(
+        np.array([-32768, 0, 32767], dtype="<i2").tobytes(),
+        initial_prompt="Larochelle",
+    )
+
+    audio, kwargs = whisper.calls[0]
+    np.testing.assert_allclose(audio, [-1.0, 0.0, 32767 / 32768])
+    assert kwargs == {
+        "language": "en",
+        "vad_filter": True,
+        "condition_on_previous_text": False,
+        "initial_prompt": "Larochelle",
+    }
+    assert result.text == "hello world"
+    assert result.no_speech_prob == pytest.approx(0.08)
+
+
+def test_transcribe_empty_has_no_invented_probability(monkeypatch, tmp_path):
+    monkeypatch.setattr("manage.voice.speech.WhisperModel",
+                        lambda *a, **k: _Whisper([]))
+
+    result = Speech(
+        tmp_path / "voice.onnx", tmp_path / "whisper"
+    ).transcribe(b"\0\0" * 320)
+
+    assert result.text == ""
+    assert result.no_speech_prob is None
+
+
+def test_transcribe_rejects_partial_sample(tmp_path):
+    with pytest.raises(ValueError, match="whole 16-bit samples"):
+        Speech(tmp_path / "voice.onnx", tmp_path / "whisper").transcribe(b"\0")
+
+
+def test_synthesize_streams_normalized_16k_s16le(monkeypatch, tmp_path):
+    piper = _Piper([
+        _Chunk(np.array([-1.0, 0.5], dtype=np.float32)),
+        _Chunk(np.array([0.25], dtype=np.float32)),
+    ])
+    monkeypatch.setattr(
+        "manage.voice.speech.PiperVoice.load", lambda *a, **k: piper
+    )
+    chunks = Speech(
+        tmp_path / "voice.onnx", tmp_path / "whisper"
+    ).synthesize("One. Two.")
+
+    first = next(chunks)
+    assert np.frombuffer(first, dtype="<i2").tolist() == [-29490, 14745]
+    assert len(piper.calls) == 1
+    assert list(chunks)
+
+
+def test_synthesize_resamples_to_16k(monkeypatch, tmp_path):
+    piper = _Piper([_Chunk(np.linspace(-0.5, 0.5, 2205, dtype=np.float32),
+                           sample_rate=22_050)])
+    monkeypatch.setattr(
+        "manage.voice.speech.PiperVoice.load", lambda *a, **k: piper
+    )
+
+    [pcm] = Speech(
+        tmp_path / "voice.onnx", tmp_path / "whisper"
+    ).synthesize("Hello.")
+
+    assert len(pcm) // 2 == 1600
+
+
+@pytest.mark.skipif(not _WHISPER_TEST_MODEL,
+                    reason="ASSIST_WHISPER_TEST_MODEL is not provisioned")
+def test_real_whisper_transcribes_fixture_and_rejects_noise(tmp_path):
+    with wave.open("tests/voice/fixtures/speech_16k.wav", "rb") as wav:
+        spoken = wav.readframes(wav.getnframes())
+    speech = Speech(tmp_path / "voice.onnx", _WHISPER_TEST_MODEL)
+
+    result = speech.transcribe(spoken)
+    noise = np.random.default_rng(7).integers(
+        -200, 201, 16_000, dtype=np.int16
+    )
+    noise_result = speech.transcribe(noise.astype("<i2").tobytes())
+
+    assert result.text.lower().strip(".") == (
+        "the quick brown fox jumps over the lazy dog"
+    )
+    assert result.no_speech_prob is not None and result.no_speech_prob < 0.6
+    assert noise_result.text == ""
+
+
+@pytest.mark.skipif(not _PIPER_TEST_MODEL,
+                    reason="ASSIST_PIPER_TEST_MODEL is not provisioned")
+def test_real_piper_produces_16k_pcm():
+    chunks = list(
+        Speech(_PIPER_TEST_MODEL, "/unused/whisper").synthesize(
+            "The quick brown fox."
+        )
+    )
+    samples = np.frombuffer(b"".join(chunks), dtype="<i2")
+
+    assert chunks
+    assert len(samples) > 16_000 // 2
+    assert 20_000 < np.abs(samples).max() <= 29_490


### PR DESCRIPTION
## What changed

- add lazy, in-process faster-whisper STT and Piper TTS for Voice P1
- keep inference local, CPU-only, and torch-free
- resample Piper output to 16 kHz s16le and expose Whisper no-speech evidence
- provision immutable model artifacts before restart with exact sizes and SHA-256 checks
- rebase onto authoritative PR #213 and reconcile the later voice session contract with durable Runs and the terminal observer
- keep operator-only local artifacts out of deploy-code rsyncs

## Scope

This is P1 PR2. It ships only the speech boundary, dependencies, model provisioning, tests, and state-doc reconciliation. Wire and session behavior remain in later slices.

## Validation

- full suite: 1,381 passed, 2 opt-in model tests skipped
- fresh pinned model provision: passed
- real Whisper + Piper suite: 8 passed
- flake8: clean
- pip check: clean
- torch/CUDA absence: verified
- python -m manage.web startup smoke: passed
- deployed branch: service active, HTTPS 200, real deployed-model tests 8/8
- local review: converged across correctness, event-loop liveness, error/edge, adversarial security, simplicity, design adherence, and doc alignment

## Design reconciliation after #213

PR #213 remains authoritative. Future voice session work commits ordinary durable Runs before dispatch, receives replies only through the terminal observer, and keeps all blocking speech and buffer work off the uvicorn event loop. The state doc also pins generation-safe barge-in and bounded teardown contracts for PR4.