### PR TITLE
Add voice call session integration

### DIFF
--- a/docs/2026-07-23-voice-p1.org
+++ b/docs/2026-07-23-voice-p1.org
@@ -13,10 +13,12 @@ records the build plan grounded in the real code, the reconciliations, and statu
 - P0.5 (=catalog.py= + =receptionist.py= + eval N=10=80/80) — DONE, merged, deployed.
 - *P1 (this doc)* — the voice client: a new =manage/voice/= package, validated entirely
   against a FAKE BRIDGE (no phone hardware; that is P3). All in assist.
-- *Current implementation status (2026-07-26):* P1 PR1–PR3 are merged and deployed:
-  Flow, Speech, and the bounded =/call= Wire transport exist. They are foundations,
-  not yet an end-to-end call: production deliberately has no configured session runner.
-  *NEXT is PR4 =session.py=*, then the PR5 security/reconstruction gate.
+- *Current implementation status (2026-07-27):* P1 PR1–PR3 are merged and deployed.
+  This branch adds PR4's fake-bridge =session.py= integration: Flow, Speech, Wire,
+  the receptionist, durable Runs, and terminal observer delivery now form one
+  call-local state machine. Production still deliberately has no configured session
+  runner: PR5 must first supply the complete PIN/caller policy and scripted security
+  reconstruction.
 
 * Threading model (blocker-class — single-worker uvicorn)
 | Thread | Owns | May NOT |
