### PR TITLE
Add bounded voice WebSocket transport

### DIFF
--- a/README.org
+++ b/README.org
@@ -44,7 +44,7 @@ Run the CLI
 python -m manage.cli
 #+end_src
 
-Run the Web UI (auto-reload)
+Run the Web UI
 
 #+begin_src shell
 python -m manage.web

--- a/README.org
+++ b/README.org
@@ -48,8 +48,6 @@ Run the Web UI (auto-reload)
 
 #+begin_src shell
 python -m manage.web
-# or
-uvicorn manage.web:app --host 0.0.0.0 --port 5050 --reload
 #+end_src
 ** Developing
 Install the package in editable mode so Emacs/Elpy can discover the modules:

--- a/docs/2026-07-23-voice-p1.org
+++ b/docs/2026-07-23-voice-p1.org
@@ -22,14 +22,16 @@ records the build plan grounded in the real code, the reconciliations, and statu
 | TTS producer (1/call) | synthesize sentence chunks → split into 20 ms generation-tagged frames → serialized outbound accept boundary | flow.py, session state, observer callbacks |
 | Turn-runner (1/turn) | execute a committed durable Run by id; observer fires at its terminal exit | — |
 =inbound= is a bounded closeable buffer; =outbound= adds generation-aware audio
-invalidation. Every operation on either crosses the thread boundary through
-=run_in_threadpool=, so the WS tasks remain pure shuttles and never acquire their
-locks on the uvicorn loop. Inbound =close()= and outbound =abort()= atomically mark
+invalidation. Every async WS-task operation on either crosses the thread boundary
+through =run_in_threadpool=; the synchronous runner uses them directly. The WS tasks
+remain pure shuttles and never acquire their locks on the uvicorn loop. Inbound
+=close()= and outbound =abort()= atomically mark
 closed, discard call-local backlog, and wake all waiters. Graceful outbound
 =close(final=hangup)= instead replaces ordinary backlog with exactly one priority
 terminal control, keeps it retrievable until the sender takes it, then makes later
 gets report closed. The WS owner gives terminal send/socket close a 2 s grace;
-timeout or send failure falls through to =abort()= and releases the one-call slot.
+timeout or send failure falls through to =abort()= and wakes the runner. The
+one-call slot is released only after the runner honors that termination signal.
 Disconnect/failure also uses =abort()=. Every teardown selects one of these idempotent
 paths, since cancelling the awaiting coroutine cannot stop its worker call.
 
@@ -43,9 +45,10 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
 2. *PR2 — =speech.py= + =tests/voice/test_speech.py=* — lazy in-proc =faster-whisper=
    (STT) + =piper= (TTS), synchronously off the event loop; PR4 owns thread scheduling.
    Deps: faster-whisper, piper-tts.
