### PR TITLE
Separate natural async acceptance from capability coverage

### DIFF
--- a/docs/2026-08-03-prompt-architecture-p1b.org
+++ b/docs/2026-08-03-prompt-architecture-p1b.org
@@ -3,6 +3,12 @@
 
 * Status
 
+P1b is complete at measured code SHA
+=95ee4fef332a6cdcdb01cb23006f4259bdcbaaa6=.  The frozen candidate passed
+natural 36/36 and capability 36/36 across official N=3, N=5, and N=10 runs.
+The completion-report commit changes documentation only; the measured eval code
+remains at that named SHA.
+
 The prior direct-validator candidate completed five local code-review rounds;
 the judge-adoption redesign and terminal-response follow-up have completed
 focused review and fixes.  The final deterministic suite is green: 1,571
@@ -300,6 +306,30 @@ SECONDS=0
   requested-field gates.  Only =pass= passes, and the private run log records
   model and prompt provenance.
 
+* Experiment results
+
+| Arm | Repetitions | Natural | Capability | Total |
+|-----+-------------+---------+------------+-------|
+| Baseline =10a66ce= | N=3 | 3/6 | 6/6 | 9/12 |
+| Candidate =95ee4fe= | N=3 | 6/6 | 6/6 | 12/12 |
+| Candidate =95ee4fe= | N=5 | 10/10 | 10/10 | 20/20 |
+| Candidate =95ee4fe= | N=10 | 20/20 | 20/20 | 40/40 |
+| Candidate aggregate | N=18 | 36/36 | 36/36 | 72/72 |
+
+All eighteen counted candidate repetitions used served model
+=Qwen_Qwen3.6-27B-Q4_K_M.gguf= and judge prompt SHA-256
+=f6d7f5ff9f1bebcda15ea095b25b2aefd35300c8e2f2852f727e4726eff3f884=.
+Each log contains the exact candidate SHA, two judge provenance records, and
+=run_rc=0=.  N=10 wall time was 3,510 seconds across two five-repetition blocks
+with a 15-minute GPU rest between them.  N=3 plus N=5 also stayed below one hour
+and was followed by a 15-minute rest.
+
+The baseline and candidate deliberately use different acceptance signals, so
+the table shows that the new signal is stable, not that runtime behavior
+improved.  Agent prompts and runtime code were identical in both arms.  Earlier
+candidate runs are diagnostic only because review changed the validator after
+each exposed false negative; none are included above.
+
 * Risks, decisions, and deferred findings
 
 - Model variance remains despite frozen prompts.  Repeated arms measure whether
@@ -379,11 +409,108 @@ SECONDS=0
   that fix; it corrected only the documentation boundary for task IDs that may
   appear naturally inside the verbatim visible response.
 
-* Completion report requirements
+* Implementation guide and what was hard
 
-The final report records the classification changes, exact run counts and
-results by layer, deterministic status, review rounds, declined out-of-scope
-findings with their risk/value, and what was hard.  Review
-findings do not expand implementation beyond this objective.  A directly
-related issue requiring significant unplanned rework triggers a blocked report
-with options before throwaway implementation.
+** Final data path
+
+1. The natural test snapshots each named source as bounded raw bytes before the
+   agent runs.
+2. The ordinary agent handles the unchanged user prompt.  The harness delivers
+   pending synthetic completions until the task graph is quiet, capped at 32.
+   A successful delegate completion materializes only exact report names found
+   in its brief, before the parent receives the wake.  Direct work requires no
+   fabricated delegate route.
+3. The validator proves the source is byte-for-byte unchanged, acquires every
+   requested artifact through the bounded no-follow reader, and requires each
+   requested visible field exactly once and nonempty after comment removal.
+4. One closed =OutcomeObservation= contains the prompt, authoritative initial
+   sources, sanitized final artifacts, and terminal visible response.  It
+   contains no separately supplied route trace.
+5. One existing =OutcomeJudge= call grades all outcomes in that natural case.
+   Only overall =pass= passes.  The two paired capability methods remain strict
+   checks of delegate fan-out and dependency propagation.
+
+** What was hard
+
+- The central difficulty was defining semantic acceptance without quietly
+  rebuilding the old route test.  Direct validators first failed valid Markdown
+  field content, then valid “tag-loss bug” and “tag import loses tags” wording.
+  Those were real outputs, not hypothetical synonyms.  The repeated failures
+  justified using the already-qualified semantic judge while retaining exact
+  file and field gates.
+- Synthetic async completion had to support direct, serial, parallel, and
+  whole-task routes without awarding points for any one of them.  Moving fixed
+  artifact side effects to successful completion before the wake made the
+  harness route-neutral and kept all changes in eval code.
+- Evidence custody was more work than the judge call.  Review found post-run
+  source reads, answer facts in evaluator requirements, unbounded reads,
+  symlink/FIFO exposure, newline-normalized equality, hidden markup, payload
+  expansion during JSON serialization, and omission of the final visible
+  response.  The final path makes each bad observation unreachable before the
+  judge is called.
+- Ambiguous canned recommendations made a weak judge pass look stronger than it
+  was.  The fixtures now state an actual launch or release decision.  This fixed
+  the evidence rather than tuning the judge to the fixture.
+- Judge-backed repetitions take roughly five to ten minutes rather than the
+  earlier two to three.  Private per-repetition logs, exact SHA checks, bounded
+  blocks, and GPU rests made the longer experiment auditable.
+
+** Maintainability and scope audit
+
+- The final diff has exactly two tracked paths: this P1b document and
+  =edd/eval/test_async_subagents.py=.  At the measured SHA the eval module is
+  264 insertions and 113 deletions against =10a66ce=, all in the synthetic
+  harness and two natural validators.
+- No code under =assist/=, =manage/=, or =scripts/= changed.  The judge
+  implementation, judge prompt, qualification corpus, agent prompts, tools,
+  middleware, and model settings are unchanged.
+- P1c owns the overall architecture document and roadmap in another lane.  P1b
+  neither edits nor waits on them.
+- Proposed registries, pytest plugins, markers, workspace collectors, evidence
+  history systems, and production guards were removed or declined.  They add
+  maintenance without a current P1b consumer.
+
+* Completion report
+
+** Review and verification
+
+- Design review completed.  Code review ran five full direct-validator rounds
+  plus four focused judge-adoption and response-follow-up rounds.
+- Final blockers: none.  Important findings were fixed in scope, including
+  route-biased completion, source/evidence custody, ambiguous fixture decisions,
+  and omission of the visible response.  The last follow-up found only one
+  documentation-alignment nit, which was fixed.
+- The full deterministic suite passed: 1,571 passed, 2 skipped, 5 existing
+  warnings, and 2 subtests passed.  The 23 deterministic outcome-judge tests
+  also passed, and all four experiment node IDs collected exactly.
+- Official real-model results are the table above.  Candidate acceptance was
+  72/72 at the frozen measured SHA.
+
+** Declined and deferred findings
+
+- A reviewer suggested replacing the bounded read loop with one =os.read= to
+  save lines.  This was rejected because a short read could silently omit valid
+  evidence; the loop pins the complete bounded-read contract.
+- A stale module description in the separate skill-loading suite remains
+  deferred.  Fixing it has documentation value, but no effect on P1b results;
+  leaving it risks reader confusion but avoids unrelated scope growth.
+- Repository-wide executable classification machinery remains deferred.  Its
+  value is preventing future taxonomy drift; its current cost is code and
+  maintenance with no runtime or test consumer.
+
+** Process learnings
+
+- One measurement setup command initially started without the shared LLM wrapper.
+  It was stopped immediately, its partial log was renamed as aborted, and it is
+  excluded from every result.
+- The first N=3 wrapper used a brace group whose =exit= ended the outer shell,
+  so it completed only repetition 1.  That repetition was valid and logged;
+  repetitions 2 and 3 ran afterward with a subshell group.  No result was rerun
+  or selected for favorability.
+- Review-driven validator changes always stopped the current cadence and
+  restarted N=3/N=5/N=10 together at a new SHA.  This cost time, but prevented
+  mixing incompatible acceptance definitions.
+
+External PR review and the final Kindle delivery are the remaining shipping
+steps.  Any valuable external finding outside P1b will be reported with its
+risk and value instead of widening this implementation.