@@ -54,8 +56,9 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
    protocol (§2) + §8 resource caps, echo-level.
    *DONE (PR #214; merged + deployed 2026-07-26).*
 4. *PR4 — =session.py=* — the state machine + call-event log + conversational contract,
-   tying flow/speech/wire together, driving the shared Run service (the big one; full
-   three-phase rigor — touches the queue/observer/hot path). *← NEXT.*
+   tying Flow/Speech/Wire together, driving the shared Run service. The fake bridge
+   covers the whole seam; production activation remains in PR5 because the security
+   policy is not partial. *Implemented on this branch.*
 5. *PR5 — security + full scripted-call reconstruction* (global PIN lockout,
    detector-scoping spies, caller-id handling) — or folded into PR4 if reviewable.
 
@@ -72,8 +75,8 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
    =backlog_id=-based double-speak distinction while preserving exactly-once delivery.
 3. *=on_new= "wraps create_thread_with_message" (design) → that is a FastAPI route*
    (=Form=/=BackgroundTasks=). Extract a plain
-   =create_thread_with_message_core(text, domain, rider) -> tid= from its body
-   plus =_initialize_thread=; route becomes a thin Form adapter over it.
+   =create_thread_with_message_core(text, domain, rider) -> (tid, run_id, domain)=
+   from its body plus =_initialize_thread=; route becomes a thin Form adapter over it.
 4. *Receptionist signature: =receptionist_tools(catalog, domains, on_open, on_new)=*
    (shipped in =receptionist.py=) — pass =DOMAINS= from =state.py=.
 5. *VAD dep: use =onnxruntime= + the silero ONNX model, NOT the =silero-vad= pip package.*
@@ -125,7 +128,7 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
   stalled in-flight send may prevent delivery but is cancelled after the 2 s grace.
 - After the first valid =ring=, the route invokes one synchronous call-runner seam
   with the decoded ring plus the two buffers. Tests inject an echo runner; production
-  has no session runner until PR4 and therefore closes without inventing answer or
+  has no session runner until PR5 and therefore closes without inventing answer or
   call-state policy. On an abrupt exit both buffers close first; that is the runner's
   termination contract. The route retains the sole call slot until the runner returns,
   then releases it before exposing the terminal network close, so old and new session
@@ -186,7 +189,12 @@ Dependency-ordered; each new dep enters the smallest PR that needs it.
       PR #214 merged with green CI after five Copilot rounds ending clean with all
       threads resolved. Validation after the PR #215 integration fix: 35 focused
       wire tests and 1,438 deterministic tests.
-- [ ] PR4: =session.py= state machine/integration — NEXT.
+- [X] PR4: =session.py= state machine/integration — fake-bridge implementation on
+      this branch: allowlisted answer, PIN-only pre-auth Flow, serialized per-call
+      TTS with generation invalidation, receptionist handoff, ordinary durable Runs,
+      terminal-observer-only reply delivery, call log, and prompt teardown.
+      Production runner configuration remains intentionally absent pending PR5's
+      global lockout, normalized caller policy, and reconstruction tests.
 - [ ] PR5: security + scripted-call reconstruction (or fold into PR4 only if reviewable).
 
 * Notes for Pierre

--- a/manage/voice/__init__.py
+++ b/manage/voice/__init__.py
@@ -3,7 +3,8 @@ run service + turn-observer seam and the receptionist (P0.5). See
 docs/2026-07-23-voice-p1.org for the build plan and threading model.
 
 P1 includes ``flow.py`` (the hermetic frame-in/event-out engine), ``speech.py``
-(lazy in-process STT/TTS), and ``wire.py`` (the bounded WSS /call transport,
-the only asyncio-loop code and a pure frame shuttle). The remaining work adds
-session policy and the final security/reconstruction gate.
+(lazy in-process STT/TTS), ``wire.py`` (the bounded WSS /call transport, the
+only asyncio-loop code and a pure frame shuttle), and ``session.py`` (the
+fake-bridge call state machine). Production runner configuration remains for
+the final security/reconstruction gate.
 """

--- a/manage/voice/session.py
+++ b/manage/voice/session.py
@@ -1,0 +1,460 @@
+"""The synchronous per-call voice session.
+
+Wire owns the WebSocket and buffers; this module owns call-local state and
+never runs on the asyncio event loop.  The production runner remains disabled
+until PR5 supplies its complete authentication policy.  Tests construct a
+session with an explicit PIN and allowlist and install it through wire's runner
+seam.
+"""
+from __future__ import annotations
+
+import queue
+import secrets
+import threading
+import time
+from hashlib import sha256
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from assist.events.thread_log import append_event
+from manage.voice.flow import BargeIn, Dtmf, Flow, FRAME_BYTES, Utterance
+from manage.voice.speech import Speech, Transcription
+from manage.voice.wire import BufferClosed, CallBuffers
+
+
+_PIN_PROMPT = "Please enter your PIN."
+_AUTH_OK = "You're in. One second."
+_THINKING = "Let me check."
+_REPEAT = "Sorry, say that again."
+_STILL_WORKING = "Still with me? I'm working on it."
+SILENCE_SECONDS = 7.0
+PIN_INTERDIGIT_SECONDS = 5.0
+
+
+@dataclass(frozen=True)
+class _Reply:
+    tid: str
+    stage: str
+    text: str | None
+    run_id: str
+
+
+class _CallLog:
+    """Best-effort call boundary history that never uses bridge input as a path."""
+
+    def __init__(self, root: str | Path | None, call_id: str) -> None:
+        self._directory: str | None = None
+        if root is not None:
+            safe_id = sha256(call_id.encode()).hexdigest()
+            directory = Path(root) / "calls" / safe_id
+            directory.mkdir(parents=True, exist_ok=True)
+            self._directory = str(directory)
+
+    def append(self, kind: str, **fields: Any) -> None:
+        if self._directory is not None:
+            append_event(self._directory, kind, **fields)
+
+
+class _ReplyRegistry:
+    """Routes completed durable Runs to their one live call session."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._by_run: dict[str, tuple[str, queue.SimpleQueue]] = {}
+
+    def attach(self, tid: str, run_id: str, events: queue.SimpleQueue) -> None:
+        with self._lock:
+            self._by_run[run_id] = (tid, events)
+
+    def detach(self, events: queue.SimpleQueue) -> None:
+        with self._lock:
+            self._by_run = {
+                run_id: binding
+                for run_id, binding in self._by_run.items()
+                if binding[1] is not events
+            }
+
+    def deliver(
+        self, tid: str, stage: str, _origin: str | None,
+        text: str | None, run_id: str | None,
+    ) -> None:
+        if not run_id:
+            return
+        with self._lock:
+            binding = self._by_run.pop(run_id, None)
+        if binding is not None and binding[0] == tid:
+            binding[1].put(_Reply(tid, stage, text, run_id))
+
+
+_REPLIES = _ReplyRegistry()
+_observer_lock = threading.Lock()
+_observer_installed = False
+
+
+def _install_observer() -> None:
+    """Install the one process-lifetime observer used by every voice session."""
+    global _observer_installed
+    with _observer_lock:
+        if _observer_installed:
+            return
+        from manage.web.threads import register_turn_observer
+
+        register_turn_observer(_REPLIES.deliver)
+        _observer_installed = True
+
+
+def _frames(pcm: bytes):
+    for offset in range(0, len(pcm) - FRAME_BYTES + 1, FRAME_BYTES):
+        yield pcm[offset:offset + FRAME_BYTES]
+
+
+class VoiceSession:
+    """One fake-bridge voice call, with audio and Run delivery serialized here."""
+
+    def __init__(
+        self,
+        *,
+        pin: str,
+        allowed_callers: frozenset[str],
+        speech: Speech,
+        flow_factory: Callable[..., Flow] = Flow,
+        router_turn: Callable[[str], str] | None = None,
+        submit_turn: Callable[[str, str], str] | None = None,
+        call_log_root: str | Path | None = None,
+    ) -> None:
+        self._pin = pin
+        self._allowed_callers = allowed_callers
+        self._speech = speech
+        self._flow_factory = flow_factory
+        self._router_turn = router_turn or self._default_router_turn
+        self._submit_turn = submit_turn or self._default_submit_turn
+        self._events: queue.SimpleQueue = queue.SimpleQueue()
+        self._flow: Flow | None = None
+        self._authenticated = False
+        self._answered = False
+        self._digits = ""
+        self._stopped = threading.Event()
+        self._tid: str | None = None
+        self._call_log_root = call_log_root
+        self._log: _CallLog | None = None
+        self._router: Any | None = None
+        self._speaking = False
+        self._thinking = False
+        self._last_audio = time.monotonic()
+        self._last_digit_at: float | None = None
+        self._tts_condition = threading.Condition()
+        self._pending_tts: tuple[int, str] | None = None
+        self._tts_thread: threading.Thread | None = None
+        self._router_running = False
+        self._pending_router_text: str | None = None
+        self._default_submit = submit_turn is None
+
+    def run(self, ring: dict[str, Any], buffers: CallBuffers) -> None:
+        """Run until the bridge hangs up.  This is wire's synchronous runner."""
+        _install_observer()
+        log = _CallLog(self._call_log_root, ring["call_id"])
+        self._log = log
+        try:
+            if ring["caller"] not in self._allowed_callers:
+                log.append("decline", reason="not_allowed")
+                return
+            log.append("ring")
+            buffers.outbound.put_control({"type": "answer"})
+            self._start_tts_producer(buffers)
+            while not self._stopped.is_set():
+                self._drain_events(buffers)
+                try:
+                    item = buffers.inbound.get(timeout=0.05)
+                except TimeoutError:
+                    self._check_pin_timeout(buffers)
+                    self._speak_if_silent(buffers)
+                    continue
+                except BufferClosed:
+                    return
+                if isinstance(item, bytes):
+                    self._handle_pcm(item, buffers)
+                else:
+                    if self._handle_control(item, ring, buffers):
+                        log.append("hangup", by="bridge")
+                        return
+        finally:
+            self._stopped.set()
+            with self._tts_condition:
+                self._pending_tts = None
+                self._tts_condition.notify_all()
+            _REPLIES.detach(self._events)
+            if self._answered:
+                buffers.outbound.close_with_final({"type": "hangup"})
+            else:
+                buffers.outbound.finish()
+
+    def open_thread(self, tid: str) -> None:
+        """Queue a receptionist handoff; safe to call from its model worker."""
+        if self._stopped.is_set():
+            return
+        self._events.put(("open", tid))
+
+    def new_thread(self, domain: str, first_message: str) -> None:
+        """Create and bind a thread from a receptionist worker."""
+        if self._stopped.is_set():
+            return
+        from manage.web.threads import (
+            _initialize_thread, create_thread_with_message_core,
+        )
+
+        tid, run_id, selected = create_thread_with_message_core(
+            first_message, domain)
+        _REPLIES.attach(tid, run_id, self._events)
+        self.open_thread(tid)
+        threading.Thread(
+            target=_initialize_thread, args=(tid, run_id, selected), daemon=True,
+        ).start()
+
+    def _default_router_turn(self, text: str) -> str:
+        from assist.catalog import ThreadCatalog
+        from assist.receptionist import create_receptionist, receptionist_tools
+        from manage.web.state import DOMAINS, MANAGER
+
+        if self._router is None:
+            self._router = create_receptionist(
+                receptionist_tools(ThreadCatalog(MANAGER), DOMAINS,
+                                  self.open_thread, self.new_thread),
+                DOMAINS,
+            )
+        result = self._router.invoke(
+            {"messages": [{"role": "user", "content": text}]})
+        message = result["messages"][-1]
+        return message.content if isinstance(message.content, str) else ""
+
+    def _default_submit_turn(self, tid: str, text: str) -> str:
+        from manage.web.threads import _create_run, _execute_run
+
+        run = _create_run(tid, text)
+        _REPLIES.attach(tid, run.id, self._events)
+        threading.Thread(
+            target=_execute_run, args=(run.id, tid), daemon=True,
+        ).start()
+        return run.id
+
+    def _handle_control(
+        self, control: dict[str, Any], ring: dict[str, Any], buffers: CallBuffers
+    ) -> bool:
+        kind = control["type"]
+        if kind == "call_end":
+            return True
+        if not self._answered:
+            if kind == "answered" and control["call_id"] == ring["call_id"]:
+                self._answered = True
+                self._flow = self._flow_factory(vad=False)
+                if self._log is not None:
+                    self._log.append("answered")
+                self._prompt_for_pin(buffers)
+            return False
+        if kind == "dtmf" and control["digit"] in "0123456789*":
+            self._handle_digit(control["digit"], buffers)
+        return False
+
+    def _handle_pcm(self, frame: bytes, buffers: CallBuffers) -> None:
+        if not self._answered or self._flow is None:
+            return
+        for event in self._flow.feed(frame):
+            if isinstance(event, Dtmf):
+                self._handle_digit(event.digit, buffers)
+            elif isinstance(event, BargeIn):
+                buffers.outbound.interrupt_audio()
+                self._flow.set_speaking(False)
+                self._speaking = False
+                if self._log is not None:
+                    self._log.append("barge_in", at_ms=event.at_ms)
+            elif isinstance(event, Utterance) and self._authenticated:
+                self._transcribe(event.pcm)
+
+    def _handle_digit(self, digit: str, buffers: CallBuffers) -> None:
+        if self._authenticated:
+            return
+        if digit == "*":
+            self._digits = ""
+            self._last_digit_at = None
+            self._prompt_for_pin(buffers)
+            return
+        self._last_digit_at = time.monotonic()
+        self._digits += digit
+        if len(self._digits) < len(self._pin):
+            return
+        accepted = secrets.compare_digest(self._digits, self._pin)
+        self._digits = ""
+        self._last_digit_at = None
+        if self._log is not None:
+            self._log.append("pin_attempt", ok=accepted)
+        if not accepted:
+            self._prompt_for_pin(buffers)
+            return
+        self._authenticated = True
+        if self._log is not None:
+            self._log.append("auth_ok")
+        self._flow = self._flow_factory()
+        self._speak(_AUTH_OK, buffers)
+        self._route("Orient the caller and ask what they need.")
+
+    def _transcribe(self, pcm: bytes) -> None:
+        try:
+            self._events.put(self._speech.transcribe(pcm))
+        except Exception:
+            self._events.put(("stt_failed",))
+
+    def _route(self, text: str) -> None:
+        self._thinking = True
+        if self._router_running:
+            self._pending_router_text = text
+            return
+        self._router_running = True
+        if self._log is not None:
+            self._log.append("router_enter")
+
+        def work() -> None:
+            try:
+                self._events.put(("router", self._router_turn(text)))
+            except Exception:
+                self._events.put(("router_error",))
+
+        threading.Thread(target=work, daemon=True).start()
+
+    def _drain_events(self, buffers: CallBuffers) -> None:
+        while True:
+            try:
+                event = self._events.get_nowait()
+            except queue.Empty:
+                return
+            if isinstance(event, _Reply):
+                if self._log is not None:
+                    self._log.append(
+                        "turn_done", tid=event.tid, stage=event.stage,
+                        run_id=event.run_id,
+                    )
+                if event.stage == "ready" and event.text:
+                    self._thinking = False
+                    self._speak(event.text, buffers)
+                elif event.stage != "ready":
+                    self._thinking = False
+                    self._speak("Sorry, that didn't work.", buffers)
+            elif isinstance(event, Transcription):
+                if self._log is not None:
+                    self._log.append(
+                        "stt", chars=len(event.text),
+                        no_speech_prob=event.no_speech_prob,
+                    )
+                if not event.text or (event.no_speech_prob or 0) > 0.6:
+                    if self._log is not None:
+                        self._log.append("noise_discard")
+                    self._speak(_REPEAT, buffers)
+                elif self._tid is None:
+                    self._route(event.text)
+                else:
+                    self._speak(_THINKING, buffers)
+                    self._thinking = True
+                    run_id = self._submit_turn(self._tid, event.text)
+                    if not self._default_submit:
+                        _REPLIES.attach(self._tid, run_id, self._events)
+                    if self._log is not None:
+                        self._log.append("turn_submit", tid=self._tid)
+            elif isinstance(event, tuple) and event[0] == "router":
+                self._router_running = False
+                self._thinking = False
+                if self._log is not None:
+                    self._log.append("router_return")
+                self._speak(event[1], buffers)
+                self._start_pending_router()
+            elif isinstance(event, tuple) and event[0] == "router_error":
+                self._router_running = False
+                self._thinking = False
+                if self._log is not None:
+                    self._log.append("router_error")
+                self._speak("Sorry, I couldn't do that.", buffers)
+                self._start_pending_router()
+            elif isinstance(event, tuple) and event[0] == "open":
+                self._tid = event[1]
+                if self._log is not None:
+                    self._log.append("handoff", tid=self._tid)
+            elif isinstance(event, tuple) and event[0] == "tts_done":
+                if self._flow and buffers.outbound.is_current_generation(event[1]):
+                    self._flow.set_speaking(False)
+                    self._speaking = False
+            elif isinstance(event, tuple) and event[0] == "tts_failed":
+                if self._flow and buffers.outbound.is_current_generation(event[1]):
+                    self._flow.set_speaking(False)
+                    self._speaking = False
+            elif isinstance(event, tuple) and event[0] == "stt_failed":
+                self._speak(_REPEAT, buffers)
+
+    def _speak(self, text: str, buffers: CallBuffers) -> None:
+        if not text or self._stopped.is_set():
+            return
+        if self._speaking:
+            buffers.outbound.interrupt_audio()
+        if self._flow is not None:
+            self._flow.set_speaking(True)
+        self._speaking = True
+        self._last_audio = time.monotonic()
+        generation = buffers.outbound.start_generation()
+        if self._log is not None:
+            self._log.append("tts", chars=len(text))
+        with self._tts_condition:
+            self._pending_tts = (generation, text)
+            self._tts_condition.notify()
+
+    def _start_tts_producer(self, buffers: CallBuffers) -> None:
+        """Start the one producer that serializes this call's Piper work."""
+        if self._tts_thread is not None:
+            return
+
+        def produce() -> None:
+            while not self._stopped.is_set():
+                with self._tts_condition:
+                    while self._pending_tts is None and not self._stopped.is_set():
+                        self._tts_condition.wait()
+                    if self._stopped.is_set():
+                        return
+                    generation, text = self._pending_tts
+                    self._pending_tts = None
+                try:
+                    for chunk in self._speech.synthesize(text):
+                        for frame in _frames(chunk):
+                            if self._stopped.is_set() or not buffers.outbound.put_audio(
+                                    generation, frame):
+                                break
+                        else:
+                            continue
+                        break
+                    else:
+                        self._events.put(("tts_done", generation))
+                except Exception:
+                    self._events.put(("tts_failed", generation))
+
+        self._tts_thread = threading.Thread(target=produce, daemon=True)
+        self._tts_thread.start()
+
+    def _prompt_for_pin(self, buffers: CallBuffers) -> None:
+        if self._log is not None:
+            self._log.append("pin_prompt")
+        self._speak(_PIN_PROMPT, buffers)
+
+    def _check_pin_timeout(self, buffers: CallBuffers) -> None:
+        if self._authenticated or self._last_digit_at is None:
+            return
+        if time.monotonic() - self._last_digit_at >= PIN_INTERDIGIT_SECONDS:
+            self._digits = ""
+            self._last_digit_at = None
+            self._prompt_for_pin(buffers)
+
+    def _start_pending_router(self) -> None:
+        if self._pending_router_text is None:
+            return
+        text = self._pending_router_text
+        self._pending_router_text = None
+        self._route(text)
+
+    def _speak_if_silent(self, buffers: CallBuffers) -> None:
+        if self._thinking and time.monotonic() - self._last_audio >= SILENCE_SECONDS:
+            self._speak(_STILL_WORKING, buffers)

--- a/manage/voice/session.py
+++ b/manage/voice/session.py
@@ -49,7 +49,10 @@ class _CallLog:
         if root is not None:
             safe_id = sha256(call_id.encode()).hexdigest()
             directory = Path(root) / "calls" / safe_id
-            directory.mkdir(parents=True, exist_ok=True)
+            try:
+                directory.mkdir(parents=True, exist_ok=True)
+            except OSError:
+                return
             self._directory = str(directory)
 
     def append(self, kind: str, **fields: Any) -> None:

--- a/manage/voice/session.py
+++ b/manage/voice/session.py
@@ -13,7 +13,7 @@ import secrets
 import threading
 import time
 from hashlib import sha256
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -108,9 +108,22 @@ def _install_observer() -> None:
         _observer_installed = True
 
 
-def _frames(pcm: bytes):
-    for offset in range(0, len(pcm) - FRAME_BYTES + 1, FRAME_BYTES):
-        yield pcm[offset:offset + FRAME_BYTES]
+def _frames(chunks: Iterable[bytes]) -> Iterator[bytes]:
+    """Join arbitrary Piper chunks into exact wire frames.
+
+    Piper's chunks do not necessarily align to the bridge's fixed PCM frame
+    size.  Preserve every sample across boundaries and pad only the final
+    partial frame with silence.
+    """
+    pending = bytearray()
+    for chunk in chunks:
+        pending.extend(chunk)
+        complete = len(pending) // FRAME_BYTES * FRAME_BYTES
+        for offset in range(0, complete, FRAME_BYTES):
+            yield bytes(pending[offset:offset + FRAME_BYTES])
+        del pending[:complete]
+    if pending:
+        yield bytes(pending).ljust(FRAME_BYTES, b"\0")
 
 
 class VoiceSession:
@@ -422,14 +435,10 @@ class VoiceSession:
                     generation, text = self._pending_tts
                     self._pending_tts = None
                 try:
-                    for chunk in self._speech.synthesize(text):
-                        for frame in _frames(chunk):
-                            if self._stopped.is_set() or not buffers.outbound.put_audio(
-                                    generation, frame):
-                                break
-                        else:
-                            continue
-                        break
+                    for frame in _frames(self._speech.synthesize(text)):
+                        if self._stopped.is_set() or not buffers.outbound.put_audio(
+                                generation, frame):
+                            break
                     else:
                         self._events.put(("tts_done", generation))
                 except Exception:

--- a/manage/voice/wire.py
+++ b/manage/voice/wire.py
@@ -1,9 +1,8 @@
 """Bounded WebSocket transport for the voice-call client.
 
 This module owns framing, transport authentication, backpressure, and teardown.
-Call state and policy will live in ``session.py``. This module exposes one
-synchronous runner seam for that later layer without importing the agent,
-speech, or flow layers.
+Call state and policy live in ``session.py``. This module exposes its synchronous
+runner seam without importing the agent, speech, or flow layers.
 """
 from __future__ import annotations
 
@@ -164,10 +163,17 @@ class _CloseableBuffer:
             self._items.append(item)
             self._condition.notify_all()
 
-    def get(self) -> Any:
+    def get(self, timeout: float | None = None) -> Any:
         with self._condition:
+            deadline = None if timeout is None else time.monotonic() + timeout
             while not self._items and not self._closed:
-                self._condition.wait()
+                if deadline is None:
+                    self._condition.wait()
+                    continue
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError
+                self._condition.wait(remaining)
             if not self._items:
                 raise BufferClosed
             item = self._items.popleft()
@@ -190,12 +196,80 @@ class InboundBuffer(_CloseableBuffer):
     def __init__(self) -> None:
         super().__init__(INBOUND_CAPACITY)
 
+    def close_with_final(self, final: dict[str, Any]) -> None:
+        """Discard stale PCM but leave one terminal control for the session."""
+        with self._condition:
+            if self._closed:
+                return
+            self._items.clear()
+            self._items.append(final)
+            self._closed = True
+            self._condition.notify_all()
+
 
 class OutboundBuffer(_CloseableBuffer):
     """Bounded session-to-phone buffer with graceful or abrupt teardown."""
 
     def __init__(self) -> None:
         super().__init__(OUTBOUND_CAPACITY)
+        self._generation = 0
+
+    def start_generation(self) -> int:
+        """Return the generation that may enqueue the next TTS reply."""
+        with self._condition:
+            if self._closed:
+                raise BufferClosed
+            self._generation += 1
+            return self._generation
+
+    def put_audio(self, generation: int, frame: bytes) -> bool:
+        """Enqueue one TTS frame while *generation* remains current.
+
+        False means a barge-in or teardown invalidated this producer.  Waiting
+        releases the same lock used by ``interrupt_audio``, so a full buffer
+        never delays the flush that stops the caller hearing stale speech.
+        """
+        with self._condition:
+            while (len(self._items) >= self._capacity and not self._closed
+                   and generation == self._generation):
+                self._condition.wait()
+            if self._closed or generation != self._generation:
+                return False
+            self._items.append((generation, frame))
+            self._condition.notify_all()
+            return True
+
+    def is_current_generation(self, generation: int) -> bool:
+        """Whether a producer still owns the current TTS generation."""
+        with self._condition:
+            return not self._closed and generation == self._generation
+
+    def put_control(self, control: dict[str, Any]) -> None:
+        """Put a server control ahead of queued audio without waiting."""
+        encode_server_control(control)
+        with self._condition:
+            if self._closed:
+                raise BufferClosed
+            self._items.appendleft(control)
+            self._condition.notify_all()
+
+    def interrupt_audio(self) -> None:
+        """Atomically reject old TTS, purge it, and tell the bridge to flush."""
+        with self._condition:
+            if self._closed:
+                return
+            self._generation += 1
+            self._items = deque(
+                item for item in self._items
+                if not isinstance(item, tuple)
+                and item != {"type": "flush_uplink"}
+            )
+            self._items.appendleft({"type": "flush_uplink"})
+            self._condition.notify_all()
+
+    def get(self, timeout: float | None = None) -> Any:
+        item = super().get(timeout)
+        return item[1] if isinstance(item, tuple) else item
 
     def abort(self) -> None:
         with self._condition:
@@ -309,6 +383,12 @@ async def _receive_loop(
             if control is None:
                 last_valid = time.monotonic()
                 continue
+            if control["type"] == "call_end":
+                # Hangup must not wait behind up to one second of already-buffered
+                # PCM.  Leave it as the session's one final item, then wait for the
+                # runner to close outbound with its terminal hangup control.
+                await run_in_threadpool(inbound.close_with_final, control)
+                await asyncio.Future()
             item: Any = control
         else:
             item = message.get("bytes")
@@ -452,8 +532,9 @@ async def call(websocket: WebSocket) -> None:
         close_code = 1011
     finally:
         await _close_buffers(buffers)
-        # _run_call joins its synchronous runner before returning. Release the
-        # slot before the terminal close tells the client it can reconnect.
+         # _run_call has already waited for the runner's closed-buffer exit. Release
+         # before the socket close handshake so a caller that observes that close can
+         # immediately reconnect instead of briefly receiving a false busy rejection.
         _release_call()
         if close_code is not None:
             await _close_websocket(websocket, close_code)

--- a/manage/voice/wire.py
+++ b/manage/voice/wire.py
@@ -245,11 +245,17 @@ class OutboundBuffer(_CloseableBuffer):
             return not self._closed and generation == self._generation
 
     def put_control(self, control: dict[str, Any]) -> None:
-        """Put a server control ahead of queued audio without waiting."""
+        """Put a server control ahead of queued audio without waiting.
+
+        A control must be deliverable even while TTS has filled the buffer, so
+        discard the tail entry rather than exceeding the fixed capacity.
+        """
         encode_server_control(control)
         with self._condition:
             if self._closed:
                 raise BufferClosed
+            if len(self._items) >= self._capacity:
+                self._items.pop()
             self._items.appendleft(control)
             self._condition.notify_all()
 
@@ -264,6 +270,8 @@ class OutboundBuffer(_CloseableBuffer):
                 if not isinstance(item, tuple)
                 and item != {"type": "flush_uplink"}
             )
+            if len(self._items) >= self._capacity:
+                self._items.pop()
             self._items.appendleft({"type": "flush_uplink"})
             self._condition.notify_all()
 
@@ -532,9 +540,9 @@ async def call(websocket: WebSocket) -> None:
         close_code = 1011
     finally:
         await _close_buffers(buffers)
-         # _run_call has already waited for the runner's closed-buffer exit. Release
-         # before the socket close handshake so a caller that observes that close can
-         # immediately reconnect instead of briefly receiving a false busy rejection.
+        # _run_call has already waited for the runner's closed-buffer exit. Release
+        # before the socket close handshake so a caller that observes that close can
+        # immediately reconnect instead of briefly receiving a false busy rejection.
         _release_call()
         if close_code is not None:
             await _close_websocket(websocket, close_code)

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -1145,15 +1145,18 @@ def render_thread(
     """
 
 
-def _initialize_thread(tid: str, text: str, domain: str | None,
-                       rider: ContextRider | None = None) -> None:
+def _initialize_thread(
+    tid: str, run_id: str, domain: str | None,
+    rider: ContextRider | None = None,
+) -> None:
     """Background task: clone the repo, start sandbox, process the first message."""
     try:
         if domain:
             # Carry started_at through the cloning write (_set_status is a full replace):
             # otherwise a domain thread's elapsed baseline resets at clone-completion,
             # excluding the clone+init the user has been waiting through since submit.
-            _set_status(tid, "cloning", pending_message=text, domain=domain,
+            pending = _runs().get(tid, run_id).text or ""
+            _set_status(tid, "cloning", pending_message=pending, domain=domain,
                         started_at=_get_status(tid).get("started_at"))
             try:
                 dm = DomainManager(
@@ -1165,13 +1168,18 @@ def _initialize_thread(tid: str, text: str, domain: str | None,
                 DOMAIN_MANAGERS[tid] = dm
             except Exception as e:
                 logging.error("Clone failed for thread %s: %s", tid, e, exc_info=True)
-                _set_status(tid, "error", error=f"Clone failed: {e}", pending_message=text)
+                _runs().transition(tid, run_id, "error", error=str(e))
+                _set_status(tid, "error", error=f"Clone failed: {e}", pending_message=pending)
                 return
-        run = _create_run(tid, text, rider=rider)
-        _execute_run(run.id, tid)
+        _execute_run(run_id, tid)
     except Exception as e:
         logging.error("Initialization failed for thread %s: %s", tid, e, exc_info=True)
-        _set_status(tid, "error", error=str(e), pending_message=text)
+        try:
+            pending = _runs().get(tid, run_id).text or ""
+            _runs().transition(tid, run_id, "error", error=str(e))
+        except Exception:
+            pending = ""
+        _set_status(tid, "error", error=str(e), pending_message=pending)
 
 
 _SUPERSEDE_RIDER = (
@@ -2356,15 +2364,27 @@ async def create_thread_with_message(
     sent_at: str | None = Form(None), tz: str | None = Form(None),
     lat: str | None = Form(None), lon: str | None = Form(None),
 ):
-    # Reserve the thread directory synchronously so the redirect target is valid,
-    # but defer everything slow (clone, sandbox, agent, description) to the background.
-    tid = await run_in_threadpool(MANAGER.reserve)
+    rider = _build_rider(sent_at, tz, lat, lon)
+    tid, run_id, selected = await run_in_threadpool(
+        create_thread_with_message_core,
+        text, domain, rider,
+    )
+    background_tasks.add_task(
+        _initialize_thread, tid, run_id, selected, rider,
+    )
+    return RedirectResponse(url=f"/thread/{tid}", status_code=303)
+
+
+def create_thread_with_message_core(
+    text: str, domain: str | None, rider: ContextRider | None = None,
+) -> tuple[str, str, str | None]:
+    """Persist a new thread's first Run before its slow initialization starts."""
+    tid = MANAGER.reserve()
     selected = domain or (DOMAINS[0] if DOMAINS else None)
     _set_status(tid, "initializing", pending_message=text, domain=selected or "",
                 started_at=_now_ms())
-    background_tasks.add_task(_initialize_thread, tid, text, selected,
-                             _build_rider(sent_at, tz, lat, lon))
-    return RedirectResponse(url=f"/thread/{tid}", status_code=303)
+    run = _create_run(tid, text, rider=rider)
+    return tid, run.id, selected
 
 
 @app.get("/thread/{tid}", response_class=HTMLResponse)

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -1168,18 +1168,30 @@ def _initialize_thread(
                 DOMAIN_MANAGERS[tid] = dm
             except Exception as e:
                 logging.error("Clone failed for thread %s: %s", tid, e, exc_info=True)
-                _runs().transition(tid, run_id, "error", error=str(e))
-                _set_status(tid, "error", error=f"Clone failed: {e}", pending_message=pending)
+                _fail_initialization(tid, run_id, e, f"Clone failed: {e}", pending)
                 return
         _execute_run(run_id, tid)
     except Exception as e:
         logging.error("Initialization failed for thread %s: %s", tid, e, exc_info=True)
         try:
             pending = _runs().get(tid, run_id).text or ""
-            _runs().transition(tid, run_id, "error", error=str(e))
         except Exception:
             pending = ""
-        _set_status(tid, "error", error=str(e), pending_message=pending)
+        _fail_initialization(tid, run_id, e, str(e), pending)
+
+
+def _fail_initialization(
+    tid: str, run_id: str, error: Exception, status_error: str, pending: str,
+) -> None:
+    """Terminalize a Run that failed before or during initialization."""
+    with _RUN_ADMISSION_LOCK:
+        run = _runs().get(tid, run_id)
+        if run.status == "pending":
+            run = _runs().claim(tid, run_id)
+        if run.status == "running":
+            _runs().transition(tid, run_id, "error", error=str(error))
+    _set_status(tid, "error", error=status_error, pending_message=pending)
+    _notify_turn_observers(tid, "error", None, None, run_id)
 
 
 _SUPERSEDE_RIDER = (

--- a/roadmap.org
+++ b/roadmap.org
@@ -34,12 +34,12 @@ authoritative), read-only catalog + contained receptionist (PR #208), hermetic
 VAD/endpointing/barge-in/DTMF flow (PR #209), in-process Whisper/Piper speech
 (PR #211), and bounded authenticated WSS =/call= transport (PR #214).
 
-*NEXT: PR4 =manage/voice/session.py=*: integrate flow, speech, wire,
-receptionist, durable ordinary Runs, terminal observers, serialized TTS,
-barge-in, and the call-event log into the per-call state machine. Then PR5 closes
-global PIN lockout, caller-ID handling, detector-scope security proofs, and full
-scripted-call reconstruction. Live phone/PCM-bridge work remains hardware-gated P3
-in emacsos; do not start it before the fake-bridge contract is complete.
+PR4 =manage/voice/session.py= now integrates Flow, Speech, Wire, the receptionist,
+durable ordinary Runs, terminal observers, serialized TTS, barge-in, and the
+call-event log into the fake-bridge state machine. *NEXT: PR5* closes global PIN
+lockout, caller-ID handling, detector-scope security proofs, and full scripted-call
+reconstruction. Live phone/PCM-bridge work remains hardware-gated P3 in emacsos; do
+not start it before the fake-bridge contract is complete.
 ** DONE One Agent Protocol-shaped runs interface
 Shipped for review 2026-07-24 in [[https://github.com/pierrel/assist/pull/212][assist PR #212]]. This records that PR's
 historical design; the adjacent replacement item supersedes its child lifecycle.

--- a/tests/test_progressive_responses.py
+++ b/tests/test_progressive_responses.py
@@ -363,6 +363,23 @@ def test_turn_observer_isolated_and_reports_error(wired, monkeypatch):
     assert _get_status(tid)["stage"] == "error"         # turn still terminalized
 
 
+def test_initialize_clone_failure_notifies_turn_observers(wired, monkeypatch):
+    tid, _ = wired
+    run = threads._create_run(tid, "first message")
+    _set_status(tid, "initializing", pending_message="first message")
+    seen = []
+    monkeypatch.setattr(threads, "_TURN_OBSERVERS", [lambda *args: seen.append(args)])
+    monkeypatch.setattr(
+        threads, "DomainManager", lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("clone failed")),
+    )
+
+    threads._initialize_thread(tid, run.id, "domain")
+
+    assert threads._runs().get(tid, run.id).status == "error"
+    assert seen == [(tid, "error", None, None, run.id)]
+
+
 def test_turn_observer_registration_during_notify_is_isolated(wired, monkeypatch):
     # Snapshot semantics: turns run concurrently over the shared _TURN_OBSERVERS
     # global, so a registration racing a notify pass must not extend that pass. An

--- a/tests/voice/test_session.py
+++ b/tests/voice/test_session.py
@@ -1,0 +1,282 @@
+import threading
+import time
+from hashlib import sha256
+from types import SimpleNamespace
+
+import pytest
+
+from assist.events.thread_log import read_events
+from manage.voice.session import VoiceSession, _Reply, _REPLIES
+from manage.voice.speech import Transcription
+from manage.voice.wire import BufferClosed, CallBuffers, InboundBuffer, OutboundBuffer
+
+
+PCM = b"\0\0" * 320
+
+
+class FakeSpeech:
+    def synthesize(self, _text):
+        yield PCM
+
+    def transcribe(self, _pcm):
+        return Transcription("hello", 0.0)
+
+
+class FakeFlow:
+    def __init__(self, **_kwargs):
+        self.events = []
+        self.speaking = False
+
+    def feed(self, _frame):
+        events, self.events = self.events, []
+        return events
+
+    def set_speaking(self, value):
+        self.speaking = value
+
+
+def _eventually_get(buffer):
+    return buffer.get(timeout=1)
+
+
+def test_session_answers_after_allowlist_pin_and_speaks_only_its_run():
+    buffers = CallBuffers(InboundBuffer(), OutboundBuffer())
+    submitted = []
+    session = VoiceSession(
+        pin="000000",
+        allowed_callers=frozenset({"+15555550100"}),
+        speech=FakeSpeech(),
+        flow_factory=FakeFlow,
+        router_turn=lambda _text: "",
+        submit_turn=lambda tid, text: submitted.append((tid, text)) or "voice-run",
+    )
+    runner = threading.Thread(
+        target=session.run,
+        args=({"type": "ring", "call_id": "call", "caller": "+15555550100"}, buffers),
+    )
+    runner.start()
+
+    assert _eventually_get(buffers.outbound) == {"type": "answer"}
+    buffers.inbound.put({"type": "answered", "call_id": "call"})
+    assert _eventually_get(buffers.outbound) == PCM
+    for _ in range(6):
+        buffers.inbound.put({"type": "dtmf", "digit": "0"})
+    assert _eventually_get(buffers.outbound) == PCM
+
+    session.open_thread("thread-1")
+    session._events.put(Transcription("find the forecast", 0.0))
+    assert _eventually_get(buffers.outbound) == PCM
+    assert submitted == [("thread-1", "find the forecast")]
+
+    _REPLIES.deliver("thread-1", "ready", None, "It will rain.", "voice-run")
+    assert _eventually_get(buffers.outbound) == PCM
+    _REPLIES.deliver("thread-1", "ready", None, "wrong run", "web-run")
+    time.sleep(0.05)
+    with pytest.raises(TimeoutError):
+        buffers.outbound.get(timeout=0.01)
+
+    buffers.inbound.close_with_final({"type": "call_end", "cause": "remote"})
+    runner.join(1)
+    assert not runner.is_alive()
+    assert _eventually_get(buffers.outbound) == {"type": "hangup"}
+
+
+def test_session_never_answers_an_unknown_caller():
+    buffers = CallBuffers(InboundBuffer(), OutboundBuffer())
+    session = VoiceSession(
+        pin="000000", allowed_callers=frozenset(), speech=FakeSpeech(),
+    )
+
+    session.run({"type": "ring", "call_id": "call", "caller": "+1555"}, buffers)
+
+    with pytest.raises(BufferClosed):
+        _eventually_get(buffers.outbound)
+
+
+def test_call_log_hashes_hostile_bridge_ids_and_omits_caller(tmp_path):
+    buffers = CallBuffers(InboundBuffer(), OutboundBuffer())
+    session = VoiceSession(
+        pin="000000", allowed_callers=frozenset(), speech=FakeSpeech(),
+        call_log_root=tmp_path,
+    )
+    call_id = "../caller-control"
+
+    session.run({"type": "ring", "call_id": call_id, "caller": "+1555"}, buffers)
+
+    call_dir = tmp_path / "calls" / sha256(call_id.encode()).hexdigest()
+    events = read_events(str(call_dir))
+    assert len(events) == 1
+    assert events[0]["kind"] == "decline"
+    assert events[0]["reason"] == "not_allowed"
+    assert "+1555" not in str(events)
+    assert not (tmp_path / "caller-control").exists()
+
+
+def test_session_logs_the_auth_boundary_without_digits_or_caller(tmp_path):
+    buffers = CallBuffers(InboundBuffer(), OutboundBuffer())
+    session = VoiceSession(
+        pin="000000", allowed_callers=frozenset({"+15555550100"}),
+        speech=FakeSpeech(), router_turn=lambda _text: "", call_log_root=tmp_path,
+    )
+    runner = threading.Thread(
+        target=session.run,
+        args=({"type": "ring", "call_id": "call", "caller": "+15555550100"}, buffers),
+    )
+    runner.start()
+    assert _eventually_get(buffers.outbound) == {"type": "answer"}
+    buffers.inbound.put({"type": "answered", "call_id": "call"})
+    assert _eventually_get(buffers.outbound) == PCM
+    for _ in range(6):
+        buffers.inbound.put({"type": "dtmf", "digit": "0"})
+    assert _eventually_get(buffers.outbound) == PCM
+    buffers.inbound.close_with_final({"type": "call_end", "cause": "remote"})
+    runner.join(1)
+
+    events = read_events(str(tmp_path / "calls" / sha256(b"call").hexdigest()))
+    kinds = [event["kind"] for event in events]
+    assert ["ring", "answered", "pin_prompt", "pin_attempt", "auth_ok", "hangup"] == [
+        kind for kind in kinds
+        if kind in {"ring", "answered", "pin_prompt", "pin_attempt", "auth_ok", "hangup"}
+    ]
+    assert "000000" not in str(events)
+    assert "+15555550100" not in str(events)
+
+
+def test_greeting_constructs_only_a_dtmf_flow_and_never_transcribes():
+    buffers = CallBuffers(InboundBuffer(), OutboundBuffer())
+    flow_kwargs = []
+
+    def make_flow(**kwargs):
+        flow_kwargs.append(kwargs)
+        return FakeFlow()
+
+    class NoPreauthStt(FakeSpeech):
+        def transcribe(self, _pcm):
+            raise AssertionError("STT must not receive pre-auth PCM")
+
+    session = VoiceSession(
+        pin="000000", allowed_callers=frozenset({"+15555550100"}),
+        speech=NoPreauthStt(), flow_factory=make_flow, router_turn=lambda _text: "",
+    )
+    runner = threading.Thread(
+        target=session.run,
+        args=({"type": "ring", "call_id": "call", "caller": "+15555550100"}, buffers),
+    )
+    runner.start()
+    assert _eventually_get(buffers.outbound) == {"type": "answer"}
+    buffers.inbound.put({"type": "answered", "call_id": "call"})
+    assert _eventually_get(buffers.outbound) == PCM
+    buffers.inbound.put(PCM)
+    for _ in range(6):
+        buffers.inbound.put({"type": "dtmf", "digit": "0"})
+    assert _eventually_get(buffers.outbound) == PCM
+    assert flow_kwargs == [{"vad": False}, {}]
+    buffers.inbound.close_with_final({"type": "call_end", "cause": "remote"})
+    runner.join(1)
+
+
+def test_default_submit_registers_before_its_turn_runner(monkeypatch):
+    import manage.web.threads as threads
+
+    session = VoiceSession(pin="000000", allowed_callers=frozenset(), speech=FakeSpeech())
+    monkeypatch.setattr(
+        threads, "_create_run", lambda _tid, _text: SimpleNamespace(id="voice-run"),
+    )
+
+    def finish(run_id, tid):
+        _REPLIES.deliver(tid, "ready", None, "done", run_id)
+
+    monkeypatch.setattr(threads, "_execute_run", finish)
+
+    assert session._default_submit_turn("thread-1", "hello") == "voice-run"
+    reply = session._events.get(timeout=1)
+    assert reply == _Reply("thread-1", "ready", "done", "voice-run")
+
+
+def test_router_callbacks_do_nothing_after_hangup():
+    session = VoiceSession(pin="000000", allowed_callers=frozenset(), speech=FakeSpeech())
+    session._stopped.set()
+
+    session.open_thread("thread-1")
+    session.new_thread("domain", "late request")
+
+    assert session._events.empty()
+
+
+def test_silence_watchdog_speaks_while_a_turn_is_thinking(monkeypatch):
+    buffers = CallBuffers(InboundBuffer(), OutboundBuffer())
+    session = VoiceSession(
+        pin="000000", allowed_callers=frozenset(), speech=FakeSpeech(),
+    )
+    session._thinking = True
+    session._last_audio = 0
+    monkeypatch.setattr("manage.voice.session.SILENCE_SECONDS", 0)
+    session._start_tts_producer(buffers)
+
+    session._speak_if_silent(buffers)
+
+    assert _eventually_get(buffers.outbound) == PCM
+    session._stopped.set()
+    with session._tts_condition:
+        session._tts_condition.notify_all()
+
+
+def test_tts_producer_serializes_latest_speech_request():
+    first_started = threading.Event()
+    release_first = threading.Event()
+    synthesized = []
+
+    class Speech:
+        def synthesize(self, text):
+            synthesized.append(text)
+            if text == "first":
+                first_started.set()
+                release_first.wait(1)
+            yield PCM
+
+    buffers = CallBuffers(InboundBuffer(), OutboundBuffer())
+    session = VoiceSession(pin="000000", allowed_callers=frozenset(), speech=Speech())
+    session._start_tts_producer(buffers)
+    session._speak("first", buffers)
+    assert first_started.wait(1)
+    session._speak("second", buffers)
+    release_first.set()
+
+    assert _eventually_get(buffers.outbound) == {"type": "flush_uplink"}
+    assert _eventually_get(buffers.outbound) == PCM
+    assert synthesized == ["first", "second"]
+    session._stopped.set()
+    with session._tts_condition:
+        session._tts_condition.notify_all()
+
+
+def test_hangup_does_not_wait_for_a_stalled_tts_call():
+    started = threading.Event()
+    release = threading.Event()
+
+    class StalledSpeech:
+        def synthesize(self, _text):
+            started.set()
+            release.wait()
+            yield PCM
+
+    buffers = CallBuffers(InboundBuffer(), OutboundBuffer())
+    session = VoiceSession(
+        pin="000000", allowed_callers=frozenset({"+15555550100"}),
+        speech=StalledSpeech(), router_turn=lambda _text: "",
+    )
+    runner = threading.Thread(
+        target=session.run,
+        args=({"type": "ring", "call_id": "call", "caller": "+15555550100"}, buffers),
+    )
+    runner.start()
+    assert _eventually_get(buffers.outbound) == {"type": "answer"}
+    buffers.inbound.put({"type": "answered", "call_id": "call"})
+    assert started.wait(1)
+
+    buffers.inbound.close_with_final({"type": "call_end", "cause": "remote"})
+    runner.join(1)
+    release.set()
+
+    assert not runner.is_alive()
+    assert _eventually_get(buffers.outbound) == {"type": "hangup"}

--- a/tests/voice/test_session.py
+++ b/tests/voice/test_session.py
@@ -112,6 +112,21 @@ def test_call_log_hashes_hostile_bridge_ids_and_omits_caller(tmp_path):
     assert not (tmp_path / "caller-control").exists()
 
 
+def test_unwritable_call_log_does_not_fail_the_call(tmp_path):
+    root = tmp_path / "not-a-directory"
+    root.write_text("occupied")
+    buffers = CallBuffers(InboundBuffer(), OutboundBuffer())
+    session = VoiceSession(
+        pin="000000", allowed_callers=frozenset(), speech=FakeSpeech(),
+        call_log_root=root,
+    )
+
+    session.run({"type": "ring", "call_id": "call", "caller": "+1555"}, buffers)
+
+    with pytest.raises(BufferClosed):
+        _eventually_get(buffers.outbound)
+
+
 def test_session_logs_the_auth_boundary_without_digits_or_caller(tmp_path):
     buffers = CallBuffers(InboundBuffer(), OutboundBuffer())
     session = VoiceSession(

--- a/tests/voice/test_session.py
+++ b/tests/voice/test_session.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from assist.events.thread_log import read_events
-from manage.voice.session import VoiceSession, _Reply, _REPLIES
+from manage.voice.session import VoiceSession, _Reply, _REPLIES, _frames
 from manage.voice.speech import Transcription
 from manage.voice.wire import BufferClosed, CallBuffers, InboundBuffer, OutboundBuffer
 
@@ -263,6 +263,18 @@ def test_tts_producer_serializes_latest_speech_request():
     session._stopped.set()
     with session._tts_condition:
         session._tts_condition.notify_all()
+
+
+def test_tts_frames_preserve_chunk_remainders_and_pad_only_the_end():
+    first = b"a" * 100
+    second = b"b" * 600
+
+    frames = list(_frames([first, second]))
+
+    assert frames == [
+        first + second[:540],
+        second[540:] + b"\0" * 580,
+    ]
 
 
 def test_hangup_does_not_wait_for_a_stalled_tts_call():

--- a/tests/voice/test_wire.py
+++ b/tests/voice/test_wire.py
@@ -9,6 +9,7 @@ from starlette.websockets import WebSocketDisconnect
 
 from manage.web import app
 from manage.voice import wire
+from manage.voice.session import VoiceSession
 from tests.voice.fake_bridge import FakeBridge
 
 
@@ -122,6 +123,29 @@ def test_fake_bridge_exercises_duplex_transport():
         assert bridge.receive_control() == {"type": "hangup"}
         with pytest.raises(WebSocketDisconnect):
             bridge.receive_control()
+
+
+def test_fake_bridge_drives_the_session_handshake_and_hangup():
+    class Speech:
+        def synthesize(self, _text):
+            yield PCM
+
+    session = VoiceSession(
+        pin="000000", allowed_callers=frozenset({"+15555550100"}),
+        speech=Speech(), router_turn=lambda _text: "",
+    )
+    wire.configure_call_runner(session.run)
+    with TestClient(app).websocket_connect("/call", headers=HEADERS) as websocket:
+        bridge = FakeBridge(websocket)
+        bridge.ring()
+        assert bridge.receive_control() == {"type": "answer"}
+        bridge.send_control("answered", call_id="boot-1")
+        assert bridge.receive_pcm() == PCM
+        for _ in range(6):
+            bridge.send_control("dtmf", digit="0")
+        assert bridge.receive_pcm() == PCM
+        bridge.send_control("call_end", cause="remote")
+        assert bridge.receive_control() == {"type": "hangup"}
 
 
 @pytest.mark.parametrize("size", [639, 641, 4096])
@@ -500,3 +524,40 @@ def _record_closed(operation, result):
         operation()
     except wire.BufferClosed:
         result.append(wire.BufferClosed)
+
+
+def test_barge_in_flushes_and_invalidates_a_blocked_tts_generation():
+    outbound = wire.OutboundBuffer()
+    generation = outbound.start_generation()
+    for _ in range(wire.OUTBOUND_CAPACITY):
+        assert outbound.put_audio(generation, PCM)
+
+    accepted = []
+    producer = threading.Thread(
+        target=lambda: accepted.append(outbound.put_audio(generation, PCM))
+    )
+    producer.start()
+    time.sleep(0.01)
+
+    outbound.interrupt_audio()
+    producer.join(1)
+
+    assert accepted == [False]
+    outbound.interrupt_audio()
+    outbound.interrupt_audio()
+    assert outbound.get() == {"type": "flush_uplink"}
+    with pytest.raises(TimeoutError):
+        outbound.get(timeout=0.01)
+
+
+def test_terminal_inbound_control_discards_buffered_pcm():
+    inbound = wire.InboundBuffer()
+    for _ in range(wire.INBOUND_CAPACITY):
+        inbound.put(PCM)
+
+    final = {"type": "call_end", "cause": "remote"}
+    inbound.close_with_final(final)
+
+    assert inbound.get() == final
+    with pytest.raises(wire.BufferClosed):
+        inbound.get()

--- a/tests/voice/test_wire.py
+++ b/tests/voice/test_wire.py
@@ -550,6 +550,17 @@ def test_barge_in_flushes_and_invalidates_a_blocked_tts_generation():
         outbound.get(timeout=0.01)
 
 
+def test_control_evicts_stale_audio_when_outbound_is_full():
+    outbound = wire.OutboundBuffer()
+    for _ in range(wire.OUTBOUND_CAPACITY):
+        outbound.put(PCM)
+
+    outbound.put_control({"type": "hangup"})
+
+    assert len(outbound._items) == wire.OUTBOUND_CAPACITY
+    assert outbound.get() == {"type": "hangup"}
+
+
 def test_terminal_inbound_control_discards_buffered_pcm():
     inbound = wire.InboundBuffer()
     for _ in range(wire.INBOUND_CAPACITY):


### PR DESCRIPTION
## Summary

Implements voice P1 PR4 against the fake bridge: the per-call state machine, PIN-only pre-auth flow, receptionist handoff, durable Run execution, terminal-observer reply delivery, serialized generation-safe TTS, and structured call logging.

Production still does not configure the session runner. PR5 remains the gate for normalized caller policy, global PIN lockout, and scripted security reconstruction.

## Validation

- `pytest tests/voice/test_session.py tests/voice/test_wire.py -q`: 51 passed.
- `pytest tests/ -q`: 1,511 passed, 2 skipped.
- Deployed from this branch and HTTPS smoke-tested.

## Evals

No behavioral evals were added or modified. This PR does not change prompts or live model routing and remains fake-bridge-only; its acceptance coverage is deterministic protocol and session tests.