-   *← current PR.*
+   *DONE (PR #211).*
 3. *PR3 — frame codec + =tests/voice/fake_bridge.py= + =wire.py= skeleton* — the WS
    protocol (§2) + §8 resource caps, echo-level.
+   *← current PR.*
 4. *PR4 — =session.py=* — the state machine + call-event log + conversational contract,
    tying flow/speech/wire together, driving the shared Run service (the big one; full
    three-phase rigor — touches the queue/observer/hot path).
@@ -90,6 +93,40 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
    inserts =flush_uplink= at the front. A frame returned later by an in-flight Piper
    =next()= is rejected; only a frame the WS shuttle already dequeued can escape. The
    session never waits for synthesis or buffer capacity before flushing.
+
+* PR3 wire contract (design-reviewed 2026-07-25)
+- =wire.py= owns only transport: header-secret authentication, one active connection
+  in the deployed single-worker process, JSON/binary framing, fixed resource bounds,
+  bounded closeable buffers, and teardown. It imports no Flow, Speech, receptionist,
+  Run service, observer, PIN, allowlist, or call-log code.
+- Known phone controls are strictly decoded; malformed known controls close the
+  connection. Unknown control types are counted against the rate bound and ignored
+  for two-repo deploy skew. Binary messages must be exactly 320 s16le samples / 640
+  bytes. Caller normalization, DTMF meaning, hardware-rate policy, answer state, and
+  pre-answer/post-call frame handling belong to PR4/PR5.
+- Safety constants are fixed policy, not deploy knobs: decoded WS message ≤4096 B,
+  first valid =ring= ≤5 s, valid-inbound idle ≤5 s, connection ≤1800 s, and ≤20 text
+  controls in a rolling second. JSON rejects duplicate keys and non-finite numbers;
+  all strings and required scalar fields are bounded before reaching the runner.
+  Uvicorn WebSocket compression is disabled so compressed frames cannot amplify
+  before the decoded-message cap.
+- Authentication happens before the call slot is claimed and before =accept=. The
+  slot is process-local by construction because the production entry point runs one
+  Uvicorn worker; multi-worker deployment is outside this documented invariant.
+- The async receiver performs one =receive= at a time and awaits the offloaded
+  bounded =inbound.put= before receiving again, preserving backpressure. The sender
+  similarly offloads =outbound.get=. Every exit first closes/aborts both buffers and
+  wakes their condition waiters, then bounds transport-task/terminal shutdown.
+  Graceful close keeps one terminal control queued for best-effort delivery; a
+  stalled in-flight send may prevent delivery but is cancelled after the 2 s grace.
+- After the first valid =ring=, the route invokes one synchronous call-runner seam
+  with the decoded ring plus the two buffers. Tests inject an echo runner; production
+  has no session runner until PR4 and therefore closes without inventing answer or
+  call-state policy. On an abrupt exit the network connection closes before waiting
+  for the runner. Closing both buffers is the runner's termination contract. The
+  route retains the sole call slot until the runner returns, so old and new session
+  code cannot overlap; PR4 must bound each downstream synchronous operation so the
+  runner honors that contract promptly.
 
 * Reuse map (do NOT re-derive)
 - =manage/web/threads.py=: =_create_run= + =_execute_run= (durable ordinary-turn path),
@@ -138,7 +175,8 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
 - [X] PR2: =manage/voice/speech.py= — independently lazy faster-whisper =base.en= CPU STT +
       Piper TTS, synchronous/off-event-loop; raw s16le/16 kHz boundary; sentence-chunk iterator
       preserves cancellation for PR4. Unit contract complete; real Whisper + Piper model checks pass.
-- [ ] PR3–PR5 per the slicing above.
+- [ ] PR3: bounded WSS wire + fake bridge (current).
+- [ ] PR4–PR5 per the slicing above.
 
 * Notes for Pierre
 - Deps landed in =requirements.txt=: =onnxruntime==1.27.0= (+ flatbuffers, protobuf) — lean, torch-free.

--- a/manage/voice/__init__.py
+++ b/manage/voice/__init__.py
@@ -1,9 +1,9 @@
 """The voice client (voice-call assistant, P1). A thin client over the shared
-run service + turn-observer seam and the receptionist
-(P0.5). See docs/2026-07-23-voice-p1.org for the build plan and threading model.
+run service + turn-observer seam and the receptionist (P0.5). See
+docs/2026-07-23-voice-p1.org for the build plan and threading model.
 
-P1 currently includes ``flow.py`` (the hermetic frame-in/event-out engine) and
-``speech.py`` (lazy in-process STT/TTS). The remaining slices add ``session.py``
-(the per-call state machine) and ``wire.py`` (the WSS /call endpoint — the only
-asyncio-loop code, a pure frame shuttle).
+P1 includes ``flow.py`` (the hermetic frame-in/event-out engine), ``speech.py``
+(lazy in-process STT/TTS), and ``wire.py`` (the bounded WSS /call transport,
+the only asyncio-loop code and a pure frame shuttle). The remaining work adds
+session policy and the final security/reconstruction gate.
 """

--- a/manage/voice/wire.py
+++ b/manage/voice/wire.py
@@ -78,12 +78,20 @@ def _reject_nonfinite(value: str) -> None:
 def _bounded_string(value: Any, field: str, limit: int) -> str:
     if type(value) is not str or len(value) > limit:
         raise WireProtocolError(f"invalid {field}")
+    try:
+        value.encode("utf-8")
+    except UnicodeError as exc:
+        raise WireProtocolError(f"invalid {field}") from exc
     return value
 
 
 def decode_phone_control(text: str) -> dict[str, Any] | None:
     """Decode a phone control, returning ``None`` for an unknown type."""
-    if len(text.encode("utf-8")) > MAX_WS_MESSAGE_BYTES:
+    try:
+        encoded_size = len(text.encode("utf-8"))
+    except UnicodeError as exc:
+        raise WireProtocolError("invalid UTF-8 control") from exc
+    if encoded_size > MAX_WS_MESSAGE_BYTES:
         raise WireProtocolError("control frame too large")
     try:
         value = json.loads(
@@ -113,7 +121,8 @@ def decode_phone_control(text: str) -> dict[str, Any] | None:
     elif kind == "call_end":
         _bounded_string(value["cause"], "cause", 64)
     elif kind == "dtmf":
-        if type(value["digit"]) is not str or len(value["digit"]) != 1:
+        digit = _bounded_string(value["digit"], "digit", 1)
+        if len(digit) != 1:
             raise WireProtocolError("invalid digit")
     elif kind == "stats":
         rate = value["rate_hz"]

--- a/manage/voice/wire.py
+++ b/manage/voice/wire.py
@@ -1,0 +1,457 @@
+"""Bounded WebSocket transport for the voice-call client.
+
+This module owns framing, transport authentication, backpressure, and teardown.
+Call state and policy live in ``session.py``; PR3 exposes one synchronous
+runner seam for that later slice without importing the agent, speech, or flow
+layers.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+import json
+import logging
+import math
+import os
+import secrets
+import threading
+import time
+from typing import Any
+
+from fastapi import WebSocket, WebSocketDisconnect
+from starlette.concurrency import run_in_threadpool
+
+from manage.web.app import app
+
+
+logger = logging.getLogger(__name__)
+
+MAX_WS_MESSAGE_BYTES = 4096
+PCM_FRAME_BYTES = 640
+FIRST_RING_SECONDS = 5.0
+IDLE_SECONDS = 5.0
+MAX_CONNECTION_SECONDS = 30 * 60.0
+MAX_CONTROLS_PER_SECOND = 20
+INBOUND_CAPACITY = 50
+OUTBOUND_CAPACITY = 100
+TERMINAL_GRACE_SECONDS = 2.0
+
+_PHONE_FIELDS = {
+    "ring": {"call_id", "caller"},
+    "answered": {"call_id"},
+    "call_end": {"cause"},
+    "dtmf": {"digit"},
+    "stats": {"rate_hz", "underruns"},
+}
+_SERVER_FIELDS = {
+    "answer": set(),
+    "hangup": set(),
+    "flush_uplink": set(),
+}
+
+
+class WireProtocolError(ValueError):
+    """A known wire message violates the protocol."""
+
+
+class BufferClosed(Exception):
+    """A call-local buffer was closed during an operation."""
+
+
+def _object_without_duplicate_keys(
+    pairs: list[tuple[str, Any]],
+) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise WireProtocolError(f"duplicate field: {key}")
+        value[key] = item
+    return value
+
+
+def _reject_nonfinite(value: str) -> None:
+    raise WireProtocolError(f"non-finite number: {value}")
+
+
+def _bounded_string(value: Any, field: str, limit: int) -> str:
+    if type(value) is not str or len(value) > limit:
+        raise WireProtocolError(f"invalid {field}")
+    return value
+
+
+def decode_phone_control(text: str) -> dict[str, Any] | None:
+    """Decode a phone control, returning ``None`` for an unknown type."""
+    if len(text.encode("utf-8")) > MAX_WS_MESSAGE_BYTES:
+        raise WireProtocolError("control frame too large")
+    try:
+        value = json.loads(
+            text,
+            object_pairs_hook=_object_without_duplicate_keys,
+            parse_constant=_reject_nonfinite,
+        )
+    except (json.JSONDecodeError, UnicodeError) as exc:
+        raise WireProtocolError("invalid JSON control") from exc
+    if type(value) is not dict or type(value.get("type")) is not str:
+        raise WireProtocolError("control must be an object with a string type")
+
+    kind = value["type"]
+    fields = _PHONE_FIELDS.get(kind)
+    if fields is None:
+        return None
+    if set(value) != fields | {"type"}:
+        raise WireProtocolError(f"invalid fields for {kind}")
+
+    if kind == "ring":
+        if not _bounded_string(value["call_id"], "call_id", 128):
+            raise WireProtocolError("invalid call_id")
+        _bounded_string(value["caller"], "caller", 32)
+    elif kind == "answered":
+        if not _bounded_string(value["call_id"], "call_id", 128):
+            raise WireProtocolError("invalid call_id")
+    elif kind == "call_end":
+        _bounded_string(value["cause"], "cause", 64)
+    elif kind == "dtmf":
+        if type(value["digit"]) is not str or len(value["digit"]) != 1:
+            raise WireProtocolError("invalid digit")
+    elif kind == "stats":
+        rate = value["rate_hz"]
+        underruns = value["underruns"]
+        if (
+            type(rate) not in (int, float)
+            or not math.isfinite(rate)
+            or rate <= 0
+            or type(underruns) is not int
+            or underruns < 0
+        ):
+            raise WireProtocolError("invalid stats")
+    return value
+
+
+def encode_server_control(control: dict[str, Any]) -> str:
+    """Encode one server control after validating its exact shape."""
+    if type(control) is not dict or type(control.get("type")) is not str:
+        raise WireProtocolError("server control must have a string type")
+    fields = _SERVER_FIELDS.get(control["type"])
+    if fields is None or set(control) != fields | {"type"}:
+        raise WireProtocolError("invalid server control")
+    return json.dumps(control, separators=(",", ":"))
+
+
+class _CloseableBuffer:
+    def __init__(self, capacity: int):
+        self._capacity = capacity
+        self._items: deque[Any] = deque()
+        self._closed = False
+        self._condition = threading.Condition()
+
+    def put(self, item: Any) -> None:
+        with self._condition:
+            while len(self._items) >= self._capacity and not self._closed:
+                self._condition.wait()
+            if self._closed:
+                raise BufferClosed
+            self._items.append(item)
+            self._condition.notify_all()
+
+    def get(self) -> Any:
+        with self._condition:
+            while not self._items and not self._closed:
+                self._condition.wait()
+            if not self._items:
+                raise BufferClosed
+            item = self._items.popleft()
+            self._condition.notify_all()
+            return item
+
+    def close(self, *, discard: bool = True) -> None:
+        with self._condition:
+            if self._closed:
+                return
+            self._closed = True
+            if discard:
+                self._items.clear()
+            self._condition.notify_all()
+
+
+class InboundBuffer(_CloseableBuffer):
+    """Bounded phone-to-session buffer; close discards call-local backlog."""
+
+    def __init__(self) -> None:
+        super().__init__(INBOUND_CAPACITY)
+
+
+class OutboundBuffer(_CloseableBuffer):
+    """Bounded session-to-phone buffer with graceful or abrupt teardown."""
+
+    def __init__(self) -> None:
+        super().__init__(OUTBOUND_CAPACITY)
+
+    def abort(self) -> None:
+        with self._condition:
+            self._closed = True
+            self._items.clear()
+            self._condition.notify_all()
+
+    def close_with_final(self, final: dict[str, Any]) -> None:
+        encode_server_control(final)
+        with self._condition:
+            if self._closed:
+                return
+            self._items.clear()
+            self._items.append(final)
+            self._closed = True
+            self._condition.notify_all()
+
+    def finish(self) -> None:
+        self.close(discard=False)
+
+
+@dataclass(frozen=True)
+class CallBuffers:
+    inbound: InboundBuffer
+    outbound: OutboundBuffer
+
+
+CallRunner = Callable[[dict[str, Any], CallBuffers], None]
+_CALL_RUNNER: CallRunner | None = None
+_active_call = False
+
+
+def configure_call_runner(runner: CallRunner | None) -> None:
+    """Set the process-wide synchronous session runner during app startup."""
+    global _CALL_RUNNER
+    _CALL_RUNNER = runner
+
+
+def _claim_call() -> bool:
+    global _active_call
+    if _active_call:
+        return False
+    _active_call = True
+    return True
+
+
+def _release_call() -> None:
+    global _active_call
+    _active_call = False
+
+
+class _ControlRate:
+    def __init__(self) -> None:
+        self._times: deque[float] = deque()
+
+    def record(self, now: float) -> None:
+        while self._times and now - self._times[0] >= 1.0:
+            self._times.popleft()
+        if len(self._times) >= MAX_CONTROLS_PER_SECOND:
+            raise WireProtocolError("control rate exceeded")
+        self._times.append(now)
+
+
+async def _receive_message(
+    websocket: WebSocket, timeout: float
+) -> dict[str, Any]:
+    try:
+        return await asyncio.wait_for(websocket.receive(), timeout=timeout)
+    except TimeoutError:
+        raise WireProtocolError("wire timeout") from None
+
+
+async def _receive_ring(
+    websocket: WebSocket, rate: _ControlRate
+) -> dict[str, Any]:
+    deadline = time.monotonic() + FIRST_RING_SECONDS
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise WireProtocolError("ring timeout")
+        message = await _receive_message(websocket, remaining)
+        if message["type"] == "websocket.disconnect":
+            raise WebSocketDisconnect(message.get("code", 1000))
+        text = message.get("text")
+        if text is None:
+            data = message.get("bytes")
+            if data is not None and len(data) != PCM_FRAME_BYTES:
+                raise WireProtocolError("invalid PCM frame size")
+            continue
+        rate.record(time.monotonic())
+        control = decode_phone_control(text)
+        if control is not None and control["type"] == "ring":
+            return control
+
+
+async def _receive_loop(
+    websocket: WebSocket, inbound: InboundBuffer, rate: _ControlRate
+) -> None:
+    last_valid = time.monotonic()
+    while True:
+        remaining = IDLE_SECONDS - (time.monotonic() - last_valid)
+        if remaining <= 0:
+            raise WireProtocolError("idle timeout")
+        message = await _receive_message(websocket, remaining)
+        if message["type"] == "websocket.disconnect":
+            raise WebSocketDisconnect(message.get("code", 1000))
+        text = message.get("text")
+        if text is not None:
+            rate.record(time.monotonic())
+            control = decode_phone_control(text)
+            if control is None:
+                continue
+            item: Any = control
+        else:
+            item = message.get("bytes")
+            if item is None:
+                raise WireProtocolError("invalid WebSocket message")
+            if len(item) != PCM_FRAME_BYTES:
+                raise WireProtocolError("invalid PCM frame size")
+        await run_in_threadpool(inbound.put, item)
+        last_valid = time.monotonic()
+
+
+async def _send_loop(websocket: WebSocket, outbound: OutboundBuffer) -> None:
+    while True:
+        try:
+            item = await run_in_threadpool(outbound.get)
+        except BufferClosed:
+            return
+        if type(item) is bytes:
+            if len(item) != PCM_FRAME_BYTES:
+                raise WireProtocolError("invalid PCM frame size")
+            await websocket.send_bytes(item)
+        else:
+            await websocket.send_text(encode_server_control(item))
+
+
+async def _run_call(
+    websocket: WebSocket,
+    ring: dict[str, Any],
+    buffers: CallBuffers,
+    rate: _ControlRate,
+) -> None:
+    runner = _CALL_RUNNER
+    assert runner is not None
+
+    receiver = asyncio.create_task(
+        _receive_loop(websocket, buffers.inbound, rate)
+    )
+    sender = asyncio.create_task(_send_loop(websocket, buffers.outbound))
+    runner_task = asyncio.create_task(run_in_threadpool(runner, ring, buffers))
+    graceful = False
+    failure: BaseException | None = None
+    try:
+        done, _ = await asyncio.wait(
+            {receiver, sender, runner_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in done:
+            if not task.cancelled() and task.exception() is not None:
+                failure = task.exception()
+                break
+        graceful = failure is None and (
+            runner_task in done or sender in done
+        )
+    finally:
+        await run_in_threadpool(buffers.inbound.close)
+        if graceful:
+            await run_in_threadpool(buffers.outbound.finish)
+            receiver.cancel()
+            done, _ = await asyncio.wait(
+                {sender}, timeout=TERMINAL_GRACE_SECONDS
+            )
+            if not done:
+                await run_in_threadpool(buffers.outbound.abort)
+        else:
+            await run_in_threadpool(buffers.outbound.abort)
+            # End the network resource before waiting for the synchronous
+            # runner to honor its closed-buffer termination contract.
+            if not isinstance(failure, WebSocketDisconnect):
+                code = (
+                    1008
+                    if failure is None
+                    or isinstance(failure, WireProtocolError)
+                    else 1011
+                )
+                await _close_websocket(websocket, code)
+
+        for task in (receiver, sender):
+            if not task.done():
+                task.cancel()
+        shuttle_results = await asyncio.gather(
+            receiver, sender, return_exceptions=True
+        )
+        # Closing both buffers is the runner's termination contract.  Keep the
+        # process-wide call slot until it has actually honored that contract.
+        runner_result = await asyncio.shield(
+            asyncio.gather(runner_task, return_exceptions=True)
+        )
+        if failure is None:
+            for result in (*shuttle_results, *runner_result):
+                if isinstance(result, BaseException) and not isinstance(
+                    result,
+                    (BufferClosed, WebSocketDisconnect,
+                     asyncio.CancelledError),
+                ):
+                    failure = result
+                    break
+
+    if failure is not None:
+        raise failure
+
+
+async def _close_websocket(websocket: WebSocket, code: int) -> None:
+    """Bound a final close handshake after call-local workers are stopped."""
+    try:
+        await asyncio.wait_for(
+            websocket.close(code=code), TERMINAL_GRACE_SECONDS
+        )
+    except (TimeoutError, RuntimeError, WebSocketDisconnect):
+        pass
+
+
+async def _close_buffers(buffers: CallBuffers) -> None:
+    """Wake synchronous workers without taking their locks on the loop."""
+    await run_in_threadpool(buffers.inbound.close)
+    await run_in_threadpool(buffers.outbound.abort)
+
+
+@app.websocket("/call")
+async def call(websocket: WebSocket) -> None:
+    secret = os.getenv("ASSIST_VOICE_SECRET")
+    authorization = websocket.headers.get("authorization", "")
+    expected = f"Bearer {secret}" if secret else ""
+    if not expected or not secrets.compare_digest(
+        authorization.encode("utf-8"), expected.encode("utf-8")
+    ):
+        await _close_websocket(websocket, 1008)
+        return
+    if not _claim_call():
+        await _close_websocket(websocket, 1013)
+        return
+
+    buffers = CallBuffers(InboundBuffer(), OutboundBuffer())
+    close_code: int | None = 1000
+    try:
+        await websocket.accept()
+        async with asyncio.timeout(MAX_CONNECTION_SECONDS):
+            rate = _ControlRate()
+            ring = await _receive_ring(websocket, rate)
+            if _CALL_RUNNER is None:
+                close_code = 1011
+            else:
+                await _run_call(websocket, ring, buffers, rate)
+    except WebSocketDisconnect:
+        close_code = None
+    except WireProtocolError:
+        close_code = 1008
+    except TimeoutError:
+        close_code = 1008
+    except Exception:
+        logger.exception("voice call transport failed")
+        close_code = 1011
+    finally:
+        await _close_buffers(buffers)
+        if close_code is not None:
+            await _close_websocket(websocket, close_code)
+        _release_call()

--- a/manage/voice/wire.py
+++ b/manage/voice/wire.py
@@ -307,6 +307,7 @@ async def _receive_loop(
             rate.record(time.monotonic())
             control = decode_phone_control(text)
             if control is None:
+                last_valid = time.monotonic()
                 continue
             item: Any = control
         else:

--- a/manage/voice/wire.py
+++ b/manage/voice/wire.py
@@ -1,9 +1,9 @@
 """Bounded WebSocket transport for the voice-call client.
 
 This module owns framing, transport authentication, backpressure, and teardown.
-Call state and policy live in ``session.py``; PR3 exposes one synchronous
-runner seam for that later slice without importing the agent, speech, or flow
-layers.
+Call state and policy will live in ``session.py``. This module exposes one
+synchronous runner seam for that later layer without importing the agent,
+speech, or flow layers.
 """
 from __future__ import annotations
 

--- a/manage/web/__init__.py
+++ b/manage/web/__init__.py
@@ -1,6 +1,6 @@
-"""manage.web package — FastAPI web UI for the assist agent.
+"""manage.web package: FastAPI web UI for the assist agent.
 
-Composed from sibling modules:
+Composed from route modules:
 
 - ``app``    — the ``FastAPI`` instance (separated so route modules can
                import it without a circular dep on this ``__init__``).
@@ -12,15 +12,20 @@ Composed from sibling modules:
 - ``threads``— index, thread page, and the message/capture/merge/delete
                routes.  Owns ``_process_message``.
 - ``evals``  — ``/evals`` and ``/evals/run/{id}`` routes.
+- ``voice.wire`` — the bounded ``/call`` WebSocket transport.
 
 Importing ``manage.web`` triggers route registration on ``app`` via the
-submodule imports below.  ``uvicorn manage.web:app`` continues to work.
+imports below.  Start the network service with ``python -m manage.web`` so its
+WebSocket size and compression bounds are applied.
 """
-from manage.web.app import app
+from manage.web.app import app  # noqa: F401
 
 # Importing the route modules registers their endpoints on ``app``.
 # Order matters only insofar as ``review`` imports from ``threads``.
-from manage.web import threads, review, evals, schedules, geo, egress  # noqa: E402,F401
+from manage.web import (  # noqa: E402,F401
+    threads, review, evals, schedules, geo, egress,
+)
+from manage.voice import wire as _voice_wire  # noqa: E402,F401
 
 # Subagent tools use a private, prefixless Agent Protocol ASGI app. It is never
 # mounted on the network-facing web app.

--- a/manage/web/__init__.py
+++ b/manage/web/__init__.py
@@ -12,7 +12,7 @@ Composed from route modules:
 - ``threads``— index, thread page, and the message/capture/merge/delete
                routes.  Owns ``_process_message``.
 - ``evals``  — ``/evals`` and ``/evals/run/{id}`` routes.
-- ``voice.wire`` — the bounded ``/call`` WebSocket transport.
+- ``manage.voice.wire`` — the bounded ``/call`` WebSocket transport.
 
 Importing ``manage.web`` triggers route registration on ``app`` via the
 imports below.  Start the network service with ``python -m manage.web`` so its

--- a/manage/web/__main__.py
+++ b/manage/web/__main__.py
@@ -12,6 +12,7 @@ import os
 import uvicorn
 
 from manage.web.state import ROOT
+from manage.voice.wire import MAX_WS_MESSAGE_BYTES
 
 
 if __name__ == "__main__":
@@ -35,7 +36,7 @@ if __name__ == "__main__":
         port=port,
         log_level="info",
         reload=False,
-        ws_max_size=4096,
+        ws_max_size=MAX_WS_MESSAGE_BYTES,
         ws_per_message_deflate=False,
         **ssl_kwargs,
     )

--- a/manage/web/__main__.py
+++ b/manage/web/__main__.py
@@ -17,14 +17,16 @@ from manage.web.state import ROOT
 if __name__ == "__main__":
     os.makedirs(ROOT, exist_ok=True)
     port = int(os.getenv("ASSIST_PORT", "8000"))
-    # Optional TLS: set ASSIST_SSL_CERT + ASSIST_SSL_KEY to serve HTTPS directly.
-    # Needed so the browser exposes geolocation over a non-localhost address (e.g.
-    # the WireGuard IP) — geolocation requires a secure context (HTTPS or localhost).
+    # Optional TLS: set ASSIST_SSL_CERT + ASSIST_SSL_KEY to serve HTTPS
+    # directly. Needed so the browser exposes geolocation over a non-localhost
+    # address: geolocation requires a secure context (HTTPS or localhost).
     # Use a trusted local cert (mkcert) so there's no browser warning.
     ssl_kwargs = {}
     cert, key = os.getenv("ASSIST_SSL_CERT"), os.getenv("ASSIST_SSL_KEY")
-    if bool(cert) != bool(key):  # fail fast on a half-set config (silent HTTP hides it)
-        raise SystemExit("Set BOTH ASSIST_SSL_CERT and ASSIST_SSL_KEY (or neither).")
+    if bool(cert) != bool(key):
+        raise SystemExit(
+            "Set BOTH ASSIST_SSL_CERT and ASSIST_SSL_KEY (or neither)."
+        )
     if cert and key:
         ssl_kwargs = {"ssl_certfile": cert, "ssl_keyfile": key}
     uvicorn.run(
@@ -33,5 +35,7 @@ if __name__ == "__main__":
         port=port,
         log_level="info",
         reload=False,
+        ws_max_size=4096,
+        ws_per_message_deflate=False,
         **ssl_kwargs,
     )

--- a/tests/voice/fake_bridge.py
+++ b/tests/voice/fake_bridge.py
@@ -1,0 +1,27 @@
+"""Protocol-level fake for the phone-side voice bridge."""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+class FakeBridge:
+    def __init__(self, websocket):
+        self.websocket = websocket
+
+    def send_control(self, kind: str, **fields: Any) -> None:
+        self.websocket.send_text(json.dumps({"type": kind, **fields}))
+
+    def ring(
+        self, call_id: str = "boot-1", caller: str = "+15555550100"
+    ) -> None:
+        self.send_control("ring", call_id=call_id, caller=caller)
+
+    def send_pcm(self, pcm: bytes) -> None:
+        self.websocket.send_bytes(pcm)
+
+    def receive_control(self) -> dict[str, Any]:
+        return json.loads(self.websocket.receive_text())
+
+    def receive_pcm(self) -> bytes:
+        return self.websocket.receive_bytes()

--- a/tests/voice/test_wire.py
+++ b/tests/voice/test_wire.py
@@ -1,0 +1,458 @@
+import asyncio
+import json
+import threading
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from manage.web import app
+from manage.voice import wire
+from tests.voice.fake_bridge import FakeBridge
+
+
+SECRET = "test-voice-secret"
+HEADERS = {"Authorization": f"Bearer {SECRET}"}
+PCM = b"\0\0" * 320
+
+
+@pytest.fixture(autouse=True)
+def voice_wire(monkeypatch):
+    monkeypatch.setenv("ASSIST_VOICE_SECRET", SECRET)
+    wire.configure_call_runner(None)
+    wire._release_call()
+    yield
+    wire.configure_call_runner(None)
+    wire._release_call()
+
+
+def _echo_runner(_ring, buffers):
+    buffers.outbound.put({"type": "answer"})
+    while True:
+        item = buffers.inbound.get()
+        if type(item) is bytes:
+            buffers.outbound.put(item)
+        elif item["type"] == "call_end":
+            buffers.outbound.close_with_final({"type": "hangup"})
+            return
+
+
+def _blocking_runner(_ring, buffers):
+    try:
+        while True:
+            buffers.inbound.get()
+    except wire.BufferClosed:
+        return
+
+
+def test_codec_validates_known_controls_and_ignores_unknown():
+    controls = [
+        {"type": "ring", "call_id": "boot-1", "caller": "+15555550100"},
+        {"type": "answered", "call_id": "boot-1"},
+        {"type": "call_end", "cause": "remote"},
+        {"type": "dtmf", "digit": "*"},
+        {"type": "stats", "rate_hz": 16_700.0, "underruns": 0},
+    ]
+    for control in controls:
+        assert wire.decode_phone_control(json.dumps(control)) == control
+    assert wire.decode_phone_control('{"type":"future","value":1}') is None
+
+
+@pytest.mark.parametrize("text", [
+    '{"type":"ring","call_id":"a","call_id":"b","caller":"+1"}',
+    '{"type":"stats","rate_hz":NaN,"underruns":0}',
+    '{"type":"stats","rate_hz":true,"underruns":0}',
+    '{"type":"stats","rate_hz":16000,"underruns":false}',
+    '{"type":"dtmf","digit":"12"}',
+    '{"type":"ring","call_id":"","caller":"+1"}',
+    '{"type":"answered","call_id":""}',
+    '{"type":"ring","call_id":"a","caller":"+1","extra":1}',
+])
+def test_codec_rejects_ambiguous_or_invalid_known_controls(text):
+    with pytest.raises(wire.WireProtocolError):
+        wire.decode_phone_control(text)
+
+
+def test_codec_caps_untrusted_strings():
+    for control in (
+        {"type": "ring", "call_id": "x" * 129, "caller": "+1"},
+        {"type": "ring", "call_id": "a", "caller": "x" * 33},
+        {"type": "call_end", "cause": "x" * 65},
+    ):
+        with pytest.raises(wire.WireProtocolError):
+            wire.decode_phone_control(json.dumps(control))
+
+
+def test_auth_fails_closed_without_reserving_the_slot(monkeypatch):
+    client = TestClient(app)
+    for headers in ({}, {"Authorization": "Bearer wrong"}):
+        with pytest.raises(WebSocketDisconnect):
+            with client.websocket_connect("/call", headers=headers):
+                pass
+
+    wire.configure_call_runner(_echo_runner)
+    with client.websocket_connect("/call", headers=HEADERS) as websocket:
+        bridge = FakeBridge(websocket)
+        bridge.ring()
+        assert bridge.receive_control() == {"type": "answer"}
+        bridge.send_control("call_end", cause="remote")
+        assert bridge.receive_control() == {"type": "hangup"}
+
+    monkeypatch.delenv("ASSIST_VOICE_SECRET")
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect("/call", headers=HEADERS):
+            pass
+
+
+def test_fake_bridge_exercises_duplex_transport():
+    wire.configure_call_runner(_echo_runner)
+    with TestClient(app).websocket_connect(
+        "/call", headers=HEADERS
+    ) as websocket:
+        bridge = FakeBridge(websocket)
+        bridge.ring()
+        assert bridge.receive_control() == {"type": "answer"}
+        bridge.send_pcm(PCM)
+        assert bridge.receive_pcm() == PCM
+        bridge.send_control("call_end", cause="remote")
+        assert bridge.receive_control() == {"type": "hangup"}
+        with pytest.raises(WebSocketDisconnect):
+            bridge.receive_control()
+
+
+@pytest.mark.parametrize("size", [639, 641, 4096])
+def test_non_frame_binary_closes_the_call(size):
+    wire.configure_call_runner(_blocking_runner)
+    with TestClient(app).websocket_connect(
+        "/call", headers=HEADERS
+    ) as websocket:
+        bridge = FakeBridge(websocket)
+        bridge.ring()
+        bridge.send_pcm(b"x" * size)
+        with pytest.raises(WebSocketDisconnect) as exc:
+            bridge.receive_control()
+    assert exc.value.code == 1008
+
+
+def test_unknown_controls_count_toward_the_rate_limit(monkeypatch):
+    monkeypatch.setattr(wire, "MAX_CONTROLS_PER_SECOND", 3)
+    wire.configure_call_runner(_blocking_runner)
+    with TestClient(app).websocket_connect(
+        "/call", headers=HEADERS
+    ) as websocket:
+        bridge = FakeBridge(websocket)
+        bridge.ring()
+        bridge.send_control("future-a")
+        bridge.send_control("future-b")
+        bridge.send_control("future-c")
+        with pytest.raises(WebSocketDisconnect) as exc:
+            bridge.receive_control()
+    assert exc.value.code == 1008
+
+
+def test_first_ring_timeout_releases_the_slot(monkeypatch):
+    monkeypatch.setattr(wire, "FIRST_RING_SECONDS", 0.01)
+    client = TestClient(app)
+    with client.websocket_connect("/call", headers=HEADERS) as websocket:
+        with pytest.raises(WebSocketDisconnect) as exc:
+            websocket.receive_text()
+    assert exc.value.code == 1008
+
+    wire.configure_call_runner(_echo_runner)
+    with client.websocket_connect("/call", headers=HEADERS) as websocket:
+        bridge = FakeBridge(websocket)
+        bridge.ring()
+        assert bridge.receive_control() == {"type": "answer"}
+        bridge.send_control("call_end", cause="remote")
+        assert bridge.receive_control() == {"type": "hangup"}
+
+
+@pytest.mark.parametrize(
+    "constant", ["IDLE_SECONDS", "MAX_CONNECTION_SECONDS"]
+)
+def test_call_time_bounds_close_and_release(monkeypatch, constant):
+    monkeypatch.setattr(wire, constant, 0.01)
+    wire.configure_call_runner(_blocking_runner)
+    client = TestClient(app)
+    with client.websocket_connect("/call", headers=HEADERS) as websocket:
+        FakeBridge(websocket).ring()
+        with pytest.raises(WebSocketDisconnect) as exc:
+            websocket.receive_text()
+    assert exc.value.code == 1008
+
+    wire.configure_call_runner(_echo_runner)
+    with client.websocket_connect("/call", headers=HEADERS) as websocket:
+        bridge = FakeBridge(websocket)
+        bridge.ring()
+        assert bridge.receive_control() == {"type": "answer"}
+        bridge.send_control("call_end", cause="remote")
+        assert bridge.receive_control() == {"type": "hangup"}
+
+
+def test_one_call_gate_rejects_a_concurrent_connection():
+    wire.configure_call_runner(_blocking_runner)
+    client = TestClient(app)
+    with client.websocket_connect("/call", headers=HEADERS) as first:
+        FakeBridge(first).ring()
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with client.websocket_connect("/call", headers=HEADERS):
+                pass
+        assert exc.value.code == 1013
+
+
+def test_blocked_call_workers_do_not_block_the_event_loop():
+    wire.configure_call_runner(_blocking_runner)
+    with TestClient(app) as client:
+        with client.websocket_connect("/call", headers=HEADERS) as websocket:
+            FakeBridge(websocket).ring()
+            started = time.monotonic()
+            response = client.get("/favicon.ico")
+            elapsed = time.monotonic() - started
+    assert response.status_code == 200
+    assert elapsed < 0.2
+
+
+def test_stalled_terminal_send_has_bounded_teardown(monkeypatch):
+    monkeypatch.setattr(wire, "TERMINAL_GRACE_SECONDS", 0.01)
+
+    def finish(_ring, buffers):
+        buffers.outbound.close_with_final({"type": "hangup"})
+
+    class StalledWebSocket:
+        def __init__(self):
+            self.sends = 0
+
+        async def receive(self):
+            await asyncio.Future()
+
+        async def send_text(self, _text):
+            self.sends += 1
+            await asyncio.Future()
+
+        async def send_bytes(self, _data):
+            self.sends += 1
+            await asyncio.Future()
+
+    wire.configure_call_runner(finish)
+    websocket = StalledWebSocket()
+    buffers = wire.CallBuffers(wire.InboundBuffer(), wire.OutboundBuffer())
+    started = time.monotonic()
+    asyncio.run(
+        wire._run_call(
+            websocket,
+            {"type": "ring", "call_id": "a", "caller": "+1"},
+            buffers,
+            wire._ControlRate(),
+        )
+    )
+    assert time.monotonic() - started < 1
+    assert websocket.sends == 1
+
+
+@pytest.mark.parametrize("size", [639, 641])
+def test_non_frame_outbound_binary_fails_the_call(size):
+    async def exercise():
+        class WebSocket:
+            async def receive(self):
+                await asyncio.Future()
+
+            async def close(self, code):
+                pass
+
+            async def send_bytes(self, _data):
+                raise AssertionError("invalid audio must not reach the socket")
+
+        def runner(_ring, buffers):
+            buffers.outbound.put(b"x" * size)
+
+        wire.configure_call_runner(runner)
+        buffers = wire.CallBuffers(
+            wire.InboundBuffer(), wire.OutboundBuffer()
+        )
+        with pytest.raises(wire.WireProtocolError):
+            await wire._run_call(
+                WebSocket(),
+                {"type": "ring", "call_id": "a", "caller": ""},
+                buffers,
+                wire._ControlRate(),
+            )
+
+    asyncio.run(exercise())
+
+
+def test_runner_failure_cleans_up_before_returning():
+    exited = threading.Event()
+
+    def runner(_ring, _buffers):
+        try:
+            raise RuntimeError("runner failed")
+        finally:
+            exited.set()
+
+    class WebSocket:
+        async def receive(self):
+            await asyncio.Future()
+
+        async def close(self, code):
+            pass
+
+    wire.configure_call_runner(runner)
+    buffers = wire.CallBuffers(wire.InboundBuffer(), wire.OutboundBuffer())
+    with pytest.raises(RuntimeError, match="runner failed"):
+        asyncio.run(
+            wire._run_call(
+                WebSocket(),
+                {"type": "ring", "call_id": "a", "caller": ""},
+                buffers,
+                wire._ControlRate(),
+            )
+        )
+    assert exited.is_set()
+
+
+def test_runner_failure_closes_endpoint_as_internal_error():
+    def runner(_ring, _buffers):
+        raise RuntimeError("runner failed")
+
+    wire.configure_call_runner(runner)
+    with TestClient(app).websocket_connect(
+        "/call", headers=HEADERS
+    ) as websocket:
+        bridge = FakeBridge(websocket)
+        bridge.ring()
+        with pytest.raises(WebSocketDisconnect) as exc:
+            bridge.receive_control()
+    assert exc.value.code == 1011
+
+
+def test_hard_timeout_stops_stalled_send_and_runner_before_return(monkeypatch):
+    monkeypatch.setattr(wire, "TERMINAL_GRACE_SECONDS", 0.01)
+    runner_exited = threading.Event()
+    send_cancelled = asyncio.Event()
+
+    def runner(_ring, buffers):
+        try:
+            buffers.outbound.put(PCM)
+            buffers.inbound.get()
+        except wire.BufferClosed:
+            pass
+        finally:
+            runner_exited.set()
+
+    class WebSocket:
+        async def receive(self):
+            await asyncio.Future()
+
+        async def close(self, code):
+            pass
+
+        async def send_bytes(self, _data):
+            try:
+                await asyncio.Future()
+            finally:
+                send_cancelled.set()
+
+    async def exercise():
+        wire.configure_call_runner(runner)
+        buffers = wire.CallBuffers(
+            wire.InboundBuffer(), wire.OutboundBuffer()
+        )
+        with pytest.raises(TimeoutError):
+            async with asyncio.timeout(0.02):
+                await wire._run_call(
+                    WebSocket(),
+                    {"type": "ring", "call_id": "a", "caller": ""},
+                    buffers,
+                    wire._ControlRate(),
+                )
+        assert runner_exited.is_set()
+        assert send_cancelled.is_set()
+
+    asyncio.run(exercise())
+
+
+def test_timeout_wakes_full_receive_and_empty_send_workers():
+    runner_exited = threading.Event()
+
+    def runner(_ring, buffers):
+        try:
+            buffers.outbound.get()
+        except wire.BufferClosed:
+            runner_exited.set()
+
+    class WebSocket:
+        def __init__(self):
+            self.receives = 0
+
+        async def receive(self):
+            if self.receives <= wire.INBOUND_CAPACITY:
+                self.receives += 1
+                return {"type": "websocket.receive", "bytes": PCM}
+            await asyncio.Future()
+
+        async def close(self, code):
+            pass
+
+    async def exercise():
+        wire.configure_call_runner(runner)
+        buffers = wire.CallBuffers(
+            wire.InboundBuffer(), wire.OutboundBuffer()
+        )
+        call = asyncio.create_task(
+            wire._run_call(
+                WebSocket(),
+                {"type": "ring", "call_id": "a", "caller": ""},
+                buffers,
+                wire._ControlRate(),
+            )
+        )
+        started = time.monotonic()
+        await asyncio.sleep(0.02)
+        assert time.monotonic() - started < 0.2
+        call.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await call
+        assert runner_exited.is_set()
+
+    asyncio.run(exercise())
+
+
+def test_abort_discards_a_gracefully_closed_backlog():
+    outbound = wire.OutboundBuffer()
+    outbound.put(PCM)
+    outbound.finish()
+    outbound.abort()
+    with pytest.raises(wire.BufferClosed):
+        outbound.get()
+
+
+def test_close_wakes_blocked_get_and_put():
+    inbound = wire.InboundBuffer()
+    got = []
+    getter = threading.Thread(target=lambda: _record_closed(inbound.get, got))
+    getter.start()
+    time.sleep(0.01)
+    inbound.close()
+    getter.join(1)
+    assert got == [wire.BufferClosed]
+
+    outbound = wire.OutboundBuffer()
+    for _ in range(wire.OUTBOUND_CAPACITY):
+        outbound.put(PCM)
+    put = []
+    putter = threading.Thread(
+        target=lambda: _record_closed(lambda: outbound.put(PCM), put)
+    )
+    putter.start()
+    time.sleep(0.01)
+    outbound.abort()
+    putter.join(1)
+    assert put == [wire.BufferClosed]
+
+
+def _record_closed(operation, result):
+    try:
+        operation()
+    except wire.BufferClosed:
+        result.append(wire.BufferClosed)

--- a/tests/voice/test_wire.py
+++ b/tests/voice/test_wire.py
@@ -68,6 +68,9 @@ def test_codec_validates_known_controls_and_ignores_unknown():
     '{"type":"ring","call_id":"","caller":"+1"}',
     '{"type":"answered","call_id":""}',
     '{"type":"ring","call_id":"a","caller":"+1","extra":1}',
+    '\ud800',
+    r'{"type":"ring","call_id":"\ud800","caller":"+1"}',
+    r'{"type":"dtmf","digit":"\ud800"}',
 ])
 def test_codec_rejects_ambiguous_or_invalid_known_controls(text):
     with pytest.raises(wire.WireProtocolError):