--- a/docs/2026-08-03-prompt-architecture-p1b.org
+++ b/docs/2026-08-03-prompt-architecture-p1b.org
@@ -1,0 +1,352 @@
+#+title: Prompt architecture P1b: natural acceptance and capability coverage
+#+date: 2026-08-03
+
+* Status
+
+Candidate implementation completed and five local code-review rounds converged.
+The counted baseline was natural 3/6 and capability 6/6.  The initial candidate
+was natural 6/6 and capability 6/6, but review found hidden route constraints in
+synthetic completion and field validation, so that measurement is diagnostic
+only.  The first post-review repetition was natural 1/2 and capability 2/2; its
+direct-route artifact exposed a real validator defect where a colon inside a
+Markdown bullet prematurely ended the requested field.  That repetition is also
+diagnostic only, and candidate measurement restarts after the case-derived fix.
+That candidate then passed natural 6/6 and capability 6/6 at N=3.  Its first
+post-review repetition was natural 1/2 and capability 2/2 because a valid
+recommendation described the source's “tag-loss bug” without the validator's
+literal “tag import” phrase.  Remaining repetitions stopped, the direct source-
+fact vocabulary was corrected, and all official measurements restart together
+at the next frozen SHA.  P1b changes eval classification and its two natural-
+test harness/validators only.
+Agent prompts, tools, middleware, model settings, runtime behavior, and
+production paths remain frozen at Assist =main= commit =10a66ce=.
+
+P1c is proceeding in another lane and owns
+=docs/2026-07-26-agent-prompt-architecture.org= and =roadmap.org=.  P1b neither
+touches those files nor waits on P1c.
+
+* Objective and hypothesis
+
+P1b makes a natural acceptance case answer whether the user received the
+requested visible outcome without a forbidden outcome.  Separately named
+capability and deterministic security/state cases retain strict internal and
+lifecycle diagnostics.  The hypothesis is that this separation preserves
+failure detection while no longer failing a natural request merely because the
+agent used a different valid route.
+
+* Scope
+
+P1b does now:
+
+1. classify the existing cases selected for P2 through P7;
+2. remove orchestration-shaped assertions from two P2 natural artifact cases;
+3. retain two strict P2 capability probes as the paired diagnostic signal; and
+4. run the frozen four-case experiment through baseline N=3, candidate N=3,
+   post-review N=5, and stability N=10.
+
+P1b does not add a registry, pytest plugin, marker system, eval runner, workspace
+collector, evidence-custody/history system, production guard, or prompt/runtime
+change.  It does not alter SMS triage or development guidance.  Later phases add
+their missing phase-specific cases when they change the corresponding prompt.
+
+* Classification contract
+
+Every selected case has exactly one acceptance layer:
+
+- =natural=: user-shaped prompt and user-visible outcome;
+- =capability=: exact mechanism, route, tool, or orchestration coverage; or
+- =deterministic-security/state=: exact safety, authorization, lifecycle,
+  resource, or persisted-state coverage.
+
+A natural case may run a deterministic prerequisite first.  That prerequisite
+is metadata, not a second acceptance layer, and it cannot be waived by semantic
+judging.  Exact task IDs remain a deterministic user-visible lifecycle contract
+where the user needs them to inspect, update, or cancel work.  Exact agent names,
+tool order, delegate counts, and brief vocabulary are capability coverage.
+
+The P2 async test harness uses Assist's web async-subagent tools, not Deep
+Agents' native synchronous =task= mechanism.  Its capability results apply only
+to that boundary.
+
+* P2 async inventory
+
+Each of the 13 existing cases is named exactly once.  The =Prerequisite= column
+records exact gates that run before the acceptance assertion; it does not alter
+the case's layer.
+
+| Test method in =TestAsyncSubagentSupervisor= | Layer | Prerequisite or gate |
+|-
+| =test_starts_subagents_and_returns_without_polling= | deterministic-security/state | Visible task-shaped ID; no launch-turn polling, invented completion, or misleading terminology |
+| =test_starts_independent_context_and_research_without_polling= | capability | At least two starts, no polling, and each started task's visible ID |
+| =test_completion_wake_checks_then_uses_result= | capability | Exact context start/check path plus returned fact |
+| =test_user_stop_request_reports_cancellation_requested_for_running_tasks= | deterministic-security/state | Request cancellation for every running task; never claim terminal cancellation |
+| =test_explicit_delegate_fanout_capability= | capability | Exact three-way delegate fan-out and target mapping |
+| =test_natural_long_list_chooses_one_delegate_per_outcome= | natural | Requested four files must exist; no route assertion |
+| =test_natural_two_independent_outcomes_delegate= | natural | Requested two files must exist; no route assertion |
+| =test_single_outcome_with_several_steps_stays_with_main= | capability | Exact no-delegate route plus requested summary and source fact |
+| =test_explicit_dependent_delegate_starts_after_prerequisite_completion= | capability | Exact check-before-start ordering, brief propagation, and isolation |
+| =test_explicit_timed_out_prerequisite_blocks_dependent_delegate= | deterministic-security/state | No dependent artifact or continuation after timeout |
+| =test_overlapping_workspace_changes_are_serialized= | deterministic-security/state | Final shared-file state proves both ordered edits without corruption |
+| =test_explicit_failed_sibling_preserves_success_and_blocks_join= | deterministic-security/state | Preserve success, report failure, and do not create joined output |
+| =test_pure_external_research_uses_research_not_delegate= | capability | Exact research rather than delegate route plus returned fact |
+
+Only the two named natural multi-artifact cases and their synthetic artifact
+completion change in P1b.  Launch, stop, completion, overlap, failure, and
+pure-research cases are classified but their validators are not rewritten by
+this experiment.
+
+* Later-phase cohort inventory
+
+This table selects the existing cohorts later phases may compare.  Module and
+class selectors are used only when that entire selected scope has one layer.
+Explicit gaps prevent a weak current assertion from being mistaken for future
+acceptance coverage.  Every selector resolves from the repository root.
+
+| Phase | Existing selected cases | Layer | Deterministic prerequisite / known gap |
+|-
+| P2 | =edd/eval/test_context_agent.py::TestContextInvocation=; =edd/eval/test_skill_loading.py= | capability | Context-first and skill-loading mechanism only |
+| P2 | =edd/eval/test_interjection.py::TestInterjection::test_redirect_mid_turn=; =edd/eval/test_interjection.py::TestInterjection::test_incorporate_addition=; =edd/eval/test_interjection.py::TestInterjection::test_coalesce_two_rapid_interjections= | natural | Presentation is a deterministic prerequisite; the pass bit grades the redirected or combined answer |
+| P2 | =edd/eval/test_interjection.py::TestInterjection::test_stop_halts_with_account=; =edd/eval/test_prompt_injection.py= | deterministic-security/state | Bounded stop/liveness and injection containment |
+| P2b | =edd/eval/test_domain_skills.py=; =edd/eval/test_travel_agent.py=; =edd/eval/test_directions_agent.py=; =edd/eval/test_schedule_agent.py= | capability | Exact skill/tool availability and invocation |
+| P2b | =edd/eval/test_egress_approval.py= | deterministic-security/state | Host effect remains denied until explicit approval |
+| P3 | =edd/eval/test_memory.py=; =edd/eval/test_thread_memory.py::TestThreadMemory::test_infers_repo_and_thread_scope= | natural | Exact file/scope state first; add secret/transient non-save and scheduled-continuity cases in P3 |
+| P3 | =edd/eval/test_thread_memory.py::TestThreadMemory::test_natural_process_prompt_writes_thread_memory= | capability | Current assertion proves only a nonempty write, not correct process capture; P3 must replace or strengthen it |
+| P4 | =edd/eval/test_research_agent.py=; =edd/eval/test_research_partial_results.py=; =edd/eval/test_research_large_multipart.py=; =edd/eval/test_read_url_deep_content.py=; =edd/eval/test_agent.py::TestAgent::test_research_saved_to_references=; =edd/eval/test_agent.py::TestAgent::test_combines_context_and_research=; =edd/eval/test_agent.py::TestResearchRunsToCompletion= | natural | Exact source/provenance, cleanup, and retrieval bounds remain deterministic prerequisites |
+| P4 | =edd/eval/test_research_reliability.py=; =edd/eval/test_read_url_fabrication_loop.py=; =edd/eval/test_read_url_reread_loop.py=; =edd/eval/test_search_runaway_loop.py=; =edd/eval/test_agent.py::TestResearchSearchUnavailableHandoff=; =edd/eval/test_agent.py::TestSearchDownMidflightDoesNotGrind= | deterministic-security/state | Provenance, unavailable state, and resource bounds |
+| P5 | =edd/eval/test_research_agent.py=; =edd/eval/test_research_large_multipart.py= | natural | Existing lead coverage; P5 must add or identify leaf, critique, and fact-check acceptance coverage |
+| P6 | =edd/eval/test_context_agent.py::TestContextAgent= | natural | Relevance remains direct; later P6 role changes may need richer synthesis cases |
+| P6 | =edd/eval/test_receptionist.py::TestReceptionist::test_picks_thread_by_topic=; =edd/eval/test_receptionist.py::TestReceptionist::test_ambiguous_asks_which=; =edd/eval/test_receptionist.py::TestReceptionist::test_new_thread_uses_named_domain=; =edd/eval/test_receptionist.py::TestReceptionist::test_new_thread_asks_domain_when_missing=; =edd/eval/test_receptionist.py::TestReceptionist::test_no_content_fabrication=; =edd/eval/test_receptionist.py::TestReceptionist::test_spoken_output_no_markdown= | natural | Open/create/reply state is exact and user-visible |
+| P6 | =edd/eval/test_receptionist.py::TestReceptionist::test_yields_without_reading_the_list=; =edd/eval/test_receptionist.py::TestReceptionist::test_offers_when_unsure= | capability | Exact =list_threads= routing behavior |
+| P6 | =edd/eval/test_thread_e2e.py::TestThreadE2E::test_description_generation= | capability | Current nonempty-string assertion is not relevance coverage; P6 must add relevant, bounded, empty/short, and adversarial cases |
+| P6 | =tests/test_capture.py= | deterministic-security/state | Deterministic serialization only, not real-model acceptance |
+| P7 | =edd/eval/test_edit_files.py=; =edd/eval/test_agent.py::TestAgent::test_adds_item_correctly=; =edd/eval/test_agent.py::TestAgent::test_finds_and_updates_relevant_files_direct= | natural | Exact requested filesystem state and truthful summary first; P7 adds answer-only/no-unrequested-artifact cases |
+
+The inventory is maintained here because there is no execution consumer for a
+Python registry.  Before baseline, =pytest --collect-only= confirms every exact
+node ID used by the experiment exists.  P1c is a separate experiment and does
+not gate P1b.
+
+* Focused implementation
+
+At baseline, the two natural async cases asserted complex-skill loading,
+delegate count, one delegate per target, brief vocabulary, and result-check
+calls before checking the requested files.  P1b removes those route assertions
+from their pass bits.  Harness code uses pending synthetic task state solely to
+deliver completion events and supports duplicate, serial, and whole-task
+delegation without grading the chosen route.  Terminal failed, timed-out, or
+cancelled tasks are never resurrected.  The harness accepts at most 32
+synthetic completions so a nonquiescent task graph fails deterministically.
+Synthetic delegate side effects materialize before the corresponding completion
+wake, independently of whether the parent later checks the result.
+
+Each natural validator then checks only what its prompt requests:
+
+- the four-report case requires all four named files, each containing its own
+  nonempty recommendation, risks, and next actions.  Distinct source facts pin
+  the pairing: Alpha's tag import, Beta's 25 percent cap and peak-load risk,
+  Gamma's owned medium findings, and Delta's rollback rehearsal; and
+- the two-brief case requires both named files, with the requested independent
+  nonempty fields in each.  Alpha must carry the tag-import risk; Beta must
+  carry the 25 percent rollout limit and a source-relevant capacity, error, or
+  latency monitoring trigger.  Facts outside an empty labelled field do not
+  satisfy that field.
+
+When a completed delegate brief names an exact requested report, as either its
+canonical root path or an unprefixed case-sensitive basename, the stub writes
+that target's fixed artifact content before the parent receives the completion
+wake.  A semantic judge over those artifacts would grade canned
+fixture output and add no signal.  Therefore P1b uses the clearer direct
+validators and does not change =edd/outcome_judge.py= or its frozen calibration
+corpus.  The P1 adoption contract remains binding for a later natural case
+whose outcome is genuinely semantic: exact security/state gates first,
+case-local bounded observation, one judge call, and only =pass= satisfies
+acceptance.  Observed artifact absence is valid =state="missing"= evidence;
+failure to acquire or bound required evidence stops before judging.
+
+The two paired capability cases remain byte-for-byte strict:
+
+- =test_explicit_delegate_fanout_capability=; and
+- =test_explicit_dependent_delegate_starts_after_prerequisite_completion=.
+
+No test method is renamed, so baseline and candidate use identical node IDs.
+No new helper survives unless it reduces the existing natural-test code.
+
+* Preregistered experiment
+
+** Fixed variables
+
+- Baseline source is =10a66ce=; candidate differs only in the two natural cases,
+  their synthetic artifact-completion harness, aligned module documentation,
+  and this state document.
+- Agent prompts, production tools, middleware, model settings, and runtime code
+  are byte-for-byte frozen.  Review may change only the two measured validators
+  or their synthetic completion mechanics; any acceptance-affecting change
+  restarts candidate measurement and is recorded in the changelog.
+- All arms run these exact four node IDs:
+  - =edd/eval/test_async_subagents.py::TestAsyncSubagentSupervisor::test_natural_long_list_chooses_one_delegate_per_outcome=
+  - =edd/eval/test_async_subagents.py::TestAsyncSubagentSupervisor::test_natural_two_independent_outcomes_delegate=
+  - =edd/eval/test_async_subagents.py::TestAsyncSubagentSupervisor::test_explicit_delegate_fanout_capability=
+  - =edd/eval/test_async_subagents.py::TestAsyncSubagentSupervisor::test_explicit_dependent_delegate_starts_after_prerequisite_completion=
+- Logs live under a mode-0700 =$HOME/deploy/assist/eval/p1b/= directory, never on
+  the small root partition.  Each run creates a fresh mode-0600 log and records
+  source SHA, arm, iteration, node IDs, run result, and wall time without
+  printing secrets.
+- Each block uses the workspace =llm= resource and an OS timeout, stays below 60
+  minutes, and is not rerun to seek a favorable answer.
+
+** Sequence and cadence
+
+1. Baseline N=3 on =10a66ce= with current mixed validators.
+2. Candidate N=3 after only the two natural cases, their synthetic
+   artifact-completion harness, and aligned module documentation change.
+3. Deterministic checks and the full local code-review loop.  If review changes
+   a measured validator, restart the affected candidate measurement.
+4. Post-review N=5 on the unchanged candidate.
+5. Stability N=10 on the unchanged candidate, split into bounded blocks with a
+   GPU rest between blocks when needed.
+
+The exact invocation below is run from the lane's Assist worktree.  Only =ARM=
+and =ITER= change between baseline invocations.  After committing the candidate,
+=EXPECTED_SHA= is set once to that commit and remains identical for N=3, N=5,
+and N=10.
+
+#+begin_src shell
+umask 077
+ASSIST_WORKTREE="$PWD"
+AGENTIC_ROOT="$(realpath "$ASSIST_WORKTREE/../../..")"
+PYTEST="$HOME/deploy/assist/code/.venv/bin/pytest"
+ARM=baseline
+ITER=1
+EXPECTED_SHA=10a66ceee3e9801f1af0d5b5f9406b320735f8dc
+LOG_DIR="$HOME/deploy/assist/eval/p1b"
+install -d -m 0700 "$LOG_DIR"
+LOG="$(mktemp "$LOG_DIR/${ARM}-${ITER}-XXXXXX.log")"
+chmod 0600 "$LOG"
+SECONDS=0
+{
+  set -e
+  set -a
+  source "$AGENTIC_ROOT/assist/.dev.env"
+  set +a
+  actual_sha="$(git rev-parse HEAD)"
+  test "$actual_sha" = "$EXPECTED_SHA"
+  if [ "$ARM" = baseline ]; then
+    test "$(git status --porcelain)" = \
+      "?? docs/2026-08-03-prompt-architecture-p1b.org"
+  else
+    test -z "$(git status --porcelain)"
+    changed="$(git diff --name-only 10a66ceee3e9801f1af0d5b5f9406b320735f8dc "$actual_sha")"
+    expected="$(printf '%s\n' \
+      docs/2026-08-03-prompt-architecture-p1b.org \
+      edd/eval/test_async_subagents.py)"
+    test "$changed" = "$expected"
+  fi
+  echo "source_sha=$actual_sha"
+  echo "arm=$ARM iteration=$ITER"
+  echo "node=edd/eval/test_async_subagents.py::TestAsyncSubagentSupervisor::test_natural_long_list_chooses_one_delegate_per_outcome"
+  echo "node=edd/eval/test_async_subagents.py::TestAsyncSubagentSupervisor::test_natural_two_independent_outcomes_delegate"
+  echo "node=edd/eval/test_async_subagents.py::TestAsyncSubagentSupervisor::test_explicit_delegate_fanout_capability"
+  echo "node=edd/eval/test_async_subagents.py::TestAsyncSubagentSupervisor::test_explicit_dependent_delegate_starts_after_prerequisite_completion"
+  set +e
+  "$AGENTIC_ROOT/tools/agentic" resource run llm -- /usr/bin/bash -lc \
+    "cd '$ASSIST_WORKTREE' && timeout --kill-after=30s 3500 '$PYTEST' -qq -s \
+    edd/eval/test_async_subagents.py::TestAsyncSubagentSupervisor::test_natural_long_list_chooses_one_delegate_per_outcome \
+    edd/eval/test_async_subagents.py::TestAsyncSubagentSupervisor::test_natural_two_independent_outcomes_delegate \
+    edd/eval/test_async_subagents.py::TestAsyncSubagentSupervisor::test_explicit_delegate_fanout_capability \
+    edd/eval/test_async_subagents.py::TestAsyncSubagentSupervisor::test_explicit_dependent_delegate_starts_after_prerequisite_completion"
+  rc=$?
+  echo "run_rc=$rc wall_seconds=$SECONDS"
+  exit "$rc"
+} >"$LOG" 2>&1
+#+end_src
+
+** Gates
+
+- Collection resolves the same four node IDs in every arm.
+- Both capability probes pass 100% at N=3, N=5, and N=10.
+- Natural acceptance is reported separately and reaches at least 70%, with no
+  false pass when a requested file or field is absent.
+- The candidate natural pass bit contains no agent-name, tool-order,
+  delegate-count, task-ID, or brief-vocabulary assertion.
+- The candidate diff against =10a66ce= contains exactly
+  =edd/eval/test_async_subagents.py= and this state document.  Any other path is
+  a gate failure; local review of that file verifies only the two named natural
+  cases, their synthetic artifact-completion helpers, and aligned module
+  documentation changed.  Every candidate command checks a clean worktree and
+  the same preregistered candidate SHA; in particular, no prompt/runtime
+  behavior changed.
+- No judge is called because these exact artifact outcomes have clearer direct
+  validators.  This is an experiment conclusion, not a waiver of the P1
+  adoption contract for later semantic cases.
+
+* Risks, decisions, and deferred findings
+
+- Model variance remains despite frozen prompts.  Repeated arms measure whether
+  the revised pass signal stays useful; they do not claim runtime improvement.
+- Synthetic completions require internal task IDs.  That is harness control,
+  not an acceptance assertion.
+- Removing route checks from the natural cases reduces diagnosis in those two
+  methods.  The paired strict fan-out/dependency cases retain mechanism
+  diagnosis; skill/context routing also remains covered by its selected
+  capability cohorts.
+- Launch and stop have important UX semantics, but changing them is outside the
+  measured four-case objective.  Their exact current state gates remain intact.
+- A repository-wide executable classification system could prevent future
+  drift, but it has no current consumer and adds maintenance.  The reviewed
+  state document plus exact experiment IDs is sufficient now.
+- Review found that the selected skill-loading suite's module doc still
+  describes an older three-test, path-based loader.  Updating that unrelated
+  suite has documentation value but no effect on P1b classification or results,
+  so it remains deferred rather than widening this change.
+- A report that conveys recommendation, risk, or action with entirely different
+  vocabulary can still false-fail the direct validator.  The current prompts
+  explicitly request those named fields, so accepting their colon labels or
+  Markdown headings is a practical deterministic boundary.  A semantic judge
+  would accept more paraphrases but adds a second model signal; use it only if
+  real outputs expose this risk rather than expanding P1b speculatively.
+- Direct validators remove hidden HTML comments and reject raw HTML before
+  checking visible field content.  They do not attempt a general natural-
+  language contradiction detector; that is the known direct-validator boundary
+  above.
+
+* Review changelog
+
+- Removed semantic judging from canned async artifacts; direct validators are
+  the stronger signal.
+- Removed the proposed Python cohort registry and fixture module.
+- Classified all 13 async cases exactly once and separated prerequisites from
+  the three-value acceptance layer.
+- Preserved task IDs where they are a real user-visible lifecycle contract.
+- Corrected cancellation-request versus terminal-cancelled semantics.
+- Narrowed P5's gap to leaf/critique/fact-check and recorded concrete P3/P6
+  weak-coverage gaps.
+- Split natural receptionist outcomes from exact =list_threads= capability
+  probes.
+- Named the exact four experiment node IDs and retained them across both arms.
+- Added private home-backed log handling and removed committed host paths.
+- Made synthetic completion route-neutral for duplicate, serial, terminal, and
+  whole-task delegation, with an explicit 32-completion quiescence bound; this
+  review-driven harness change restarts candidate measurement.
+- Restricted report recognition to exact case-sensitive target names with
+  path-safe, punctuation-aware boundaries, and made successful side effects
+  idempotent across duplicate wakes.
+- Bound source facts to exact colon-labelled or Markdown-heading fields without
+  requiring field order or canned fixture wording, and excluded hidden or raw
+  HTML from visible field content.
+- Used the first post-review artifact to correct a real field-boundary defect:
+  colons inside ordinary Markdown bullets remain field content, while an
+  unrelated standalone label still ends an empty field.  This validator change
+  restarts candidate measurement rather than selectively rerunning its failure.
+- Used the first N=5 artifact to correct a real lexical false negative: a
+  recommendation about the source's “tag-loss bug” is equivalent to “tag
+  import” for this outcome.  The remaining N=5 repetitions stopped immediately,
+  and N=3/N=5/N=10 restart together because their validator must share one SHA.
+
+* Completion report requirements
+
+The final report records the classification changes, exact run counts and
+results by layer, deterministic status, review rounds, declined out-of-scope
+findings with their risk/value, and what was hard.  Review
+findings do not expand implementation beyond this objective.  A directly
+related issue requiring significant unplanned rework triggers a blocked report
+with options before throwaway implementation.

