### PR TITLE
Add per-thread agent memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,17 @@ where reliability is harder than with frontier APIs.
 - **Endpoint auto-discovery.** Model name and runtime context length
   are discovered from your local LLM endpoint on first request.
 
-- **Small-LLM-tuned memory.** Persistent facts and preferences live in
-  the workspace's `AGENTS.md` and auto-load on every
-  session. Instructions tuned to work well with small LLMs.
+- **Small-LLM-tuned memory.** Cross-conversation facts and preferences live in
+  the workspace's `AGENTS.md`; private working state for one long-running thread
+  lives under `/agent`. Visible web main-agent turns auto-load both; other
+  constructions retain repository memory alone.
 
 - **Small-LLM-tuned skills.** Shared skills are progressively-disclosed
   capability bundles under `assist/skills/<name>/SKILL.md`; supervisor-only
   workflows live under `assist/main_skills/`. Both are tuned to small LLMs.
 
-- **Built-in sandboxing.** Every tool call that touches the filesystem
-  or runs code happens inside a per-thread Docker container with the
+- **Built-in sandboxing.** When Docker is available, tool calls that touch the
+  filesystem or run code happen inside a per-turn container with the
   workspace bind-mounted at `/workspace` with reasonable guards.
 
 - **Specialized agents and skills out of the box.**
@@ -202,7 +203,7 @@ Skill-specific:
 Cross-cutting:
 - `test_async_subagents.py` — 13-case supervisor/delegation acceptance suite
 - `test_domain_integration.py` — git integration and domain management
-- `test_memory.py`, `test_various_failures.py` — memory + failure modes
+- `test_memory.py`, `test_thread_memory.py`, `test_various_failures.py` — memory + failure modes
 - `test_thread_e2e.py` — thread/conversation persistence
 - `eval_multi_turn_research.py` — long multi-turn research (10+ turns)
 - `eval_large_tool_results.py` — context overflow handling
@@ -373,14 +374,14 @@ See [ENVIRONMENT_VARIABLES.md](ENVIRONMENT_VARIABLES.md) for complete reference.
 - Data: `ASSIST_THREADS_DIR` (default: `/tmp/assist_threads`)
 - Model: Your local model endpoint
 - Domains: Your local git repositories (optional)
-- Sandbox: Docker container per thread for isolated command execution
+- Sandbox: Docker container per turn for isolated command execution
 
 ### Production Deployment
 - Configuration: `.deploy.env` (gitignored)
 - Data: `/var/lib/assist/threads` (persists across deployments)
 - Model: Production model endpoint
 - Domains: Production git repositories (optional, local to server)
-- Sandbox: Docker container per thread
+- Sandbox: Docker container per turn
 - Service: systemd manages the process
 - Logs: `journalctl -u assist-web`
 
@@ -634,7 +635,22 @@ small models we run (e.g. Qwen3.6-27B) once the system prompt is
 shaped for them; we do not register a dedicated `save_memory` tool.
 
 `assist/middleware/memory_middleware.py` rewrites the system-prompt