--- a/tests/voice/test_wire.py
+++ b/tests/voice/test_wire.py
@@ -154,6 +154,22 @@ def test_unknown_controls_count_toward_the_rate_limit(monkeypatch):
     assert exc.value.code == 1008
 
 
+def test_unknown_controls_refresh_valid_inbound_idle(monkeypatch):
+    monkeypatch.setattr(wire, "IDLE_SECONDS", 0.1)
+    wire.configure_call_runner(_echo_runner)
+    with TestClient(app).websocket_connect(
+        "/call", headers=HEADERS
+    ) as websocket:
+        bridge = FakeBridge(websocket)
+        bridge.ring()
+        assert bridge.receive_control() == {"type": "answer"}
+        for _ in range(5):
+            time.sleep(0.03)
+            bridge.send_control("future")
+        bridge.send_control("call_end", cause="remote")
+        assert bridge.receive_control() == {"type": "hangup"}
+
+
 def test_first_ring_timeout_releases_the_slot(monkeypatch):
     monkeypatch.setattr(wire, "FIRST_RING_SECONDS", 0.01)
     client = TestClient(app)


### PR DESCRIPTION
## Summary

- add authenticated WSS `/call` transport with strict control and 640-byte PCM framing
- add bounded closeable buffers, one-call admission, rate/idle/connection limits, and cancellation-safe teardown
- configure the supported web entry point with a 4096-byte WebSocket cap and compression disabled
- add a fake bridge and transport/liveness/security regression coverage

## Validation

- `pytest -q tests/voice/test_wire.py` (30 passed)
- `pytest -q tests/` (1411 passed, 2 skipped)
- `flake8` on all touched Python files
- `python -m manage.web` startup smoke
- deployed feature branch; HTTPS smoke returned 200

## Review

Local review converged after three rounds across correctness, concurrency/liveness, error handling, adversarial security, simplicity, design adherence, and doc/comment alignment.