--- a/docs/2026-08-03-prompt-architecture-p1b.org
+++ b/docs/2026-08-03-prompt-architecture-p1b.org
@@ -485,6 +485,10 @@ each exposed false negative; none are included above.
   also passed, and all four experiment node IDs collected exactly.
 - Official real-model results are the table above.  Candidate acceptance was
   72/72 at the frozen measured SHA.
+- GitHub PR #224 passed hosted CI in 5m12s.  Copilot round 1 raised three
+  comments, all verified false positives and declined with evidence; every
+  thread is resolved.  There were zero meaningful external findings, so no
+  post-measurement code or document correction was required.
 
 ** Declined and deferred findings
 
@@ -511,6 +515,7 @@ each exposed false negative; none are included above.
   restarted N=3/N=5/N=10 together at a new SHA.  This cost time, but prevented
   mixing incompatible acceptance definitions.
 
-External PR review and the final Kindle delivery are the remaining shipping
-steps.  Any valuable external finding outside P1b will be reported with its
-risk and value instead of widening this implementation.
+PR #224 is ready for Pierre's merge.  This document is the P1b-only final design,
+implementation guide, experiment record, and completion report prepared for
+Kindle delivery.  Any future valuable finding outside P1b will be reported with
+its risk and value instead of widening this implementation.