-block and re-reads the memory file from disk on every turn:
+block and re-reads its configured memory sources from disk on every turn.
+
+Visible Assist threads have two sources:
+
+- `AGENTS.md` is user/repository memory across conversations (addressed as
+  `/workspace/AGENTS.md` in Docker and virtual `/AGENTS.md` in local mode):
+  facts, preferences, and forward-looking rules.
+- `/agent/memory.md` is private state for this thread: its goal, operating
+  protocol, corrections, decisions, progress, blockers, and useful working notes.
+  Other `/agent/*` files can hold supporting material. The main agent manages the
+  directory proactively; it survives turns and is deleted with the thread. Spawned
+  child agents receive a self-contained brief instead of the private `/agent`
+  route/mount or its prompt.
+
+The original one-source shape remains available to other embedders. Its
+`SMALL_MODEL_MEMORY_PROMPT` provides:
 
 - A short, imperative **system-prompt template** (`SMALL_MODEL_MEMORY_PROMPT`)
   that names the configured memory path (rendered as an absolute path
@@ -648,8 +664,8 @@ block and re-reads the memory file from disk on every turn:
   shows `(No memory loaded)` the model uses `write_file`; otherwise
   it uses `edit_file`.  This sidesteps the `WriteCollisionMiddleware`
   redirect for non-empty files and keeps the empty-file path simple.
-- A `before_agent` / `abefore_agent` override that re-reads the
-  memory file every turn instead of upstream's once-per-thread cache.
+- A `before_agent` / `abefore_agent` override, shared by both shapes, that re-reads
+  every configured memory file each turn instead of upstream's once-per-thread cache.
   Without this, a write made via `edit_file` on turn N would be
   invisible to turn N+1's rendered `<agent_memory>` block — the
   next-turn anchor would not match and the next save would either
@@ -658,9 +674,8 @@ block and re-reads the memory file from disk on every turn:
 The agent never receives a memory-specific tool; the read pathway
 exposes the file's contents in the system prompt, and the write
 pathway reuses tools the agent already has for every other file.
-Adding a second source (e.g. a global `~/AGENTS.md`) means extending
-`sources=` in `agent.py` and updating the `_format_agent_memory`
-override — no prompt-text edits beyond the agent_memory framing.
+Both files are ordinary model context: there is no deterministic precedence or
+conflict layer.
 
 ### Concurrency note
 
@@ -683,7 +698,7 @@ assist/
 │   ├── model_manager.py     # Model selection and configuration
 │   ├── domain_manager.py    # Git repository and sandbox management
 │   ├── sandbox.py           # Docker sandbox backend
-│   ├── sandbox_manager.py   # Sandbox lifecycle and per-thread containers
+│   ├── sandbox_manager.py   # Sandbox lifecycle and per-turn containers
 │   ├── thread.py            # Conversation thread state
 │   ├── backends.py          # CompositeBackend wiring (state + filesystem + skills)
 │   ├── checkpoint_rollback.py
@@ -769,7 +784,7 @@ When enabled, each thread creates a git branch and can merge changes back to mai
 
 ## Docker Sandbox
 
-The agent executes shell commands inside a Docker container rather than on the host. Each thread gets its own container with the domain repository bind-mounted at `/workspace`.
+The agent executes shell commands inside a Docker container rather than on the host. Each turn gets a fresh container with the domain repository bind-mounted at `/workspace`. Visible main-agent turns also mount private thread state at `/agent`.
 
 The sandbox image is built automatically by `make web` (and `make deploy`). To build it manually:
 ```bash

--- a/assist/agent.py
+++ b/assist/agent.py
@@ -254,6 +254,7 @@ def create_agent(model: BaseChatModel,
                  checkpointer=None,
                  sandbox_backend=None,
                  *,
+                 agent_dir: str | None = None,
                  spec: AgentSpec | None = None,
                  ) -> CompiledStateGraph:
     """Build an Assist main or delegate agent.
@@ -264,6 +265,11 @@ def create_agent(model: BaseChatModel,
     backend — canonical field semantics live on the spec.  ``spec=None``
     means ``AgentSpec()`` — the defaults.  ``spec.default_backend`` is
     mutually exclusive with ``sandbox_backend``.
+
+    Passing ``agent_dir`` enables local-mode private state at ``/agent`` and
+    auto-loads ``/agent/memory.md``. A sandbox enables the same state through
+    its native ``/agent`` capability. The web composition supplies either only
+    to visible main agents and omits them for delegates and specialists.
 
     **Domain skills are auto-discovered** from
     ``<working_dir>/.claude/skills/`` (the agent-agnostic agentskills.io
@@ -294,16 +300,19 @@ def create_agent(model: BaseChatModel,
             "not both")
     delegate = spec.role == "delegate"
     async_main = not delegate and bool(spec.async_subagent_tools)
+    thread_memory_enabled = bool(
+        getattr(sandbox_backend, "native_agent_dir", False) is True
+        if sandbox_backend is not None else agent_dir is not None)
     mw, (retry_middle, json_validation_mw, tool_name_mw) = _hardening_middleware()
     logging_mw = ModelLoggingMiddleware(
         "delegate-agent" if delegate else "general-agent")
-
     workspace_dir = sandbox_backend.work_dir if sandbox_backend else "/"
     # Single-slashed path that's safe to interpolate without producing
     # `//references/` in local mode (where workspace_dir == "/").
     references_dir = os.path.join(workspace_dir, "references")
 
     memories_path = os.path.join(workspace_dir, _MEMORY_FILE)
+    thread_memories_path = "/agent/memory.md" if thread_memory_enabled else None
 
     # Plain dict copy of the spec's read-only mapping; the backend
     # factories treat an empty mapping and None identically.
@@ -311,6 +320,10 @@ def create_agent(model: BaseChatModel,
     if async_main:
         extra_routes.setdefault(
             MAIN_SKILLS_ROUTE, create_skills_backend(MAIN_SKILLS_DIR))
+    if agent_dir is not None and sandbox_backend is None:
+        from deepagents.backends import FilesystemBackend
+        extra_routes["/agent/"] = FilesystemBackend(
+            root_dir=agent_dir, virtual_mode=True)
     if sandbox_backend:
         backend = create_sandbox_composite_backend(sandbox_backend,
                                                    extra_routes=extra_routes)
@@ -349,14 +362,18 @@ def create_agent(model: BaseChatModel,
     if DOMAIN_SKILLS_PATH not in skill_sources and _has_domain_skills(backend):
         skill_sources.insert(1 if async_main else 0, DOMAIN_SKILLS_PATH)
     skills_mw = SmallModelSkillsMiddleware(backend=backend, sources=skill_sources)
-    memory_mw = SmallModelMemoryMiddleware(backend=backend, memories_path=memories_path)
+    memory_mw = SmallModelMemoryMiddleware(
+        backend=backend, memories_path=memories_path,
+        thread_memories_path=thread_memories_path)
 
-    # ``None`` retains the legacy in-process subagents. Any explicit sequence
-    # suppresses them: web main supplies five subagent lifecycle tools, while the
-    # restricted web triage profile deliberately supplies none.
+    # ``None`` retains the legacy in-process subagents for the one-source shape.
+    # Thread-memory agents suppress them because deepagents would make the child
+    # inherit the private /agent backend. Any explicit sequence also suppresses
+    # them: web main supplies lifecycle tools, while web triage supplies none.
     context_sub = None
     research_sub = None
-    legacy_subagents = spec.async_subagent_tools is None
+    legacy_subagents = (
+        spec.async_subagent_tools is None and not thread_memory_enabled)
     if legacy_subagents:
         context_sub = CompiledSubAgent(
             name="context-agent",

--- a/assist/middleware/memory_middleware.py
+++ b/assist/middleware/memory_middleware.py
@@ -18,9 +18,13 @@ having the model invoke its existing ``write_file`` / ``edit_file``
 tools against ``AGENTS.md``, with the loaded ``<agent_memory>`` block
 serving as the anchor for the ``edit_file`` replace.
 
-Read happens automatically: the upstream ``before_agent`` loads the
-memory file into state on the first turn, and our
-``_format_agent_memory`` injects the contents into the system message.
+Read happens automatically: our ``before_agent`` / ``abefore_agent``
+overrides discard the upstream state cache and reload every configured
+file each turn; ``_format_agent_memory`` injects the contents into the
+system message.
+Web main agents may also load a thread-private ``/agent/memory.md``;
+the established one-source prompt remains unchanged for every other
+construction path.
 """
 from __future__ import annotations
 
@@ -107,19 +111,42 @@ in prose but never persists it.  The check exists to prevent that.
 """
 
 
+THREAD_MEMORY_PROMPT = """{repo_prompt}
+
+<thread_memory>
+{thread_memory}
+</thread_memory>
+
+## Thread memory
+
+`{repo_memory_path}` is durable repository memory shared across threads.
+`{thread_memory_path}` belongs only to this thread. Use it for the current
+goal, decisions, corrections, progress, blockers, and useful working notes.
+
+`/agent` is your agent-owned working space for anything useful across this
+long-running thread. Proactively manage it without waiting for the user to ask.
+Put a fact in repository memory only when it should remain useful across
+threads. Never put current-thread state there. When one message contains both
+scopes, update the two files separately.
+"""
+
+
 class SmallModelMemoryMiddleware(MemoryMiddleware):
     """``MemoryMiddleware`` variant with a small-model-friendly system prompt.
 
-    Inherits ``before_agent`` / ``abefore_agent`` (file load into state)
-    and ``modify_request`` / ``wrap_model_call`` (system-message
-    injection) unchanged from the upstream class.  Only the formatted
-    prompt body changes; no tools are registered.  The model saves new
-    memory by invoking its existing filesystem tools against
-    ``AGENTS.md``.
+    Overrides ``before_agent`` / ``abefore_agent`` to reload files every
+    turn and the formatted prompt body to distinguish the optional thread
+    source. Inherits the request/model-injection hooks unchanged; no tools
+    are registered. The model saves repository and optional thread
+    memory through its existing filesystem tools.
     """
 
-    def __init__(self, *, backend, memories_path: str) -> None:
-        super().__init__(backend=backend, sources=[memories_path])
+    def __init__(self, *, backend, memories_path: str,
+                 thread_memories_path: str | None = None) -> None:
+        sources = [memories_path]
+        if thread_memories_path is not None:
+            sources.append(thread_memories_path)
+        super().__init__(backend=backend, sources=sources)
 
     def before_agent(self, state, runtime, config):
         # Force a fresh read every turn.  Upstream short-circuits when
@@ -138,11 +165,12 @@ class SmallModelMemoryMiddleware(MemoryMiddleware):
     def _format_agent_memory(self, contents: dict[str, str]) -> str:
         """Format loaded memory using the small-model prompt template.
 
-        Mirrors upstream's logic (memory.py:218-236) but substitutes
+        The one-source branch mirrors upstream's logic (memory.py:218-236) but substitutes
         ``SMALL_MODEL_MEMORY_PROMPT`` and drops upstream's per-source
         path prefix (``"{path}\\n{content}"``) — the path is rendered
         once in the prompt body via ``{memory_path}`` instead of
-        per-source, since we configure exactly one source.
+        per-source. The optional second source is rendered separately so
+        repository and thread scope cannot be mistaken for each other.
 
         Keeps the ``<agent_memory>...</agent_memory>`` wrapper because
         the read-path tests (and the save-path prompt above) both
@@ -154,21 +182,22 @@ class SmallModelMemoryMiddleware(MemoryMiddleware):
         empty-string anchor).
         """
         memory_path = self.sources[0]
-        if not contents:
-            return SMALL_MODEL_MEMORY_PROMPT.format(
-                agent_memory="(No memory loaded)", memory_path=memory_path,
-            )
-
-        sections = [
-            contents[path] for path in self.sources
-            if contents.get(path) and contents[path].strip()
-        ]
-        if not sections:
-            return SMALL_MODEL_MEMORY_PROMPT.format(
-                agent_memory="(No memory loaded)", memory_path=memory_path,
-            )
-
-        memory_body = "\n\n".join(sections)
-        return SMALL_MODEL_MEMORY_PROMPT.format(
+        memory_body = contents.get(memory_path, "")
+        if not memory_body.strip():
+            memory_body = "(No memory loaded)"
+        repo_prompt = SMALL_MODEL_MEMORY_PROMPT.format(
             agent_memory=memory_body, memory_path=memory_path,
+        )
+        if len(self.sources) == 1:
+            return repo_prompt
+
+        thread_memory_path = self.sources[1]
+        thread_memory = contents.get(thread_memory_path, "")
+        if not thread_memory.strip():
+            thread_memory = "(No thread memory loaded)"
+        return THREAD_MEMORY_PROMPT.format(
+            repo_prompt=repo_prompt,
+            repo_memory_path=memory_path,
+            thread_memory_path=thread_memory_path,
+            thread_memory=thread_memory,
         )

--- a/assist/middleware/memory_middleware.py
+++ b/assist/middleware/memory_middleware.py
@@ -121,7 +121,8 @@ THREAD_MEMORY_PROMPT = """{repo_prompt}
 
 `{repo_memory_path}` is durable repository memory shared across threads.
 `{thread_memory_path}` belongs only to this thread. Use it for the current
-goal, decisions, corrections, progress, blockers, and useful working notes.
+goal, processes, decisions, corrections, progress, blockers, and useful working
+notes.
 
 `/agent` is your agent-owned working space for anything useful across this
 long-running thread. Proactively manage it without waiting for the user to ask.

--- a/assist/sandbox.py
+++ b/assist/sandbox.py
@@ -8,7 +8,8 @@ explicitly (see _run_uid_gid / upload_files).
 
 Paths are prefixed with work_dir (/workspace) so that agent paths like
 /myfile.txt map to /workspace/myfile.txt inside the container, which is
-where the host bind mount lives.
+where the host bind mount lives. ``/agent`` passes through only on a
+backend explicitly constructed for a container with that private main-agent mount.
 """
 
 import logging
@@ -113,7 +114,8 @@ class DockerSandboxBackend(BaseSandbox):
     """
 
     def __init__(self, container, work_dir: str = "/workspace",
-                 strip_prefixes: tuple[str, ...] = ()):
+                 strip_prefixes: tuple[str, ...] = (),
+                 native_agent_dir: bool = False):
         """Args:
             container: A running Docker container object.
             work_dir: Root directory inside the container that paths are
@@ -125,11 +127,20 @@ class DockerSandboxBackend(BaseSandbox):
                 references-rooted ``work_dir``.  Each prefix is checked
                 in both bare (``"references/"``) and absolute
                 (``"/references/"``) form.
+            native_agent_dir: Whether the container has an explicit
+                ``/agent`` bind mount. Unmounted backends preserve the
+                historical workspace-relative meaning of that path.
         """
         self.container = container
         self.work_dir = work_dir.rstrip("/")
         self._strip_prefixes = strip_prefixes
+        self._native_agent_dir = native_agent_dir
         self._run_ids: tuple[int, int] | None = None
+
+    @property
+    def native_agent_dir(self) -> bool:
+        """Whether this backend exposes a dedicated ``/agent`` mount."""
+        return self._native_agent_dir
 
     def _strip(self, path: str | None) -> str | None:
         if not path or not self._strip_prefixes:
@@ -164,6 +175,9 @@ class DockerSandboxBackend(BaseSandbox):
         # (strip_prefixes=("references",)) a "/references/tmp/x" strips to "/tmp/x" —
         # that must stay confined under work_dir, NOT escape into the shared /tmp.
         if path == "/tmp" or path.startswith("/tmp/"):
+            return stripped
+        if (self._native_agent_dir
+                and (path == "/agent" or path.startswith("/agent/"))):
             return stripped
         return self.work_dir + (stripped if stripped.startswith("/") else "/" + stripped)
 

--- a/assist/sandbox_manager.py
+++ b/assist/sandbox_manager.py
@@ -264,10 +264,13 @@ class SandboxManager:
         )
 
     @classmethod
-    def get_sandbox_backend(cls, work_dir: str, tz: str | None = None):
+    def get_sandbox_backend(cls, work_dir: str, tz: str | None = None,
+                            agent_dir: str | None = None):
         """Return a DockerSandboxBackend for work_dir, creating a container if needed.
 
-        Returns None if Docker is not available.
+        Passing ``agent_dir`` mounts it at ``/agent``. The web composition passes
+        it only for visible main-agent turns; child turns omit it. Returns None if
+        Docker is not available.
         """
         # Per-turn lifecycle: never reuse a container across turns.  The web
         # layer tears each container down at the end of its turn
@@ -390,13 +393,25 @@ class SandboxManager:
                     pass  # not permitted (web non-root, uids differ) — mount still
                           # works when web uid == work_dir owner (the deployment case)
 
+            volumes = {work_dir: {"bind": "/workspace", "mode": "rw"},
+                       tmp_dir: {"bind": "/tmp", "mode": "rw"}}
+            if agent_dir is not None:
+                os.makedirs(agent_dir, exist_ok=True)
+                try:
+                    os.chown(agent_dir, st.st_uid, st.st_gid)
+                except OSError:
+                    pass
+                volumes[agent_dir] = {
+                    "bind": "/agent",
+                    "mode": "rw",
+                }
+
             container = client.containers.run(
                 SANDBOX_IMAGE,
                 detach=True,
                 remove=True,
                 user=user_arg,
-                volumes={work_dir: {"bind": "/workspace", "mode": "rw"},
-                         tmp_dir: {"bind": "/tmp", "mode": "rw"}},
+                volumes=volumes,
                 working_dir="/workspace",
                 stdin_open=True,
                 tty=False,
@@ -408,7 +423,8 @@ class SandboxManager:
             cls._containers[work_dir] = container
             cls._record_egress_client(container, work_dir)
             from assist.sandbox import DockerSandboxBackend
-            return DockerSandboxBackend(container)
+            return DockerSandboxBackend(
+                container, native_agent_dir=agent_dir is not None)
         except DockerException as e:
             logger.warning("Docker sandbox unavailable: %s", e)
             return None

--- a/assist/spec.py
+++ b/assist/spec.py
@@ -7,7 +7,8 @@ kwargs that used to accrete on ``Thread`` / ``create_agent``
 docs/2026-06-11-embedder-contract.org for the design and the split
 rule: *spec = the agent's shape, consumed by create_agent; Thread
 kwargs = per-instance and per-run wiring* (identity, persistence,
-model, concurrency, status callback, per-request ``configurable``).
+model, concurrency, status callback, app-owned ``agent_dir``, and
+per-request ``configurable``).
 
 Admission rule: a field requires a real, existing client need.  Do not
 add fields for needs no client has yet — deferred candidates
@@ -78,11 +79,12 @@ class AgentSpec:
     default_backend: BackendProtocol | None = None
 
     # Deep Agents-compatible subagent selection surface for this graph.
-    # ``None`` keeps the established synchronous subagents for legacy embedders;
-    # an explicit empty sequence disables delegation (the web triage profile),
-    # and the web main profile supplies all five lifecycle tools. The delegate
-    # profile deliberately uses ``None`` for synchronous specialists. This one field
-    # selects the delegation mechanism without a second mode flag.
+    # ``None`` selects the established synchronous subagents for one-source legacy
+    # embedders; thread-memory construction suppresses them so they cannot inherit
+    # its private backend. An explicit empty sequence disables delegation (web
+    # triage), and web main supplies all five lifecycle tools. The delegate profile
+    # uses ``None`` for synchronous specialists. This field selects the delegation
+    # mechanism without a second mode flag.
     async_subagent_tools: tuple[BaseTool, ...] | None = None
 
     # Tools to gate with human-in-the-loop: a mapping ``{tool_name -> True |

--- a/assist/thread.py
+++ b/assist/thread.py
@@ -139,6 +139,7 @@ class Thread:
                  model: BaseChatModel | None = None,
                  max_concurrency: int = 5,
                  sandbox_backend=None,
+                 agent_dir: str | None = None,
                  on_queue_state: Callable[[str], None] | None = None,
                  agent=None):
         """The embedder surface (docs/2026-06-11-embedder-contract.org):
@@ -160,6 +161,10 @@ class Thread:
         `agent` — an internal prebuilt-graph injection for specialized web child
         runs. It is mutually exclusive with `spec`; ordinary embedders use the
         single `AgentSpec` declaration surface.
+
+        Passing ``agent_dir`` enables per-thread private working state. It is
+        per-instance wiring, not part of the reusable ``AgentSpec`` declaration;
+        the web composition passes it only to visible main agents.
 
         The remaining params are per-instance/run wiring: identity
         (``thread_id``), persistence (``checkpointer``), model,
@@ -216,7 +221,8 @@ class Thread:
 
         self.agent = agent or create_agent(
             self.model, working_dir=working_dir, checkpointer=checkpointer,
-            sandbox_backend=sandbox_backend, spec=spec)
+            sandbox_backend=sandbox_backend, agent_dir=agent_dir,
+            spec=spec)
 
     def _run(self, graph_input) -> str:
         """Acquire the per-thread LLM affinity queue for the agent loop (so concurrent

--- a/assist/thread_manager.py
+++ b/assist/thread_manager.py
@@ -320,6 +320,10 @@ class ThreadManager:
             return Thread(
                 working_dir, **thread_kwargs,
                 spec=AgentSpec(role="delegate", async_subagent_tools=None))
+        if sandbox_backend is None:
+            agent_dir = self.thread_agent_dir(thread_id)
+            os.makedirs(agent_dir, exist_ok=True)
+            thread_kwargs["agent_dir"] = agent_dir
         return Thread(
             working_dir, **thread_kwargs,
             spec=AgentSpec(
@@ -350,17 +354,9 @@ class ThreadManager:
     def new(self, working_dir: str|None = None, sandbox_backend=None,
             on_queue_state: Callable[[str], None] | None = None) -> Thread:
         tid = self.reserve()
-        tdir = os.path.join(self.root_dir, tid)
-        if not working_dir:
-            working_dir = self.make_default_working_dir(tdir)
-
-        # A freshly-created thread is never a triage turn → normal tools, no reply HITL.
-        return Thread(working_dir, thread_id=tid, checkpointer=self.checkpointer,
-                      model=self.model, sandbox_backend=sandbox_backend,
-                      on_queue_state=on_queue_state,
-                      spec=AgentSpec(skill_sources=_web_skill_sources(), tools=_web_tools,
-                                     async_subagent_tools=async_task_tools,
-                                     interrupt_on=None))
+        return self.get(
+            tid, working_dir=working_dir, sandbox_backend=sandbox_backend,
+            on_queue_state=on_queue_state)
 
     def reserve(self, thread_id: str | None = None,
                 *, hidden: dict | None = None) -> str:
@@ -433,6 +429,11 @@ class ThreadManager:
     # thread dir on hard_delete.
     def thread_tmp_dir(self, tid: str) -> str:
         return os.path.join(self.thread_dir(tid), "tmp")
+
+    # Private main-agent state, outside both the repo and renderable scratch.
+    # The thread directory owns its lifecycle, so hard_delete removes it naturally.
+    def thread_agent_dir(self, tid: str) -> str:
+        return os.path.join(self.thread_dir(tid), "agent")
 
     def make_default_working_dir(self, tdir: str) -> str:
         wdir = self.DEFAULT_THREAD_WORKING_DIRECTORY

--- a/docs/2026-06-11-embedder-contract.org
+++ b/docs/2026-06-11-embedder-contract.org
@@ -23,9 +23,10 @@ file move (=ThreadManager= out of =assist/thread.py=).  No package
 split, no new distribution.
 
 *Current extension:* the frozen spec now also accepts =async_subagent_tools=.
-=None= retains the legacy synchronous subagents, an explicit empty sequence
-disables delegation for the restricted web triage profile, and a nonempty
-sequence replaces blocking =task= with the subagent lifecycle tools. See
+=None= retains the legacy synchronous subagents in the one-source construction;
+thread-memory construction suppresses them so they cannot inherit its private backend.
+An explicit empty sequence disables delegation for the restricted web triage profile,
+and a nonempty sequence replaces blocking =task= with the subagent lifecycle tools. See
 [[file:2026-07-25-async-subagents-asgi.org][the subagent ASGI design]] for that field's runtime contract.
 
 The one-level delegate adds =role= (=main= by default, or =delegate=). This is a
@@ -78,7 +79,8 @@ class AgentSpec:
     # paths go.  Mutually exclusive with sandbox_backend (a Thread/
     # create_agent param), validated at create_agent time.
     default_backend: BackendProtocol | None = None
-    # None = legacy sync; () = no delegation; nonempty = async tools.
+    # None = legacy sync in the one-source shape (thread memory suppresses it);
+    # () = no delegation; nonempty = async tools.
     async_subagent_tools: tuple[BaseTool, ...] | None = None
 #+end_src
 
@@ -104,13 +106,15 @@ Every field maps to a live client need:
 
 #+begin_src python
 create_agent(model, working_dir, checkpointer=None, sandbox_backend=None,
-             *, spec: AgentSpec | None = None)
+             *, agent_dir: str | None = None,
+             spec: AgentSpec | None = None)
 
 Thread(working_dir, *,
        spec: AgentSpec | None = None,
        configurable: Mapping[str, Any] | None = None,
        thread_id=None, checkpointer=None, model=None,
-       max_concurrency=5, sandbox_backend=None, on_queue_state=None)
+       max_concurrency=5, sandbox_backend=None, agent_dir=None,
+       on_queue_state=None, agent=None)
 #+end_src
 
 =spec= is keyword-only in both (an out-of-tree positional call must not
@@ -121,7 +125,8 @@ passes its web tools, skills, and subagent profile through one spec.
 *The split rule* (articulable, by design): /spec = the agent's shape,
 consumed by =create_agent=; Thread kwargs = per-instance and per-run
 wiring/ (identity, persistence, model, concurrency, status callback,
-per-request context).  One documented exception: =sandbox_backend=
+per-request context, and app-owned =agent_dir= private state). One documented
+exception: =sandbox_backend=
 stays a param despite being agent-shape-adjacent, because ~15 eval
 files use it positionally and it is per-turn runtime isolation in the
 web app; folding it into the spec is possible later if the boundary
@@ -157,7 +162,7 @@ asymmetry dies with the adapter at the legacy-kwarg removal step.
   =async_subagent_tools= field selects the established synchronous profile,
   no delegation, or the web's asynchronous profile; it does not accept arbitrary
   child graph definitions. Web main passes the five lifecycle tools, web triage
-  passes an empty tuple, and delegate/legacy graphs use the synchronous profile;
+  passes an empty tuple, and delegate/one-source legacy graphs use the synchronous profile;
   emacsos keeps that default because research is routine phone traffic. If arbitrary
   child definitions come back, settle: naming (spec names vs the registered
   =*-agent= names), the empty-set semantics against deepagents'

--- a/docs/2026-07-26-per-thread-memory.org
+++ b/docs/2026-07-26-per-thread-memory.org
@@ -1,0 +1,98 @@
+#+title: Per-thread main-agent memory
+#+date: 2026-07-26
+
+* Status
+
+Implementation and local verification are complete. Deployment and external review
+remain in progress.
+
+* Why
+
+Long-running threads need working state that survives turns without becoming durable
+repository guidance. Threads =20260723170746-d10af2fb= and
+=20260722202239-f12319a8= had to encode that state in repository working files or a
+schedule prompt. Neither location represented its actual lifetime.
+
+This feature adds thread memory alongside existing repository memory. It does not
+replace or reinterpret repository memory.
+
+* Contract
+
+1. Each visible thread owns =<thread-dir>/agent=. Its main agent sees that directory
+   read-write at =/agent= through a local virtual route or Docker bind mount. It
+   persists across turns and is removed with the thread.
+2. The main agent auto-loads =/agent/memory.md= alongside existing repository memory,
+   addressed as =/AGENTS.md= locally and =/workspace/AGENTS.md= in Docker.
+3. Prompt guidance distinguishes the scopes:
+   - repository memory is durable across threads;
+   - thread memory holds this thread's goal, decisions, corrections, progress,
+     blockers, and useful working notes;
+   - =/agent= is agent-owned working space to manage proactively.
+4. Spawned children receive neither the private =/agent= route/mount nor the
+   thread-memory prompt. Their parent must continue to provide a self-contained brief.
+5. Agent constructions without a thread agent directory retain the existing single
+   memory source and prompt.
+
+Scheduled turns need no special behavior: they enter through the ordinary visible
+main-agent construction path and therefore see the same thread directory naturally.
+There is no deterministic precedence or conflict mechanism between the two memory
+files.
+
+* Design
+
+=ThreadManager.thread_agent_dir= locates the directory under the thread root. Local
+agents receive a virtual =/agent/= filesystem route. Docker main-agent turns receive
+an explicit bind mount, represented by a small backend capability so =/agent= resolves
+to the mount rather than =/workspace/agent=. Child construction omits the mount;
+memory-enabled agents also omit the legacy in-process child profile, which would share
+the main backend.
+
+=SmallModelMemoryMiddleware= accepts one optional second source. With one source it
+renders the established prompt unchanged. With two, it keeps repository contents in
+=<agent_memory>= and thread contents in =<thread_memory>=, followed by the short scope
+guidance above.
+
+No schedule schema or tool changes, retry loops, queue integration, promotion
+transactions, triage profile, path aliases, collision handling, or other enforcement
+mechanisms belong to this feature.
+
+* Verification contract
+
+The retained deterministic tests cover:
+
+- thread-directory location, isolation by thread ID, and deletion with the thread;
+- local =/agent= routing and Docker mount/path resolution;
+- repository and thread sources both loading into separately labelled prompt blocks;
+- the unchanged one-source prompt tests;
+- visible-main versus delegate/specialized-child containment in =ThreadManager=,
+  child-run mount omission, and a real mounted/unmounted Docker boundary.
+
+One natural small-model eval gives a single user message containing both a durable
+cross-thread preference and a current-thread workflow decision. It passes only when
+the preference lands in repository memory, the workflow decision lands in thread
+memory, and neither fact leaks into the other scope.
+
+* Results
+
+The simplicity-first review converged in two rounds. It removed the earlier schedule,
+retry, promotion, path-enforcement, collision, queue, and triage machinery, reused
+=ThreadManager.get= from =new=, and reduced the production diff to the eight runtime
+files named by the design. Against the rebased main that diff is +150/-59 lines (net
+91), including docstrings and prompt text.
+
+The full local review found and fixed two real construction leaks, documentation drift,
+and an eval assertion that could miss paraphrased leakage. Correctness, containment,
+simplicity, and doc-alignment convergence passes then reported no real findings. The
+unsupported =agent_dir= plus non-native-sandbox combination remains unenforced by
+design; real web callers select exactly one construction mode.
+
+Deterministic verification: 1,478 passed, 2 skipped. Focused post-prompt verification:
+140 passed. =git diff --check= and Python compile checks passed; mypy was unavailable in
+the deploy environment.
+
+The natural eval first caught a real mixed-scope failure: one of three trials copied the
+thread workflow stage into repository memory. A two-sentence prompt correction made
+mixed-scope messages update the files separately. The final cadence then passed N=3
+(3/3), N=5 (5/5), and N=10 (10/10). The feature-branch deployment restarted cleanly
+and the live HTTPS root smoke passed; PR/Copilot state will be recorded after
+publication.

--- a/docs/2026-07-26-per-thread-memory.org
+++ b/docs/2026-07-26-per-thread-memory.org
@@ -3,8 +3,7 @@
 
 * Status
 
-Implementation and local verification are complete. Deployment and external review
-remain in progress.
+The implementation is deployed and PR review is in progress.
 
 * Why
 
@@ -25,8 +24,8 @@ replace or reinterpret repository memory.
    addressed as =/AGENTS.md= locally and =/workspace/AGENTS.md= in Docker.
 3. Prompt guidance distinguishes the scopes:
    - repository memory is durable across threads;
-   - thread memory holds this thread's goal, decisions, corrections, progress,
-     blockers, and useful working notes;
+   - thread memory holds this thread's goal, processes, decisions, corrections,
+     progress, blockers, and useful working notes;
    - =/agent= is agent-owned working space to manage proactively.
 4. Spawned children receive neither the private =/agent= route/mount nor the
    thread-memory prompt. Their parent must continue to provide a self-contained brief.
@@ -67,18 +66,24 @@ The retained deterministic tests cover:
 - visible-main versus delegate/specialized-child containment in =ThreadManager=,
   child-run mount omission, and a real mounted/unmounted Docker boundary.
 
-One natural small-model eval gives a single user message containing both a durable
-cross-thread preference and a current-thread workflow decision. It passes only when
-the preference lands in repository memory, the workflow decision lands in thread
+One required natural small-model eval gives a single user message containing both a
+durable cross-thread preference and a current-thread workflow decision. It passes only
+when the preference lands in repository memory, the workflow decision lands in thread
 memory, and neither fact leaks into the other scope.
+
+A second natural eval is intentionally aspirational. “We'll use this thread … The
+process is …” asks the model to infer that a user-established process belongs in thread
+memory and asserts that it writes something there. The current small model is
+inconsistent; keep this as a prompt-rearchitecture target, not a release gate for this
+storage and lifecycle feature.
 
 * Results
 
 The simplicity-first review converged in two rounds. It removed the earlier schedule,
 retry, promotion, path-enforcement, collision, queue, and triage machinery, reused
 =ThreadManager.get= from =new=, and reduced the production diff to the eight runtime
-files named by the design. Against the rebased main that diff is +150/-59 lines (net
-91), including docstrings and prompt text.
+files named by the design. Against the rebased main that diff is +151/-59 lines (net
+92), including docstrings and prompt text.
 
 The full local review found and fixed two real construction leaks, documentation drift,
 and an eval assertion that could miss paraphrased leakage. Correctness, containment,
@@ -90,9 +95,14 @@ Deterministic verification: 1,478 passed, 2 skipped. Focused post-prompt verific
 140 passed. =git diff --check= and Python compile checks passed; mypy was unavailable in
 the deploy environment.
 
-The natural eval first caught a real mixed-scope failure: one of three trials copied the
-thread workflow stage into repository memory. A two-sentence prompt correction made
-mixed-scope messages update the files separately. The final cadence then passed N=3
-(3/3), N=5 (5/5), and N=10 (10/10). The feature-branch deployment restarted cleanly
-and the live HTTPS root smoke passed; PR/Copilot state will be recorded after
-publication.
+The required natural eval first caught a real mixed-scope failure: one of three trials
+copied the thread workflow stage into repository memory. A two-sentence prompt
+correction made mixed-scope messages update the files separately. The final cadence
+then passed N=3 (3/3), N=5 (5/5), and N=10 (10/10).
+
+Pierre's review added the ordinary “We'll use this thread … The process is …” case.
+Descriptive “processes” guidance alone did not make it reliable: several prompt
+variants created a todo artifact or used =write_todos= instead. The strongest
+enforcement passed N=3 (3/3) but failed N=5 on trial 3 after two passes. That extra
+enforcement was removed rather than accumulated. The retained eval and this result
+make the behavior an explicit prompt-rearchitecture target.

--- a/edd/eval/test_thread_memory.py
+++ b/edd/eval/test_thread_memory.py
@@ -1,0 +1,45 @@
+"""Natural behavior eval for repository versus thread memory scope."""
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest import TestCase
+
+from assist.agent import AgentHarness, create_agent
+from assist.model_manager import select_assistant_model
+from assist.spec import AgentSpec
+
+from .utils import create_filesystem, read_file
+
+
+class TestThreadMemory(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = select_assistant_model(0.1)
+
+    def test_infers_repo_and_thread_scope(self):
+        root = tempfile.mkdtemp()
+        agent_dir = tempfile.mkdtemp()
+        create_filesystem(root, {"AGENTS.md": ""})
+        graph = create_agent(
+            self.model,
+            root,
+            agent_dir=agent_dir,
+            spec=AgentSpec(async_subagent_tools=()),
+        )
+        agent = AgentHarness(graph, thread_id="thread-memory-eval")
+
+        agent.message(
+            "Across all conversations, use my label atlas-grid for compact "
+            "tables. For this "
+            "thread's application workflow, use the stage name "
+            "candidate-replied after I answer.",
+        )
+
+        repo = read_file(os.path.join(root, "AGENTS.md"))
+        memory_path = os.path.join(agent_dir, "memory.md")
+        thread = read_file(memory_path) if os.path.exists(memory_path) else ""
+        self.assertIn("atlas-grid", repo.lower(), agent.all_messages())
+        self.assertNotIn("candidate-replied", repo)
+        self.assertIn("candidate-replied", thread)
+        self.assertNotIn("atlas-grid", thread.lower())

--- a/edd/eval/test_thread_memory.py
+++ b/edd/eval/test_thread_memory.py
@@ -43,3 +43,32 @@ class TestThreadMemory(TestCase):
         self.assertNotIn("candidate-replied", repo)
         self.assertIn("candidate-replied", thread)
         self.assertNotIn("atlas-grid", thread.lower())
+
+    def test_natural_process_prompt_writes_thread_memory(self):
+        """Aspirational thread-memory-write target for prompt rearchitecture.
+
+        The current small model is inconsistent here: it may create a todo
+        artifact instead of recording the process. This eval asserts only that
+        the message produces a non-empty thread-memory write; it does not verify
+        that the process itself was captured or gate the thread-storage feature.
+        """
+        root = tempfile.mkdtemp()
+        agent_dir = tempfile.mkdtemp()
+        create_filesystem(root, {"AGENTS.md": ""})
+        graph = create_agent(
+            self.model,
+            root,
+            agent_dir=agent_dir,
+            spec=AgentSpec(async_subagent_tools=()),
+        )
+        agent = AgentHarness(graph, thread_id="thread-process-eval")
+
+        agent.message(
+            "We'll use this thread to manage my todo list. The process is: new "
+            "items start in inbox, move to doing when I begin, and move to done "
+            "only after I confirm completion.",
+        )
+
+        memory_path = os.path.join(agent_dir, "memory.md")
+        thread = read_file(memory_path) if os.path.exists(memory_path) else ""
+        self.assertTrue(thread.strip(), agent.all_messages())

--- a/manage/web/state.py
+++ b/manage/web/state.py
@@ -252,11 +252,15 @@ def _get_domain_manager(tid: str, domain: str | None = None) -> DomainManager | 
         return None
 
 
-def _get_sandbox_backend(tid: str, tz: str | None = None):
+def _get_sandbox_backend(tid: str, tz: str | None = None, *,
+                         include_agent: bool = True):
     """Get sandbox backend for a thread, or None if Docker is unavailable.
 
     ``tz`` is the per-turn context-rider timezone, so this turn's sandbox ``date``
     runs in the user's local time (else the host/server zone).
+
+    ``include_agent`` mounts the visible thread's private main-agent directory.
+    Hidden child runs pass false and receive self-contained task briefs instead.
 
     Runs off the event loop (from ``_process_message``'s background task), so the
     turn-start origin pre-fetch is safe here: the host refreshes ``origin/main`` in the
@@ -269,7 +273,9 @@ def _get_sandbox_backend(tid: str, tz: str | None = None):
             dm.fetch_origin()
         except Exception as e:
             logging.getLogger(__name__).warning("origin pre-fetch failed for %s: %s", tid, e)
-    return SandboxManager.get_sandbox_backend(work_dir, tz=tz)
+    return SandboxManager.get_sandbox_backend(
+        work_dir, tz=tz,
+        agent_dir=(MANAGER.thread_agent_dir(tid) if include_agent else None))
 
 
 def _has_unmerged_changes(tid: str) -> bool:

--- a/manage/web/state.py
+++ b/manage/web/state.py
@@ -260,7 +260,7 @@ def _get_sandbox_backend(tid: str, tz: str | None = None, *,
     runs in the user's local time (else the host/server zone).
 
     ``include_agent`` mounts the visible thread's private main-agent directory.
-    Hidden child runs pass false and receive self-contained task briefs instead.
+    Hidden child runs pass ``False`` and receive self-contained task briefs instead.
 
     Runs off the event loop (from ``_process_message``'s background task), so the
     turn-start origin pre-fetch is safe here: the host refreshes ``origin/main`` in the

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -1440,7 +1440,8 @@ def _execute_child_run(run: Run, *, resume: bool = False) -> None:
                     parent_working_dir = MANAGER.thread_default_working_dir(
                         run.parent_thread_id)
                     try:
-                        sandbox = _get_sandbox_backend(run.parent_thread_id)
+                        sandbox = _get_sandbox_backend(
+                            run.parent_thread_id, include_agent=False)
                         sandbox_generation = sandbox.container if sandbox else None
                     except Exception:
                         sandbox_generation = SandboxManager.current_container(
@@ -1922,7 +1923,8 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
                 # creation registers a container and then raises — cleanup
                 # keys on work_dir, not on the `sandbox` handle.
                 try:
-                    sandbox = _get_sandbox_backend(tid, tz=rider.tz if rider else None)
+                    sandbox = _get_sandbox_backend(
+                        tid, tz=rider.tz if rider else None)
                     sandbox_generation = sandbox.container if sandbox else None
                 except Exception:
                     sandbox_generation = SandboxManager.current_container(

--- a/roadmap.org
+++ b/roadmap.org
@@ -68,8 +68,9 @@ tools. Design and verification contract:
 Shipped 2026-06-12: the =AgentSpec= embedder contract
 ([[file:docs/2026-06-11-embedder-contract.org][docs/2026-06-11-embedder-contract.org]], assist PR #134 + the
 legacy-kwarg removal PR; emacsos ported in its PR #24).  The accreted
-kwargs are gone — =Thread= / =create_agent= take =spec= +
-=configurable= only.  The deepagents-upstream classification is
+embedder shape kwargs are gone: =create_agent= takes =spec=, while =Thread=
+additionally takes per-request =configurable=. App-owned per-instance wiring remains
+separate. The deepagents-upstream classification is
 recorded in the design doc (decision only; upstreaming not planned).
 Deferred with named triggers: =subagents= selection, =system_prompt=,
 middleware tuning, package split.
@@ -91,8 +92,9 @@ further.  Must keep =manage.web= working — incremental migration, not a
 big-bang rewrite.
 
 * Memory
-** TODO Per-thread memory — a =/tmp= memory file that survives only the thread
-An additional memory location in =/tmp= so that it only survives the thread and not in the workspace. Guidance on when to use one memory file over the other: =/workspace/AGENTS.md= for facts about the user, preferences, and forward-looking rules that outlive any single conversation; =/tmp/memory.md= for thread-local learnings (codebase state, current SHA, roadmap understanding, session context) that evolve with the work in progress and should not persist beyond the thread.
+** DONE Per-thread memory — private =/agent= state that survives only the thread
+Visible main-agent turns auto-load =/agent/memory.md= beside unchanged repo memory;
+spawned child agents receive self-contained briefs instead of that private state.
 
 * Dev updates
 The dev agent needs significant improvements

--- a/tests/middleware/test_memory_middleware.py
+++ b/tests/middleware/test_memory_middleware.py
@@ -123,6 +123,7 @@ class TestMemoryPromptFormatting(TestCase):
         self.assertNotIn("Prefer compact tables", out[thread_start:thread_end])
         self.assertIn("durable repository memory shared across threads", out)
         self.assertIn("belongs only to this thread", out)
+        self.assertIn("goal, processes, decisions", " ".join(out.split()))
         self.assertIn("update the two files separately", out)
 
 

--- a/tests/middleware/test_memory_middleware.py
+++ b/tests/middleware/test_memory_middleware.py
@@ -2,7 +2,7 @@
 
 The middleware no longer registers a `save_memory` tool — memory is
 written via the model's existing `write_file` / `edit_file` tools
-against the configured memory file.  These tests guard against
+against the configured repository and optional thread-memory files. These tests guard against
 regression (re-introducing the tool), verify the system-prompt body
 formats loaded memory correctly, and lock in two reliability fixes:
 re-reading from disk on every turn, and rendering the absolute memory
@@ -98,6 +98,32 @@ class TestMemoryPromptFormatting(TestCase):
         self.assertIn("write_file", SMALL_MODEL_MEMORY_PROMPT)
         self.assertIn("edit_file", SMALL_MODEL_MEMORY_PROMPT)
         self.assertNotIn("save_memory", SMALL_MODEL_MEMORY_PROMPT)
+
+    def test_repo_and_thread_memory_are_loaded_and_distinguished(self):
+        mw = SmallModelMemoryMiddleware(
+            backend=MagicMock(),
+            memories_path="/workspace/AGENTS.md",
+            thread_memories_path="/agent/memory.md",
+        )
+        self.assertEqual(
+            mw.sources, ["/workspace/AGENTS.md", "/agent/memory.md"])
+
+        out = mw._format_agent_memory({
+            "/workspace/AGENTS.md": "Prefer compact tables across threads.",
+            "/agent/memory.md": "Current goal: finish the application workflow.",
+        })
+
+        repo_start = out.index("<agent_memory>")
+        repo_end = out.index("</agent_memory>")
+        thread_start = out.index("<thread_memory>")
+        thread_end = out.index("</thread_memory>")
+        self.assertIn("Prefer compact tables", out[repo_start:repo_end])
+        self.assertNotIn("Current goal", out[repo_start:repo_end])
+        self.assertIn("Current goal", out[thread_start:thread_end])
+        self.assertNotIn("Prefer compact tables", out[thread_start:thread_end])
+        self.assertIn("durable repository memory shared across threads", out)
+        self.assertIn("belongs only to this thread", out)
+        self.assertIn("update the two files separately", out)
 
 
 class TestStaleMemoryReread(TestCase):

--- a/tests/test_async_subagent_runs.py
+++ b/tests/test_async_subagent_runs.py
@@ -64,6 +64,26 @@ def test_agent_protocol_start_is_idempotent(monkeypatch, tmp_path):
     assert {item[:2] for item in submitted} == {(first.id, "sub-stable")}
 
 
+def test_child_sandbox_explicitly_omits_parent_agent_mount(monkeypatch, tmp_path):
+    _, _, metadata = _parent_and_metadata(monkeypatch, tmp_path)
+    child = SERVICE.create_run(
+        "sub-stable", "context-agent", "inspect files", metadata=metadata)
+    sandbox_calls = []
+
+    def sandbox(tid, tz=None, **kwargs):
+        sandbox_calls.append((tid, kwargs))
+        return None
+
+    monkeypatch.setattr(threads, "_get_sandbox_backend", sandbox)
+    monkeypatch.setattr(
+        threads.MANAGER, "get",
+        lambda *args, **kwargs: SimpleNamespace(message=lambda text: "done"))
+
+    threads._execute_child_run(child)
+
+    assert sandbox_calls == [("parent", {"include_agent": False})]
+
+
 def test_task_thread_replay_does_not_rewrite_its_identity(monkeypatch, tmp_path):
     _, _, metadata = _parent_and_metadata(monkeypatch, tmp_path)
     marker = os.path.join(threads.MANAGER.thread_dir("sub-stable"), ".subagent")

--- a/tests/test_create_agent_spec.py
+++ b/tests/test_create_agent_spec.py
@@ -1,9 +1,11 @@
 """Wiring tests for the AgentSpec embedder contract — the canonical
 surface pins (docs/2026-06-11-embedder-contract.org): spec fields
 reaching `create_deep_agent`, checkpointer/sandbox_backend forwarding,
-and `Thread`-level `spec=` / `configurable=` wiring.
+agent-directory and memory-source wiring, and `Thread`-level `spec=` /
+`configurable=` wiring.
 """
 
+import os
 import tempfile
 from unittest.mock import patch, MagicMock
 
@@ -304,6 +306,73 @@ class TestSpecWiring(_CreateAgentHarness):
             self._build(spec=AgentSpec(default_backend=MagicMock()),
                         sandbox_backend=MagicMock())
 
+    def test_thread_memory_source_reaches_main_middleware(self):
+        from assist.middleware.memory_middleware import SmallModelMemoryMiddleware
+
+        with tempfile.TemporaryDirectory() as agent_dir:
+            kwargs = self._build(
+                agent_dir=agent_dir,
+                spec=AgentSpec(async_subagent_tools=()))
+        memory = next(m for m in kwargs["middleware"]
+                      if isinstance(m, SmallModelMemoryMiddleware))
+        assert memory.sources == ["/AGENTS.md", "/agent/memory.md"]
+
+    def test_thread_memory_omits_legacy_in_process_subagents(self):
+        with tempfile.TemporaryDirectory() as agent_dir:
+            kwargs = self._build(agent_dir=agent_dir, spec=AgentSpec())
+        assert kwargs["subagents"] == []
+
+    def test_native_sandbox_capability_enables_thread_memory(self):
+        from assist.middleware.memory_middleware import SmallModelMemoryMiddleware
+
+        backend = MagicMock()
+        backend.native_agent_dir = True
+        backend.work_dir = "/workspace"
+        kwargs = self._build(
+            sandbox_backend=backend,
+            spec=AgentSpec(async_subagent_tools=()))
+        memory = next(m for m in kwargs["middleware"]
+                      if isinstance(m, SmallModelMemoryMiddleware))
+        assert memory.sources == ["/workspace/AGENTS.md", "/agent/memory.md"]
+
+    def test_local_agent_route_writes_outside_repository(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            agent_dir = os.path.join(temp_dir, "missing", "agent")
+            kwargs = self._build(
+                agent_dir=agent_dir,
+                spec=AgentSpec(async_subagent_tools=()))
+            assert not os.path.exists(agent_dir)
+            backend = kwargs["backend"]
+            result = backend.write("/agent/memory.md", "private state")
+            assert result.error is None
+            with open(f"{agent_dir}/memory.md") as stream:
+                assert stream.read() == "private state"
+
+    def test_local_specialized_child_cannot_read_parent_agent_dir(self):
+        from assist.agent import create_context_agent
+
+        with tempfile.TemporaryDirectory() as thread_dir:
+            working_dir = os.path.join(thread_dir, "domain")
+            agent_dir = os.path.join(thread_dir, "agent")
+            os.makedirs(working_dir)
+            os.makedirs(agent_dir)
+            with open(os.path.join(agent_dir, "memory.md"), "w") as stream:
+                stream.write("private-parent-canary")
+
+            parent_kwargs = self._build(
+                agent_dir=agent_dir,
+                spec=AgentSpec(async_subagent_tools=()))
+            parent_read = parent_kwargs["backend"].read("/agent/memory.md")
+            assert "private-parent-canary" in parent_read.file_data["content"]
+
+            with patch("assist.agent.create_deep_agent") as child_factory:
+                child_factory.return_value = MagicMock()
+                create_context_agent(MagicMock(), working_dir)
+            child_backend = child_factory.call_args.kwargs["backend"]
+            child_read = child_backend.read("/agent/memory.md")
+            assert child_read.error is not None
+            assert "private-parent-canary" not in str(child_read)
+
 
 class TestForwardingGaps(_CreateAgentHarness):
     """create_agent-level forwarding that was previously unpinned:
@@ -350,6 +419,10 @@ class _ThreadHarness:
 
 
 class TestThreadSpecForwarding(_ThreadHarness):
+    def test_agent_dir_forwarded(self):
+        _, ca_kwargs = self._build(agent_dir="/host/thread/agent")
+        assert ca_kwargs["agent_dir"] == "/host/thread/agent"
+
     def test_spec_forwarded_to_create_agent(self):
         spec = AgentSpec(tools=(_tool_a,))
         _, ca_kwargs = self._build(spec=spec)

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -64,6 +64,14 @@ class TestDockerSandboxBackend(TestCase):
         self.assertEqual(ref._resolve("/references/tmp/x"), "/workspace/references/tmp/x")
         self.assertEqual(ref._resolve("/tmp/x"), "/tmp/x")
 
+    def test_agent_passthrough_requires_explicit_capability(self):
+        self.assertEqual(self.sandbox._resolve("/agent/memory.md"),
+                         "/workspace/agent/memory.md")
+        mounted = DockerSandboxBackend(self.container, native_agent_dir=True)
+        self.assertEqual(mounted._resolve("/agent"), "/agent")
+        self.assertEqual(mounted._resolve("/agent/memory.md"), "/agent/memory.md")
+        self.assertEqual(mounted._resolve("/agentfoo"), "/workspace/agentfoo")
+
     def test_execute_success(self):
         self.container.exec_run.return_value = (0, b"hello world\n")
         resp = self.sandbox.execute("echo hello world")
@@ -464,6 +472,30 @@ class TestSandboxManager(TestCase):
                          "Expected exactly one assist-sandbox containers.run call")
         # Verify container is registered
         self.assertIn(test_path, SandboxManager._containers)
+
+    @patch('assist.sandbox.DockerSandboxBackend')
+    def test_agent_dir_is_created_mounted_and_enables_native_paths(self,
+                                                                  mock_backend_cls):
+        test_path = os.path.join(self.temp_dir, "thread", "domain")
+        agent_dir = os.path.join(self.temp_dir, "thread", "agent")
+        os.makedirs(test_path)
+        mock_client = MagicMock()
+        mock_container = MagicMock()
+        mock_container.id = "test123456ab"
+        mock_container.logs.return_value = b"egress-proxy: listening on 0.0.0.0:8888\n"
+        mock_client.containers.run.return_value = mock_container
+
+        with patch.object(SandboxManager, '_get_docker_client', return_value=mock_client):
+            SandboxManager.get_sandbox_backend(test_path, agent_dir=agent_dir)
+
+        sandbox_call = next(
+            c for c in mock_client.containers.run.call_args_list
+            if c.args and c.args[0] == "assist-sandbox")
+        self.assertEqual(sandbox_call.kwargs["volumes"][agent_dir],
+                         {"bind": "/agent", "mode": "rw"})
+        self.assertTrue(os.path.isdir(agent_dir))
+        mock_backend_cls.assert_called_once_with(
+            mock_container, native_agent_dir=True)
 
     @patch('assist.sandbox.DockerSandboxBackend')
     def test_get_sandbox_backend_passes_host_uid(self, mock_backend_cls):

--- a/tests/test_sandbox_egress_integration.py
+++ b/tests/test_sandbox_egress_integration.py
@@ -20,6 +20,7 @@ Docker is genuinely missing, setUpClass fails loudly with a real
 error — that's better than a silent skip that masks the regression.
 """
 import shutil
+import os
 import tempfile
 import unittest
 
@@ -138,3 +139,35 @@ class TestSandboxEgressEndToEnd(unittest.TestCase):
             f"Direct-IP curl unexpectedly reached upstream: "
             f"exit={resp.exit_code}, output={resp.output!r}",
         )
+
+
+class TestThreadMemorySandboxContainment(unittest.TestCase):
+    """A child container cannot read the parent's private bind mount."""
+
+    def test_parent_file_and_shell_access_child_has_neither(self):
+        thread_dir = tempfile.mkdtemp(prefix="agent-memory-e2e-")
+        work_dir = os.path.join(thread_dir, "domain")
+        agent_dir = os.path.join(thread_dir, "agent")
+        os.makedirs(work_dir)
+        os.makedirs(agent_dir)
+        with open(os.path.join(agent_dir, "memory.md"), "w") as stream:
+            stream.write("private-parent-canary")
+        try:
+            parent = SandboxManager.get_sandbox_backend(
+                work_dir, agent_dir=agent_dir)
+            parent_read = parent.read("/agent/memory.md")
+            self.assertIsNone(parent_read.error)
+            self.assertIn("private-parent-canary", parent_read.file_data["content"])
+            self.assertEqual(
+                parent.execute("grep -q private-parent-canary /agent/memory.md").exit_code,
+                0)
+            SandboxManager.cleanup(work_dir)
+
+            child = SandboxManager.get_sandbox_backend(work_dir)
+            child_read = child.read("/agent/memory.md")
+            child_content = ((child_read.file_data or {}).get("content") or "")
+            self.assertNotIn("private-parent-canary", child_content)
+            self.assertEqual(child.execute("test ! -e /agent/memory.md").exit_code, 0)
+        finally:
+            SandboxManager.cleanup(work_dir)
+            shutil.rmtree(thread_dir, ignore_errors=True)

--- a/tests/test_thread_manager_hard_delete.py
+++ b/tests/test_thread_manager_hard_delete.py
@@ -83,6 +83,10 @@ class TestHardDeleteRemovesAllThree(TestCase):
             try:
                 tid = "20260504000000-aaaaaaaa"
                 tdir = _seed_thread(mgr, tid)
+                agent_dir = mgr.thread_agent_dir(tid)
+                os.makedirs(agent_dir)
+                with open(os.path.join(agent_dir, "memory.md"), "w") as stream:
+                    stream.write("private state")
                 expected_workdir = mgr.thread_default_working_dir(tid)
 
                 self.assertTrue(os.path.isdir(tdir))
@@ -95,6 +99,7 @@ class TestHardDeleteRemovesAllThree(TestCase):
 
                 mock_cleanup.assert_called_once_with(expected_workdir)
                 self.assertFalse(os.path.exists(tdir))
+                self.assertFalse(os.path.exists(agent_dir))
                 self.assertEqual(_count_rows(mgr, "checkpoints", tid), 0)
                 self.assertEqual(_count_rows(mgr, "writes", tid), 0)
             finally:

--- a/tests/test_thread_manager_lazy.py
+++ b/tests/test_thread_manager_lazy.py
@@ -25,6 +25,45 @@ from assist.thread_manager import ThreadManager
 
 
 class TestThreadManagerLazy(TestCase):
+    def test_thread_agent_dir_is_a_sibling_of_workspace_and_isolated_by_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manager = ThreadManager(root_dir=tmp)
+            try:
+                assert manager.thread_agent_dir("one") == os.path.join(tmp, "one", "agent")
+                assert manager.thread_agent_dir("two") == os.path.join(tmp, "two", "agent")
+                assert manager.thread_agent_dir("one") != manager.thread_agent_dir("two")
+            finally:
+                manager.close()
+
+    def test_visible_main_get_receives_agent_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manager = ThreadManager(root_dir=tmp)
+            manager.reserve("visible")
+            manager._model = MagicMock()
+            try:
+                with patch("assist.thread_manager.Thread", return_value=MagicMock()) as thread:
+                    manager.get("visible")
+                assert thread.call_args.kwargs["agent_dir"] == manager.thread_agent_dir(
+                    "visible")
+                assert os.path.isdir(manager.thread_agent_dir("visible"))
+            finally:
+                manager.close()
+
+    def test_specialized_child_get_does_not_receive_agent_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manager = ThreadManager(root_dir=tmp)
+            manager.reserve("child", hidden={"parent_thread_id": "visible"})
+            manager._model = MagicMock()
+            try:
+                with patch("assist.thread_manager.create_context_agent",
+                           return_value=MagicMock()), \
+                     patch("assist.thread_manager.Thread", return_value=MagicMock()) as thread:
+                    manager.get("child", working_dir=os.path.join(tmp, "visible", "domain"),
+                                assistant_id="context-agent")
+                assert "agent_dir" not in thread.call_args.kwargs
+            finally:
+                manager.close()
+
     def test_init_does_not_call_select_assistant_model(self):
         """Constructing a ``ThreadManager`` must not touch the model."""
         with patch(
@@ -101,3 +140,4 @@ class TestThreadManagerLazy(TestCase):
         self.assertEqual(spec.tools, ())
         self.assertEqual(dict(spec.skill_sources), {})
         self.assertIsNone(spec.interrupt_on)
+        self.assertNotIn("agent_dir", thread.call_args.kwargs)


### PR DESCRIPTION
## Summary

- Give each visible thread an agent-owned `<thread-dir>/agent` directory, exposed read-write to its main agent at `/agent` and deleted with the thread.
- Auto-load `/agent/memory.md` beside unchanged repository memory, with short guidance that separates cross-thread facts from the current thread's goal, processes, decisions, corrections, progress, blockers, and useful working notes.
- Keep delegates and specialized children outside the private route/mount and prompt; their parent remains responsible for a self-contained brief.
- Preserve the existing one-source memory construction for other embedders. Scheduled turns need no special machinery because they reuse ordinary main-agent construction.

The earlier schedule, retry, promotion, queue, collision, triage, and path-enforcement machinery was removed during the simplicity-first redesign. Final runtime diff: +151/-59 lines across eight files, including prompt text and docstrings.

## Added and updated evals

### Required: `edd/eval/test_thread_memory.py::TestThreadMemory::test_infers_repo_and_thread_scope`

This natural behavior eval is unchanged by the review update. One ordinary user message combines two differently scoped instructions without naming either storage file:

> Across all conversations, use my label atlas-grid for compact tables. For this thread's application workflow, use the stage name candidate-replied after I answer.

It passes only when all four observable outcomes hold:

1. repository `AGENTS.md` contains the durable `atlas-grid` label;
2. repository memory does not contain `candidate-replied`;
3. thread `/agent/memory.md` contains `candidate-replied`;
4. thread memory does not contain `atlas-grid`.

The exact canaries make paraphrased cross-scope leakage impossible to miss while leaving the agent to infer the intended scope naturally.

The strengthened eval initially passed 2/3: one trial copied the thread workflow stage into repository memory. A two-sentence prompt correction tells the model never to put current-thread state in repository memory and to update the two files separately for mixed-scope messages. Final results on that behavior are N=3: 3/3, N=5: 5/5, and N=10: 10/10.

### Aspirational: `edd/eval/test_thread_memory.py::TestThreadMemory::test_natural_process_prompt_writes_thread_memory`

Pierre's review added a second, more conversational case:

> We'll use this thread to manage my todo list. The process is: new items start in inbox, move to doing when I begin, and move to done only after I confirm completion.

It intentionally asserts only that the message produces a non-empty thread-memory write. Its name and docstring state that it is aspirational, does not verify full process capture, and does not gate this storage/lifecycle feature. Reliable natural process capture belongs to the prompt-rearchitecture follow-up.

Observed behavior was inconsistent. Descriptive `processes` guidance alone often created a todo artifact or used `write_todos` instead of saving memory. The strongest experimental enforcement passed N=3 (3/3), then failed N=5 on trial 3 after two passes. N=10 was not run. The enforcement was removed rather than accumulated; the natural eval and the short `processes` scope guidance remain.

Superseded experimental schedule/promotion/retry evals were removed from the branch during simplification rather than retained as feature contract.

## Verification

- `pytest -q tests/`: 1,478 passed, 2 skipped, 2 subtests passed
- focused memory middleware tests: 10 passed
- focused post-prompt suite from the initial implementation: 140 passed
- `python -m compileall`: passed for the review-touched Python files
- `git diff --check`: passed
- mypy: unavailable in the deploy environment
- reviewed commit `c4f4945`: deployed; service restarted cleanly; HTTPS root smoke passed

## Local review

The initial simplicity-first review converged in two rounds. The full correctness, concurrency/liveness, error/edge, adversarial-security, simplicity, design-adherence, and docstring/comment-alignment loop then converged after fixing constructor containment leaks, stale construction/lifecycle docs, and the original eval's paraphrase blind spot.

Pierre's review update received another full seven-lens round plus a targeted correctness/doc-alignment convergence round. It removed the experimental prompt enforcement, clarified the aspirational eval's exact weak contract, and corrected the production diff count. Remaining reviewer objections were rejected because they contradicted explicit review requirements: remove `processes`, or strengthen the aspirational assertion beyond “something was written.”