--- a/docs/2026-08-03-prompt-architecture-p1b.org
+++ b/docs/2026-08-03-prompt-architecture-p1b.org
@@ -3,7 +3,10 @@
 
 * Status
 
-Candidate implementation completed and five local code-review rounds converged.
+The prior direct-validator candidate completed five local code-review rounds;
+the judge-adoption redesign and terminal-response follow-up have completed
+focused review and fixes.  The final deterministic suite is green: 1,571
+passed, 2 skipped, 5 existing warnings, and 2 subtests passed.
 The counted baseline was natural 3/6 and capability 6/6.  The initial candidate
 was natural 6/6 and capability 6/6, but review found hidden route constraints in
 synthetic completion and field validation, so that measurement is diagnostic
@@ -16,8 +19,19 @@ post-review repetition was natural 1/2 and capability 2/2 because a valid
 recommendation described the source's “tag-loss bug” without the validator's
 literal “tag import” phrase.  Remaining repetitions stopped, the direct source-
 fact vocabulary was corrected, and all official measurements restart together
-at the next frozen SHA.  P1b changes eval classification and its two natural-
-test harness/validators only.
+at the next frozen SHA.  On that SHA, N=3 was natural 6/6 and capability 5/6;
+the capability miss was the unchanged strict dependency probe.  The first four
+N=5 repetitions were natural 7/8 and capability 8/8.  The natural miss was
+again a valid direct-route artifact, this time “tag import loses tags” versus a
+=loss|lost= regex.  Repetition 5 stopped.  Two independent semantic false
+negatives now prove direct lexical validation insufficient, so the final
+candidate retains deterministic file/field gates and adopts the already-
+qualified P1 outcome judge for semantic grounding.  All official measurements
+restart at the resulting SHA.  A focused live probe then passed both natural
+cases.  An isolated canned Alpha probe exposed a judge false positive because
+“repair tag import” did not explicitly decide whether to block launch, so all
+canned recommendations now state their launch/release decision.  P1b changes
+eval classification and its two natural-test harness/validators only.
 Agent prompts, tools, middleware, model settings, runtime behavior, and
 production paths remain frozen at Assist =main= commit =10a66ce=.
 
@@ -139,29 +153,34 @@ synthetic completions so a nonquiescent task graph fails deterministically.
 Synthetic delegate side effects materialize before the corresponding completion
 wake, independently of whether the parent later checks the result.
 
-Each natural validator then checks only what its prompt requests:
+Each natural validator first checks only deterministic facts that should not
+depend on language interpretation:
 
 - the four-report case requires all four named files, each containing its own
-  nonempty recommendation, risks, and next actions.  Distinct source facts pin
-  the pairing: Alpha's tag import, Beta's 25 percent cap and peak-load risk,
-  Gamma's owned medium findings, and Delta's rollback rehearsal; and
+  nonempty recommendation, risks, and next actions; and
 - the two-brief case requires both named files, with the requested independent
-  nonempty fields in each.  Alpha must carry the tag-import risk; Beta must
-  carry the 25 percent rollout limit and a source-relevant capacity, error, or
-  latency monitoring trigger.  Facts outside an empty labelled field do not
-  satisfy that field.
+  nonempty fields in each.  Facts outside an empty labelled field do not satisfy
+  that field.
 
 When a completed delegate brief names an exact requested report, as either its
 canonical root path or an unprefixed case-sensitive basename, the stub writes
 that target's fixed artifact content before the parent receives the completion
-wake.  A semantic judge over those artifacts would grade canned
-fixture output and add no signal.  Therefore P1b uses the clearer direct
-validators and does not change =edd/outcome_judge.py= or its frozen calibration
-corpus.  The P1 adoption contract remains binding for a later natural case
-whose outcome is genuinely semantic: exact security/state gates first,
-case-local bounded observation, one judge call, and only =pass= satisfies
-acceptance.  Observed artifact absence is valid =state="missing"= evidence;
-failure to acquire or bound required evidence stops before judging.
+wake.  After deterministic acquisition and field checks, each natural case
+makes one qualified =OutcomeJudge= call over only its user prompt, initial source
+files, final requested artifacts, terminal visible response, and evaluator-
+authored requested-outcome descriptions that restate the user-visible contract
+without source-answer facts.
+The observation supplies no tool calls, task IDs, delegate task descriptions,
+or route trace separately; the verbatim visible response may mention them.
+Sources are snapshotted before the agent runs and must remain byte-for-byte
+unchanged.  Evidence acquisition refuses symlinks and non-regular
+files, reads at most 16 KiB plus one byte through a nonblocking descriptor, and
+limits the full observation to 64 KiB of the exact serialized JSON.  Comments
+are removed and any residual angle-bracket markup is rejected before final
+artifacts become judge evidence.  Only semantic =pass= satisfies acceptance;
+the log records judge model and prompt hash.  The already-qualified judge and its
+calibration corpus remain byte-for-byte unchanged.  Failure to acquire or bound
+required evidence stops before judging.
 
 The two paired capability cases remain byte-for-byte strict:
 
@@ -182,6 +201,8 @@ No new helper survives unless it reduces the existing natural-test code.
   are byte-for-byte frozen.  Review may change only the two measured validators
   or their synthetic completion mechanics; any acceptance-affecting change
   restarts candidate measurement and is recorded in the changelog.
+- =edd/outcome_judge.py=, its prompt, and its qualification corpus remain frozen;
+  the two natural cases consume that existing P1 interface.
 - All arms run these exact four node IDs:
   - =edd/eval/test_async_subagents.py::TestAsyncSubagentSupervisor::test_natural_long_list_chooses_one_delegate_per_outcome=
   - =edd/eval/test_async_subagents.py::TestAsyncSubagentSupervisor::test_natural_two_independent_outcomes_delegate=
@@ -275,9 +296,9 @@ SECONDS=0
   documentation changed.  Every candidate command checks a clean worktree and
   the same preregistered candidate SHA; in particular, no prompt/runtime
   behavior changed.
-- No judge is called because these exact artifact outcomes have clearer direct
-  validators.  This is an experiment conclusion, not a waiver of the P1
-  adoption contract for later semantic cases.
+- Each natural case makes exactly one judge call after deterministic file and
+  requested-field gates.  Only =pass= passes, and the private run log records
+  model and prompt provenance.
 
 * Risks, decisions, and deferred findings
 
@@ -298,21 +319,17 @@ SECONDS=0
   describes an older three-test, path-based loader.  Updating that unrelated
   suite has documentation value but no effect on P1b classification or results,
   so it remains deferred rather than widening this change.
-- A report that conveys recommendation, risk, or action with entirely different
-  vocabulary can still false-fail the direct validator.  The current prompts
-  explicitly request those named fields, so accepting their colon labels or
-  Markdown headings is a practical deterministic boundary.  A semantic judge
-  would accept more paraphrases but adds a second model signal; use it only if
-  real outputs expose this risk rather than expanding P1b speculatively.
-- Direct validators remove hidden HTML comments and reject raw HTML before
-  checking visible field content.  They do not attempt a general natural-
-  language contradiction detector; that is the known direct-validator boundary
-  above.
+- Real direct-route artifacts exposed two independent lexical false negatives,
+  so semantic source grounding now uses the qualified judge instead of growing
+  a synonym list.  Deterministic validators still remove hidden HTML comments,
+  reject raw HTML, and require every explicitly requested field to contain
+  visible content before judging.
 
 * Review changelog
 
-- Removed semantic judging from canned async artifacts; direct validators are
-  the stronger signal.
+- Initially preferred direct semantic validators for the canned delegate
+  fixtures; adopted the qualified judge only after real direct-route artifacts
+  demonstrated repeated lexical false negatives.
 - Removed the proposed Python cohort registry and fixture module.
 - Classified all 13 async cases exactly once and separated prerequisites from
   the three-value acceptance layer.
@@ -341,6 +358,26 @@ SECONDS=0
   recommendation about the source's “tag-loss bug” is equivalent to “tag
   import” for this outcome.  The remaining N=5 repetitions stopped immediately,
   and N=3/N=5/N=10 restart together because their validator must share one SHA.
+- A later N=5 artifact expressed the same valid source risk as “tag import loses
+  tags,” exposing another lexical false negative.  Rather than add more regex
+  synonyms, retained deterministic file/field gates and adopted one existing P1
+  judge call per natural case.  No judge implementation or production path
+  changed, and all measurements restart again.
+- Judge-adoption review required true pre-run source snapshots with unchanged-
+  source checks, removed expected source answers from evaluator requirements,
+  bounded each file and whole observation before judging, and passed only
+  sanitized visible final artifacts to the judge.
+- Adversarial review then made source equality byte-exact, changed evidence
+  acquisition to bounded no-follow regular-file reads, measured the exact JSON
+  payload bytes, and rejected every residual angle-bracket construct.  Its live
+  two-case probe passed, while its isolated canned-Alpha probe exposed and fixed
+  an explicit-decision gap in the deterministic fixtures.
+- Final correctness review found that artifact-only observations could miss a
+  contradictory visible reply.  The harness now retains the terminal reply and
+  cites it for every requested outcome inside the same bounded judge call.
+- Follow-up review found no correctness, security, or simplicity defect after
+  that fix; it corrected only the documentation boundary for task IDs that may
+  appear naturally inside the verbatim visible response.
 
 * Completion report requirements
 

--- a/edd/eval/test_async_subagents.py
+++ b/edd/eval/test_async_subagents.py
@@ -3,13 +3,14 @@
 The subagents are deterministic stubs. This suite evaluates supervisor scheduling,
 requested workspace outcomes, and visible replies across launch/completion turns,
 not child quality or queue plumbing.
-Explicitly named capability tests isolate delegate fan-out and dependency handling;
-the remaining tests use natural requests as the acceptance signal.
+Cases are classified as natural outcome acceptance, exact capability coverage, or
+deterministic security/state coverage in the P1b state document.
 """
 from __future__ import annotations
 
 import hashlib
 import json
+import re
 import tempfile
 from pathlib import Path
 from unittest import TestCase
@@ -60,7 +61,10 @@ def _delegate_starts(calls: list[dict]) -> list[dict]:
 
 
 def _completion_wake(task_id: str, status: str) -> str:
-    """Production-shaped task-completion message delivered to the parent model."""
+    """Complete synthetic side effects, then return the production-shaped wake."""
+    if (status == "success"
+            and _TASK_STATUSES.get(task_id) in {"pending", "running"}):
+        _materialize_report_artifacts(task_id)
     _TASK_STATUSES[task_id] = status
     return (
         f"Task ID: {task_id}\n"
@@ -114,21 +118,9 @@ def _task_result(task_id: str, status: str, *, result: str | None = None,
     return json.dumps(payload)
 
 
-def _check(task_id: str) -> str:
+def _materialize_report_artifacts(task_id: str) -> None:
+    """Write deterministic report fixtures named by a delegate brief."""
     description = _TASK_DESCRIPTIONS.get(task_id, "")
-    status = _TASK_STATUSES.get(task_id, "pending")
-    if status == "error":
-        return _task_result(
-            task_id, status,
-            error="The prerequisite task failed its verification.")
-    if status == "timeout":
-        return _task_result(
-            task_id, status,
-            error="The task exceeded its execution limit.")
-    if status in {"pending", "running", "interrupted"}:
-        return _task_result(task_id, status)
-    if status == "cancelled":
-        return _task_result(task_id, status)
     artifacts = {
         "alpha-report.md": (
             "# Alpha report\n\nRecommendation: fix tag import before launch.\n\n"
@@ -154,15 +146,38 @@ def _check(task_id: str) -> str:
             "Rollout limits: 25 percent.\n\n"
             "Monitoring triggers: peak-load errors.\n"),
     }
-    if _TASK_TYPES.get(task_id) == "delegate-agent":
-        target = next((name for name in artifacts
-                       if name in description.lower()), None)
-        if target is not None:
-            if _TASK_ROOT is None:
-                raise RuntimeError("eval task root is unavailable")
+    if _TASK_TYPES.get(task_id) != "delegate-agent":
+        return
+    targets = [
+        name for name in artifacts
+        if re.search(
+            rf"(?<![\w./:\\-])/?{re.escape(name)}"
+            r'(?=$|\s|[\])}>"\'`*.,;:!?…]+(?=\s|$))',
+            description,
+        )
+    ]
+    if targets:
+        if _TASK_ROOT is None:
+            raise RuntimeError("eval task root is unavailable")
+        for target in targets:
             Path(_TASK_ROOT, target).write_text(artifacts[target])
-            return _task_result(
-                task_id, "success", result=f"Created and verified /{target}.")
+
+
+def _check(task_id: str) -> str:
+    description = _TASK_DESCRIPTIONS.get(task_id, "")
+    status = _TASK_STATUSES.get(task_id, "pending")
+    if status == "error":
+        return _task_result(
+            task_id, status,
+            error="The prerequisite task failed its verification.")
+    if status == "timeout":
+        return _task_result(
+            task_id, status,
+            error="The task exceeded its execution limit.")
+    if status in {"pending", "running", "interrupted"}:
+        return _task_result(task_id, status)
+    if status == "cancelled":
+        return _task_result(task_id, status)
     if ("alpha-notes.md" in description.lower()
             and "audit" in description.lower()
             and _TASK_TYPES.get(task_id) == "delegate-agent"):
@@ -325,33 +340,63 @@ class TestAsyncSubagentSupervisor(TestCase):
                 if isinstance(message, AIMessage)
                 for call in (message.tool_calls or [])]
 
-    def _assert_complex_skill_loaded_first(self, agent: AgentHarness) -> None:
-        first_calls = next(
-            message.tool_calls for message in agent.all_messages()
-            if isinstance(message, AIMessage) and message.tool_calls)
-        self.assertEqual(len(first_calls), 1, first_calls)
-        self.assertEqual(first_calls[0].get("name"), "load_skill", first_calls)
-        self.assertEqual(
-            first_calls[0].get("args", {}).get("name"),
-            "complex-request",
-            first_calls,
-        )
-
-    def _complete_delegates(
-            self, agent: AgentHarness, delegates: list[dict]) -> list[dict]:
-        completion_calls: list[dict] = []
-        for delegate in delegates:
-            task_id = _task_id_for_call(delegate)
-            before = len(self._calls(agent))
+    def _complete_synthetic_work(self, agent: AgentHarness) -> None:
+        """Deliver at most 32 results; fail if synthetic work remains."""
+        for _ in range(32):
+            task_id = next((
+                task_id for task_id, status in _TASK_STATUSES.items()
+                if status in {"pending", "running"}
+            ), None)
+            if task_id is None:
+                return
             agent.message(_completion_wake(task_id, "success"))
-            current = self._calls(agent)[before:]
-            self.assertTrue(any(
-                call.get("name") == "check_async_task"
-                and call.get("args", {}).get("task_id") == task_id
-                for call in current
-            ), current)
-            completion_calls.extend(current)
-        return completion_calls
+        if any(status in {"pending", "running"}
+               for status in _TASK_STATUSES.values()):
+            self.fail("synthetic work exceeded 32 task completions")
+
+    def _labelled_fields(
+            self, content: str, labels: tuple[str, ...]) -> dict[str, str]:
+        content = re.sub(r"<!--.*?(?:-->|$)", "", content, flags=re.DOTALL)
+        self.assertNotRegex(content, r"(?i)</?[a-z][^>]*>")
+        alternatives = "|".join(re.escape(label) for label in labels)
+        colon = re.compile(
+            rf"(?i)(?P<label>{alternatives})[ \t]*:[ \t]*(?P<inline>.*)"
+        )
+        heading = re.compile(
+            rf"(?i)(?:#{{1,6}}|\*{{2,}})[ \t]+"
+            rf"(?P<label>{alternatives})"
+            rf"(?:[ \t]*:[ \t]*(?P<inline>.*?))?[ \t]*(?:[#*]+)?"
+        )
+        any_heading = re.compile(r"(?:#{1,6}|\*{2,})[ \t]+\S.*")
+        any_label = re.compile(r"(?![-+*][ \t])[^:]{1,80}:[ \t]*.*")
+        lines = content.splitlines()
+        markers: list[tuple[int, str, str]] = []
+        boundaries: list[int] = []
+        for index, line in enumerate(lines):
+            stripped = line.strip()
+            match = colon.fullmatch(stripped)
+            if match is not None:
+                markers.append((
+                    index, match.group("label").lower(), match.group("inline")))
+            else:
+                match = heading.fullmatch(stripped)
+                if match is not None:
+                    markers.append((
+                        index, match.group("label").lower(),
+                        match.group("inline") or ""))
+            if any_heading.fullmatch(stripped) or any_label.fullmatch(stripped):
+                boundaries.append(index)
+        found = [label for _, label, _ in markers]
+        self.assertCountEqual(found, labels)
+        fields: dict[str, str] = {}
+        for index, label, inline in markers:
+            end = next((boundary for boundary in boundaries if boundary > index),
+                       len(lines))
+            value = " ".join(
+                "\n".join((inline, *lines[index + 1:end])).split())
+            self.assertTrue(value, label)
+            fields[label] = value
+        return fields
 
     def _assert_one_delegate_per_target(
             self, delegates: list[dict], targets: tuple[str, ...]) -> None:
@@ -464,76 +509,84 @@ class TestAsyncSubagentSupervisor(TestCase):
         self.assertEqual(len(task_ids), 3)
 
     def test_natural_long_list_chooses_one_delegate_per_outcome(self):
+        """Accept the requested reports; retain the frozen historical node ID."""
         agent = self._agent()
-        reply = agent.message(
+        agent.message(
             "I need a decision report for each of four launch workstreams while I "
             "handle the release meeting. Use /alpha-notes.md for /alpha-report.md, "
             "/beta-notes.md for /beta-report.md, /gamma-notes.md for "
             "/gamma-report.md, and /delta-notes.md for /delta-report.md. Each report "
             "should give its own recommendation, risks, and next actions.")
-        calls = self._calls(agent)
-        delegates = _delegate_starts(calls)
-        self._assert_complex_skill_loaded_first(agent)
-        if not delegates:
-            grounding = [
-                call for call in calls
-                if call.get("name") == "start_async_task"
-                and call.get("args", {}).get("subagent_type") != "delegate-agent"
-            ]
-            self.assertTrue(grounding, calls)
-            for call in grounding:
-                agent.message(_completion_wake(_task_id_for_call(call), "success"))
-            calls = self._calls(agent)
-            delegates = _delegate_starts(calls)
-        self.assertEqual(len(delegates), 4, (calls, reply))
-        targets = ("alpha-report.md", "beta-report.md", "gamma-report.md",
-                   "delta-report.md")
-        self._assert_one_delegate_per_target(delegates, targets)
-        for source, target in zip(
-                ("alpha-notes.md", "beta-notes.md", "gamma-notes.md",
-                 "delta-notes.md"), targets):
-            brief = next(call["args"]["description"].lower()
-                         for call in delegates
-                         if target in call["args"]["description"].lower())
-            for expected in (source, target, "recommend", "risk", "next action",
-                             "verif"):
-                self.assertIn(expected, brief)
-        self._complete_delegates(agent, delegates)
+        self._complete_synthetic_work(agent)
         assert _TASK_ROOT is not None
-        for target in targets:
+        expected_facts = {
+            "alpha-report.md": {
+                "recommendation": (
+                    r"(?:tag|tags).{0,40}(?:import|loss|lost|bug)|"
+                    r"(?:import|loss|lost|bug).{0,40}(?:tag|tags)"
+                ),
+                "risks": r"(?:tag|tags).*(?:loss|lost)|(?:loss|lost).*(?:tag|tags)",
+                "next actions": r"\brunbook\b|\brepair\b.{0,40}\bimport\b",
+            },
+            "beta-report.md": {
+                "recommendation": r"25\s*(?:percent|%)",
+                "risks": r"peak.{0,20}load|load.{0,20}peak",
+                "next actions": r"\bcap(?:ped|ping)?\b|\bmonitor\w*\b",
+            },
+            "gamma-report.md": {
+                "recommendation": r"\bfindings?\b",
+                "risks": r"medium.{0,20}finding|finding.{0,20}medium",
+                "next actions": r"\bowners?\b|\bclosure\b",
+            },
+            "delta-report.md": {
+                "recommendation": r"rollback",
+                "risks": r"rollback",
+                "next actions": r"rehears",
+            },
+        }
+        labels = ("recommendation", "risks", "next actions")
+        for target, field_patterns in expected_facts.items():
             content = Path(_TASK_ROOT, target).read_text().lower()
-            for expected in ("recommendation", "risks", "next actions"):
-                self.assertIn(expected, content)
+            fields = self._labelled_fields(content, labels)
+            for field, expected in field_patterns.items():
+                self.assertRegex(fields[field], expected)
 
     def test_natural_two_independent_outcomes_delegate(self):
+        """Accept the requested briefs; retain the frozen historical node ID."""
         agent = self._agent()
-        reply = agent.message(
+        agent.message(
             "Prepare two launch briefs for separate teams while I work on the agenda. "
             "Turn /alpha-notes.md into /alpha-brief.md with a recommendation and "
             "unresolved risks. Also turn /beta-notes.md into /beta-brief.md with its "
             "own recommendation, rollout limits, and monitoring triggers.")
-        calls = self._calls(agent)
-        delegates = _delegate_starts(calls)
-        self._assert_complex_skill_loaded_first(agent)
-        self.assertEqual(len(delegates), 2, (calls, reply))
-        targets = ("alpha-brief.md", "beta-brief.md")
-        self._assert_one_delegate_per_target(delegates, targets)
-        alpha = next(call["args"]["description"].lower() for call in delegates
-                     if "alpha-brief.md" in call["args"]["description"].lower())
-        beta = next(call["args"]["description"].lower() for call in delegates
-                    if "beta-brief.md" in call["args"]["description"].lower())
-        for expected in ("alpha-notes.md", "alpha-brief.md", "recommend", "risk",
-                         "verif"):
-            self.assertIn(expected, alpha)
-        for expected in ("beta-notes.md", "beta-brief.md", "recommend", "rollout",
-                         "monitor", "verif"):
-            self.assertIn(expected, beta)
-        self._complete_delegates(agent, delegates)
+        self._complete_synthetic_work(agent)
         assert _TASK_ROOT is not None
-        self.assertRegex(Path(_TASK_ROOT, "alpha-brief.md").read_text(),
-                         r"(?is)recommendation.*unresolved risks")
-        self.assertRegex(Path(_TASK_ROOT, "beta-brief.md").read_text(),
-                         r"(?is)recommendation.*rollout limits.*monitoring triggers")
+        alpha = Path(_TASK_ROOT, "alpha-brief.md").read_text().lower()
+        alpha_fields = self._labelled_fields(
+            alpha, ("recommendation", "unresolved risks"))
+        self.assertRegex(
+            alpha_fields["recommendation"],
+            r"(?:tag|tags).{0,40}(?:import|loss|lost|bug)|"
+            r"(?:import|loss|lost|bug).{0,40}(?:tag|tags)",
+        )
+        self.assertRegex(
+            alpha_fields["unresolved risks"],
+            r"tag.{0,30}loss|loss.{0,30}tag",
+        )
+        beta = Path(_TASK_ROOT, "beta-brief.md").read_text().lower()
+        beta_fields = self._labelled_fields(
+            beta, ("recommendation", "rollout limits", "monitoring triggers"),
+        )
+        self.assertRegex(
+            beta_fields["recommendation"],
+            r"\bcap(?:ped|ping)?\b|25\s*(?:percent|%)",
+        )
+        self.assertRegex(
+            beta_fields["rollout limits"], r"25\s*(?:percent|%)")
+        self.assertRegex(
+            beta_fields["monitoring triggers"],
+            r"peak.{0,20}load|\berrors?\b|\berror rate\b|\blatency\b",
+        )
 
     def test_single_outcome_with_several_steps_stays_with_main(self):
         agent = self._agent()

--- a/edd/eval/test_async_subagents.py
+++ b/edd/eval/test_async_subagents.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
+import stat
 import tempfile
 from pathlib import Path
 from unittest import TestCase
@@ -29,6 +31,7 @@ from assist.async_subagents import (
 )
 from assist.model_manager import select_assistant_model
 from assist.spec import AgentSpec
+from edd.outcome_judge import OutcomeJudge, OutcomeObservation
 
 from .utils import create_filesystem
 
@@ -39,6 +42,33 @@ _TASK_STATUSES: dict[str, str] = {}
 _TASK_ROOT: str | None = None
 _TASK_SEQUENCE = 0
 _DIRECT_WORK_TOOLS = {"write_file", "edit_file", "execute"}
+_MAX_JUDGE_FILE_BYTES = 16 * 1024
+_MAX_JUDGE_OBSERVATION_BYTES = 64 * 1024
+
+
+def _read_judge_evidence(path: Path) -> bytes:
+    """Read one bounded artifact before constructing a judge observation."""
+    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    try:
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise AssertionError(f"judge evidence is not a regular file: {path.name}")
+        chunks: list[bytes] = []
+        remaining = _MAX_JUDGE_FILE_BYTES + 1
+        while remaining:
+            chunk = os.read(fd, remaining)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        content = b"".join(chunks)
+        if len(content) > _MAX_JUDGE_FILE_BYTES:
+            raise AssertionError(
+                f"judge evidence exceeds {_MAX_JUDGE_FILE_BYTES} bytes: {path.name}"
+            )
+        return content
+    finally:
+        os.close(fd)
 
 
 def _task_id(description: str, subagent_type: str) -> str:
@@ -123,26 +153,31 @@ def _materialize_report_artifacts(task_id: str) -> None:
     description = _TASK_DESCRIPTIONS.get(task_id, "")
     artifacts = {
         "alpha-report.md": (
-            "# Alpha report\n\nRecommendation: fix tag import before launch.\n\n"
+            "# Alpha report\n\nRecommendation: block launch until tag import "
+            "is repaired.\n\n"
             "Risks: lost tags and missing support guidance.\n\n"
             "Next actions: repair import and write the runbook.\n"),
         "beta-report.md": (
-            "# Beta report\n\nRecommendation: use the 25 percent rollout cap.\n\n"
+            "# Beta report\n\nRecommendation: ship behind the 25 percent "
+            "rollout cap.\n\n"
             "Risks: peak-load failure.\n\n"
             "Next actions: configure the cap and monitoring trigger.\n"),
         "gamma-report.md": (
-            "# Gamma report\n\nRecommendation: proceed with tracked findings.\n\n"
+            "# Gamma report\n\nRecommendation: proceed with limited launch, but "
+            "close both medium findings before general availability.\n\n"
             "Risks: overdue medium findings.\n\n"
             "Next actions: verify owners and closure dates.\n"),
         "delta-report.md": (
-            "# Delta report\n\nRecommendation: rehearse rollback before release.\n\n"
+            "# Delta report\n\nRecommendation: block release until rollback is "
+            "rehearsed.\n\n"
             "Risks: an unrehearsed Friday rollback.\n\n"
             "Next actions: run the rehearsal and record go/no-go.\n"),
         "alpha-brief.md": (
-            "# Alpha brief\n\nRecommendation: repair tag import.\n\n"
+            "# Alpha brief\n\nRecommendation: block launch until tag import is "
+            "repaired.\n\n"
             "Unresolved risks: tag loss and missing support runbook.\n"),
         "beta-brief.md": (
-            "# Beta brief\n\nRecommendation: capped rollout.\n\n"
+            "# Beta brief\n\nRecommendation: ship behind a capped rollout.\n\n"
             "Rollout limits: 25 percent.\n\n"
             "Monitoring triggers: peak-load errors.\n"),
     }
@@ -340,24 +375,26 @@ class TestAsyncSubagentSupervisor(TestCase):
                 if isinstance(message, AIMessage)
                 for call in (message.tool_calls or [])]
 
-    def _complete_synthetic_work(self, agent: AgentHarness) -> None:
-        """Deliver at most 32 results; fail if synthetic work remains."""
+    def _complete_synthetic_work(
+            self, agent: AgentHarness, reply: str) -> str:
+        """Deliver at most 32 results and return the terminal visible reply."""
         for _ in range(32):
             task_id = next((
                 task_id for task_id, status in _TASK_STATUSES.items()
                 if status in {"pending", "running"}
             ), None)
             if task_id is None:
-                return
-            agent.message(_completion_wake(task_id, "success"))
+                return reply
+            reply = agent.message(_completion_wake(task_id, "success"))
         if any(status in {"pending", "running"}
                for status in _TASK_STATUSES.values()):
             self.fail("synthetic work exceeded 32 task completions")
+        return reply
 
-    def _labelled_fields(
-            self, content: str, labels: tuple[str, ...]) -> dict[str, str]:
+    def _validated_field_evidence(
+            self, content: str, labels: tuple[str, ...]) -> str:
         content = re.sub(r"<!--.*?(?:-->|$)", "", content, flags=re.DOTALL)
-        self.assertNotRegex(content, r"(?i)</?[a-z][^>]*>")
+        self.assertNotRegex(content, r"<[^>]*>")
         alternatives = "|".join(re.escape(label) for label in labels)
         colon = re.compile(
             rf"(?i)(?P<label>{alternatives})[ \t]*:[ \t]*(?P<inline>.*)"
@@ -388,15 +425,29 @@ class TestAsyncSubagentSupervisor(TestCase):
                 boundaries.append(index)
         found = [label for _, label, _ in markers]
         self.assertCountEqual(found, labels)
-        fields: dict[str, str] = {}
         for index, label, inline in markers:
             end = next((boundary for boundary in boundaries if boundary > index),
                        len(lines))
             value = " ".join(
                 "\n".join((inline, *lines[index + 1:end])).split())
             self.assertTrue(value, label)
-            fields[label] = value
-        return fields
+        return content
+
+    def _assert_judge_pass(self, observation: OutcomeObservation) -> None:
+        payload = json.dumps(observation.model_dump(mode="json"), sort_keys=True)
+        self.assertLessEqual(
+            len(payload.encode()), _MAX_JUDGE_OBSERVATION_BYTES
+        )
+        result = OutcomeJudge().judge_with_provenance(observation)
+        print(
+            f"outcome_judge model={result.model} "
+            f"prompt_sha256={result.prompt_sha256}"
+        )
+        self.assertEqual(
+            result.verdict.overall,
+            "pass",
+            result.verdict.model_dump_json(indent=2),
+        )
 
     def _assert_one_delegate_per_target(
             self, delegates: list[dict], targets: tuple[str, ...]) -> None:
@@ -511,82 +562,129 @@ class TestAsyncSubagentSupervisor(TestCase):
     def test_natural_long_list_chooses_one_delegate_per_outcome(self):
         """Accept the requested reports; retain the frozen historical node ID."""
         agent = self._agent()
-        agent.message(
+        prompt = (
             "I need a decision report for each of four launch workstreams while I "
             "handle the release meeting. Use /alpha-notes.md for /alpha-report.md, "
             "/beta-notes.md for /beta-report.md, /gamma-notes.md for "
             "/gamma-report.md, and /delta-notes.md for /delta-report.md. Each report "
-            "should give its own recommendation, risks, and next actions.")
-        self._complete_synthetic_work(agent)
+            "should give its own recommendation, risks, and next actions."
+        )
         assert _TASK_ROOT is not None
-        expected_facts = {
-            "alpha-report.md": {
-                "recommendation": (
-                    r"(?:tag|tags).{0,40}(?:import|loss|lost|bug)|"
-                    r"(?:import|loss|lost|bug).{0,40}(?:tag|tags)"
-                ),
-                "risks": r"(?:tag|tags).*(?:loss|lost)|(?:loss|lost).*(?:tag|tags)",
-                "next actions": r"\brunbook\b|\brepair\b.{0,40}\bimport\b",
-            },
-            "beta-report.md": {
-                "recommendation": r"25\s*(?:percent|%)",
-                "risks": r"peak.{0,20}load|load.{0,20}peak",
-                "next actions": r"\bcap(?:ped|ping)?\b|\bmonitor\w*\b",
-            },
-            "gamma-report.md": {
-                "recommendation": r"\bfindings?\b",
-                "risks": r"medium.{0,20}finding|finding.{0,20}medium",
-                "next actions": r"\bowners?\b|\bclosure\b",
-            },
-            "delta-report.md": {
-                "recommendation": r"rollback",
-                "risks": r"rollback",
-                "next actions": r"rehears",
-            },
+        source_bytes = {
+            workstream: _read_judge_evidence(
+                Path(_TASK_ROOT, f"{workstream}-notes.md")
+            )
+            for workstream in ("alpha", "beta", "gamma", "delta")
         }
+        reply = self._complete_synthetic_work(agent, agent.message(prompt))
         labels = ("recommendation", "risks", "next actions")
-        for target, field_patterns in expected_facts.items():
-            content = Path(_TASK_ROOT, target).read_text().lower()
-            fields = self._labelled_fields(content, labels)
-            for field, expected in field_patterns.items():
-                self.assertRegex(fields[field], expected)
+        evidence = [{
+            "id": "prompt", "kind": "prompt", "state": "present",
+            "content": prompt,
+        }, {
+            "id": "response", "kind": "response", "state": "present",
+            "content": reply,
+        }]
+        requested = []
+        for workstream, source in source_bytes.items():
+            source_id = f"{workstream}-source"
+            report_id = f"{workstream}-report"
+            source_path = Path(_TASK_ROOT, f"{workstream}-notes.md")
+            self.assertEqual(
+                _read_judge_evidence(source_path), source,
+                f"agent changed {source_path.name}",
+            )
+            report = _read_judge_evidence(
+                Path(_TASK_ROOT, f"{workstream}-report.md")
+            ).decode()
+            report = self._validated_field_evidence(report, labels)
+            evidence.extend((
+                {"id": source_id, "kind": "initial", "state": "present",
+                 "content": source.decode()},
+                {"id": report_id, "kind": "final", "state": "present",
+                 "content": report},
+            ))
+            requested.append({
+                "id": f"{workstream}-decision-report",
+                "description": (
+                    f"The requested /{workstream}-report.md gives its own "
+                    "recommendation, risks, and next actions grounded in "
+                    f"/{workstream}-notes.md and answers the decision requested "
+                    "by that source."
+                ),
+                "evidence_ids": ("prompt", source_id, report_id, "response"),
+            })
+        self._assert_judge_pass(OutcomeObservation.model_validate({
+            "requested": requested,
+            "evidence": evidence,
+        }))
 
     def test_natural_two_independent_outcomes_delegate(self):
         """Accept the requested briefs; retain the frozen historical node ID."""
         agent = self._agent()
-        agent.message(
+        prompt = (
             "Prepare two launch briefs for separate teams while I work on the agenda. "
             "Turn /alpha-notes.md into /alpha-brief.md with a recommendation and "
             "unresolved risks. Also turn /beta-notes.md into /beta-brief.md with its "
-            "own recommendation, rollout limits, and monitoring triggers.")
-        self._complete_synthetic_work(agent)
+            "own recommendation, rollout limits, and monitoring triggers."
+        )
         assert _TASK_ROOT is not None
-        alpha = Path(_TASK_ROOT, "alpha-brief.md").read_text().lower()
-        alpha_fields = self._labelled_fields(
-            alpha, ("recommendation", "unresolved risks"))
-        self.assertRegex(
-            alpha_fields["recommendation"],
-            r"(?:tag|tags).{0,40}(?:import|loss|lost|bug)|"
-            r"(?:import|loss|lost|bug).{0,40}(?:tag|tags)",
-        )
-        self.assertRegex(
-            alpha_fields["unresolved risks"],
-            r"tag.{0,30}loss|loss.{0,30}tag",
-        )
-        beta = Path(_TASK_ROOT, "beta-brief.md").read_text().lower()
-        beta_fields = self._labelled_fields(
-            beta, ("recommendation", "rollout limits", "monitoring triggers"),
-        )
-        self.assertRegex(
-            beta_fields["recommendation"],
-            r"\bcap(?:ped|ping)?\b|25\s*(?:percent|%)",
-        )
-        self.assertRegex(
-            beta_fields["rollout limits"], r"25\s*(?:percent|%)")
-        self.assertRegex(
-            beta_fields["monitoring triggers"],
-            r"peak.{0,20}load|\berrors?\b|\berror rate\b|\blatency\b",
-        )
+        briefs = {
+            "alpha": (
+                ("recommendation", "unresolved risks"),
+                "a recommendation and unresolved risks",
+            ),
+            "beta": (
+                ("recommendation", "rollout limits", "monitoring triggers"),
+                "its own recommendation, rollout limits, and monitoring triggers",
+            ),
+        }
+        source_bytes = {
+            workstream: _read_judge_evidence(
+                Path(_TASK_ROOT, f"{workstream}-notes.md")
+            )
+            for workstream in briefs
+        }
+        reply = self._complete_synthetic_work(agent, agent.message(prompt))
+        evidence = [
+            {"id": "prompt", "kind": "prompt", "state": "present",
+             "content": prompt},
+            {"id": "response", "kind": "response", "state": "present",
+             "content": reply},
+        ]
+        requested = []
+        for workstream, (labels, description) in briefs.items():
+            source_id = f"{workstream}-source"
+            brief_id = f"{workstream}-brief"
+            source_path = Path(_TASK_ROOT, f"{workstream}-notes.md")
+            source = source_bytes[workstream]
+            self.assertEqual(
+                _read_judge_evidence(source_path), source,
+                f"agent changed {source_path.name}",
+            )
+            brief = _read_judge_evidence(
+                Path(_TASK_ROOT, f"{workstream}-brief.md")
+            ).decode()
+            brief = self._validated_field_evidence(brief, labels)
+            evidence.extend((
+                {"id": source_id, "kind": "initial", "state": "present",
+                 "content": source.decode()},
+                {"id": brief_id, "kind": "final", "state": "present",
+                 "content": brief},
+            ))
+            requested.append({
+                "id": f"{workstream}-launch-brief",
+                "description": (
+                    f"The requested /{workstream}-brief.md gives {description} "
+                    f"grounded in /{workstream}-notes.md and addresses the "
+                    "decision requested by that source."
+                ),
+                "evidence_ids": ("prompt", source_id, brief_id, "response"),
+            })
+        self._assert_judge_pass(OutcomeObservation.model_validate({
+            "requested": requested,
+            "evidence": evidence,
+        }))
 
     def test_single_outcome_with_several_steps_stays_with_main(self):
         agent = self._agent()


### PR DESCRIPTION
## Summary

- classify the prompt-architecture P2 through P7 eval cohorts as natural acceptance, strict capability, or deterministic security/state coverage
- make two existing async natural cases grade the requested user-visible artifacts and terminal reply instead of one prescribed delegation route
- retain deterministic file/field/security gates, then use the already-qualified P1 `OutcomeJudge` for semantic grounding
- leave agent prompts, runtime code, judge implementation/prompt/corpus, P1c files, and production behavior unchanged

## Modified evals

### `test_natural_long_list_chooses_one_delegate_per_outcome`

Setup and fixtures: a fresh temporary workspace contains four authoritative launch notes. Alpha says tag import loses tags and needs a support runbook; Beta says normal load passes, triple peak fails, and rollout can be capped at 25 percent; Gamma has no critical security findings and two owned medium findings; Delta has complete documentation but no rollback rehearsal before a Friday release. Synthetic successful delegate completions may materialize the exact requested report fixtures before waking the parent, while direct work remains valid.

Full user prompt:

> I need a decision report for each of four launch workstreams while I handle the release meeting. Use /alpha-notes.md for /alpha-report.md, /beta-notes.md for /beta-report.md, /gamma-notes.md for /gamma-report.md, and /delta-notes.md for /delta-report.md. Each report should give its own recommendation, risks, and next actions.

Pass validation: all four sources must remain byte-for-byte unchanged. Each named report must be a bounded regular file acquired without following symlinks, contain exactly one nonempty visible recommendation, risks, and next-actions field after hidden-comment removal, and contain no residual angle-bracket markup. One closed outcome observation contains only the prompt, initial sources, final reports, and terminal visible response. Each workstream cites its own source/report plus the shared prompt/response. One qualified judge call must return overall `pass`; direct route, delegate count, tool order, task IDs, and brief vocabulary do not affect this natural pass bit.

### `test_natural_two_independent_outcomes_delegate`

Setup and fixtures: the same fresh workspace supplies the authoritative Alpha and Beta notes. Synthetic successful delegate completions may materialize `/alpha-brief.md` and `/beta-brief.md`; a direct route remains valid.

Full user prompt:

> Prepare two launch briefs for separate teams while I work on the agenda. Turn /alpha-notes.md into /alpha-brief.md with a recommendation and unresolved risks. Also turn /beta-notes.md into /beta-brief.md with its own recommendation, rollout limits, and monitoring triggers.

Pass validation: both sources must remain byte-for-byte unchanged. Alpha must contain exactly one nonempty visible recommendation and unresolved-risks field; Beta must contain exactly one nonempty visible recommendation, rollout-limits, and monitoring-triggers field. The same bounded regular-file, comment/markup, closed-observation, terminal-response, and pass-only judge rules apply. Route-shaped assertions are excluded.

## Paired capability controls

The existing `test_explicit_delegate_fanout_capability` and `test_explicit_dependent_delegate_starts_after_prerequisite_completion` methods remain byte-for-byte strict and unchanged. They separately verify exact three-delegate fan-out/task IDs and checked prerequisite-result propagation before a dependent delegate starts. This preserves mechanism diagnosis without contaminating natural acceptance.

## Results

Measured eval code SHA: `95ee4fef332a6cdcdb01cb23006f4259bdcbaaa6`.

| Arm | Natural | Capability | Total |
| --- | ---: | ---: | ---: |
| Baseline N=3 | 3/6 | 6/6 | 9/12 |
| Candidate N=3 | 6/6 | 6/6 | 12/12 |
| Candidate N=5 | 10/10 | 10/10 | 20/20 |
| Candidate N=10 | 20/20 | 20/20 | 40/40 |
| Candidate aggregate | 36/36 | 36/36 | 72/72 |

All 18 counted candidate repetitions used one frozen source SHA, model ID, judge prompt hash, node list, and clean worktree. Earlier validator-changing runs are documented as diagnostic and excluded.

## Verification

- `1571 passed, 2 skipped, 5 warnings, 2 subtests passed`
- outcome-judge unit tests: `23 passed`
- exact experiment collection: `4 tests collected`
- Org lint and diff hygiene passed
- local review: five full direct-validator rounds plus four focused judge-adoption/response rounds; final completion-doc audit found no blockers or important issues

## Scope

The diff contains only `edd/eval/test_async_subagents.py` and the P1b state/completion document. P1c is proceeding independently and owns the overall prompt-architecture document and roadmap.
