### PR TITLE
Gate bundled tools behind skill loads

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,8 +427,9 @@ keeps progressive disclosure but changes how the model interacts with it:
   middleware, replaces the upstream "use `read_file` with this path"
   mechanism. The model never sees skill paths.
 - A short, imperative **system-prompt template** that ends with a
-  mandatory pre-action check — scan the latest user message against
-  every skill description before any other tool call.
+  mandatory pre-action check: scan the latest user message and the active task
+  established by the conversation against every skill description before any
+  other tool call.
 - A **name-only skill listing** (`- **name**: description`) — upstream's
   `-> Read \`{path}\` for full instructions` line is stripped so there
   are no path strings for the model to copy.
@@ -467,8 +468,8 @@ evidence and must leave its detailed policy in the skill body.
 
 The description is normally the model's routing signal for whether to load. The
 main-only orchestration exception also has the short system-prompt hook above. A
-description is matched against the user's latest message by the
-pre-action check (and by the model's general attention). Every built-in
+description is matched against the user's latest message and the active task
+established by the conversation (and by the model's general attention). Every built-in
 skill uses the same shape — **a one-line capability sentence, a few
 concrete `EXAMPLES`, and a `MUST load before` clause**:
 
@@ -505,10 +506,10 @@ description: Editing or creating org-mode (`.org`) files without breaking headin
 
 ### Writing a skill body
 
-The body is what the agent applies after `load_skill` returns. By the
-time the body is read the agent has already committed to applying the
-skill, so the body's job is to be a clear reference for the rules — not
-to re-justify loading.
+`load_skill` returns the complete `SKILL.md`, including frontmatter. The body
+portion is what the agent applies. By the time the file is loaded the agent has
+already committed to applying the skill, so the body's job is to be a clear
+reference for the rules, not to re-justify loading.
 
 - Skip "When to apply" / "When to use" sections. The description (layer
   3) already covered the trigger conditions, and the body is read only
@@ -531,6 +532,8 @@ to re-justify loading.
    compositions. Those application tools are absent from provider schemas until
    `load_skill` successfully loads the winning bundled skill in the current
    invocation; both schema visibility and execution reset on the next turn.
+   Inbound SMS triage is deliberately excluded and retains its pre-P2b prompt,
+   loader, schemas, and backend behavior.
 2. That's it for a skill shared by every Assist role. `SkillsMiddleware`
    discovers it via the `/skills/` source path on next agent construction;
    the system prompt automatically lists it and
@@ -573,7 +576,7 @@ tools that support it — author once, use everywhere.
 assist serves `<repo>/.claude/skills/` through the working-directory
 backend in both local and sandbox modes; on the first turn of a chat the
 middleware lists every skill it finds there alongside the built-ins, and
-`load_skill(name="<skill-name>")` loads the body. (Skills are listed
+`load_skill(name="<skill-name>")` loads the complete `SKILL.md`. (Skills are listed
 once per chat — add one and start a new chat to pick it up.)
 
 During the P2b migration, domain-repository declarations are validated and

--- a/README.md
+++ b/README.md
@@ -527,8 +527,10 @@ to re-justify loading.
    tool, add the official space-separated `allowed-tools:` field with its exact
    model-visible names. Omit framework kernel tools such as filesystem, TODO,
    delegation/lifecycle, and `load_skill`; their availability does not depend on
-   a domain skill. The P2b.1 census validates bundled declarations against real
-   compositions; runtime disclosure and enforcement belong to later P2b phases.
+   a domain skill. Assist validates bundled declarations against real
+   compositions. Those application tools are absent from provider schemas until
+   `load_skill` successfully loads the winning bundled skill in the current
+   invocation; both schema visibility and execution reset on the next turn.
 2. That's it for a skill shared by every Assist role. `SkillsMiddleware`
    discovers it via the `/skills/` source path on next agent construction;
    the system prompt automatically lists it and
@@ -573,6 +575,11 @@ backend in both local and sandbox modes; on the first turn of a chat the
 middleware lists every skill it finds there alongside the built-ins, and
 `load_skill(name="<skill-name>")` loads the body. (Skills are listed
 once per chat — add one and start a new chat to pick it up.)
+
+During the P2b migration, domain-repository declarations are validated and
+recorded but do not yet hide tools at runtime. Bundled Assist skills use
+progressive disclosure now; domain and embedder-owned skills join that contract
+in P2b.3.
 
 **Authoring one on request.** Ask the agent to "make a skill for X" and
 the `author-skill` built-in walks it through writing a correct

--- a/assist/agent.py
+++ b/assist/agent.py
@@ -27,7 +27,7 @@ from assist.backends import (
     create_references_backend,
     create_sandbox_composite_backend,
     create_skills_backend,
-    ReadOnlyFilesystemBackend,
+    BundledSkillsBackend,
 )
 from assist.checkpoint_rollback import invoke_with_rollback, RollbackRunnable
 from assist.research_cleanup import ReferencesCleanupRunnable
@@ -58,6 +58,20 @@ from assist.env import env_int
 
 
 logger = logging.getLogger(__name__)
+
+
+def _tool_name(tool_value) -> str:
+    """Name a tool in any form accepted by Deep Agents."""
+    if isinstance(tool_value, dict):
+        function = tool_value.get("function")
+        name = (tool_value.get("name") or
+                (function.get("name") if isinstance(function, dict) else None))
+    else:
+        name = (getattr(tool_value, "name", None)
+                or getattr(tool_value, "__name__", None))
+    if not isinstance(name, str):
+        raise TypeError(f"tool has no registered name: {tool_value!r}")
+    return name
 
 # No auto-added `general-purpose` subagent, anywhere assist builds a deep
 # agent. Evidence (prod logs, 2026-07-21): every observed general-purpose
@@ -363,10 +377,15 @@ def create_agent(model: BaseChatModel,
     # _has_domain_skills is skipped when an embedder already supplied the path.
     if DOMAIN_SKILLS_PATH not in skill_sources and _has_domain_skills(backend):
         skill_sources.insert(1 if async_main else 0, DOMAIN_SKILLS_PATH)
-    bundled_skill_sources = {
+    agent_tools = (list(spec.async_subagent_tools or ())
+                   + list(spec.tools)
+                   + [tool_value for tool_value in
+                      (travel, directions, map_data, read_url)
+                      if tool_value not in spec.tools])
+    bundled_skill_sources: set[str] = set()
+    bundled_skill_sources.update(
         source for source, route_backend in extra_routes.items()
-        if isinstance(route_backend, ReadOnlyFilesystemBackend)
-    }
+        if isinstance(route_backend, BundledSkillsBackend))
     if SKILLS_ROUTE not in spec.skill_sources:
         bundled_skill_sources.add(SKILLS_ROUTE)
     if async_main and MAIN_SKILLS_ROUTE not in spec.skill_sources:
@@ -375,6 +394,7 @@ def create_agent(model: BaseChatModel,
         backend=backend,
         sources=skill_sources,
         bundled_sources=bundled_skill_sources,
+        registered_tools=(_tool_name(tool_value) for tool_value in agent_tools),
     )
     memory_mw = SmallModelMemoryMiddleware(
         backend=backend, memories_path=memories_path,
@@ -447,6 +467,7 @@ def create_agent(model: BaseChatModel,
                        SearchUnavailableBreakerMiddleware(
                            threshold=env_int("ASSIST_SEARCH_UNAVAILABLE_THRESHOLD", 4)),
                        EmptyResponseRecoveryMiddleware()],
+        **({"interrupt_on": spec.interrupt_on} if spec.interrupt_on else {}),
     }
 
     delegation_mode = ("legacy" if legacy_subagents else
@@ -522,10 +543,7 @@ def create_agent(model: BaseChatModel,
         # built-ins: direct deterministic real-world lookups the Assist graph answers
         # inline (gated by the travel / render skills), like a calculation — not web
         # research, so not on the research sub-agent.  Skip any a spec supplies (no dup).
-        tools=list(spec.async_subagent_tools or ())
-              + list(spec.tools)
-              + [t for t in (travel, directions, map_data, read_url)
-                 if t not in spec.tools],
+        tools=agent_tools,
     )
 
     return agent

--- a/assist/agent.py
+++ b/assist/agent.py
@@ -11,6 +11,7 @@ from langgraph.checkpoint.memory import InMemorySaver
 from langchain_core.language_models.chat_models import BaseChatModel
 from langgraph.graph.state import CompiledStateGraph
 from langchain.agents.middleware import ModelRetryMiddleware
+from langchain.agents.middleware import HumanInTheLoopMiddleware
 from openai import APIConnectionError, InternalServerError
 
 from assist.promptable import base_prompt_for
@@ -26,6 +27,7 @@ from assist.backends import (
     create_references_backend,
     create_sandbox_composite_backend,
     create_skills_backend,
+    ReadOnlyFilesystemBackend,
 )
 from assist.checkpoint_rollback import invoke_with_rollback, RollbackRunnable
 from assist.research_cleanup import ReferencesCleanupRunnable
@@ -361,7 +363,19 @@ def create_agent(model: BaseChatModel,
     # _has_domain_skills is skipped when an embedder already supplied the path.
     if DOMAIN_SKILLS_PATH not in skill_sources and _has_domain_skills(backend):
         skill_sources.insert(1 if async_main else 0, DOMAIN_SKILLS_PATH)
-    skills_mw = SmallModelSkillsMiddleware(backend=backend, sources=skill_sources)
+    bundled_skill_sources = {
+        source for source, route_backend in extra_routes.items()
+        if isinstance(route_backend, ReadOnlyFilesystemBackend)
+    }
+    if SKILLS_ROUTE not in spec.skill_sources:
+        bundled_skill_sources.add(SKILLS_ROUTE)
+    if async_main and MAIN_SKILLS_ROUTE not in spec.skill_sources:
+        bundled_skill_sources.add(MAIN_SKILLS_ROUTE)
+    skills_mw = SmallModelSkillsMiddleware(
+        backend=backend,
+        sources=skill_sources,
+        bundled_sources=bundled_skill_sources,
+    )
     memory_mw = SmallModelMemoryMiddleware(
         backend=backend, memories_path=memories_path,
         thread_memories_path=thread_memories_path)
@@ -490,6 +504,12 @@ def create_agent(model: BaseChatModel,
             ),
             # Mid-turn interjection delivery is installed on the user-facing main
             # agent only. A delegate is an atomic task worker and omits it.
+            # Keep HITL immediately before skills. after-model hooks run in
+            # reverse order, so skills rejects a hidden outward-effect call
+            # before HITL can interrupt on it. Execution remains HITL-gated
+            # after a successful matching skill load.
+            *([HumanInTheLoopMiddleware(interrupt_on=spec.interrupt_on)]
+              if spec.interrupt_on else []),
             skills_mw, memory_mw, ContextRiderMiddleware(),
             *([] if delegate else [InterjectionMiddleware()]), logging_mw],
         backend=backend,
@@ -506,8 +526,6 @@ def create_agent(model: BaseChatModel,
               + list(spec.tools)
               + [t for t in (travel, directions, map_data, read_url)
                  if t not in spec.tools],
-        # HITL gating for web outward-effect tools; None off.
-        **({"interrupt_on": spec.interrupt_on} if spec.interrupt_on else {}),
     )
 
     return agent

--- a/assist/agent.py
+++ b/assist/agent.py
@@ -377,11 +377,21 @@ def create_agent(model: BaseChatModel,
     # _has_domain_skills is skipped when an embedder already supplied the path.
     if DOMAIN_SKILLS_PATH not in skill_sources and _has_domain_skills(backend):
         skill_sources.insert(1 if async_main else 0, DOMAIN_SKILLS_PATH)
-    agent_tools = (list(spec.async_subagent_tools or ())
-                   + list(spec.tools)
-                   + [tool_value for tool_value in
-                      (travel, directions, map_data, read_url)
-                      if tool_value not in spec.tools])
+    agent_tools = []
+    registered_tool_names = set()
+    for tool_value in (
+        *list(spec.async_subagent_tools or ()),
+        *list(spec.tools),
+        travel, directions, map_data, read_url,
+    ):
+        # Deep Agents binds tools by name.  Specs may use provider-schema dicts
+        # while the built-ins are BaseTool instances, so object identity is not
+        # a sufficient duplicate check.
+        tool_name = _tool_name(tool_value)
+        if tool_name in registered_tool_names:
+            continue
+        registered_tool_names.add(tool_name)
+        agent_tools.append(tool_value)
     bundled_skill_sources: set[str] = set()
     bundled_skill_sources.update(
         source for source, route_backend in extra_routes.items()

--- a/assist/backends.py
+++ b/assist/backends.py
@@ -100,9 +100,18 @@ class ReadOnlyFilesystemBackend(FilesystemBackend):
                 for path, _content in files]
 
 
+class BundledSkillsBackend(ReadOnlyFilesystemBackend):
+    """Read-only backend marking an Assist-owned packaged skill route."""
+
+
 def create_skills_backend(root_dir: str) -> BackendProtocol:
-    """Return the shared read-only backend used for packaged agent skills."""
+    """Return a read-only backend for a skill tree."""
     return ReadOnlyFilesystemBackend(root_dir=root_dir, virtual_mode=True)
+
+
+def create_bundled_skills_backend(root_dir: str) -> BackendProtocol:
+    """Return a read-only backend marked as an Assist-owned skill tree."""
+    return BundledSkillsBackend(root_dir=root_dir, virtual_mode=True)
 
 # Domain skills live in the cloned repo at <working_dir>/.claude/skills/ — the
 # agentskills.io open-standard path that Claude Code and the Agent SDK also read
@@ -117,7 +126,7 @@ DOMAIN_SKILLS_PATH = "/.claude/skills/"
 
 def routes(stateful_paths: list[str]) -> dict:
     routes = {path: StateBackend() for path in stateful_paths}
-    routes[SKILLS_ROUTE] = create_skills_backend(SKILLS_DIR)
+    routes[SKILLS_ROUTE] = create_bundled_skills_backend(SKILLS_DIR)
     return routes
 
 

--- a/assist/middleware/skills_middleware.py
+++ b/assist/middleware/skills_middleware.py
@@ -1,29 +1,39 @@
-"""Small-model-friendly skills middleware.
+"""Small-model skill loading and bundled-tool progressive disclosure.
 
-Subclasses deepagents' SkillsMiddleware so the small models we run (e.g.
-Qwen3.6-27B) reliably load skills before acting in their domain.
-
-Two changes from the upstream behavior:
-
-1. A dedicated ``load_skill`` tool. The small model is much more reliable
-   invoking a single-arg named tool than constructing a path string for
-   ``read_file`` — the upstream mechanism. The tool takes a skill name
-   (e.g. ``"org-format"``) and returns the skill body.
-2. An imperative system-prompt template. The upstream template is
-   verbose and example-heavy. Ours is short, name-based (no paths
-   anywhere), and ends with a mandatory pre-action check that tells the
-   model to scan each user message for skill triggers before any other
-   tool call.
-
-The skill listing in the system prompt is name + description only — no
-filesystem paths and no specific skill names baked into the surrounding
-prose. The model interacts with skills through ``load_skill(name=...)``,
-so paths and file structure are irrelevant from its perspective.
+The model always sees the skill catalog and ``load_skill``. Tools declared by
+winning packaged Assist skills are withheld until that exact skill loads
+successfully in the current graph invocation. Domain and embedder skill/tool
+sources remain baseline-visible until P2b.3.
 """
-from langchain_core.tools import tool
+from __future__ import annotations
 
-from deepagents.middleware.skills import SkillsMiddleware
+import hashlib
+import json
+import operator
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Annotated, Any, NotRequired, TypedDict
 
+import deepagents.middleware.skills as deepagents_skills
+from deepagents.middleware.skills import (
+    MAX_SKILL_FILE_SIZE,
+    SkillsMiddleware,
+    SkillsState,
+)
+from langchain.agents.middleware.types import (
+    ModelRequest,
+    ModelResponse,
+    PrivateStateAttr,
+    ToolCallRequest,
+)
+from langchain_core.messages import AIMessage, ToolMessage
+from langchain_core.tools import BaseTool, tool
+from langgraph.prebuilt import ToolRuntime
+from langgraph.types import Command, Overwrite
+
+from assist.middleware.output_sanitization import _sanitize
+
+
+_LOAD_ARTIFACT_SCHEMA = "assist.skill-load.v1"
 
 SMALL_MODEL_SKILLS_PROMPT = """
 
@@ -41,42 +51,82 @@ the skill.
 ### How to use a skill
 
 1. **Match.** If a skill's description fits what you're about to do, continue to step 2.
-2. **Load.** Call `load_skill(name="<skill name>")`. The tool returns the full skill body.
-3. **Apply.** Use the rules from the loaded skill when you compose your action or response.
+2. **Load.** Call `load_skill(name="<skill name>")`. Make it the only tool call in that response and wait for its result.
+3. **Apply.** On the next response, use the newly available tools and the loaded rules.
 
-The descriptions only summarize *when* to load — they do not contain
-the rules. You will not know the rules until you complete step 2. You
-MUST complete step 2 before performing the matching action; relying on
-the description alone leads to incorrect outcomes.
+The descriptions only summarize *when* to load. You will not know the rules
+until the load completes. A referential follow-up such as "make it 8 instead"
+still matches the skill for the active task established by the conversation.
 
 ### Pre-action check (MANDATORY — apply on every turn before any tool call)
 
-Before issuing your first tool call on a turn, scan the user's latest
-message against every skill description above:
+Before issuing your first tool call on a turn, scan the user's latest message
+and its active task against every skill description above. If a skill matches,
+call only `load_skill(name="<matched skill>")` in that response. Do not combine
+it with `ls`, `read_file`, `task`, `edit_file`, or a newly disclosed tool. Only
+if no skill matches may you proceed directly to the task.
 
-1. Look for any keyword, file extension, filename, or topic from a
-   skill description that appears in the user's message.
-2. If a skill matches, your FIRST tool call this turn MUST be
-   `load_skill(name="<matched skill>")`. Do not run `ls`, `read_file`,
-   `task` to a sub-agent, or `edit_file` first — those steps come AFTER
-   the skill is loaded.
-3. Only if no skill matches may you proceed directly to your task.
-
-Skipping this check is a bug. The skill exists precisely because acting
-without it produces incorrect output for that domain.
+Tools available for this response: {tools_available}.
 """
 
 
-def _make_load_skill_tool(backend, sources):
-    """Build a `load_skill` tool that downloads the skill body from the backend.
+class SmallModelSkillsState(SkillsState):
+    """Private activation state for one graph invocation."""
 
-    Closes over the backend and source list so the tool itself takes only
-    a skill name — easier for the small model to invoke reliably than
-    constructing a path string for read_file.
-    """
+    loaded_skill_tools: NotRequired[
+        Annotated[frozenset[str], PrivateStateAttr, operator.or_]
+    ]
+
+
+class _LoadArtifact(TypedDict):
+    schema: str
+    requested_name: str
+    winner_fingerprint: str
+    result_sha256: str
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _source_contains(source: str, path: str) -> bool:
+    return path.startswith(f"{source.rstrip('/')}/")
+
+
+def _tool_name(tool_value: BaseTool | dict[str, Any]) -> str | None:
+    """Return the exact provider tool name from a final request entry."""
+    if isinstance(tool_value, BaseTool):
+        return tool_value.name
+    name = tool_value.get("name")
+    if isinstance(name, str):
+        return name
+    function = tool_value.get("function")
+    if isinstance(function, dict) and isinstance(function.get("name"), str):
+        return function["name"]
+    return None
+
+
+def _winner(state: dict[str, Any], requested_name: str) -> dict[str, Any] | None:
+    return next(
+        (skill for skill in state.get("skills_metadata", ())
+         if skill.get("name") == requested_name),
+        None,
+    )
+
+
+def _load_failure(name: str, reason: str | None = None) -> str:
+    detail = f" ({reason})" if reason else ""
+    return (
+        f"Skill '{name}' could not be loaded{detail}. The system prompt's "
+        "'## Skills' section lists every available name; use one of those."
+    )
+
+
+def _make_load_skill_tool(middleware: "SmallModelSkillsMiddleware"):
+    """Build the exact-winner loader bound to this middleware instance."""
 
     @tool
-    def load_skill(name: str) -> str:
+    def load_skill(name: str, runtime: ToolRuntime) -> str | Command:
         """Load and return the full body of the named skill.
 
         Use this whenever a skill description matches your task. Pass
@@ -84,55 +134,189 @@ def _make_load_skill_tool(backend, sources):
         Returns the full body of the skill, including the rules you
         must follow before continuing with the task.
         """
-        # Resolve in REVERSE source order to match the deepagents listing,
-        # which is last-source-wins (it builds a name->skill dict, so a later
-        # source overwrites an earlier one).  Iterating forward here would make
-        # load_skill first-source-wins and disagree with the description the
-        # model just read on any name collision (e.g. a domain skill shadowing
-        # a built-in).  See docs/2026-06-06-in-repo-domain-skills.org.
-        for source in reversed(sources):
-            path = f"{source.rstrip('/')}/{name}/SKILL.md"
-            try:
-                responses = backend.download_files([path])
-            except Exception:
-                continue
-            if not responses:
-                continue
-            response = responses[0]
-            if response.error or response.content is None:
-                continue
-            try:
-                return response.content.decode("utf-8")
-            except UnicodeDecodeError:
-                continue
-        return (
-            f"Skill '{name}' not found. The system prompt's '## Skills' "
-            f"section lists every available name; use one of those."
+        skill = _winner(runtime.state, name)
+        if skill is None:
+            return _load_failure(name)
+
+        backend = middleware._get_backend(  # noqa: SLF001 - subclass-owned seam
+            runtime.state, runtime, runtime.config)
+        try:
+            responses = backend.download_files([skill["path"]])
+        except Exception as exc:
+            return _load_failure(name, type(exc).__name__)
+        if len(responses) != 1:
+            return _load_failure(name)
+        response = responses[0]
+        if response.error or response.content is None:
+            return _load_failure(name, response.error)
+        if len(response.content) > MAX_SKILL_FILE_SIZE:
+            return _load_failure(name, "skill file is too large")
+        try:
+            body = _sanitize(response.content.decode("utf-8"))
+        except UnicodeDecodeError:
+            return _load_failure(name, "skill file is not UTF-8")
+
+        newly_available = middleware._bundled_declared_tools(runtime.state, skill)
+        already_loaded = frozenset(runtime.state.get("loaded_skill_tools", ()))
+        new_names = sorted(newly_available - already_loaded)
+        disclosure = (
+            "Newly available tools: " + ", ".join(new_names) + "."
+            if new_names else "No additional tools became available."
         )
+        content = f"{body}\n\n{disclosure}"
+        fingerprint_payload = {
+            "allowed_tools": list(skill.get("allowed_tools", ())),
+            "body_sha256": _sha256(body),
+            "description": skill["description"],
+            "name": skill["name"],
+        }
+        artifact: _LoadArtifact = {
+            "schema": _LOAD_ARTIFACT_SCHEMA,
+            "requested_name": name,
+            "winner_fingerprint": _sha256(json.dumps(
+                fingerprint_payload, ensure_ascii=False, separators=(",", ":"),
+                sort_keys=True)),
+            "result_sha256": _sha256(content),
+        }
+        message = ToolMessage(
+            content=content,
+            artifact=artifact,
+            name="load_skill",
+            status="success",
+            tool_call_id=runtime.tool_call_id,
+        )
+        return Command(update={
+            "messages": [message],
+            "loaded_skill_tools": newly_available,
+        })
 
     return load_skill
 
 
 class SmallModelSkillsMiddleware(SkillsMiddleware):
-    """SkillsMiddleware variant with a `load_skill` tool and an imperative
-    system prompt — name-based throughout, no paths exposed to the model.
-    """
+    """Name-based skill loader with invocation-local bundled-tool disclosure."""
 
-    def __init__(self, *, backend, sources):
+    state_schema = SmallModelSkillsState
+
+    def __init__(self, *, backend, sources, bundled_sources: Iterable[str] = ()):
         super().__init__(backend=backend, sources=sources)
         self.system_prompt_template = SMALL_MODEL_SKILLS_PROMPT
-        self.tools = [_make_load_skill_tool(backend, sources)]
+        self._bundled_sources = frozenset(bundled_sources)
+        self.tools = [_make_load_skill_tool(self)]
 
     def _format_skills_list(self, skills):
-        """Name + description only.
-
-        Upstream's listing appends a ``-> Read `{path}` for full
-        instructions`` line, which is misleading now that we load by
-        name. Strip everything except ``- **name**: description`` so the
-        model has no spurious path string to copy from.
-        """
+        """Render only name and description; declarations remain undisclosed."""
         if not skills:
             return "(No skills available.)"
         return "\n".join(
-            f"- **{s['name']}**: {s['description']}" for s in skills
+            f"- **{skill['name']}**: {skill['description']}" for skill in skills
         )
+
+    def _is_bundled(self, skill: dict[str, Any]) -> bool:
+        path = skill.get("path")
+        return isinstance(path, str) and any(
+            _source_contains(source, path) for source in self._bundled_sources)
+
+    def _bundled_declared_tools(
+            self, state: dict[str, Any], skill: dict[str, Any]) -> frozenset[str]:
+        if not self._is_bundled(skill) or _winner(state, skill["name"]) is not skill:
+            return frozenset()
+        return frozenset(skill.get("allowed_tools", ()))
+
+    def _gated_tools(self, state: dict[str, Any]) -> frozenset[str]:
+        gated: set[str] = set()
+        for skill in state.get("skills_metadata", ()):
+            if self._is_bundled(skill):
+                gated.update(skill.get("allowed_tools", ()))
+        return frozenset(gated)
+
+    def _tool_is_allowed(self, state: dict[str, Any], name: str) -> bool:
+        return name not in self._gated_tools(state) or name in state.get(
+            "loaded_skill_tools", ())
+
+    def modify_request(self, request: ModelRequest) -> ModelRequest:
+        """Add the catalog and expose exactly the tools allowed for this request."""
+        retained = [
+            tool_value for tool_value in request.tools
+            if (name := _tool_name(tool_value)) is None
+            or self._tool_is_allowed(request.state, name)
+        ]
+        names = [name for tool_value in retained
+                 if (name := _tool_name(tool_value)) is not None]
+        skills_section = self.system_prompt_template.format(
+            skills_locations=self._format_skills_locations(),
+            skills_load_warnings=self._format_skills_load_warnings(
+                request.state.get("skills_load_errors", [])),
+            skills_list=self._format_skills_list(
+                request.state.get("skills_metadata", [])),
+            tools_available=", ".join(names) if names else "(none)",
+        )
+        return request.override(
+            tools=retained,
+            system_message=deepagents_skills.append_to_system_message(
+                request.system_message, skills_section),
+        )
+
+    def before_agent(self, state, runtime, config):
+        update = super().before_agent(state, runtime, config) or {}
+        return {**update, "loaded_skill_tools": Overwrite(frozenset())}
+
+    async def abefore_agent(self, state, runtime, config):
+        update = await super().abefore_agent(state, runtime, config) or {}
+        return {**update, "loaded_skill_tools": Overwrite(frozenset())}
+
+    def _hidden_call_message(self, tool_call: dict[str, Any]) -> ToolMessage:
+        return ToolMessage(
+            content=(
+                f"Tool '{tool_call['name']}' is unavailable in this response. "
+                "Load its matching skill, wait for the result, and call the tool "
+                "in a later response."
+            ),
+            name=tool_call["name"],
+            status="error",
+            tool_call_id=tool_call["id"],
+        )
+
+    def after_model(self, state, runtime):
+        """Reject hidden hallucinated calls before HITL sees outward effects."""
+        last_ai = next(
+            (message for message in reversed(state.get("messages", ()))
+             if isinstance(message, AIMessage)),
+            None,
+        )
+        if last_ai is None or not last_ai.tool_calls:
+            return None
+        allowed = []
+        rejected = []
+        for tool_call in last_ai.tool_calls:
+            if self._tool_is_allowed(state, tool_call["name"]):
+                allowed.append(tool_call)
+            else:
+                rejected.append(self._hidden_call_message(tool_call))
+        if not rejected:
+            return None
+        last_ai.tool_calls = allowed
+        return {"messages": [last_ai, *rejected]}
+
+    async def aafter_model(self, state, runtime):
+        return self.after_model(state, runtime)
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        if not self._tool_is_allowed(request.state, request.tool_call["name"]):
+            return self._hidden_call_message(request.tool_call)
+        return handler(request)
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[
+            [ToolCallRequest], Awaitable[ToolMessage | Command]
+        ],
+    ) -> ToolMessage | Command:
+        if not self._tool_is_allowed(request.state, request.tool_call["name"]):
+            return self._hidden_call_message(request.tool_call)
+        return await handler(request)

--- a/assist/middleware/skills_middleware.py
+++ b/assist/middleware/skills_middleware.py
@@ -399,7 +399,10 @@ class SmallModelSkillsMiddleware(SkillsMiddleware):
              else self._cancelled_sibling_message(tool_call))
             for tool_call in last_ai.tool_calls
         ]
-        return {"messages": [last_ai, *results], "jump_to": "model"}
+        # ``last_ai`` is already in the graph state.  Returning it again can
+        # duplicate an ID-less adapter message when ``add_messages`` merges the
+        # update; only the paired results are new state.
+        return {"messages": results, "jump_to": "model"}
 
     async def aafter_model(self, state, runtime):
         return self.after_model(state, runtime)

--- a/assist/middleware/skills_middleware.py
+++ b/assist/middleware/skills_middleware.py
@@ -21,9 +21,9 @@ from deepagents.middleware.skills import (
 )
 from langchain.agents.middleware.types import (
     ModelRequest,
-    ModelResponse,
     PrivateStateAttr,
     ToolCallRequest,
+    hook_config,
 )
 from langchain_core.messages import AIMessage, ToolMessage
 from langchain_core.tools import BaseTool, tool
@@ -67,6 +67,50 @@ it with `ls`, `read_file`, `task`, `edit_file`, or a newly disclosed tool. Only
 if no skill matches may you proceed directly to the task.
 
 Tools available for this response: {tools_available}.
+"""
+
+# Compatibility boundary: this historical prompt and the legacy loader's tool
+# docstring call the complete SKILL.md file a "body". Inbound SMS triage must
+# remain byte-for-byte on that pre-P2b prompt and schema, so keep the wording.
+LEGACY_SMALL_MODEL_SKILLS_PROMPT = """
+
+## Skills
+
+You have access to named skills. Each skill is a self-contained set of
+rules for a specific domain. The list below shows each skill's *name*
+and *description*; the rules themselves are revealed only when you load
+the skill.
+
+**Available skills:**
+
+{skills_list}
+
+### How to use a skill
+
+1. **Match.** If a skill's description fits what you're about to do, continue to step 2.
+2. **Load.** Call `load_skill(name="<skill name>")`. The tool returns the full skill body.
+3. **Apply.** Use the rules from the loaded skill when you compose your action or response.
+
+The descriptions only summarize *when* to load — they do not contain
+the rules. You will not know the rules until you complete step 2. You
+MUST complete step 2 before performing the matching action; relying on
+the description alone leads to incorrect outcomes.
+
+### Pre-action check (MANDATORY — apply on every turn before any tool call)
+
+Before issuing your first tool call on a turn, scan the user's latest
+message against every skill description above:
+
+1. Look for any keyword, file extension, filename, or topic from a
+   skill description that appears in the user's message.
+2. If a skill matches, your FIRST tool call this turn MUST be
+   `load_skill(name="<matched skill>")`. Do not run `ls`, `read_file`,
+   `task` to a sub-agent, or `edit_file` first — those steps come AFTER
+   the skill is loaded.
+3. Only if no skill matches may you proceed directly to your task.
+
+Skipping this check is a bug. The skill exists precisely because acting
+without it produces incorrect output for that domain.
 """
 
 
@@ -122,17 +166,52 @@ def _load_failure(name: str, reason: str | None = None) -> str:
     )
 
 
-def _make_load_skill_tool(middleware: "SmallModelSkillsMiddleware"):
-    """Build the exact-winner loader bound to this middleware instance."""
+def _make_legacy_load_skill_tool(backend, sources):
+    """Build the pre-P2b loader for compositions excluded from disclosure."""
 
     @tool
-    def load_skill(name: str, runtime: ToolRuntime) -> str | Command:
+    def load_skill(name: str) -> str:
         """Load and return the full body of the named skill.
 
         Use this whenever a skill description matches your task. Pass
         only the skill's short name (e.g. "org-format") — no paths.
         Returns the full body of the skill, including the rules you
         must follow before continuing with the task.
+        """
+        for source in reversed(sources):
+            path = f"{source.rstrip('/')}/{name}/SKILL.md"
+            try:
+                responses = backend.download_files([path])
+            except Exception:
+                continue
+            if not responses:
+                continue
+            response = responses[0]
+            if response.error or response.content is None:
+                continue
+            try:
+                return response.content.decode("utf-8")
+            except UnicodeDecodeError:
+                continue
+        return (
+            f"Skill '{name}' not found. The system prompt's '## Skills' "
+            "section lists every available name; use one of those."
+        )
+
+    return load_skill
+
+
+def _make_load_skill_tool(middleware: "SmallModelSkillsMiddleware"):
+    """Build the exact-winner loader bound to this middleware instance."""
+
+    @tool
+    def load_skill(name: str, runtime: ToolRuntime) -> str | Command:
+        """Load and return the complete named skill file.
+
+        Use this whenever a skill description matches your task. Pass
+        only the skill's short name (e.g. "org-format") — no paths.
+        Returns the full SKILL.md content and the tools newly available
+        after the load.
         """
         skill = _winner(runtime.state, name)
         if skill is None:
@@ -148,25 +227,27 @@ def _make_load_skill_tool(middleware: "SmallModelSkillsMiddleware"):
             return _load_failure(name)
         response = responses[0]
         if response.error or response.content is None:
-            return _load_failure(name, response.error)
+            return _load_failure(name, "backend error")
         if len(response.content) > MAX_SKILL_FILE_SIZE:
             return _load_failure(name, "skill file is too large")
         try:
-            body = _sanitize(response.content.decode("utf-8"))
+            raw_skill_file = response.content.decode("utf-8")
         except UnicodeDecodeError:
             return _load_failure(name, "skill file is not UTF-8")
+        skill_file = _sanitize(raw_skill_file)
 
-        newly_available = middleware._bundled_declared_tools(runtime.state, skill)
+        newly_available = middleware._bundled_declared_tools(skill)
         already_loaded = frozenset(runtime.state.get("loaded_skill_tools", ()))
-        new_names = sorted(newly_available - already_loaded)
+        new_names = [name for name in skill.get("allowed_tools", ())
+                     if name in newly_available and name not in already_loaded]
         disclosure = (
             "Newly available tools: " + ", ".join(new_names) + "."
             if new_names else "No additional tools became available."
         )
-        content = f"{body}\n\n{disclosure}"
+        content = f"{skill_file}\n\n{disclosure}"
         fingerprint_payload = {
             "allowed_tools": list(skill.get("allowed_tools", ())),
-            "body_sha256": _sha256(body),
+            "skill_file_sha256": _sha256(raw_skill_file),
             "description": skill["description"],
             "name": skill["name"],
         }
@@ -198,11 +279,18 @@ class SmallModelSkillsMiddleware(SkillsMiddleware):
 
     state_schema = SmallModelSkillsState
 
-    def __init__(self, *, backend, sources, bundled_sources: Iterable[str] = ()):
+    def __init__(self, *, backend, sources, bundled_sources: Iterable[str] = (),
+                 registered_tools: Iterable[str] | None = None):
         super().__init__(backend=backend, sources=sources)
-        self.system_prompt_template = SMALL_MODEL_SKILLS_PROMPT
         self._bundled_sources = frozenset(bundled_sources)
-        self.tools = [_make_load_skill_tool(self)]
+        self._registered_tools = (None if registered_tools is None
+                                  else frozenset(registered_tools))
+        if self._bundled_sources:
+            self.system_prompt_template = SMALL_MODEL_SKILLS_PROMPT
+            self.tools = [_make_load_skill_tool(self)]
+        else:
+            self.system_prompt_template = LEGACY_SMALL_MODEL_SKILLS_PROMPT
+            self.tools = [_make_legacy_load_skill_tool(backend, sources)]
 
     def _format_skills_list(self, skills):
         """Render only name and description; declarations remain undisclosed."""
@@ -214,21 +302,26 @@ class SmallModelSkillsMiddleware(SkillsMiddleware):
 
     def _is_bundled(self, skill: dict[str, Any]) -> bool:
         path = skill.get("path")
-        return isinstance(path, str) and any(
-            _source_contains(source, path) for source in self._bundled_sources)
+        if not isinstance(path, str):
+            return False
+        matches = [source for source in self.sources
+                   if _source_contains(source, path)]
+        return bool(matches) and max(matches, key=len) in self._bundled_sources
 
-    def _bundled_declared_tools(
-            self, state: dict[str, Any], skill: dict[str, Any]) -> frozenset[str]:
-        if not self._is_bundled(skill) or _winner(state, skill["name"]) is not skill:
+    def _bundled_declared_tools(self, skill: dict[str, Any]) -> frozenset[str]:
+        if not self._is_bundled(skill):
             return frozenset()
-        return frozenset(skill.get("allowed_tools", ()))
+        declared = frozenset(skill.get("allowed_tools", ()))
+        return (declared if self._registered_tools is None
+                else declared & self._registered_tools)
 
     def _gated_tools(self, state: dict[str, Any]) -> frozenset[str]:
         gated: set[str] = set()
         for skill in state.get("skills_metadata", ()):
             if self._is_bundled(skill):
                 gated.update(skill.get("allowed_tools", ()))
-        return frozenset(gated)
+        return (frozenset(gated) if self._registered_tools is None
+                else frozenset(gated) & self._registered_tools)
 
     def _tool_is_allowed(self, state: dict[str, Any], name: str) -> bool:
         return name not in self._gated_tools(state) or name in state.get(
@@ -244,9 +337,6 @@ class SmallModelSkillsMiddleware(SkillsMiddleware):
         names = [name for tool_value in retained
                  if (name := _tool_name(tool_value)) is not None]
         skills_section = self.system_prompt_template.format(
-            skills_locations=self._format_skills_locations(),
-            skills_load_warnings=self._format_skills_load_warnings(
-                request.state.get("skills_load_errors", [])),
             skills_list=self._format_skills_list(
                 request.state.get("skills_metadata", [])),
             tools_available=", ".join(names) if names else "(none)",
@@ -277,6 +367,18 @@ class SmallModelSkillsMiddleware(SkillsMiddleware):
             tool_call_id=tool_call["id"],
         )
 
+    def _cancelled_sibling_message(self, tool_call: dict[str, Any]) -> ToolMessage:
+        return ToolMessage(
+            content=(
+                f"Tool '{tool_call['name']}' was not run because the response also "
+                "contained an unavailable tool. Retry this call by itself."
+            ),
+            name=tool_call["name"],
+            status="error",
+            tool_call_id=tool_call["id"],
+        )
+
+    @hook_config(can_jump_to=["model"])
     def after_model(self, state, runtime):
         """Reject hidden hallucinated calls before HITL sees outward effects."""
         last_ai = next(
@@ -286,17 +388,18 @@ class SmallModelSkillsMiddleware(SkillsMiddleware):
         )
         if last_ai is None or not last_ai.tool_calls:
             return None
-        allowed = []
-        rejected = []
-        for tool_call in last_ai.tool_calls:
-            if self._tool_is_allowed(state, tool_call["name"]):
-                allowed.append(tool_call)
-            else:
-                rejected.append(self._hidden_call_message(tool_call))
-        if not rejected:
+        hidden = [tool_call for tool_call in last_ai.tool_calls
+                  if not self._tool_is_allowed(state, tool_call["name"])]
+        if not hidden:
             return None
-        last_ai.tool_calls = allowed
-        return {"messages": [last_ai, *rejected]}
+        hidden_ids = {tool_call["id"] for tool_call in hidden}
+        results = [
+            (self._hidden_call_message(tool_call)
+             if tool_call["id"] in hidden_ids
+             else self._cancelled_sibling_message(tool_call))
+            for tool_call in last_ai.tool_calls
+        ]
+        return {"messages": [last_ai, *results], "jump_to": "model"}
 
     async def aafter_model(self, state, runtime):
         return self.after_model(state, runtime)

--- a/assist/spec.py
+++ b/assist/spec.py
@@ -88,7 +88,7 @@ class AgentSpec:
     async_subagent_tools: tuple[BaseTool, ...] | None = None
 
     # Tools to gate with human-in-the-loop: a mapping ``{tool_name -> True |
-    # InterruptOnConfig}`` passed straight to ``create_deep_agent(interrupt_on=…)``.  Web
+    # InterruptOnConfig}`` installed as LangChain's HumanInTheLoopMiddleware. Web
     # profiles gate outward-effect tools (normal: ``send_email``; inbound triage:
     # ``send_reply``) so they can propose an action but never perform it without approval.
     # ``None`` = no HITL.

--- a/assist/thread_manager.py
+++ b/assist/thread_manager.py
@@ -40,12 +40,12 @@ from assist.agent import create_context_agent, create_research_agent
 
 logger = logging.getLogger(__name__)
 
-# The web app's main agent gets a web-only "render" skill: it tells the model to
-# embed a workspace file in the web view by emitting a ```render block (parsed by
-# manage/web/threads.py).  Scoped here BY DESIGN: ThreadManager is the web app's
-# agent builder (emacsos builds its own Thread/spec; the eval harness uses
-# create_agent directly), so the web-only render skill rides the web-only builder
-# and never reaches surfaces with no web view (nor the eval agents).
+# The web app's main agent gets web-only skills: ``render`` emits a workspace-file
+# block for the web view (parsed by manage/web/threads.py), and ``send-email`` uses
+# the web host's approval transport.  Scoped here BY DESIGN: ThreadManager is the
+# web app's agent builder (emacsos builds its own Thread/spec; the eval harness uses
+# create_agent directly), so these web-only skills never reach surfaces with no web
+# view (nor the eval agents).  The route keeps its historical render-skill name.
 _RENDER_SKILL_ROUTE = "/render-skill/"
 _RENDER_SKILLS_DIR = os.path.join(os.path.dirname(__file__), "web_skills")
 _render_skill_sources = None
@@ -53,9 +53,13 @@ _triage_skill_sources_cache = None
 
 
 def _web_skill_sources() -> dict:
-    """Route -> backend for the web AgentSpec's render skill.  Built lazily so the
-    bundled-backend construction and deepagents' transitive imports stay off module
-    load (same pattern as emacsos-server's _skill_sources)."""
+    """Route -> backend for the web AgentSpec's web-only skills.
+
+    The route keeps its historical ``render-skill`` name although it serves both
+    the render and send-email skills.  Build it lazily so bundled-backend
+    construction and deepagents' transitive imports stay off module load (same
+    pattern as emacsos-server's ``_skill_sources``).
+    """
     global _render_skill_sources
     if _render_skill_sources is None:
         from assist.backends import create_bundled_skills_backend

--- a/assist/thread_manager.py
+++ b/assist/thread_manager.py
@@ -45,7 +45,8 @@ logger = logging.getLogger(__name__)
 # the web host's approval transport.  Scoped here BY DESIGN: ThreadManager is the
 # web app's agent builder (emacsos builds its own Thread/spec; the eval harness uses
 # create_agent directly), so these web-only skills never reach surfaces with no web
-# view (nor the eval agents).  The route keeps its historical render-skill name.
+# view.  The eval harness may mount the route explicitly for render coverage.  The
+# route keeps its historical render-skill name.
 _RENDER_SKILL_ROUTE = "/render-skill/"
 _RENDER_SKILLS_DIR = os.path.join(os.path.dirname(__file__), "web_skills")
 _render_skill_sources = None

--- a/assist/thread_manager.py
+++ b/assist/thread_manager.py
@@ -57,10 +57,9 @@ def _web_skill_sources() -> dict:
     (same pattern as emacsos-server's _skill_sources)."""
     global _render_skill_sources
     if _render_skill_sources is None:
-        from deepagents.backends import FilesystemBackend
+        from assist.backends import create_skills_backend
         _render_skill_sources = {
-            _RENDER_SKILL_ROUTE: FilesystemBackend(root_dir=_RENDER_SKILLS_DIR,
-                                                   virtual_mode=True)
+            _RENDER_SKILL_ROUTE: create_skills_backend(_RENDER_SKILLS_DIR)
         }
     return _render_skill_sources
 

--- a/assist/thread_manager.py
+++ b/assist/thread_manager.py
@@ -54,8 +54,8 @@ _triage_skill_sources_cache = None
 
 def _web_skill_sources() -> dict:
     """Route -> backend for the web AgentSpec's render skill.  Built lazily so the
-    FilesystemBackend import defers deepagents' transitive imports off module load
-    (same pattern as emacsos-server's _skill_sources)."""
+    bundled-backend construction and deepagents' transitive imports stay off module
+    load (same pattern as emacsos-server's _skill_sources)."""
     global _render_skill_sources
     if _render_skill_sources is None:
         from assist.backends import create_bundled_skills_backend

--- a/assist/thread_manager.py
+++ b/assist/thread_manager.py
@@ -49,6 +49,7 @@ logger = logging.getLogger(__name__)
 _RENDER_SKILL_ROUTE = "/render-skill/"
 _RENDER_SKILLS_DIR = os.path.join(os.path.dirname(__file__), "web_skills")
 _render_skill_sources = None
+_triage_skill_sources_cache = None
 
 
 def _web_skill_sources() -> dict:
@@ -57,11 +58,25 @@ def _web_skill_sources() -> dict:
     (same pattern as emacsos-server's _skill_sources)."""
     global _render_skill_sources
     if _render_skill_sources is None:
-        from assist.backends import create_skills_backend
+        from assist.backends import create_bundled_skills_backend
         _render_skill_sources = {
-            _RENDER_SKILL_ROUTE: create_skills_backend(_RENDER_SKILLS_DIR)
+            _RENDER_SKILL_ROUTE: create_bundled_skills_backend(_RENDER_SKILLS_DIR)
         }
     return _render_skill_sources
+
+
+def _triage_skill_sources() -> dict:
+    """The unchanged pre-P2b skill backends used by inbound SMS triage."""
+    global _triage_skill_sources_cache
+    if _triage_skill_sources_cache is None:
+        from deepagents.backends import FilesystemBackend
+        from assist.backends import SKILLS_DIR, SKILLS_ROUTE, create_skills_backend
+        _triage_skill_sources_cache = {
+            SKILLS_ROUTE: create_skills_backend(SKILLS_DIR),
+            _RENDER_SKILL_ROUTE: FilesystemBackend(
+                root_dir=_RENDER_SKILLS_DIR, virtual_mode=True)
+        }
+    return _triage_skill_sources_cache
 
 
 # The web app's main agent also gets the schedule tools, injected by the web composition
@@ -333,7 +348,9 @@ class ThreadManager:
         return Thread(
             working_dir, **thread_kwargs,
             spec=AgentSpec(
-                skill_sources=_web_skill_sources(), tools=tools,
+                skill_sources=(_triage_skill_sources() if triage
+                               else _web_skill_sources()),
+                tools=tools,
                 async_subagent_tools=async_tools,
                 interrupt_on=interrupt_on))
 

--- a/docs/2026-06-06-in-repo-domain-skills.org
+++ b/docs/2026-06-06-in-repo-domain-skills.org
@@ -275,8 +275,8 @@ that the agent did the work the skill describes.
 - No UI surface (no domain-skill listing/management in the web app).
 - No auto-walk-to-repo-root discovery (deepagents gets the explicit
   =/.claude/skills/= source; we don't replicate Claude Code's ancestor walk).
-- No per-skill =allowed-tools= enforcement (parsed for compat, never gated on —
-  assist never enforced it; nothing regresses).
+- No domain-skill =allowed-tools= enforcement in P2b.2.  Bundled Assist skills
+  are gated after load; domain and embedder skills join that contract in P2b.3.
 - No mid-session hot-reload (see Known limitations).
 - No domain-vs-builtin precedence *config knob* — pick one default (built-ins
   win, recommended) and ship it.
@@ -285,12 +285,13 @@ that the agent did the work the skill describes.
 * Known limitations (call out at merge, not just in code comments)
 1. *Skills are listed once per session and cached in the checkpoint*
    (=skills_metadata= PrivateStateAttr). Consequences:
-   - A skill added to the repo **after** a session's first turn won't appear in
-     the listing until a NEW chat (the =load_skill= tool reads bodies live, so a
-     just-created skill is loadable by *exact name* — but it's invisible in the
-     prompt listing, so the model never learns to call it). The dev-flow
-     "create a skill then use it this session" case is therefore only partially
-     served.
+   - In progressively disclosed profiles, a skill added to the repo **after** a
+     session's first turn won't appear in the listing or become loadable until a
+     NEW chat.  The loader resolves only the winning metadata captured for that
+     graph, so it does not scan live sources for an unlisted exact name.  Inbound
+     SMS triage deliberately retains the legacy live-scanning loader; an exact
+     name under an already mounted domain source can load there, although an
+     unlisted skill still gives the model no discovery signal.
    - On the same thread across sessions, a stale =skills_metadata= short-circuits
      re-discovery, so a domain repo that *gains* skills later won't surface them
      for that thread's life.

--- a/docs/2026-07-01-inbound-sms-interception.org
+++ b/docs/2026-07-01-inbound-sms-interception.org
@@ -18,8 +18,9 @@ Earlier drafts added a deny-by-default "propose-only" enforcer. Dropped (Pierre)
 turn runs in the per-turn sandbox, so an injected text steering the agent to do something
 bad is contained — worst case, delete the thread (its work is on an isolated thread branch,
 never main). The ONE effect that escapes the sandbox is the outbound **reply**; that (not
-the whole turn) is what needs a gate, and deepagents already provides one:
-~create_deep_agent(interrupt_on={"send_reply": True})~ pauses before the tool runs. The web
+the whole turn) is what needs a gate, and the LangChain agent middleware already provides
+one: Assist installs ~HumanInTheLoopMiddleware(interrupt_on={"send_reply": True})~ before
+the skills middleware, so it pauses before the tool runs. The web
 thread uses a durable ~SqliteSaver~ (threads.db), so the paused interrupt survives across
 requests and restarts; the user approves later and the graph resumes via
 ~Command(resume=…)~. No custom propose-tool / pending-store / enforcer — the framework HITL
@@ -74,7 +75,7 @@ delete-the-thread) and the reply is HITL-gated.
   ~.env.example~.
 
 * HITL protocol (verified against installed langchain)
-~HumanInTheLoopMiddleware~ (added by ~create_deep_agent(interrupt_on=…)~): configure
+~HumanInTheLoopMiddleware~ (installed explicitly by Assist before skills): configure
 ~interrupt_on={"send_reply": {"allowed_decisions": ["approve", "edit", "reject"]}}~. When the
 agent calls ~send_reply~, the graph raises an interrupt carrying ~action_requests:
 [ActionRequest{name, args, …}]~ (args = the draft) — surfaced in the turn result's

--- a/docs/2026-07-26-agent-prompt-architecture.org
+++ b/docs/2026-07-26-agent-prompt-architecture.org
@@ -3,8 +3,8 @@
 
 * State
 
-Status: architecture approved; P0, P1, P1b, P1c, and P2 complete; P2b.1 gates
-complete in PR #227 pending merge; P0b deferred.
+Status: architecture approved; P0, P1, P1b, P1c, P2, and P2b.1 complete;
+P2b.2 implementation and evaluation in progress; P0b deferred.
 P2's duplicate-procedure deletion passed its registered functional and timing
 gates.  A post-review cleanup then removed an empty synchronous planning heading;
 the qualified async rendering stayed byte-identical and the affected delegate
@@ -12,6 +12,23 @@ skill case passed the bounded 3/3 follow-up selected for that cleanup.  See
 [[file:2026-08-04-prompt-architecture-p2.org][the P2 state record]].
 
 ** Change log
+
+*** 2026-08-05: P2b.2 bundled disclosure implementation
+
+- Began P2b.2 from merged P2b.1 commit =d981395=.  The current candidate gates
+  only winning Assist-owned packaged routes and leaves domain/embedder sources
+  visible until P2b.3.
+- Source ownership now uses an explicit packaged backend marker plus
+  longest-prefix matching; declarations are intersected with each graph's
+  registered tools.
+- Invalid mixed responses retain every call ID, receive paired errors, and
+  return to the model before HITL.  Declarative subagents retain the parent HITL
+  map for any inherited effect tools.
+- Inbound SMS triage remains on its pre-P2b skills prompt, loader, and backends
+  through its existing composition seam.  No SMS permission or behavior is
+  part of this experiment.
+- The detailed implementation and evidence record is
+  [[file:2026-08-05-prompt-architecture-p2b2.org][Prompt architecture P2b.2]].
 
 *** 2026-08-05: P2b.1 declaration and census boundary
 
@@ -1910,7 +1927,7 @@ from the tools the request actually retains.  The explanation and enforcement
 land together; no copied framework list or main-template registry is allowed.
 
 A successful =load_skill= updates trusted invocation-scoped graph state with
-the exact resolved winning skill and returns its body plus the newly available
+the exact resolved winning skill and returns its complete skill file plus the newly available
 tool names.  The field and reducer must isolate concurrent graph invocations
 and merge parallel successful loads deterministically; mutable middleware
 instance state is forbidden.  Failed loads, fabricated messages, model prose,
@@ -1923,13 +1940,16 @@ kernel.
 The successful tool response also attaches a non-model-visible
 =ToolMessage.artifact= with the closed schema =schema=, =requested_name=,
 =winner_fingerprint=, and =result_sha256=.  The winner fingerprint covers the
-winning name, description, loaded body digest, and declared tool names, but not
+winning name, description, loaded complete-file digest, and declared tool names, but not
 its host path; the result digest covers the exact model-visible tool content.
 Failure responses carry no success artifact.  This message artifact is the sole
 cross-invocation load evidence used by P2c; active tool state itself remains
 invocation-scoped.
 
-This child gates tools owned by bundled Assist/main-only skills.  Tools owned
+This child gates tools owned by bundled Assist/main-only skills.  Bundled
+ownership is explicit at the route backend, not inferred from generic
+read-only access, and the longest matching source wins when prefixes nest.
+Tools owned
 only by domain or embedder skill sources remain explicit baseline-visible
 migration exceptions until P2b.3.  The P2b.1 census names those exceptions;
 there is no source-specific runtime rule beyond leaving them out of the gated
@@ -1947,9 +1967,10 @@ external-source semantics enter the experiment.
 - Two valid loads produce the exact union; a new invocation resets to kernel;
   thread checkpoints never accumulate old disclosure state; concurrent
   invocations on one agent cannot observe each other's loads.
-- A model response containing =load_skill= and a hidden sibling call rejects the
-  sibling regardless of execution order.  The tool appears only on the next
-  model request.
+- A model response containing =load_skill= and a hidden sibling call executes
+  neither call: every call ID receives a paired error and the graph returns to
+  the model.  The tool appears only after a successful load in its own response
+  and only on the next model request.
 - HITL, URL provenance, read-only enforcement, role omission, and existing tool
   argument/resource guards remain unchanged and pass 100% deterministic tests.
 - Baseline/candidate natural cohorts cover travel/directions, specific-site
@@ -2619,7 +2640,7 @@ separate P2c experiment and left invocation-scoped tool activation unchanged.
 | Agentic/framework fit | final request, provenance map, and enforcement evidence are separate; capability protocol has one owner; provider-wide prompt changes remain isolated; Deep Agents already parses =allowed-tools=; request-time schema filtering is paired with tool-node rejection | Clean |
 | User intention | SMS triage moves to a separate roadmap item; memory retains its existing access model; the framework kernel remains immediately usable; non-kernel tools arrive with the workflow that explains them; domain and embedder skills follow the same contract | Clean |
 | User experience | latency/round-trip guard; complete delegate, memory, research, domain, and embedder journeys; skill selection adds no round trip beyond the existing load; load results name newly available tools | Clean |
-| Clean interfaces | no triage-specific builder, permission fields, memory authorization fields, trusted-composition-root machinery, or tool registry; P2b.1 keeps classification in the census, while P2b.2 must derive filtering and its kernel line from the same final request in the existing skills middleware | Clean |
+| Clean interfaces | no triage-specific builder, permission fields, memory authorization fields, trusted-composition-root machinery, or tool registry; P2b.1 keeps classification in the census, while P2b.2 derives filtering and its kernel line from the same final request in the existing skills middleware; triage's existing composition seam selects its unchanged legacy backends | Clean |
 | Threat model | synthetic census hygiene; fail-closed judge bounds/schema and paired injection hard gates; hidden and same-response sibling calls fail at execution; external declarations can select only already registered tools and do not bypass existing authority | Clean |
 | Event-loop/eval liveness | P0b is deferred pending observed contention; current per-node TERM/KILL bounds, cooperative development lock, infrastructure-failure classification, one-hour blocks, and actual GPU-rest interval govern P1; bare serialized judge remains bounded; disclosure state is graph-run-local, parallel loads merge deterministically, and filtering adds no I/O | Clean |
 | Documentation alignment | changelog records Pierre's boundary revisions; triage and development guidance are excluded; P2b covers bundled, domain, and embedder sources; P2c changes only catalog-row lifetime; phase names, anchors, and current-versus-target wording verified | Clean |
@@ -2627,10 +2648,10 @@ separate P2c experiment and left invocation-scoped tool activation unchanged.
 Pierre satisfied the original design gate by approving and merging PR #216, and
 P0 subsequently shipped in PR #222.  Pierre deferred P0b on 2026-07-31 because
 shared-model contention has not been a material problem.  P1 shipped in PR #223,
-P1b shipped in PR #224, P1c is complete, P2 passed its final gate, and P2b.1's
-declaration-only candidate passed its deterministic and behavioral gates in PR
-#227 pending merge.  Adding P2c to the program does not start its implementation
-or any other later phase automatically.
+P1b shipped in PR #224, P1c is complete, P2 passed its final gate, and P2b.1
+shipped in PR #227.  P2b.2 is the active child and has not yet passed its
+behavioral gate.  Adding P2c to the program does not start its implementation or
+any other later phase automatically.
 
 * Decisions deliberately deferred to evidence
 

--- a/docs/2026-07-26-agent-prompt-architecture.org
+++ b/docs/2026-07-26-agent-prompt-architecture.org
@@ -3,8 +3,8 @@
 
 * State
 
-Status: architecture approved; P0, P1, P1b, P1c, P2, and P2b.1 complete;
-P2b.2 implementation and evaluation in progress; P0b deferred.
+Status: architecture approved; P0, P1, P1b, P1c, P2, P2b.1, and P2b.2 complete;
+P0b deferred.
 P2's duplicate-procedure deletion passed its registered functional and timing
 gates.  A post-review cleanup then removed an empty synchronous planning heading;
 the qualified async rendering stayed byte-identical and the affected delegate

--- a/docs/2026-08-05-prompt-architecture-p2b2.org
+++ b/docs/2026-08-05-prompt-architecture-p2b2.org
@@ -373,6 +373,16 @@ seen in two of three baseline samples.  The referential follow-up remains 0/3
 on both sides.  No hidden-tool rejection or unavailable-schema failure appeared,
 so the experiment proceeds unchanged to the pre-registered N=5 cadence.
 
+** Post-review baseline N=5
+
+The fresh P2b.1 N=5 block completed all 55 samples with valid XML and no
+timeout or harness error.  It passed 35/55 overall: 20/35 natural outcomes
+(57.1 percent), 10/15 capability diagnostics, and 5/5 control.  Per-node pass
+counts were travel 4, directions 5, website download 5, day-of-month scheduling
+1, subscription 0, referential follow-up 0, async delegation 5, render 5,
+email 5, time control 5, and urgent notification 0.  The byte-identical
+candidate N=5 comparison follows after the required GPU cooldown.
+
 * Design-review resolution
 
 - Simplicity and clean-interface review rejected a global owner manifest and

--- a/docs/2026-08-05-prompt-architecture-p2b2.org
+++ b/docs/2026-08-05-prompt-architecture-p2b2.org
@@ -383,6 +383,24 @@ counts were travel 4, directions 5, website download 5, day-of-month scheduling
 email 5, time control 5, and urgent notification 0.  The byte-identical
 candidate N=5 comparison follows after the required GPU cooldown.
 
+** Post-review candidate N=5
+
+The candidate N=5 block also completed all 55 samples with valid XML and no
+timeout or harness error.  It passed 43/55 overall (78.2 percent): 25/35
+natural outcomes (71.4 percent), 13/15 capability diagnostics, and 5/5
+control.  Per-node counts were travel 5, directions 5, website download 5,
+day-of-month scheduling 3, subscription 5, referential follow-up 0, async
+delegation 5, render 5, email 5, time control 5, and urgent notification 0.
+
+Candidate therefore improves +8 overall and +5 natural outcomes, clears the
+70 percent natural floor, and meets or exceeds baseline on every node.  The
+remaining failures repeat previously observed classes: referential follow-up
+does not reliably reactivate and modify the schedule, day scheduling sometimes
+loads but does not invoke its tool, and urgent notification calls =notify=
+exactly once only after exploratory skill loads.  There is still no hidden-tool,
+unavailable-schema, timeout, or harness failure.  No prompt or implementation
+tuning is warranted before the pre-registered N=10 stability cadence.
+
 * Design-review resolution
 
 - Simplicity and clean-interface review rejected a global owner manifest and

--- a/docs/2026-08-05-prompt-architecture-p2b2.org
+++ b/docs/2026-08-05-prompt-architecture-p2b2.org
@@ -335,9 +335,12 @@ launch.
 The first baseline launch had no =.dev.env= in its detached worktree and is
 preserved as invalid infrastructure evidence.  The bounded replacement ran the
 merged P2b.1 runtime with the frozen candidate eval files.  The new subscription
-fixture initially supplied a UUID where the store contract requires a string;
-those three samples are also preserved as invalid and will be rerun unchanged
-except for that fixture correction.
+fixture first supplied a UUID where the store contract requires a string.  Its
+first correction then exposed a second production-shaped fixture omission: the
+real web app creates the thread directory before the per-thread store writes,
+but the isolated eval had created only the store root.  Both invalid attempts
+are preserved and excluded.  The final fixture creates its string-named thread
+directory and will be rerun unchanged on both sides.
 
 Across the other 30 valid samples the P2b.1 baseline passed 24/30.  Travel,
 directions, website download, async delegation, render, email, and the time

--- a/docs/2026-08-05-prompt-architecture-p2b2.org
+++ b/docs/2026-08-05-prompt-architecture-p2b2.org
@@ -2,9 +2,8 @@
 
 * State
 
-Status: implementation and bounded local-review fixes in progress.  The
-deterministic gating slices are green; comparative behavioral evaluation is not
-yet complete.
+Status: implementation, bounded local review, and comparative evaluation are
+complete.  The candidate passes every deterministic and behavioral gate.
 
 * Change log
 
@@ -412,6 +411,25 @@ referential follow-up 0, async delegation 10, render 10, email 10, time control
 10, and urgent notification 0.  These counts are the final per-node stability
 bar for the candidate; the candidate N=10 side follows unchanged.
 
+** Stability candidate N=10
+
+The candidate side also completed 110/110 valid samples in four bounded GPU
+blocks, with no timeout or harness error.  It passed 87/110 overall (79.1
+percent): 50/70 natural outcomes (71.4 percent), 27/30 capability diagnostics,
+and 10/10 control.  Per-node counts are travel 10, directions 10, website
+download 10, day-of-month scheduling 7, subscription 10, referential follow-up
+0, async delegation 10, render 10, email 10, time control 10, and urgent
+notification 0.
+
+Candidate therefore improves +15 overall, +9 natural outcomes, and +6
+capability diagnostics.  It clears the 70 percent natural floor and meets or
+exceeds baseline on every node: travel 10>=9, directions 10=10, website 10=10,
+schedule 7>=2, subscription 10>=1, referential 0=0, async/render/email/time
+10=10, and urgent 0=0.  The narrow 71.4 percent natural margin is an honest
+limitation: referential schedule modification and notify-first urgency remain
+weak on both sides.  They are not P2b.2 regressions and this experiment does
+not tune unrelated behavior around them.
+
 * Design-review resolution
 
 - Simplicity and clean-interface review rejected a global owner manifest and
@@ -472,5 +490,20 @@ raw-file fingerprints versus sanitized results, bounded backend errors, and
 shared eval traversal.  The rejected items were theoretical ID-less call
 recovery and broad graph-matrix expansion without an observed contract.
 
-Implementation outcome, final LOC, maintenance shape, eval results, and any
-remaining hard points will be appended after the code and review loops converge.
+The final diff is 25 files, +1,801/-252 lines: production +412/-64,
+tests/evals +807/-152, and docs/roadmap +582/-36.  Most production logic is confined to
+=SmallModelSkillsMiddleware=; the other production edits mark packaged skill
+backends, preserve triage's existing composition seam, and install the existing
+HITL middleware in the required order.  No new registry, router, authorization
+model, =AgentSpec= provenance field, SMS behavior, memory policy, development
+guidance, or Pi/runtime integration was added.
+
+The final deterministic suite passes 1,606 tests with 2 skipped and 2 subtests
+passed; compilation and =git diff --check= pass.  Local review ran five rounds,
+fixed every verified in-scope finding, and rejected only theoretical recovery
+or broad matrix work without an observed contract.  The N=3, N=5, and N=10
+candidate cohorts all beat aggregate baseline, and the decisive N=10 result
+meets every per-node bar plus the natural floor.  The remaining hard points are
+the framework ordering/state contracts described above and the pre-existing
+referential/urgent behavioral weaknesses, which are reported rather than
+expanded into this objective.

--- a/docs/2026-08-05-prompt-architecture-p2b2.org
+++ b/docs/2026-08-05-prompt-architecture-p2b2.org
@@ -401,6 +401,17 @@ exactly once only after exploratory skill loads.  There is still no hidden-tool,
 unavailable-schema, timeout, or harness failure.  No prompt or implementation
 tuning is warranted before the pre-registered N=10 stability cadence.
 
+** Stability baseline N=10
+
+The P2b.1 stability side completed 110/110 valid samples in four bounded GPU
+blocks, with the required cooldowns and no timeout or harness error.  It passed
+72/110 overall (65.5 percent): 41/70 natural outcomes (58.6 percent), 21/30
+capability diagnostics, and 10/10 control.  Per-node counts are travel 9,
+directions 10, website download 10, day-of-month scheduling 2, subscription 1,
+referential follow-up 0, async delegation 10, render 10, email 10, time control
+10, and urgent notification 0.  These counts are the final per-node stability
+bar for the candidate; the candidate N=10 side follows unchanged.
+
 * Design-review resolution
 
 - Simplicity and clean-interface review rejected a global owner manifest and

--- a/docs/2026-08-05-prompt-architecture-p2b2.org
+++ b/docs/2026-08-05-prompt-architecture-p2b2.org
@@ -1,6 +1,38 @@
 #+title: Prompt architecture P2b.2: bundled skill tool disclosure
 
+* State
+
+Status: implementation and bounded local-review fixes in progress.  The
+deterministic gating slices are green; comparative behavioral evaluation is not
+yet complete.
+
 * Change log
+
+** 2026-08-05: Bounded implementation-review corrections
+
+- Preserved provider history when rejecting a response that mixes hidden and
+  visible calls.  The response now receives one paired error result for every
+  call and jumps back to the model; no sibling call executes or reaches HITL.
+- Replaced backend-class inference with an explicit packaged-skill backend
+  marker.  Generic read-only embedder routes remain external, and longest-source
+  matching prevents a nested external route from being claimed by a bundled
+  parent prefix.
+- Intersected each declaration with the tools registered in that exact agent
+  profile.  A shared declaration can keep its full portable owner list without
+  disclosing tools absent from this graph.
+- Restored the nested provider-schema dict form accepted by =AgentSpec.tools=;
+  registered-name extraction now covers the same BaseTool, callable, and dict
+  shapes as graph construction.
+- Kept inbound SMS triage on its pre-P2b skill prompt, loader, shared-skill
+  backend, and render backend.  This uses its existing composition boundary and
+  adds no triage permission or authorization mechanism.
+- Restored HITL propagation to the declarative critique subagent, which can
+  inherit main-agent tools under Deep Agents even though fixed compiled
+  context/research agents do not.
+- Added deterministic coverage for invalid bytes, parallel union, async reset,
+  prose-only claims, nested sources, registered-tool intersection, critique
+  HITL, and triage composition.  Consolidated changed evals on one tool-call
+  traversal helper.
 
 ** 2026-08-05: Reviewed design
 
@@ -23,20 +55,23 @@
   review identified invocation reset as a risk to an active task such as
   “make it 8 instead.”
 
-** 2026-08-05: Initial deterministic implementation evidence
+** 2026-08-05: Current deterministic implementation evidence
 
 - The canonical initial web-main system message is 29,527 characters, about
   7,382 tokens at the program's four-characters-per-token estimate.  Its 15
-  provider-bound schemas are 17,984 characters, about 4,496 tokens.  The
-  combined bootstrap is 47,511 characters, about 11,878 tokens.
-- After loading =send-email=, the same request has 16 schemas totaling 18,442
+  provider-bound schemas are 17,956 characters, about 4,489 tokens.  The
+  combined bootstrap is 47,483 characters, about 11,871 tokens.
+- After loading =send-email=, the same request has 16 schemas totaling 18,414
   characters; =send_email= is then handled by the unchanged approval pause.
 - The bounded synthetic census records 29 provider calls, 38 construction
   nodes, 25 retained audit findings, successful-load artifacts, and is
-  2,992,991 bytes with SHA-256
-  =a16e88ba2b5f0187a67423591138a856c81ed7c60aa1a547e4a5768d76df2490=.
-- These are implementation-stage measurements.  They will be regenerated after
-  review-driven edits before publication.
+  2,992,683 bytes with SHA-256
+  =628b25ac3f13d73ba1482b983b3a9379cf90b642e0a584ad2d7ab449bfa0ad6f=.
+- These measurements include the bounded round-two review fixes and are pinned
+  by the deterministic census test.  They will be regenerated after any later
+  implementation edit.
+- The final pre-eval deterministic suite passes 1,606 tests with 2 skipped and
+  2 subtests passed.  Python compilation and =git diff --check= also pass.
 
 * Objective
 
@@ -89,10 +124,12 @@ the last-source-wins metadata in =skills_metadata=.  P2b.2 uses that exact
 winner set.
 
 A winning skill is bundled only when its metadata path belongs to a route backed
-by Assist's existing packaged read-only skill backend.  The built-in and
+by Assist's explicit packaged-skill backend marker.  A generic read-only backend
+does not imply Assist ownership.  The built-in and
 main-only routes are bundled unless an embedder overrides them.  The web
 composition mounts its existing packaged web skill directory through the same
-read-only backend.  A losing, shadowed, domain, mutable, or arbitrary embedder
+marked backend.  When source prefixes nest, the longest matching configured
+source owns the path.  A losing, shadowed, domain, mutable, or arbitrary embedder
 source contributes no gated names in this child.
 
 For each model request:
@@ -129,7 +166,7 @@ thread checkpoint still contains skill metadata.
 that recorded path.  It enforces the upstream 10 MiB skill-file limit before
 UTF-8 decoding.  On success it returns a =Command= containing the matching
 =ToolMessage= and the union-state update.  The model-visible result is the
-sanitized winning body plus the exact newly available names.  Missing, failed,
+sanitized complete winning skill file plus the exact newly available names.  Missing, failed,
 oversized, non-UTF-8, or fabricated names return an error message and no state
 or evidence update.  Prose that mentions a skill cannot update private state.
 
@@ -152,10 +189,12 @@ appends =HumanInTheLoopMiddleware= after caller middleware, and after-model hook
 run in reverse order.  A hallucinated hidden =send_email= call could therefore
 pause for approval before reaching tool execution.  Assist installs the same
 HITL middleware explicitly immediately before the skills middleware.  The
-skills after-model hook first removes hidden calls and supplies matching error
-messages; HITL then sees only currently visible outward effects.  The execution
+skills after-model hook first completes every call ID in an invalid mixed
+response with an error and jumps back to the model.  HITL therefore sees none of
+that response, and the model retries with a valid call set.  The execution
 wrapper remains the second defense.  Approval configuration and decisions are
-otherwise unchanged.
+otherwise unchanged.  Declarative subagents receive the same HITL map because
+Deep Agents can give them inherited tools.
 
 ** Load evidence
 
@@ -167,7 +206,8 @@ Each successful load attaches a non-model-visible artifact with exactly:
 - =result_sha256=.
 
 The winner fingerprint hashes canonical JSON containing the winning name,
-description, digest of the loaded body, and ordered declared names.  It contains
+description, digest of the decoded complete skill file before display
+sanitization, and ordered declared names.  It contains
 no host path.  =result_sha256= covers the exact sanitized model-visible content.
 Failures have no artifact.
 
@@ -244,7 +284,7 @@ Stop rather than tune around a regression in an adjacent cohort.
 ** Pre-registered cohort and execution budget
 
 The comparative cohort is frozen before its first P2b.2 model call at these
-eleven natural nodes:
+eleven nodes:
 
 1. =TestTravelAgent::test_calls_travel_for_distance_question=;
 2. =TestDirectionsAgent::test_step_by_step_calls_directions=;
@@ -257,6 +297,11 @@ eleven natural nodes:
 9. =TestSendEmailSkill::test_natural_request_loads_skill_and_proposes_one_email=;
 10. =TestTimeAgent::test_does_not_load_on_non_date_prompt=; and
 11. =TestUrgentNotification::test_imminent_deadline_is_flagged_with_a_message=.
+
+Nodes 3, 5, 6, 7, 8, 9, and 11 are natural outcome journeys.  Nodes 1, 2,
+and 4 are explicit capability diagnostics retained to localize routing or
+argument failures.  Node 10 is the causal no-load control.  Capability and
+control results are reported separately from the natural acceptance rate.
 
 The unchanged baseline is merged P2b.1 commit =d981395=.  Baseline execution
 uses that production tree with only the frozen candidate eval files overlaid,
@@ -285,6 +330,21 @@ result is diagnostic.  Deterministic load/disclose/execute tests localize a
 failure before any prompt tuning; no cohort prompt changes are allowed after
 launch.
 
+** Preliminary baseline N=3
+
+The first baseline launch had no =.dev.env= in its detached worktree and is
+preserved as invalid infrastructure evidence.  The bounded replacement ran the
+merged P2b.1 runtime with the frozen candidate eval files.  The new subscription
+fixture initially supplied a UUID where the store contract requires a string;
+those three samples are also preserved as invalid and will be rerun unchanged
+except for that fixture correction.
+
+Across the other 30 valid samples the P2b.1 baseline passed 24/30.  Travel,
+directions, website download, async delegation, render, email, and the time
+control each passed 3/3; day-of-month scheduling passed 2/3; the referential
+follow-up passed 0/3; and urgent notification passed 1/3.  These are diagnostic
+N=3 results, not a final gate.  Candidate execution has not started.
+
 * Design-review resolution
 
 - Simplicity and clean-interface review rejected a global owner manifest and
@@ -312,11 +372,38 @@ hooks in reverse, and a state-updating tool must return a =Command= with a
 matching =tool_call_id= terminator.  Those contracts were verified from the
 installed Deep Agents, LangChain, and LangGraph sources.
 
+The first implementation review found two additional framework-shaped details.
+Removing hidden calls from an =AIMessage= would leave orphaned tool results in
+provider history, so an invalid mixed response must be completed as a whole and
+retried.  Also, declarative Deep Agents subagents may inherit parent tools, so
+moving HITL from =create_deep_agent(interrupt_on=...)= into explicit middleware
+requires forwarding the same gate to that declarative subagent.  Both fixes are
+small, local, and deterministically tested.
+
+Preserving the explicit “do not change SMS triage” boundary also required care.
+The normal web render route must be marked bundled for this experiment, while
+triage must retain the exact pre-P2b shared and render backends so neither its
+prompt nor schemas change.  The implementation uses the existing triage
+composition seam with two legacy backend entries; it does not add a new triage
+agent, authorization rule, or tool registry.
+
 The initial architect and lens-review invocations also read far beyond the
-bounded question and overran their expected context.  They were stopped and
-redirected to concrete conclusions.  Their broad registry and route-
-centralization suggestions were declined.  No unrelated production cleanup is
-part of this child.
+bounded question and overran their expected context.  The first code-review
+round repeated that cost, producing very large logs and several broad or
+theoretical suggestions.  Only findings directly affecting P2b.2 were accepted:
+history pairing, HITL ordering/propagation, source ownership, per-profile tool
+intersection, production-shaped render coverage, triage parity, and explicit
+design gates.  ID-less-call recovery and broad graph-matrix expansion were
+declined without an observed contract.  No unrelated production cleanup is part
+of this child.
+
+The local code-review loop converged at its five-round cap.  All verified
+P2b.2 findings were fixed: provider-history pairing, HITL ordering and
+declarative-subagent propagation, explicit/longest source ownership,
+per-profile tool intersection, nested dict-form tools, exact triage parity,
+raw-file fingerprints versus sanitized results, bounded backend errors, and
+shared eval traversal.  The rejected items were theoretical ID-less call
+recovery and broad graph-matrix expansion without an observed contract.
 
 Implementation outcome, final LOC, maintenance shape, eval results, and any
 remaining hard points will be appended after the code and review loops converge.

--- a/docs/2026-08-05-prompt-architecture-p2b2.org
+++ b/docs/2026-08-05-prompt-architecture-p2b2.org
@@ -61,6 +61,9 @@ yet complete.
   7,382 tokens at the program's four-characters-per-token estimate.  Its 15
   provider-bound schemas are 17,956 characters, about 4,489 tokens.  The
   combined bootstrap is 47,483 characters, about 11,871 tokens.
+- Against the frozen P0/P2b.1 census, initial schema count is down 50 percent,
+  schema characters 36.0 percent, system-prompt characters 5.6 percent, and
+  combined bootstrap characters 19.9 percent.
 - After loading =send-email=, the same request has 16 schemas totaling 18,414
   characters; =send_email= is then handled by the unchanged approval pause.
 - The bounded synthetic census records 29 provider calls, 38 construction
@@ -342,11 +345,15 @@ but the isolated eval had created only the store root.  Both invalid attempts
 are preserved and excluded.  The final fixture creates its string-named thread
 directory and will be rerun unchanged on both sides.
 
-Across the other 30 valid samples the P2b.1 baseline passed 24/30.  Travel,
+The final subscription fixture then ran without infrastructure errors and
+failed its intended =subscribe-events= load assertion in all three samples.
+The complete P2b.1 diagnostic baseline is therefore 24/33 overall: 13/21
+natural outcomes, 8/9 capability diagnostics, and 3/3 control.  Travel,
 directions, website download, async delegation, render, email, and the time
-control each passed 3/3; day-of-month scheduling passed 2/3; the referential
-follow-up passed 0/3; and urgent notification passed 1/3.  These are diagnostic
-N=3 results, not a final gate.  Candidate execution has not started.
+control each passed 3/3; day-of-month scheduling passed 2/3; subscription and
+the referential follow-up passed 0/3; and urgent notification passed 1/3.
+These are diagnostic N=3 results, not a final gate.  Candidate execution has
+not started.
 
 * Design-review resolution
 

--- a/docs/2026-08-05-prompt-architecture-p2b2.org
+++ b/docs/2026-08-05-prompt-architecture-p2b2.org
@@ -68,8 +68,8 @@ complete.  The candidate passes every deterministic and behavioral gate.
 - The bounded synthetic census records 29 provider calls, 38 construction
   nodes, 25 retained audit findings, successful-load artifacts, and is
   2,992,683 bytes with SHA-256
-  =628b25ac3f13d73ba1482b983b3a9379cf90b642e0a584ad2d7ab449bfa0ad6f=.
-- These measurements include the bounded round-two review fixes and are pinned
+  =ef83c31bb0864f412fcca8f79e0702191a7f3ec5f1d787081519084b7925c7d0=.
+- These measurements include the post-review tool-name deduplication fix and are pinned
   by the deterministic census test.  They will be regenerated after any later
   implementation edit.
 - The final pre-eval deterministic suite passes 1,606 tests with 2 skipped and

--- a/docs/2026-08-05-prompt-architecture-p2b2.org
+++ b/docs/2026-08-05-prompt-architecture-p2b2.org
@@ -1,0 +1,322 @@
+#+title: Prompt architecture P2b.2: bundled skill tool disclosure
+
+* Change log
+
+** 2026-08-05: Reviewed design
+
+- Scoped this child to winning bundled Assist, main-only, and web-only skills.
+  Domain-repository skills and embedder-owned skill/tool representations remain
+  baseline-visible until P2b.3.
+- Reused Deep Agents' winning =skills_metadata= and the existing packaged
+  read-only skill backends.  There is no second skill manifest, copied kernel
+  list, router, or tool-owner registry in production.
+- Derived both provider visibility and execution permission from one allowed-set
+  calculation over the actual request, successful invocation-local loads, and
+  the winning bundled declarations.
+- Added a pre-HITL rejection seam after review found that the framework's
+  default after-model order could otherwise interrupt on a hallucinated hidden
+  outward-effect call before the execution wrapper rejected it.
+- Kept =notify= baseline-visible and retained its urgent-first instruction.  The
+  strict urgent notification control requires it to be the first effect and to
+  occur exactly once.  SMS triage remains unchanged.
+- Added pronoun-only scheduling follow-up coverage after the user-experience
+  review identified invocation reset as a risk to an active task such as
+  “make it 8 instead.”
+
+** 2026-08-05: Initial deterministic implementation evidence
+
+- The canonical initial web-main system message is 29,527 characters, about
+  7,382 tokens at the program's four-characters-per-token estimate.  Its 15
+  provider-bound schemas are 17,984 characters, about 4,496 tokens.  The
+  combined bootstrap is 47,511 characters, about 11,878 tokens.
+- After loading =send-email=, the same request has 16 schemas totaling 18,442
+  characters; =send_email= is then handled by the unchanged approval pause.
+- The bounded synthetic census records 29 provider calls, 38 construction
+  nodes, 25 retained audit findings, successful-load artifacts, and is
+  2,992,991 bytes with SHA-256
+  =a16e88ba2b5f0187a67423591138a856c81ed7c60aa1a547e4a5768d76df2490=.
+- These are implementation-stage measurements.  They will be regenerated after
+  review-driven edits before publication.
+
+* Objective
+
+P2b.2 makes bundled skill tools visible only after the model successfully loads
+their winning skill during the current graph invocation.  It reduces irrelevant
+provider schemas without changing the registered executable graph, outward-
+effect approval, fixed-role agents, memory authority, development guidance, or
+SMS triage.
+
+This is the second independently reviewed child of the approved P2b milestone
+in [[file:2026-07-26-agent-prompt-architecture.org::#phase-2b-tools-declare][the program design]].
+
+* Boundary
+
+** In scope
+
+- winning skills under the packaged =/skills/=, =/main-skills/=, and web-only
+  packaged skill routes;
+- exact =allowed-tools= names already validated by P2b.1;
+- invocation-local successful-load state;
+- filtering the final model request and rejecting calls outside the same
+  allowed set;
+- deterministic load evidence and prompt/schema measurements;
+- natural and explicit-capability evals for bundled workflows.
+
+** Deferred to P2b.3
+
+- =/.claude/skills/= domain-repository ownership and activation;
+- arbitrary =AgentSpec.skill_sources= and embedder tool representations;
+- external/bundled name-collision policy beyond the supported-composition
+  duplicate-name gate established in P2b.1;
+- any new =AgentSpec= provenance field.
+
+** Explicitly unchanged
+
+- =notify= and the urgent notification prompt;
+- inbound SMS triage's tool set, routing, permissions, prompts, and backends;
+- memory read/write authority;
+- development guidance;
+- fixed-role agents that do not mount skills;
+- Pi runtime/provider work.
+
+* Design
+
+** One source of disclosure truth
+
+=SmallModelSkillsMiddleware= already receives the composed backend and ordered
+skill sources.  Deep Agents loads those sources before the graph loop and stores
+the last-source-wins metadata in =skills_metadata=.  P2b.2 uses that exact
+winner set.
+
+A winning skill is bundled only when its metadata path belongs to a route backed
+by Assist's existing packaged read-only skill backend.  The built-in and
+main-only routes are bundled unless an embedder overrides them.  The web
+composition mounts its existing packaged web skill directory through the same
+read-only backend.  A losing, shadowed, domain, mutable, or arbitrary embedder
+source contributes no gated names in this child.
+
+For each model request:
+
+1. collect exact declared names from winning bundled skills;
+2. retain every actual request tool whose name is not in that collection;
+3. additionally retain declared names activated by a successful load in this
+   invocation; and
+4. preserve the retained request's original tool order and schemas.
+
+This makes framework tools, async lifecycle tools, =load_skill=, =notify=, and
+all P2b.3 migration exceptions visible by construction.  A composition that
+does not mount =render= does not gate =map_data= merely because another profile
+has that owner.
+
+The prompt line is generated from the retained request itself:
+
+: Tools available for this response: <ordered exact names>.
+
+It is intentionally not called a kernel list because the retained request may
+contain baseline-visible migration exceptions.  It gives no preference or
+first-call ordering among those tools.
+
+** Invocation-local activation
+
+The middleware adds one private graph-state field containing a set of disclosed
+tool names.  Its reducer is set union, so concurrent successful loads combine
+deterministically.  =before_agent= resets the field with LangGraph's overwrite
+value on each new graph invocation.  A paused approval continuation resumes the
+same invocation and retains the set; a later turn begins empty even when the
+thread checkpoint still contains skill metadata.
+
+=load_skill(name)= resolves an exact winning metadata entry and downloads only
+that recorded path.  It enforces the upstream 10 MiB skill-file limit before
+UTF-8 decoding.  On success it returns a =Command= containing the matching
+=ToolMessage= and the union-state update.  The model-visible result is the
+sanitized winning body plus the exact newly available names.  Missing, failed,
+oversized, non-UTF-8, or fabricated names return an error message and no state
+or evidence update.  Prose that mentions a skill cannot update private state.
+
+The skill prompt requires a matching =load_skill= to be the only call in that
+model response.  The model waits for its result and uses newly available tools
+in the next response.  Matching includes an active prior task when the latest
+message is a referential follow-up, not only literal keywords in the newest
+message.
+
+** Schema and execution agree
+
+The model-request wrapper removes hidden schemas using the derived allowed set.
+The tool-call wrapper uses the same calculation and returns a corrective error
+without invoking a hidden tool.  Parallel calls receive the same pre-node state,
+so =load_skill= and a sibling hidden tool in one model response cannot disclose
+the sibling retroactively.
+
+Outward-effect tools require one more ordering guarantee.  Deep Agents normally
+appends =HumanInTheLoopMiddleware= after caller middleware, and after-model hooks
+run in reverse order.  A hallucinated hidden =send_email= call could therefore
+pause for approval before reaching tool execution.  Assist installs the same
+HITL middleware explicitly immediately before the skills middleware.  The
+skills after-model hook first removes hidden calls and supplies matching error
+messages; HITL then sees only currently visible outward effects.  The execution
+wrapper remains the second defense.  Approval configuration and decisions are
+otherwise unchanged.
+
+** Load evidence
+
+Each successful load attaches a non-model-visible artifact with exactly:
+
+- =schema=;
+- =requested_name=;
+- =winner_fingerprint=; and
+- =result_sha256=.
+
+The winner fingerprint hashes canonical JSON containing the winning name,
+description, digest of the loaded body, and ordered declared names.  It contains
+no host path.  =result_sha256= covers the exact sanitized model-visible content.
+Failures have no artifact.
+
+The artifact is audit/provenance evidence, not authority.  Tool activation comes
+only from the middleware's private state update produced by the real loader.
+P2c must not accept a user- or model-fabricated artifact as authorization when it
+later experiments with catalog-description suppression.
+
+* Implementation plan
+
+1. Add focused red tests for reset, successful/failed loads, parallel union,
+   source precedence, exact evidence, request order, sync/async parity,
+   after-model pre-HITL rejection, and execution rejection.
+2. Extend =SmallModelSkillsMiddleware= with the private reducer state, exact
+   winner loader, one allowed-set helper, model filtering, and call rejection.
+3. Mark packaged web skill routing with the existing read-only skill backend and
+   pass the exact bundled route set from =create_agent=.  Install existing HITL
+   middleware before the skills middleware rather than through Deep Agents'
+   tail argument.
+4. Extend the P0 census/deterministic evidence only where needed to record
+   initial and post-load request schemas and the load artifact.  Do not move the
+   runtime implementation into EDD.
+5. Add natural and explicit-capability evals, run the pre-registered cadence,
+   reconcile this doc against the implementation, and close only P2b.2 in the
+   roadmap if every gate passes.
+
+* Test and experiment gate
+
+** Deterministic
+
+- Startup provider schemas omit exactly the declared tools of mounted winning
+  bundled skills and retain original order for everything else.
+- A successful exact load exposes only that winner's declared names on the next
+  request in the same invocation; a new invocation resets them.
+- Two successful parallel loads union; a same-response hidden sibling call is
+  rejected.
+- Failed, fabricated, oversized, non-UTF-8, shadowed, and prose-only cases do not
+  disclose a name or emit success evidence.
+- Sync and async graph paths produce the same visibility and rejection results.
+- A hidden HITL tool is rejected before approval; a disclosed one still pauses
+  under the existing review contract.
+- The evidence schema has exactly four keys; its fingerprint has no host path;
+  and its result digest matches the exact model-visible content after
+  sanitization.
+- Kernel-only and unrelated requests add no skill round trip.  A scoped request
+  adds at most the existing one load round trip.
+- Fixed-role, role-omission, URL provenance, read-only, HITL, SMS-triage, and
+  urgent-notification deterministic tests remain green.
+
+** Behavioral
+
+Compare candidate and merged-P2b.1 baseline on natural and capability coverage
+for:
+
+1. travel and directions;
+2. reading a user-specified site;
+3. scheduling and subscriptions, including a pronoun-only follow-up;
+4. complex-request delegation;
+5. render and approved email outward effects;
+6. an unrelated kernel-only request; and
+7. urgent notification as a causal control.
+
+Natural acceptance stays at or above 70 percent and may not regress below its
+pre-registered baseline.  Capability diagnostics separately identify whether a
+failure was load selection, disclosure, tool selection, execution, or final
+outcome.  The urgent control passes only when =notify= is the first effect and
+is called exactly once.  Every cadence reports prompt characters/tokens, schema
+characters/tokens, wrong-skill loads, unavailable-tool calls, unnecessary
+loads, and round trips.
+
+Run N=3 after implementation, N=5 after local review, and N=10 for stability.
+Stop rather than tune around a regression in an adjacent cohort.
+
+** Pre-registered cohort and execution budget
+
+The comparative cohort is frozen before its first P2b.2 model call at these
+eleven natural nodes:
+
+1. =TestTravelAgent::test_calls_travel_for_distance_question=;
+2. =TestDirectionsAgent::test_step_by_step_calls_directions=;
+3. =TestWebsiteDownload::test_download_converges_without_crawling=;
+4. =TestScheduleAgent::test_agent_maps_day_of_month=;
+5. =TestSubscriptionAgent::test_natural_request_loads_skill_and_creates_subscription=;
+6. =TestScheduleAgent::test_referential_followup_reloads_skill_and_modifies_schedule=;
+7. =TestAsyncSubagentSupervisor::test_natural_two_independent_outcomes_delegate=;
+8. =TestRenderAgent::test_creates_and_renders_requested_graph=;
+9. =TestSendEmailSkill::test_natural_request_loads_skill_and_proposes_one_email=;
+10. =TestTimeAgent::test_does_not_load_on_non_date_prompt=; and
+11. =TestUrgentNotification::test_imminent_deadline_is_flagged_with_a_message=.
+
+The unchanged baseline is merged P2b.1 commit =d981395=.  Baseline execution
+uses that production tree with only the frozen candidate eval files overlaid,
+so prompts, fixtures, and validators are byte-identical while runtime code is
+not.  The new subscription and referential-follow-up cases are part of the
+same comparison, not candidate-only evidence.
+
+Each sample has one user subject turn except the scheduling follow-up, which
+has two.  The async case starts the two requested synthetic delegates, processes
+their completion wakes, and makes one qualified-judge call; all other cases
+make no judge call and either use no subagent or the existing deterministic
+research stub.  Thus N=3 is 33 samples, 36 user turns, six synthetic delegate
+starts, and three judge calls per side.  N=5 is 55 samples and N=10 is 110.
+
+Recent P2b.1 focused runs on the unchanged model measured a roughly 20-second
+one-case median and 75-second p90.  Use a 300-second per-case deadline.  At the
+p90 bound, partition each N=10 side into blocks of at most 40 samples (50 GPU
+minutes), with the required GPU cooldown between blocks.  N=3 projects to about
+14 GPU minutes per side at p90; the async and website cases may make actual wall
+time higher but remain individually bounded.  Store every run under
+=~/deploy/assist/prompt-architecture/p2b2/= and never on the root partition.
+
+The comparison gate is per node: the N=10 candidate full-pass count must meet
+the byte-identical N=10 baseline and the 70 percent natural floor.  The N=3
+result is diagnostic.  Deterministic load/disclose/execute tests localize a
+failure before any prompt tuning; no cohort prompt changes are allowed after
+launch.
+
+* Design-review resolution
+
+- Simplicity and clean-interface review rejected a global owner manifest and
+  moving web route constants.  Winning metadata plus packaged-backend identity
+  is sufficient.
+- User-guidance review required an exclusive load response and neutral retained-
+  tool wording.
+- User-experience review added active-task referent guidance and the pronoun-only
+  follow-up case.
+- Framework review found the =ToolRuntime=/=Command= terminator requirement,
+  sync/async parity, reverse after-model order, and later output sanitization.
+- Security review confirmed exact winning-path loading, the byte bound,
+  duplicate-name gates for supported compositions, and that evidence must never
+  become authorization.
+
+* Implementation notes
+
+** What was hard
+
+The hard part in design was not the filtering algorithm.  It was locating the
+actual framework seams that preserve one invariant across schemas, execution,
+approval, parallel tool calls, checkpoints, and sanitization.  In particular,
+Deep Agents appends HITL after caller middleware while LangChain runs after-model
+hooks in reverse, and a state-updating tool must return a =Command= with a
+matching =tool_call_id= terminator.  Those contracts were verified from the
+installed Deep Agents, LangChain, and LangGraph sources.
+
+The initial architect and lens-review invocations also read far beyond the
+bounded question and overran their expected context.  They were stopped and
+redirected to concrete conclusions.  Their broad registry and route-
+centralization suggestions were declined.  No unrelated production cleanup is
+part of this child.
+
+Implementation outcome, final LOC, maintenance shape, eval results, and any
+remaining hard points will be appended after the code and review loops converge.

--- a/docs/2026-08-05-prompt-architecture-p2b2.org
+++ b/docs/2026-08-05-prompt-architecture-p2b2.org
@@ -352,8 +352,26 @@ natural outcomes, 8/9 capability diagnostics, and 3/3 control.  Travel,
 directions, website download, async delegation, render, email, and the time
 control each passed 3/3; day-of-month scheduling passed 2/3; subscription and
 the referential follow-up passed 0/3; and urgent notification passed 1/3.
-These are diagnostic N=3 results, not a final gate.  Candidate execution has
-not started.
+These are diagnostic N=3 results, not a final gate; the candidate result follows.
+
+** Candidate N=3
+
+The frozen, rebased candidate completed all 33 samples with no timeout,
+collection error, or other harness failure.  It passed 25/33 overall: 15/21
+natural outcomes (71.4 percent), 7/9 capability diagnostics, and 3/3 control.
+Travel, directions, website download, subscription, async delegation, render,
+email, and the time control passed 3/3; day-of-month scheduling passed 1/3; the
+referential follow-up and urgent notification passed 0/3.
+
+This is +1 overall and +2 natural outcomes versus baseline.  The principal
+P2b.2 journey, natural subscription creation, improved from 0/3 to 3/3 and
+completed the intended load, disclosure, and tool execution.  The two failed
+day-of-month samples successfully loaded =schedule= but ended before invoking
+=create_schedule=.  Each urgent sample invoked =notify= exactly once but first
+loaded schedule/time-related skills, the same strict first-effect failure class
+seen in two of three baseline samples.  The referential follow-up remains 0/3
+on both sides.  No hidden-tool rejection or unavailable-schema failure appeared,
+so the experiment proceeds unchanged to the pre-registered N=5 cadence.
 
 * Design-review resolution
 

--- a/docs/2026-08-05-prompt-architecture-p2b2.org
+++ b/docs/2026-08-05-prompt-architecture-p2b2.org
@@ -68,7 +68,7 @@ complete.  The candidate passes every deterministic and behavioral gate.
 - The bounded synthetic census records 29 provider calls, 38 construction
   nodes, 25 retained audit findings, successful-load artifacts, and is
   2,992,683 bytes with SHA-256
-  =ef83c31bb0864f412fcca8f79e0702191a7f3ec5f1d787081519084b7925c7d0=.
+  =d3a0ce22fcf4be92c97423742fc66ebc85ea4b2dc575246b4316625dda82b45d=.
 - These measurements include the post-review tool-name deduplication fix and are pinned
   by the deterministic census test.  They will be regenerated after any later
   implementation edit.

--- a/edd/eval/test_directions_agent.py
+++ b/edd/eval/test_directions_agent.py
@@ -13,7 +13,7 @@ from unittest import TestCase
 from assist.agent import create_agent, AgentHarness
 from assist.model_manager import select_assistant_model
 
-from .utils import create_filesystem
+from .utils import create_filesystem, skill_was_loaded
 
 
 class TestDirectionsAgent(TestCase):
@@ -38,6 +38,7 @@ class TestDirectionsAgent(TestCase):
         agent = self._agent()
         agent.message("Give me step-by-step directions from Coit Tower to Oracle "
                       "Park by car.")
+        self.assertTrue(skill_was_loaded(agent, "travel"))
         calls = self._calls(agent)
         self.assertTrue(any(n == "directions" for n, _ in calls),
                         f"expected directions; got {[n for n, _ in calls]}")
@@ -48,6 +49,7 @@ class TestDirectionsAgent(TestCase):
         agent = self._agent()
         agent.message("Which train do I take to get from Civic Center to the "
                       "Embarcadero?")
+        self.assertTrue(skill_was_loaded(agent, "travel"))
         calls = self._calls(agent)
         dir_calls = [a for n, a in calls if n == "directions"]
         self.assertTrue(dir_calls, f"expected directions; got {[n for n, _ in calls]}")
@@ -60,6 +62,7 @@ class TestDirectionsAgent(TestCase):
         agent = self._agent()
         agent.message("Roughly how long is the drive from the Ferry Building to "
                       "Oakland City Hall?")
+        self.assertTrue(skill_was_loaded(agent, "travel"))
         calls = self._calls(agent)
         self.assertTrue(any(n == "travel" for n, _ in calls),
                         f"expected travel; got {[n for n, _ in calls]}")

--- a/edd/eval/test_render_agent.py
+++ b/edd/eval/test_render_agent.py
@@ -19,18 +19,13 @@ import tempfile
 from textwrap import dedent
 from unittest import TestCase
 
-from deepagents.backends import FilesystemBackend
-
 from assist.agent import create_agent, AgentHarness
 from assist.model_manager import select_assistant_model
 from assist.sandbox_manager import SandboxManager
 from assist.spec import AgentSpec
+from assist.thread_manager import _web_skill_sources
 
-from .utils import create_filesystem
-
-# The web-only render skill, registered the same way ThreadManager wires it.
-_RENDER_SKILLS_DIR = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "assist", "web_skills")
+from .utils import agent_tool_calls, create_filesystem
 
 # A render block: a fenced ```render whose body has type: file and the path.
 _RENDER_BLOCK = re.compile(r"```render\b(.*?)```", re.S | re.I)
@@ -76,10 +71,9 @@ class TestRenderAgent(TestCase):
     def create_agent(self, filesystem: dict):
         root = tempfile.mkdtemp()
         create_filesystem(root, filesystem)
-        skills = {"/render-skill/": FilesystemBackend(root_dir=_RENDER_SKILLS_DIR,
-                                                      virtual_mode=True)}
         return AgentHarness(create_agent(self.model, root,
-                                         spec=AgentSpec(skill_sources=skills)))
+                                         spec=AgentSpec(
+                                             skill_sources=_web_skill_sources())))
 
     def create_sandbox_agent(self, filesystem: dict):
         """Production-shaped agent: real Docker execute + persistent sibling /tmp."""
@@ -93,11 +87,9 @@ class TestRenderAgent(TestCase):
             self.skipTest("Docker sandbox unavailable — is assist-sandbox built?")
         self.addCleanup(shutil.rmtree, thread_root, True)
         self.addCleanup(SandboxManager.cleanup, workspace)
-        skills = {"/render-skill/": FilesystemBackend(root_dir=_RENDER_SKILLS_DIR,
-                                                      virtual_mode=True)}
         agent = AgentHarness(create_agent(
             self.model, workspace, sandbox_backend=sandbox,
-            spec=AgentSpec(skill_sources=skills)))
+            spec=AgentSpec(skill_sources=_web_skill_sources())))
         return agent, thread_root
 
     def _render_block_paths(self, agent, message_count: int = 0) -> list[str]:
@@ -201,36 +193,21 @@ class TestRenderAgent(TestCase):
 
     def _write_paths(self, agent) -> list:
         """Paths the agent wrote/edited this turn (write_file / edit_file tool calls)."""
-        from langchain_core.messages import AIMessage
         paths = []
-        for m in agent.all_messages():
-            if not isinstance(m, AIMessage):
-                continue
-            for tc in (getattr(m, "tool_calls", None) or []):
-                if tc.get("name") in ("write_file", "edit_file"):
-                    args = tc.get("args") or tc.get("arguments") or {}
-                    if isinstance(args, dict):
-                        p = args.get("file_path") or args.get("path") or ""
-                        if p:
-                            paths.append(str(p))
+        for call in agent_tool_calls(agent):
+            if call.get("name") in ("write_file", "edit_file"):
+                args = call.get("args") or call.get("arguments") or {}
+                if isinstance(args, dict):
+                    path = args.get("file_path") or args.get("path") or ""
+                    if path:
+                        paths.append(str(path))
         return paths
-
-    def _tool_calls(self, agent) -> list[dict]:
-        """Every structured tool call emitted by the agent."""
-        from langchain_core.messages import AIMessage
-        return [
-            call
-            for message in agent.all_messages()
-            if isinstance(message, AIMessage)
-            for call in (getattr(message, "tool_calls", None) or [])
-        ]
 
     def _render_skill_was_loaded(self, agent) -> bool:
         """True only for the load_skill tool contract, never a SKILL.md path read."""
         return any(
-            call.get("name") == "load_skill"
-            and (call.get("args") or {}).get("name") == "render"
-            for call in self._tool_calls(agent)
+            (call.get("args") or {}).get("name") == "render"
+            for call in agent_tool_calls(agent, "load_skill")
         )
 
     def test_creates_and_renders_requested_graph(self):
@@ -267,9 +244,9 @@ class TestRenderAgent(TestCase):
         fs = dict(_personal_workspace())
         agent, thread_root = self.create_sandbox_agent(fs)
         self._put_png_in_workspace(thread_root, "pace_trend.png")
-        before = len(self._tool_calls(agent))
+        before = len(agent_tool_calls(agent))
         agent.message("Use the render skill to put /workspace/pace_trend.png in the conversation.")
-        calls = self._tool_calls(agent)[before:]
+        calls = agent_tool_calls(agent)[before:]
         blocks = self._render_block_paths(agent)
         self.assertTrue(self._render_skill_was_loaded(agent), "render skill should load")
         self._assert_no_skill_file_detour(calls)
@@ -286,12 +263,12 @@ class TestRenderAgent(TestCase):
         agent, thread_root = self.create_sandbox_agent(_personal_workspace())
         before_graph = len(agent.all_messages())
         agent.message("Can you show me a graph of how my weight has changed over the last 2 months?")
-        graph_calls = self._tool_calls(agent)
+        graph_calls = agent_tool_calls(agent)
         graph_blocks = self._render_block_paths(agent, before_graph)
 
         before_render = len(agent.all_messages())
         agent.message("Please render the graph here.")
-        render_followup_calls = self._tool_calls(agent)[len(graph_calls):]
+        render_followup_calls = agent_tool_calls(agent)[len(graph_calls):]
         blocks_after_render = self._render_block_paths(agent, before_render)
 
         loaded_initially = any(

--- a/edd/eval/test_schedule_agent.py
+++ b/edd/eval/test_schedule_agent.py
@@ -16,7 +16,7 @@ from assist.model_manager import select_assistant_model
 from assist.spec import AgentSpec
 from assist.schedule.tools import schedule_tools
 from assist.schedule.store import ScheduleStore
-from .utils import create_filesystem, stub_research_subagent
+from .utils import create_filesystem, skill_was_loaded, stub_research_subagent
 
 os.environ.setdefault("ASSIST_MODEL_URL", "http://127.0.0.1:8000/v1")
 
@@ -44,6 +44,13 @@ class TestScheduleAgent(TestCase):
                     calls.append(tc.get("args") or tc.get("arguments") or {})
         return calls
 
+    @staticmethod
+    def _named_calls(agent, name: str) -> list[dict]:
+        return [tc for message in agent.all_messages()
+                if isinstance(message, AIMessage)
+                for tc in (message.tool_calls or [])
+                if tc.get("name") == name]
+
     def test_agent_maps_day_of_month(self):
         # Not a research eval — stub the research subagent so a stray dispatch can't hit
         # SearXNG (AGENTS.md #5). Build the agent INSIDE the stub (create_agent binds it).
@@ -51,6 +58,7 @@ class TestScheduleAgent(TestCase):
             agent = self._agent()
             agent.message("Set up a recurring reminder on the 25th of each month to pay rent.")
         calls = self._create_calls(agent)
+        self.assertTrue(skill_was_loaded(agent, "schedule"))
         self.assertTrue(
             any(c.get("day_of_month") == 25 for c in calls),
             f"expected a create_schedule with day_of_month=25; calls: {calls}")
@@ -60,6 +68,22 @@ class TestScheduleAgent(TestCase):
             agent = self._agent()
             agent.message("Remind me on the 25th of every 2 months to review my finances.")
         calls = self._create_calls(agent)
+        self.assertTrue(skill_was_loaded(agent, "schedule"))
         self.assertTrue(
             any(c.get("day_of_month") == 25 and c.get("month_interval") == 2 for c in calls),
             f"expected create_schedule with day_of_month=25, month_interval=2; calls: {calls}")
+
+    def test_referential_followup_reloads_skill_and_modifies_schedule(self):
+        """A new invocation resets disclosure, but the active task still routes."""
+        with stub_research_subagent():
+            agent = self._agent()
+            agent.message("Remind me every day at 7 AM to take my vitamins.")
+            before = len(self._named_calls(agent, "load_skill"))
+            agent.message("Actually, make it 8 AM instead.")
+
+        later_loads = self._named_calls(agent, "load_skill")[before:]
+        self.assertTrue(any(
+            (call.get("args") or {}).get("name") == "schedule"
+            for call in later_loads), later_loads)
+        self.assertTrue(self._named_calls(agent, "modify_schedule"),
+                        "follow-up did not modify the existing schedule")

--- a/edd/eval/test_schedule_agent.py
+++ b/edd/eval/test_schedule_agent.py
@@ -9,14 +9,15 @@ import os
 import tempfile
 from unittest import TestCase
 
-from langchain_core.messages import AIMessage
-
 from assist.agent import create_agent, AgentHarness
 from assist.model_manager import select_assistant_model
 from assist.spec import AgentSpec
 from assist.schedule.tools import schedule_tools
 from assist.schedule.store import ScheduleStore
-from .utils import create_filesystem, skill_was_loaded, stub_research_subagent
+from .utils import (
+    agent_tool_calls, create_filesystem, skill_was_loaded,
+    stub_research_subagent,
+)
 
 os.environ.setdefault("ASSIST_MODEL_URL", "http://127.0.0.1:8000/v1")
 
@@ -35,21 +36,8 @@ class TestScheduleAgent(TestCase):
 
     def _create_calls(self, agent) -> list:
         """args of every create_schedule call the agent emitted."""
-        calls = []
-        for m in agent.all_messages():
-            if not isinstance(m, AIMessage):
-                continue
-            for tc in (getattr(m, "tool_calls", None) or []):
-                if tc.get("name") == "create_schedule":
-                    calls.append(tc.get("args") or tc.get("arguments") or {})
-        return calls
-
-    @staticmethod
-    def _named_calls(agent, name: str) -> list[dict]:
-        return [tc for message in agent.all_messages()
-                if isinstance(message, AIMessage)
-                for tc in (message.tool_calls or [])
-                if tc.get("name") == name]
+        return [call.get("args") or call.get("arguments") or {}
+                for call in agent_tool_calls(agent, "create_schedule")]
 
     def test_agent_maps_day_of_month(self):
         # Not a research eval — stub the research subagent so a stray dispatch can't hit
@@ -78,12 +66,12 @@ class TestScheduleAgent(TestCase):
         with stub_research_subagent():
             agent = self._agent()
             agent.message("Remind me every day at 7 AM to take my vitamins.")
-            before = len(self._named_calls(agent, "load_skill"))
+            before = len(agent_tool_calls(agent, "load_skill"))
             agent.message("Actually, make it 8 AM instead.")
 
-        later_loads = self._named_calls(agent, "load_skill")[before:]
+        later_loads = agent_tool_calls(agent, "load_skill")[before:]
         self.assertTrue(any(
             (call.get("args") or {}).get("name") == "schedule"
             for call in later_loads), later_loads)
-        self.assertTrue(self._named_calls(agent, "modify_schedule"),
+        self.assertTrue(agent_tool_calls(agent, "modify_schedule"),
                         "follow-up did not modify the existing schedule")

--- a/edd/eval/test_subscription_agent.py
+++ b/edd/eval/test_subscription_agent.py
@@ -1,0 +1,39 @@
+"""Natural acceptance eval for bundled subscription-tool disclosure."""
+import tempfile
+from unittest import TestCase
+
+from langchain_core.messages import AIMessage
+
+from assist.agent import AgentHarness, create_agent
+from assist.events.store import SubscriptionStore
+from assist.events.tools import subscription_tools
+from assist.model_manager import select_assistant_model
+from assist.spec import AgentSpec
+
+from .utils import skill_was_loaded, stub_research_subagent
+
+
+class TestSubscriptionAgent(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = select_assistant_model(0.1)
+
+    def test_natural_request_loads_skill_and_creates_subscription(self):
+        store = SubscriptionStore(tempfile.mkdtemp(prefix="subscription_eval_store_"))
+        with stub_research_subagent():
+            agent = AgentHarness(create_agent(
+                self.model,
+                tempfile.mkdtemp(prefix="subscription_eval_workspace_"),
+                spec=AgentSpec(tools=tuple(subscription_tools(store))),
+            ))
+            agent.message(
+                "Whenever a text comes in from a 415 number, check whether it is "
+                "asking to schedule something and draft a short reply for me to review."
+            )
+
+        calls = [call for message in agent.all_messages()
+                 if isinstance(message, AIMessage)
+                 for call in (message.tool_calls or [])]
+        self.assertTrue(skill_was_loaded(agent, "subscribe-events"))
+        self.assertTrue(any(call.get("name") == "create_subscription"
+                            for call in calls), calls)

--- a/edd/eval/test_subscription_agent.py
+++ b/edd/eval/test_subscription_agent.py
@@ -2,15 +2,13 @@
 import tempfile
 from unittest import TestCase
 
-from langchain_core.messages import AIMessage
-
 from assist.agent import AgentHarness, create_agent
 from assist.events.store import SubscriptionStore
 from assist.events.tools import subscription_tools
 from assist.model_manager import select_assistant_model
 from assist.spec import AgentSpec
 
-from .utils import skill_was_loaded, stub_research_subagent
+from .utils import agent_tool_calls, skill_was_loaded, stub_research_subagent
 
 
 class TestSubscriptionAgent(TestCase):
@@ -34,9 +32,7 @@ class TestSubscriptionAgent(TestCase):
                 "asking to schedule something and draft a short reply for me to review."
             )
 
-        calls = [call for message in agent.all_messages()
-                 if isinstance(message, AIMessage)
-                 for call in (message.tool_calls or [])]
+        calls = agent_tool_calls(agent)
         self.assertTrue(skill_was_loaded(agent, "subscribe-events"))
         self.assertTrue(any(call.get("name") == "create_subscription"
                             for call in calls), calls)

--- a/edd/eval/test_subscription_agent.py
+++ b/edd/eval/test_subscription_agent.py
@@ -18,24 +18,25 @@ class TestSubscriptionAgent(TestCase):
         cls.model = select_assistant_model(0.1)
 
     def test_natural_request_loads_skill_and_creates_subscription(self):
-        store_root = tempfile.mkdtemp(prefix="subscription_eval_store_")
-        os.makedirs(os.path.join(store_root, "subscription-eval"))
-        store = SubscriptionStore(store_root)
-        with stub_research_subagent():
-            agent = AgentHarness(
-                create_agent(
-                    self.model,
-                    tempfile.mkdtemp(prefix="subscription_eval_workspace_"),
-                    spec=AgentSpec(tools=tuple(subscription_tools(store))),
-                ),
-                thread_id="subscription-eval",
-            )
-            agent.message(
-                "Whenever a text comes in from a 415 number, check whether it is "
-                "asking to schedule something and draft a short reply for me to review."
-            )
+        with tempfile.TemporaryDirectory(prefix="subscription_eval_store_") as store_root, \
+                tempfile.TemporaryDirectory(prefix="subscription_eval_workspace_") as workspace_root:
+            os.makedirs(os.path.join(store_root, "subscription-eval"))
+            store = SubscriptionStore(store_root)
+            with stub_research_subagent():
+                agent = AgentHarness(
+                    create_agent(
+                        self.model,
+                        workspace_root,
+                        spec=AgentSpec(tools=tuple(subscription_tools(store))),
+                    ),
+                    thread_id="subscription-eval",
+                )
+                agent.message(
+                    "Whenever a text comes in from a 415 number, check whether it is "
+                    "asking to schedule something and draft a short reply for me to review."
+                )
 
-        calls = agent_tool_calls(agent)
+            calls = agent_tool_calls(agent)
         self.assertTrue(skill_was_loaded(agent, "subscribe-events"))
         self.assertTrue(any(call.get("name") == "create_subscription"
                             for call in calls), calls)

--- a/edd/eval/test_subscription_agent.py
+++ b/edd/eval/test_subscription_agent.py
@@ -21,11 +21,14 @@ class TestSubscriptionAgent(TestCase):
     def test_natural_request_loads_skill_and_creates_subscription(self):
         store = SubscriptionStore(tempfile.mkdtemp(prefix="subscription_eval_store_"))
         with stub_research_subagent():
-            agent = AgentHarness(create_agent(
-                self.model,
-                tempfile.mkdtemp(prefix="subscription_eval_workspace_"),
-                spec=AgentSpec(tools=tuple(subscription_tools(store))),
-            ))
+            agent = AgentHarness(
+                create_agent(
+                    self.model,
+                    tempfile.mkdtemp(prefix="subscription_eval_workspace_"),
+                    spec=AgentSpec(tools=tuple(subscription_tools(store))),
+                ),
+                thread_id="subscription-eval",
+            )
             agent.message(
                 "Whenever a text comes in from a 415 number, check whether it is "
                 "asking to schedule something and draft a short reply for me to review."

--- a/edd/eval/test_subscription_agent.py
+++ b/edd/eval/test_subscription_agent.py
@@ -1,4 +1,5 @@
 """Natural acceptance eval for bundled subscription-tool disclosure."""
+import os
 import tempfile
 from unittest import TestCase
 
@@ -17,7 +18,9 @@ class TestSubscriptionAgent(TestCase):
         cls.model = select_assistant_model(0.1)
 
     def test_natural_request_loads_skill_and_creates_subscription(self):
-        store = SubscriptionStore(tempfile.mkdtemp(prefix="subscription_eval_store_"))
+        store_root = tempfile.mkdtemp(prefix="subscription_eval_store_")
+        os.makedirs(os.path.join(store_root, "subscription-eval"))
+        store = SubscriptionStore(store_root)
         with stub_research_subagent():
             agent = AgentHarness(
                 create_agent(

--- a/edd/eval/test_travel_agent.py
+++ b/edd/eval/test_travel_agent.py
@@ -11,7 +11,7 @@ from unittest import TestCase
 from assist.agent import create_agent, AgentHarness
 from assist.model_manager import select_assistant_model
 
-from .utils import create_filesystem
+from .utils import create_filesystem, skill_was_loaded
 
 
 class TestTravelAgent(TestCase):
@@ -34,6 +34,8 @@ class TestTravelAgent(TestCase):
         agent = self._agent()
         agent.message("How long does it take to get from the Ferry Building to "
                       "Oakland City Hall?")
+        self.assertTrue(skill_was_loaded(agent, "travel"),
+                        "expected the agent to load the travel skill")
         self.assertTrue(self._called_travel(agent),
                         "expected the agent to call the travel tool")
 
@@ -41,5 +43,7 @@ class TestTravelAgent(TestCase):
         agent = self._agent()
         agent.message("Is it faster to bike or drive from Civic Center to the "
                       "Mission in San Francisco?")
+        self.assertTrue(skill_was_loaded(agent, "travel"),
+                        "expected the agent to load the travel skill")
         self.assertTrue(self._called_travel(agent),
                         "expected the agent to call the travel tool")

--- a/edd/eval/test_urgent_notification.py
+++ b/edd/eval/test_urgent_notification.py
@@ -43,6 +43,12 @@ class TestUrgentNotification(TestCase):
                 for call in (message.tool_calls or [])
                 if call.get("name") == "notify"]
 
+    @staticmethod
+    def _all_calls(agent: AgentHarness) -> list[dict]:
+        return [call for message in agent.all_messages()
+                if isinstance(message, AIMessage)
+                for call in (message.tool_calls or [])]
+
     def test_imminent_deadline_is_flagged_with_a_message(self):
         agent = self._agent()
         with stub_research_subagent():
@@ -51,7 +57,11 @@ class TestUrgentNotification(TestCase):
                 "must answer about the lease before 4pm today or the apartment goes to "
                 "someone else. Please make sure I don't miss it.")
         calls = self._notify_calls(agent)
-        self.assertTrue(calls, f"expected notify for an imminent deadline; calls: {calls}")
+        self.assertEqual(len(calls), 1,
+                         f"expected exactly one notify; calls: {calls}")
+        all_calls = self._all_calls(agent)
+        self.assertTrue(all_calls and all_calls[0].get("name") == "notify",
+                        f"notify was not the first effect: {all_calls}")
         message = (calls[0].get("args") or {}).get("message", "")
         self.assertTrue(message.strip(), f"notify omitted its message: {calls}")
         self.assertIn("4", message, f"notification lacks the deadline: {calls}")

--- a/edd/eval/test_urgent_notification.py
+++ b/edd/eval/test_urgent_notification.py
@@ -9,14 +9,12 @@ import shutil
 import tempfile
 from unittest import TestCase
 
-from langchain_core.messages import AIMessage
-
 from assist.agent import AgentHarness, create_agent
 from assist.events.notify import notify_tools
 from assist.model_manager import select_assistant_model
 from assist.spec import AgentSpec
 
-from .utils import stub_research_subagent
+from .utils import agent_tool_calls, stub_research_subagent
 
 
 class TestUrgentNotification(TestCase):
@@ -36,19 +34,6 @@ class TestUrgentNotification(TestCase):
                 self.model, self.root,
                 spec=AgentSpec(tools=notify_tools(lambda _tid: None))))
 
-    @staticmethod
-    def _notify_calls(agent: AgentHarness) -> list[dict]:
-        return [call for message in agent.all_messages()
-                if isinstance(message, AIMessage)
-                for call in (message.tool_calls or [])
-                if call.get("name") == "notify"]
-
-    @staticmethod
-    def _all_calls(agent: AgentHarness) -> list[dict]:
-        return [call for message in agent.all_messages()
-                if isinstance(message, AIMessage)
-                for call in (message.tool_calls or [])]
-
     def test_imminent_deadline_is_flagged_with_a_message(self):
         agent = self._agent()
         with stub_research_subagent():
@@ -56,10 +41,10 @@ class TestUrgentNotification(TestCase):
                 "I won't see this chat again until this evening. The landlord just said I "
                 "must answer about the lease before 4pm today or the apartment goes to "
                 "someone else. Please make sure I don't miss it.")
-        calls = self._notify_calls(agent)
+        calls = agent_tool_calls(agent, "notify")
         self.assertEqual(len(calls), 1,
                          f"expected exactly one notify; calls: {calls}")
-        all_calls = self._all_calls(agent)
+        all_calls = agent_tool_calls(agent)
         self.assertTrue(all_calls and all_calls[0].get("name") == "notify",
                         f"notify was not the first effect: {all_calls}")
         message = (calls[0].get("args") or {}).get("message", "")
@@ -70,5 +55,5 @@ class TestUrgentNotification(TestCase):
         agent = self._agent()
         with stub_research_subagent():
             agent.message("I finished reading a novel this weekend. Can you help me summarize it?")
-        calls = self._notify_calls(agent)
+        calls = agent_tool_calls(agent, "notify")
         self.assertEqual(calls, [], f"routine request should not notify: {calls}")

--- a/edd/eval/utils.py
+++ b/edd/eval/utils.py
@@ -138,26 +138,15 @@ class AgentTestMixin:
         times a subagent was dispatched, not just whether it was.
         """
         calls = []
-        for m in agent.all_messages():
-            if isinstance(m, AIMessage) and m.tool_calls:
-                for tc in m.tool_calls:
-                    if tc.get("name") == "task":
-                        # deepagents' task tool names the target via
-                        # `subagent_type`, but the small model sometimes
-                        # emits it under `agent`/`name` instead — the
-                        # dev-agent evals (test_dev_agent.py:167,
-                        # test_dev_agent_planning_flow.py:157) carry the
-                        # same fallback against that observed shape, so
-                        # match it here for consistent counting.  The
-                        # `or` chain also recovers an empty `subagent_type`
-                        # (which SubagentTypeInferenceMiddleware would
-                        # otherwise default to general-purpose).
-                        args = tc.get("args") or {}
-                        sa = (args.get("subagent_type")
-                              or args.get("agent")
-                              or args.get("name") or "")
-                        if sa:
-                            calls.append(sa)
+        for tool_call in agent_tool_calls(agent, "task"):
+            # deepagents' task tool names the target via `subagent_type`, but the
+            # small model sometimes emits it under `agent`/`name` instead. The
+            # `or` chain also recovers an empty `subagent_type`.
+            args = tool_call.get("args") or {}
+            subagent = (args.get("subagent_type") or args.get("agent")
+                        or args.get("name") or "")
+            if subagent:
+                calls.append(subagent)
         return calls
 
     def assertSubAgentCall(self, agent, subagent_name: str, msg: str = None):
@@ -253,6 +242,16 @@ def files_in_directory(path: str) -> list[str]:
     """Returns the files in path as a list"""
     return os.listdir(path)
 
+
+def agent_tool_calls(agent, name: str | None = None) -> list[dict]:
+    """Outgoing tool calls in order, optionally filtered by exact name."""
+    calls = [call for message in agent.all_messages()
+             if isinstance(message, AIMessage)
+             for call in (message.tool_calls or [])]
+    return calls if name is None else [
+        call for call in calls if call.get("name") == name]
+
+
 def skill_was_loaded(agent, skill_name: str) -> bool:
     """True iff a tool call loaded the named skill's body.
 
@@ -267,31 +266,20 @@ def skill_was_loaded(agent, skill_name: str) -> bool:
     since the model proves intent the moment it issues the call.
     """
     path_needle = f"/skills/{skill_name}/"
-    for m in agent.all_messages():
-        if not isinstance(m, AIMessage) or not m.tool_calls:
-            continue
-        for tc in m.tool_calls:
-            args = tc.get("args") or {}
-            if tc.get("name") == "load_skill" and args.get("name") == skill_name:
+    for tc in agent_tool_calls(agent):
+        args = tc.get("args") or {}
+        if tc.get("name") == "load_skill" and args.get("name") == skill_name:
+            return True
+        for value in args.values():
+            if isinstance(value, str) and path_needle in value:
                 return True
-            for v in args.values():
-                if isinstance(v, str) and path_needle in v:
-                    return True
     return False
 
 
 def executed_commands(agent) -> list[str]:
     """Command strings from every ``execute`` tool call, in order."""
-    cmds = []
-    for m in agent.all_messages():
-        if not isinstance(m, AIMessage) or not m.tool_calls:
-            continue
-        for tc in m.tool_calls:
-            if tc.get("name") == "execute":
-                cmd = (tc.get("args") or {}).get("command", "")
-                if cmd:
-                    cmds.append(cmd)
-    return cmds
+    return [command for call in agent_tool_calls(agent, "execute")
+            if (command := (call.get("args") or {}).get("command", ""))]
 
 
 def cleanup_workspace(path: str) -> None:

--- a/edd/prompt_census.py
+++ b/edd/prompt_census.py
@@ -1333,7 +1333,7 @@ def _invoke_skill_precedence(trace: CensusTrace, root: Path,
     if embedder:
         extra = root / name / "embedder-skills"
         _write_skill(extra, "dev", "SYNTHETIC EMBEDDER DEV DESCRIPTION",
-                     "SYNTHETIC_EMBEDDER_DEV_BODY")
+                     "\x1b[31mSYNTHETIC_EMBEDDER_DEV_BODY\x1b[0m")
         sources["/synthetic-embedder-skills/"] = FilesystemBackend(
             root_dir=str(extra), virtual_mode=True)
     with _scenario(name):
@@ -1888,7 +1888,10 @@ _DECLARED_TOOL_SCHEMA_HASHES = {
     "list_schedules": {"e0cd57bcb7cd8a6c27e84a665534daf714ef7867e8c95795252c3981caf7217e"},
     "list_subscriptions": {"dcb6ac3c9c61a0dab7c30d0ea6311d20fe5e3502cbc748145ba8032ee1cd931f"},
     "list_threads": {"6ac6da21f65a92eea33c6f825b98322478f3640c944969bf1a47024ed6d7c78b"},
-    "load_skill": {"9870c9427a98117cbe8f4947a569f1b490250611ca3b0b305929ddf1365a629b"},
+    "load_skill": {
+        "9870c9427a98117cbe8f4947a569f1b490250611ca3b0b305929ddf1365a629b",
+        "abc2bc372ed164d625f4f03f3b24602af5e79b99fa43e1c7c60bc5ef2c8233cb",
+    },
     "ls": {"295a42f624bb3d6fd5e8f13e3d3172bf5856df6bc32d5c700c2b4d6b559850de"},
     "map_data": {"0285e871e6f8ebe3d7bdd34068af9fd7dce5841918c76d2866d64e2620f5851f"},
     "modify_schedule": {"2b82e293c48bbdfcaaafe797533693b7d15653b7f3dd2e996c6c06f27a0c16ca"},
@@ -1919,8 +1922,22 @@ _TASK_SCHEMA_HASH_BY_PATH = {
 }
 
 
-def _expected_tool_results() -> dict[str, str]:
+def _expected_skill_file(tool_call_id: str) -> str:
     repo = Path(__file__).resolve().parents[1]
+    files = {
+        "synthetic-call-hitl-skill-load":
+            (repo / "assist/web_skills/send-email/SKILL.md").read_text(
+                encoding="utf-8"),
+        "synthetic-call-skill-precedence-built-in-load":
+            (repo / "assist/skills/dev/SKILL.md").read_text(encoding="utf-8"),
+        "synthetic-call-skill-precedence-embedder-load":
+            "---\nname: dev\ndescription: SYNTHETIC EMBEDDER DEV DESCRIPTION\n"
+            "---\n\n\x1b[31mSYNTHETIC_EMBEDDER_DEV_BODY\x1b[0m\n",
+    }
+    return files[tool_call_id]
+
+
+def _expected_tool_results() -> dict[str, str]:
     return {
         "synthetic-call-safe-exec":
             "SYNTHETIC_EXECUTE_OK\n[Command succeeded with exit code 0]",
@@ -1929,16 +1946,15 @@ def _expected_tool_results() -> dict[str, str]:
             "the web UI.  To publish your work to origin, ask the user to click "
             "'Push to origin' in their browser.",
         "synthetic-call-hitl-skill-load":
-            (repo / "assist/web_skills/send-email/SKILL.md").read_text(
-                encoding="utf-8")
+            _expected_skill_file("synthetic-call-hitl-skill-load")
             + "\n\nNewly available tools: send_email.",
         "synthetic-call-skill-precedence-built-in-load":
-            (repo / "assist/skills/dev/SKILL.md").read_text(encoding="utf-8")
+            _expected_skill_file("synthetic-call-skill-precedence-built-in-load")
             + "\n\nNo additional tools became available.",
         "synthetic-call-skill-precedence-embedder-load":
             "---\nname: dev\ndescription: SYNTHETIC EMBEDDER DEV DESCRIPTION\n"
             "---\n\nSYNTHETIC_EMBEDDER_DEV_BODY\n"
-            "\n\nNo additional tools became available.",
+            + "\n\nNo additional tools became available.",
         "synthetic-call-read-only":
             "Error: this agent is read-only and cannot call 'write_file'. If the "
             "user asked you to write or modify something, do not attempt the write "
@@ -1971,17 +1987,16 @@ def _expected_load_artifact(tool_call_id: str) -> dict[str, str]:
     from deepagents.middleware.skills import _parse_skill_metadata
 
     requested_name = _DECLARED_TOOL_CALLS[tool_call_id][1]["name"]
+    skill_file = _expected_skill_file(tool_call_id)
     content = _expected_tool_results()[tool_call_id]
-    body, separator, _disclosure = content.rpartition("\n\n")
-    if not separator:
-        raise AssertionError("declared load result lacks disclosure suffix")
     metadata = _parse_skill_metadata(
-        body, f"/{requested_name}/SKILL.md", requested_name)
+        skill_file, f"/{requested_name}/SKILL.md", requested_name)
     if metadata is None:
         raise AssertionError("declared load result metadata did not parse")
     fingerprint_payload = {
         "allowed_tools": list(metadata["allowed_tools"]),
-        "body_sha256": hashlib.sha256(body.encode("utf-8")).hexdigest(),
+        "skill_file_sha256": hashlib.sha256(
+            skill_file.encode("utf-8")).hexdigest(),
         "description": metadata["description"],
         "name": metadata["name"],
     }
@@ -2513,7 +2528,8 @@ def _assert_declared_inputs(artifact: dict[str, Any]) -> None:
             "path": "/synthetic-embedder-skills/dev/SKILL.md",
             "description": "SYNTHETIC EMBEDDER DEV DESCRIPTION",
             "content": "---\nname: dev\ndescription: SYNTHETIC EMBEDDER DEV "
-                       "DESCRIPTION\n---\n\nSYNTHETIC_EMBEDDER_DEV_BODY\n",
+                       "DESCRIPTION\n---\n\n\x1b[31mSYNTHETIC_EMBEDDER_DEV_BODY"
+                       "\x1b[0m\n",
             "allowed_tools": [],
         },
     }

--- a/edd/prompt_census.py
+++ b/edd/prompt_census.py
@@ -58,7 +58,7 @@ REQUIRED_PATHS = {
 }
 EXPECTED_PATHS_BY_SCENARIO = {
     "web-main-core": ("main", "main", "main"),
-    "web-main-full": ("main",),
+    "web-main-full": ("main", "main"),
     "web-delegate": ("delegate",),
     "legacy-main": ("legacy-main",),
     "skill-precedence-built-in": ("main", "main"),
@@ -186,6 +186,8 @@ def _message(message: BaseMessage) -> dict[str, Any]:
     if isinstance(message, ToolMessage):
         result["tool_call_id"] = message.tool_call_id
         result["status"] = message.status
+        if message.artifact is not None:
+            result["artifact"] = message.artifact
     return result
 
 
@@ -446,7 +448,10 @@ def _scripted_response(scenario: str, index: int) -> AIMessage:
             return _call("execute", {"command": "printf synthetic-ok"}, "safe-exec")
         if index == 1:
             return _call("execute", {"command": "git push origin main"}, "git-push")
-    if scenario == "web-main-full" and index == 0:
+    if scenario == "web-main-full":
+        if index == 0:
+            return _call(
+                "load_skill", {"name": "send-email"}, "hitl-skill-load")
         return _call("send_email", {
             "to": "synthetic-recipient@example.invalid",
             "subject": "Synthetic approval probe",
@@ -697,10 +702,22 @@ def _content_segments(owner: str, text: str, scenario: str,
             listing_parts.append("(No skills available.)")
             _append_owned(listing_segments, listing_parts[0], [formatter_id])
         listing = "".join(listing_parts)
+        tools_match = re.search(
+            r"Tools available for this response: ([^\n]+)\.\n?$", text)
+        if tools_match is None:
+            raise AssertionError(
+                f"retained tool guidance is absent from {scenario}")
         rendered, segments = _render_owned_template(
             SMALL_MODEL_SKILLS_PROMPT,
             "python:assist.middleware.skills_middleware.SMALL_MODEL_SKILLS_PROMPT",
-            {"skills_list": {"value": listing, "segments": listing_segments}},
+            {
+                "skills_list": {"value": listing, "segments": listing_segments},
+                "tools_available": {
+                    "value": tools_match.group(1),
+                    "source_ids": [
+                        "python:assist.middleware.skills_middleware"],
+                },
+            },
         )
     elif owner == "deepagents.MemoryMiddleware":
         from assist.middleware.memory_middleware import (
@@ -1325,9 +1342,11 @@ def _invoke_skill_precedence(trace: CensusTrace, root: Path,
             spec=AgentSpec(skill_sources=sources,
                            async_subagent_tools=async_task_tools))
         result = _invoke_agent(agent, name)
-    bodies = [str(message["content"])
-              for message in _tool_messages(result, name="load_skill")]
-    return {"loaded_skill_bodies": bodies}
+    messages = _tool_messages(result, name="load_skill")
+    return {
+        "loaded_skill_bodies": [str(message["content"]) for message in messages],
+        "load_artifacts": [message["artifact"] for message in messages],
+    }
 
 
 def _invoke_context(trace: CensusTrace, root: Path) -> dict[str, Any]:
@@ -1820,6 +1839,8 @@ _DECLARED_TOOL_CALLS = {
             "subject": "Synthetic approval probe",
             "body": "Synthetic body.",
         }),
+    "synthetic-call-hitl-skill-load": (
+        "load_skill", {"name": "send-email"}),
     "synthetic-call-read-only": (
         "write_file", {
             "file_path": "/synthetic-forbidden.txt",
@@ -1907,11 +1928,17 @@ def _expected_tool_results() -> dict[str, str]:
             "Error: direct git push is not allowed.  The user controls pushes from "
             "the web UI.  To publish your work to origin, ask the user to click "
             "'Push to origin' in their browser.",
+        "synthetic-call-hitl-skill-load":
+            (repo / "assist/web_skills/send-email/SKILL.md").read_text(
+                encoding="utf-8")
+            + "\n\nNewly available tools: send_email.",
         "synthetic-call-skill-precedence-built-in-load":
-            (repo / "assist/skills/dev/SKILL.md").read_text(),
+            (repo / "assist/skills/dev/SKILL.md").read_text(encoding="utf-8")
+            + "\n\nNo additional tools became available.",
         "synthetic-call-skill-precedence-embedder-load":
             "---\nname: dev\ndescription: SYNTHETIC EMBEDDER DEV DESCRIPTION\n"
-            "---\n\nSYNTHETIC_EMBEDDER_DEV_BODY\n",
+            "---\n\nSYNTHETIC_EMBEDDER_DEV_BODY\n"
+            "\n\nNo additional tools became available.",
         "synthetic-call-read-only":
             "Error: this agent is read-only and cannot call 'write_file'. If the "
             "user asked you to write or modify something, do not attempt the write "
@@ -1940,9 +1967,38 @@ def _expected_tool_results() -> dict[str, str]:
     }
 
 
+def _expected_load_artifact(tool_call_id: str) -> dict[str, str]:
+    from deepagents.middleware.skills import _parse_skill_metadata
+
+    requested_name = _DECLARED_TOOL_CALLS[tool_call_id][1]["name"]
+    content = _expected_tool_results()[tool_call_id]
+    body, separator, _disclosure = content.rpartition("\n\n")
+    if not separator:
+        raise AssertionError("declared load result lacks disclosure suffix")
+    metadata = _parse_skill_metadata(
+        body, f"/{requested_name}/SKILL.md", requested_name)
+    if metadata is None:
+        raise AssertionError("declared load result metadata did not parse")
+    fingerprint_payload = {
+        "allowed_tools": list(metadata["allowed_tools"]),
+        "body_sha256": hashlib.sha256(body.encode("utf-8")).hexdigest(),
+        "description": metadata["description"],
+        "name": metadata["name"],
+    }
+    return {
+        "schema": "assist.skill-load.v1",
+        "requested_name": requested_name,
+        "winner_fingerprint": hashlib.sha256(json.dumps(
+            fingerprint_payload, ensure_ascii=False, separators=(",", ":"),
+            sort_keys=True).encode("utf-8")).hexdigest(),
+        "result_sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+    }
+
+
 _TOOL_RESULT_METADATA = {
     "synthetic-call-safe-exec": ("execute", "success"),
     "synthetic-call-git-push": ("execute", "error"),
+    "synthetic-call-hitl-skill-load": ("load_skill", "success"),
     "synthetic-call-skill-precedence-built-in-load": ("load_skill", "success"),
     "synthetic-call-skill-precedence-embedder-load": ("load_skill", "success"),
     "synthetic-call-read-only": ("write_file", "error"),
@@ -1958,7 +2014,7 @@ _DECLARED_CAPTURE_TASK_SHA256 = \
 _DECLARED_TOOL_NODE_HISTORY_SHA256 = \
     "47543010e202c1c99aa62e953eafad99b81d55a345e75100ef58556f1f61ad04"
 _DECLARED_PROMPT_BLOCK_CHAIN_SHA256 = \
-    "7a18b7265e11b5a8447a49e6a1ad26e11d638a10963761dded4eae4fa7793d76"
+    "9602ca8b9d3883ee20f6391c5eade241d1b03d4179d38e0165bc7275e0913d4c"
 
 
 def _provider_tool_pair(tool_call_id: str) -> list[dict[str, Any]]:
@@ -2002,6 +2058,8 @@ def _expected_message_history(scenario: str, index: int) -> list[dict[str, Any]]
     ids: list[str] = []
     if scenario == "web-main-core":
         ids = ["synthetic-call-safe-exec", "synthetic-call-git-push"][:index]
+    elif scenario == "web-main-full" and index == 1:
+        ids = ["synthetic-call-hitl-skill-load"]
     elif scenario.startswith("skill-precedence-") and index == 1:
         ids = [f"synthetic-call-{scenario}-load"]
     elif scenario == "context-read-only":
@@ -2035,6 +2093,8 @@ def _assert_tool_result(message: dict[str, Any]) -> None:
             "tool_call_id": tool_call_id,
             "status": status,
         }
+        if name == "load_skill":
+            expected_message["artifact"] = _expected_load_artifact(tool_call_id)
         if message != expected_message:
             raise AssertionError(f"undeclared observed tool-result shape: {tool_call_id}")
 
@@ -2356,8 +2416,10 @@ def _assert_declared_inputs(artifact: dict[str, Any]) -> None:
             "web-delegate": {"sandbox_commands", "tool_messages", "interrupted",
                              "email_delivery_attempted"},
             "legacy-main": set(),
-            "skill-precedence-built-in": {"loaded_skill_bodies"},
-            "skill-precedence-embedder": {"loaded_skill_bodies"},
+            "skill-precedence-built-in": {
+                "loaded_skill_bodies", "load_artifacts"},
+            "skill-precedence-embedder": {
+                "loaded_skill_bodies", "load_artifacts"},
             "context-read-only": {"tool_messages"},
             "research-lead": {"tool_messages"},
             "research-leaf-provenance": {"tool_messages"},
@@ -2383,6 +2445,9 @@ def _assert_declared_inputs(artifact: dict[str, Any]) -> None:
             if observation["loaded_skill_bodies"] != [
                     _expected_tool_results()[call_id]]:
                 raise AssertionError(f"{scenario} has undeclared loaded skills")
+            if observation["load_artifacts"] != [
+                    _expected_load_artifact(call_id)]:
+                raise AssertionError(f"{scenario} has undeclared load evidence")
         if "description" in observation \
                 and observation["description"] != \
                 "SYNTHETIC TERMINAL thread-description 0":
@@ -2414,7 +2479,7 @@ def _assert_declared_inputs(artifact: dict[str, Any]) -> None:
         expected_tool_ids = {
             "web-main-core": ["synthetic-call-safe-exec",
                               "synthetic-call-git-push"],
-            "web-main-full": [],
+            "web-main-full": ["synthetic-call-hitl-skill-load"],
             "web-delegate": [],
             "context-read-only": ["synthetic-call-read-only",
                                   "synthetic-call-read-only-edit"],
@@ -3197,7 +3262,7 @@ def _assert_observer_payload(payload: dict[str, Any]) -> None:
     tools = payload["tools"]
     expected_tools = [
         "write_todos", "ls", "read_file", "write_file", "edit_file", "glob",
-        "grep", "load_skill", "travel", "directions", "map_data", "read_url",
+        "grep", "load_skill", "map_data",
     ]
     if not isinstance(tools, list) or [
             tool.get("function", {}).get("name") for tool in tools

--- a/roadmap.org
+++ b/roadmap.org
@@ -941,6 +941,7 @@ then run the natural/capability cohorts.  See [[file:docs/2026-07-26-agent-promp
 Completed on 2026-08-06 in =1dab6fe=: the stability candidate passed 87/110
 overall and 50/70 natural, met or exceeded all eleven P2b.1 baseline nodes, and
 reduced initial provider schemas from 30 to 15.  See
+[[https://github.com/pierrel/assist/pull/230][PR #230]] and
 [[file:docs/2026-08-05-prompt-architecture-p2b2.org][the P2b.2 state record]].
 **** TODO P2b.3: Apply the contract to domain and embedder skills
 Use the same winning-skill declaration and current composed tool registry for

--- a/roadmap.org
+++ b/roadmap.org
@@ -935,9 +935,13 @@ match current main at 30/30 in the N=10 stability cohort (2026-08-05).
 Kernel prose moves to P2b.2 with actual gating.
 See [[https://github.com/pierrel/assist/pull/227][PR #227]] and
 [[file:docs/2026-08-05-prompt-architecture-p2b1.org][the P2b.1 state record]].
-**** TODO P2b.2: Gate Assist-owned tools after skill load
+**** DONE P2b.2: Gate Assist-owned tools after skill load
 Filter model schemas and execution from trusted invocation-scoped load state,
 then run the natural/capability cohorts.  See [[file:docs/2026-07-26-agent-prompt-architecture.org::#phase-2b-tools-assist][P2b.2]].
+Completed on 2026-08-06 in =1dab6fe=: the stability candidate passed 87/110
+overall and 50/70 natural, met or exceeded all eleven P2b.1 baseline nodes, and
+reduced initial provider schemas from 30 to 15.  See
+[[file:docs/2026-08-05-prompt-architecture-p2b2.org][the P2b.2 state record]].
 **** TODO P2b.3: Apply the contract to domain and embedder skills
 Use the same winning-skill declaration and current composed tool registry for
 =.claude/skills/= and =AgentSpec.skill_sources=.  See [[file:docs/2026-07-26-agent-prompt-architecture.org::#phase-2b-tools-external][P2b.3]].

--- a/tests/middleware/test_skills_kernel.py
+++ b/tests/middleware/test_skills_kernel.py
@@ -342,11 +342,11 @@ def test_after_model_pairs_every_call_and_jumps_past_hitl():
 
     assert [call["name"] for call in message.tool_calls] == [
         "travel", "kernel_tool"]
-    assert len(update["messages"]) == 3
-    assert update["messages"][1].name == "travel"
+    assert len(update["messages"]) == 2
+    assert update["messages"][0].name == "travel"
+    assert update["messages"][0].status == "error"
+    assert update["messages"][1].name == "kernel_tool"
     assert update["messages"][1].status == "error"
-    assert update["messages"][2].name == "kernel_tool"
-    assert update["messages"][2].status == "error"
     assert update["jump_to"] == "model"
 
 

--- a/tests/middleware/test_skills_kernel.py
+++ b/tests/middleware/test_skills_kernel.py
@@ -1,10 +1,45 @@
-"""Focused tests for declarations and the deferred prompt-kernel boundary."""
-from unittest.mock import Mock
+"""Focused tests for bundled skill tool disclosure."""
+import asyncio
+import hashlib
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 from langchain.agents.middleware.types import ModelRequest
-from langchain_core.messages import SystemMessage
+from langchain.agents.middleware.types import ToolCallRequest
+from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
+from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+from langchain_core.tools import tool
+from langgraph.types import Command, Overwrite
 
 from assist.middleware.skills_middleware import SmallModelSkillsMiddleware
+
+
+@tool
+def kernel_tool(value: str) -> str:
+    """A baseline-visible tool."""
+    return value
+
+
+@tool
+def travel(origin: str, destination: str) -> str:
+    """A bundled skill-owned tool."""
+    return f"{origin}:{destination}"
+
+
+def _skill(path="/skills/travel/SKILL.md"):
+    return {
+        "name": "travel", "description": "Travel help.",
+        "path": path, "allowed_tools": ["travel"],
+        "license": None, "compatibility": None, "metadata": {},
+    }
+
+
+def _request(middleware, state, tools=(kernel_tool, travel)):
+    return ModelRequest(
+        model=Mock(), messages=[], system_message=SystemMessage(content="BASE"),
+        tools=list(tools), state=state, runtime=None)
 
 
 def _system_text(message):
@@ -20,11 +55,7 @@ def test_startup_catalog_hides_declarations_and_kernel():
     request = ModelRequest(
         model=Mock(), messages=[], system_message=SystemMessage(content="BASE"),
         tools=[],
-        state={"skills_metadata": [{
-            "name": "travel", "description": "Travel help.",
-            "path": "/skills/travel/SKILL.md", "allowed_tools": ["travel"],
-            "license": None, "compatibility": None, "metadata": {},
-        }]}, runtime=None)
+        state={"skills_metadata": [_skill()]}, runtime=None)
 
     updated = middleware.modify_request(request)
     text = _system_text(updated.system_message)
@@ -33,3 +64,242 @@ def test_startup_catalog_hides_declarations_and_kernel():
     assert "Allowed tools" not in text
     assert "allowed-tools" not in text
     assert "Kernel tools:" not in text
+
+
+def test_request_filters_only_winning_bundled_declarations_and_preserves_order():
+    middleware = SmallModelSkillsMiddleware(
+        backend=Mock(), sources=["/skills/", "/external/"],
+        bundled_sources=["/skills/"])
+    state = {"skills_metadata": [_skill()], "loaded_skill_tools": frozenset()}
+
+    updated = middleware.modify_request(_request(middleware, state))
+
+    assert [item.name for item in updated.tools] == ["kernel_tool"]
+    assert "Tools available for this response: kernel_tool." in _system_text(
+        updated.system_message)
+
+
+def test_external_winner_stays_baseline_visible():
+    middleware = SmallModelSkillsMiddleware(
+        backend=Mock(), sources=["/skills/", "/external/"],
+        bundled_sources=["/skills/"])
+    state = {
+        "skills_metadata": [_skill("/external/travel/SKILL.md")],
+        "loaded_skill_tools": frozenset(),
+    }
+
+    updated = middleware.modify_request(_request(middleware, state))
+
+    assert [item.name for item in updated.tools] == ["kernel_tool", "travel"]
+
+
+def test_before_agent_resets_activation_even_when_metadata_is_checkpointed():
+    middleware = SmallModelSkillsMiddleware(
+        backend=Mock(), sources=["/skills/"], bundled_sources=["/skills/"])
+
+    update = middleware.before_agent(
+        {"skills_metadata": [_skill()], "loaded_skill_tools": frozenset({"travel"})},
+        SimpleNamespace(),
+        {},
+    )
+
+    assert isinstance(update["loaded_skill_tools"], Overwrite)
+    assert update["loaded_skill_tools"].value == frozenset()
+
+
+def test_successful_load_returns_state_command_and_exact_closed_evidence():
+    body = "---\nname: travel\ndescription: Travel help.\n---\n\n\x1b[31mRULES\x1b[0m"
+    backend = SimpleNamespace(download_files=lambda _paths: [
+        SimpleNamespace(error=None, content=body.encode("utf-8"))])
+    middleware = SmallModelSkillsMiddleware(
+        backend=backend, sources=["/skills/"], bundled_sources=["/skills/"])
+    skill = _skill()
+    state = {"skills_metadata": [skill], "loaded_skill_tools": frozenset()}
+    runtime = SimpleNamespace(
+        state=state, config={}, tool_call_id="load-1")
+
+    result = middleware.tools[0].func("travel", runtime)
+
+    assert isinstance(result, Command)
+    assert result.update["loaded_skill_tools"] == frozenset({"travel"})
+    message = result.update["messages"][0]
+    assert message.tool_call_id == "load-1"
+    assert "\x1b" not in message.content
+    assert message.content.endswith("Newly available tools: travel.")
+    assert set(message.artifact) == {
+        "schema", "requested_name", "winner_fingerprint", "result_sha256"}
+    assert message.artifact["requested_name"] == "travel"
+    assert message.artifact["result_sha256"] == hashlib.sha256(
+        message.content.encode("utf-8")).hexdigest()
+    assert "/skills/" not in str(message.artifact)
+
+    visible = middleware.modify_request(_request(
+        middleware, {**state, "loaded_skill_tools": frozenset({"travel"})}))
+    assert [item.name for item in visible.tools] == ["kernel_tool", "travel"]
+
+
+def test_failed_load_has_no_state_or_artifact():
+    middleware = SmallModelSkillsMiddleware(
+        backend=Mock(), sources=["/skills/"], bundled_sources=["/skills/"])
+    runtime = SimpleNamespace(
+        state={"skills_metadata": [], "loaded_skill_tools": frozenset()},
+        config={}, tool_call_id="load-1")
+
+    result = middleware.tools[0].func("fabricated", runtime)
+
+    assert isinstance(result, str)
+    assert "could not be loaded" in result
+
+
+def test_hidden_execution_is_rejected_in_sync_and_async_paths():
+    middleware = SmallModelSkillsMiddleware(
+        backend=Mock(), sources=["/skills/"], bundled_sources=["/skills/"])
+    state = {"skills_metadata": [_skill()], "loaded_skill_tools": frozenset()}
+    request = ToolCallRequest(
+        tool_call={"name": "travel", "args": {}, "id": "travel-1"},
+        tool=travel, state=state, runtime=None)
+    sync_called = False
+
+    def sync_handler(_request):
+        nonlocal sync_called
+        sync_called = True
+        return ToolMessage(content="ran", tool_call_id="travel-1")
+
+    sync_result = middleware.wrap_tool_call(request, sync_handler)
+
+    async_called = False
+
+    async def async_handler(_request):
+        nonlocal async_called
+        async_called = True
+        return ToolMessage(content="ran", tool_call_id="travel-1")
+
+    async_result = asyncio.run(middleware.awrap_tool_call(request, async_handler))
+
+    assert not sync_called and not async_called
+    assert sync_result.status == "error"
+    assert async_result.status == "error"
+
+
+def test_after_model_removes_hidden_call_before_hitl_and_keeps_visible_call():
+    middleware = SmallModelSkillsMiddleware(
+        backend=Mock(), sources=["/skills/"], bundled_sources=["/skills/"])
+    message = AIMessage(content="", tool_calls=[
+        {"name": "travel", "args": {}, "id": "hidden-1"},
+        {"name": "kernel_tool", "args": {}, "id": "visible-1"},
+    ])
+    state = {
+        "messages": [message], "skills_metadata": [_skill()],
+        "loaded_skill_tools": frozenset(),
+    }
+
+    update = middleware.after_model(state, None)
+
+    assert [call["name"] for call in message.tool_calls] == ["kernel_tool"]
+    assert len(update["messages"]) == 2
+    assert update["messages"][1].name == "travel"
+    assert update["messages"][1].status == "error"
+
+
+class _RecordingModel(FakeMessagesListChatModel):
+    bound_tools: list[list[str]] = []
+
+    def bind_tools(self, tools, **_kwargs):
+        self.bound_tools.append([
+            item.name if hasattr(item, "name") else item.get("name", "")
+            for item in tools
+        ])
+        return self
+
+
+def test_compiled_graph_discloses_after_load_then_resets_next_invocation():
+    from assist.agent import create_agent
+    from assist.spec import AgentSpec
+
+    @tool("travel")
+    def fake_travel(origin: str, destination: str) -> str:
+        """Return a deterministic route."""
+        return f"route:{origin}:{destination}"
+
+    model = _RecordingModel(responses=[
+        AIMessage(content="", tool_calls=[{
+            "name": "load_skill", "args": {"name": "travel"}, "id": "load-1"}]),
+        AIMessage(content="", tool_calls=[{
+            "name": "travel", "args": {"origin": "a", "destination": "b"},
+            "id": "travel-1"}]),
+        AIMessage(content="first done"),
+        AIMessage(content="", tool_calls=[{
+            "name": "travel", "args": {"origin": "c", "destination": "d"},
+            "id": "travel-2"}]),
+        AIMessage(content="second done"),
+    ])
+    model.bound_tools = []
+
+    with patch("assist.agent.travel", fake_travel), tempfile.TemporaryDirectory() as wd:
+        agent = create_agent(
+            model, wd, spec=AgentSpec(async_subagent_tools=()))
+        config = {"configurable": {"thread_id": "skill-reset"}}
+        first = agent.invoke({"messages": [{"role": "user", "content": "route"}]}, config)
+        second = agent.invoke({"messages": [{"role": "user", "content": "again"}]}, config)
+
+    assert "travel" not in model.bound_tools[0]
+    assert "travel" in model.bound_tools[1]
+    assert any(message.name == "travel" and message.status == "success"
+               for message in first["messages"] if isinstance(message, ToolMessage))
+    assert "travel" not in model.bound_tools[3]
+    hidden = [message for message in second["messages"]
+              if isinstance(message, ToolMessage)
+              and message.tool_call_id == "travel-2"]
+    assert len(hidden) == 1 and hidden[0].status == "error"
+
+
+def test_compiled_graph_rejects_same_response_sibling_before_hitl():
+    from assist.agent import create_agent
+    from assist.backends import create_skills_backend
+    from assist.spec import AgentSpec
+
+    sent = []
+
+    @tool
+    def send_email(to: str) -> str:
+        """Send an email."""
+        sent.append(to)
+        return "sent"
+
+    model = _RecordingModel(responses=[
+        AIMessage(content="", tool_calls=[
+            {"name": "load_skill", "args": {"name": "send-email"}, "id": "load-1"},
+            {"name": "send_email", "args": {"to": "a@example.com"}, "id": "send-1"},
+        ]),
+        AIMessage(content="done"),
+    ])
+    model.bound_tools = []
+
+    with tempfile.TemporaryDirectory() as skill_root, tempfile.TemporaryDirectory() as wd:
+        skill_dir = Path(skill_root) / "send-email"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: send-email\ndescription: Send email.\n"
+            "allowed-tools: send_email\n---\n\nUse send_email.\n",
+            encoding="utf-8",
+        )
+        agent = create_agent(
+            model,
+            wd,
+            spec=AgentSpec(
+                tools=(send_email,),
+                async_subagent_tools=(),
+                skill_sources={"/mail-skill/": create_skills_backend(skill_root)},
+                interrupt_on={"send_email": True},
+            ),
+        )
+        result = agent.invoke(
+            {"messages": [{"role": "user", "content": "email"}]},
+            {"configurable": {"thread_id": "skill-sibling"}},
+        )
+
+    assert sent == []
+    rejected = [message for message in result["messages"]
+                if isinstance(message, ToolMessage)
+                and message.tool_call_id == "send-1"]
+    assert len(rejected) == 1 and rejected[0].status == "error"

--- a/tests/middleware/test_skills_kernel.py
+++ b/tests/middleware/test_skills_kernel.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from typing import get_args, get_type_hints
 from unittest.mock import Mock, patch
 
+from pydantic import PrivateAttr
 from langchain.agents.middleware.types import ModelRequest
 from langchain.agents.middleware.types import ToolCallRequest
 from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
@@ -351,7 +352,15 @@ def test_after_model_pairs_every_call_and_jumps_past_hitl():
 
 
 class _RecordingModel(FakeMessagesListChatModel):
-    bound_tools: list[list[str]] = []
+    _bound_tools: list[list[str]] = PrivateAttr(default_factory=list)
+
+    @property
+    def bound_tools(self):
+        return self._bound_tools
+
+    @bound_tools.setter
+    def bound_tools(self, value):
+        self._bound_tools = value
 
     def bind_tools(self, tools, **_kwargs):
         self.bound_tools.append([

--- a/tests/middleware/test_skills_kernel.py
+++ b/tests/middleware/test_skills_kernel.py
@@ -1,9 +1,12 @@
 """Focused tests for bundled skill tool disclosure."""
 import asyncio
 import hashlib
+import json
+import operator
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
+from typing import get_args, get_type_hints
 from unittest.mock import Mock, patch
 
 from langchain.agents.middleware.types import ModelRequest
@@ -13,7 +16,12 @@ from langchain_core.language_models.fake_chat_models import FakeMessagesListChat
 from langchain_core.tools import tool
 from langgraph.types import Command, Overwrite
 
-from assist.middleware.skills_middleware import SmallModelSkillsMiddleware
+from assist.middleware.skills_middleware import (
+    LEGACY_SMALL_MODEL_SKILLS_PROMPT,
+    MAX_SKILL_FILE_SIZE,
+    SmallModelSkillsMiddleware,
+    SmallModelSkillsState,
+)
 
 
 @tool
@@ -93,6 +101,31 @@ def test_external_winner_stays_baseline_visible():
     assert [item.name for item in updated.tools] == ["kernel_tool", "travel"]
 
 
+def test_nested_external_source_is_not_claimed_by_bundled_parent():
+    middleware = SmallModelSkillsMiddleware(
+        backend=Mock(), sources=["/skills/", "/skills/external/"],
+        bundled_sources=["/skills/"])
+    state = {
+        "skills_metadata": [_skill("/skills/external/travel/SKILL.md")],
+        "loaded_skill_tools": frozenset(),
+    }
+
+    updated = middleware.modify_request(_request(middleware, state))
+
+    assert [item.name for item in updated.tools] == ["kernel_tool", "travel"]
+
+
+def test_no_bundled_source_keeps_legacy_prompt_and_loader_schema():
+    middleware = SmallModelSkillsMiddleware(
+        backend=Mock(), sources=["/external/"])
+
+    assert len(LEGACY_SMALL_MODEL_SKILLS_PROMPT) == 1577
+    assert hashlib.sha256(LEGACY_SMALL_MODEL_SKILLS_PROMPT.encode()).hexdigest() == \
+        "93d4e684e87d4910f5c97de6919e3bb0798ba41f7239d07ff801d68d7f0dd918"
+    assert middleware.system_prompt_template == LEGACY_SMALL_MODEL_SKILLS_PROMPT
+    assert set(middleware.tools[0].args) == {"name"}
+
+
 def test_before_agent_resets_activation_even_when_metadata_is_checkpointed():
     middleware = SmallModelSkillsMiddleware(
         backend=Mock(), sources=["/skills/"], bundled_sources=["/skills/"])
@@ -129,6 +162,16 @@ def test_successful_load_returns_state_command_and_exact_closed_evidence():
     assert set(message.artifact) == {
         "schema", "requested_name", "winner_fingerprint", "result_sha256"}
     assert message.artifact["requested_name"] == "travel"
+    fingerprint_payload = {
+        "allowed_tools": ["travel"],
+        "skill_file_sha256": hashlib.sha256(
+            body.encode("utf-8")).hexdigest(),
+        "description": "Travel help.",
+        "name": "travel",
+    }
+    assert message.artifact["winner_fingerprint"] == hashlib.sha256(
+        json.dumps(fingerprint_payload, ensure_ascii=False, separators=(",", ":"),
+                   sort_keys=True).encode("utf-8")).hexdigest()
     assert message.artifact["result_sha256"] == hashlib.sha256(
         message.content.encode("utf-8")).hexdigest()
     assert "/skills/" not in str(message.artifact)
@@ -136,6 +179,52 @@ def test_successful_load_returns_state_command_and_exact_closed_evidence():
     visible = middleware.modify_request(_request(
         middleware, {**state, "loaded_skill_tools": frozenset({"travel"})}))
     assert [item.name for item in visible.tools] == ["kernel_tool", "travel"]
+
+
+def test_disclosure_intersects_declarations_with_this_agent_tools():
+    body = "---\nname: travel\ndescription: Travel help.\n---\n\nRULES"
+    backend = SimpleNamespace(download_files=lambda _paths: [
+        SimpleNamespace(error=None, content=body.encode("utf-8"))])
+    middleware = SmallModelSkillsMiddleware(
+        backend=backend, sources=["/skills/"], bundled_sources=["/skills/"],
+        registered_tools={"travel"})
+    skill = {**_skill(), "allowed_tools": ["travel", "absent_tool"]}
+    runtime = SimpleNamespace(
+        state={"skills_metadata": [skill], "loaded_skill_tools": frozenset()},
+        config={}, tool_call_id="load-1")
+
+    result = middleware.tools[0].func("travel", runtime)
+
+    assert result.update["loaded_skill_tools"] == frozenset({"travel"})
+    assert result.update["messages"][0].content.endswith(
+        "Newly available tools: travel.")
+
+
+def test_parallel_load_updates_have_union_reducer():
+    body = b"---\nname: skill\ndescription: Help.\n---\n\nRULES"
+    backend = SimpleNamespace(download_files=lambda _paths: [
+        SimpleNamespace(error=None, content=body)])
+    middleware = SmallModelSkillsMiddleware(
+        backend=backend, sources=["/skills/"], bundled_sources=["/skills/"])
+    skills = [
+        {**_skill("/skills/one/SKILL.md"), "name": "one",
+         "allowed_tools": ["travel"]},
+        {**_skill("/skills/two/SKILL.md"), "name": "two",
+         "allowed_tools": ["kernel_tool"]},
+    ]
+    state = {"skills_metadata": skills, "loaded_skill_tools": frozenset()}
+    updates = [
+        middleware.tools[0].func(
+            name, SimpleNamespace(state=state, config={}, tool_call_id=name)
+        ).update["loaded_skill_tools"]
+        for name in ("one", "two")
+    ]
+    outer = get_type_hints(
+        SmallModelSkillsState, include_extras=True)["loaded_skill_tools"]
+    annotated = get_args(outer)[0]
+
+    assert operator.or_ in get_args(annotated)[1:]
+    assert operator.or_(*updates) == frozenset({"travel", "kernel_tool"})
 
 
 def test_failed_load_has_no_state_or_artifact():
@@ -149,6 +238,62 @@ def test_failed_load_has_no_state_or_artifact():
 
     assert isinstance(result, str)
     assert "could not be loaded" in result
+
+
+def test_invalid_skill_bytes_do_not_disclose_tools():
+    for content, reason in (
+        (b"x" * (MAX_SKILL_FILE_SIZE + 1), "too large"),
+        (b"\xff", "not UTF-8"),
+    ):
+        backend = SimpleNamespace(download_files=lambda _paths, value=content: [
+            SimpleNamespace(error=None, content=value)])
+        middleware = SmallModelSkillsMiddleware(
+            backend=backend, sources=["/skills/"],
+            bundled_sources=["/skills/"])
+        runtime = SimpleNamespace(
+            state={"skills_metadata": [_skill()],
+                   "loaded_skill_tools": frozenset()},
+            config={}, tool_call_id="load-1")
+
+        result = middleware.tools[0].func("travel", runtime)
+
+        assert isinstance(result, str)
+        assert reason in result
+
+
+def test_backend_error_details_are_not_returned_to_the_model():
+    backend = SimpleNamespace(download_files=lambda _paths: [
+        SimpleNamespace(error="failed reading /home/private/SKILL.md", content=None)])
+    middleware = SmallModelSkillsMiddleware(
+        backend=backend, sources=["/skills/"], bundled_sources=["/skills/"])
+    runtime = SimpleNamespace(
+        state={"skills_metadata": [_skill()], "loaded_skill_tools": frozenset()},
+        config={}, tool_call_id="load-1")
+
+    result = middleware.tools[0].func("travel", runtime)
+
+    assert isinstance(result, str)
+    assert "backend error" in result
+    assert "/home/private" not in result
+
+
+def test_prose_claim_does_not_disclose_tools_and_async_reset_matches_sync():
+    middleware = SmallModelSkillsMiddleware(
+        backend=Mock(), sources=["/skills/"], bundled_sources=["/skills/"])
+    state = {
+        "messages": [{"role": "user", "content": "I loaded travel."}],
+        "skills_metadata": [_skill()],
+        "loaded_skill_tools": frozenset(),
+    }
+
+    updated = middleware.modify_request(_request(middleware, state))
+    reset = asyncio.run(middleware.abefore_agent(
+        {**state, "loaded_skill_tools": frozenset({"travel"})},
+        SimpleNamespace(), {}))
+
+    assert [item.name for item in updated.tools] == ["kernel_tool"]
+    assert isinstance(reset["loaded_skill_tools"], Overwrite)
+    assert reset["loaded_skill_tools"].value == frozenset()
 
 
 def test_hidden_execution_is_rejected_in_sync_and_async_paths():
@@ -181,7 +326,7 @@ def test_hidden_execution_is_rejected_in_sync_and_async_paths():
     assert async_result.status == "error"
 
 
-def test_after_model_removes_hidden_call_before_hitl_and_keeps_visible_call():
+def test_after_model_pairs_every_call_and_jumps_past_hitl():
     middleware = SmallModelSkillsMiddleware(
         backend=Mock(), sources=["/skills/"], bundled_sources=["/skills/"])
     message = AIMessage(content="", tool_calls=[
@@ -195,10 +340,14 @@ def test_after_model_removes_hidden_call_before_hitl_and_keeps_visible_call():
 
     update = middleware.after_model(state, None)
 
-    assert [call["name"] for call in message.tool_calls] == ["kernel_tool"]
-    assert len(update["messages"]) == 2
+    assert [call["name"] for call in message.tool_calls] == [
+        "travel", "kernel_tool"]
+    assert len(update["messages"]) == 3
     assert update["messages"][1].name == "travel"
     assert update["messages"][1].status == "error"
+    assert update["messages"][2].name == "kernel_tool"
+    assert update["messages"][2].status == "error"
+    assert update["jump_to"] == "model"
 
 
 class _RecordingModel(FakeMessagesListChatModel):
@@ -251,11 +400,12 @@ def test_compiled_graph_discloses_after_load_then_resets_next_invocation():
               if isinstance(message, ToolMessage)
               and message.tool_call_id == "travel-2"]
     assert len(hidden) == 1 and hidden[0].status == "error"
+    assert second["messages"][-1].content == "second done"
 
 
 def test_compiled_graph_rejects_same_response_sibling_before_hitl():
     from assist.agent import create_agent
-    from assist.backends import create_skills_backend
+    from assist.backends import create_bundled_skills_backend
     from assist.spec import AgentSpec
 
     sent = []
@@ -289,7 +439,8 @@ def test_compiled_graph_rejects_same_response_sibling_before_hitl():
             spec=AgentSpec(
                 tools=(send_email,),
                 async_subagent_tools=(),
-                skill_sources={"/mail-skill/": create_skills_backend(skill_root)},
+                skill_sources={
+                    "/mail-skill/": create_bundled_skills_backend(skill_root)},
                 interrupt_on={"send_email": True},
             ),
         )
@@ -303,3 +454,8 @@ def test_compiled_graph_rejects_same_response_sibling_before_hitl():
                 if isinstance(message, ToolMessage)
                 and message.tool_call_id == "send-1"]
     assert len(rejected) == 1 and rejected[0].status == "error"
+    paired = [message.tool_call_id for message in result["messages"]
+              if isinstance(message, ToolMessage)
+              and message.tool_call_id in {"load-1", "send-1"}]
+    assert paired == ["load-1", "send-1"]
+    assert not result.get("__interrupt__")

--- a/tests/skill_test_utils.py
+++ b/tests/skill_test_utils.py
@@ -1,0 +1,21 @@
+"""Shared test helpers for skill middleware contracts."""
+import inspect
+from types import SimpleNamespace
+
+from langgraph.types import Command
+
+
+def load_skill(middleware, name: str) -> str:
+    """Invoke either the legacy or progressive test loader by exact name."""
+    update = middleware.before_agent({}, SimpleNamespace(), {})
+    state = {
+        "skills_metadata": update["skills_metadata"],
+        "loaded_skill_tools": frozenset(),
+    }
+    arguments = [name]
+    if len(inspect.signature(middleware.tools[0].func).parameters) > 1:
+        arguments.append(SimpleNamespace(
+            state=state, config={}, tool_call_id="test-load"))
+    result = middleware.tools[0].func(*arguments)
+    return (result.update["messages"][0].content
+            if isinstance(result, Command) else result)

--- a/tests/test_create_agent_extra_skill_sources.py
+++ b/tests/test_create_agent_extra_skill_sources.py
@@ -18,6 +18,7 @@ routes that hold skill files outside the assist repo.  The contract:
 import os
 import shutil
 import tempfile
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 from assist.backends import (
@@ -30,6 +31,22 @@ from assist.backends import (
 from assist.middleware.skills_middleware import SmallModelSkillsMiddleware
 from assist.spec import AgentSpec
 from deepagents.backends import FilesystemBackend
+from langgraph.types import Command
+
+
+def _load_skill(middleware, name):
+    update = middleware.before_agent({}, SimpleNamespace(), {})
+    state = {
+        "skills_metadata": update["skills_metadata"],
+        "loaded_skill_tools": frozenset(),
+    }
+    result = middleware.tools[0].func(
+        name,
+        SimpleNamespace(state=state, config={}, tool_call_id="test-load"),
+    )
+    if isinstance(result, Command):
+        return result.update["messages"][0].content
+    return result
 
 
 def _route_backend():
@@ -337,7 +354,7 @@ class TestCreateAgentDomainSkills:
         backend = _create_standard_backend(wd)
         mw = SmallModelSkillsMiddleware(
             backend=backend, sources=[DOMAIN_SKILLS_PATH, SKILLS_ROUTE])
-        result = mw.tools[0].invoke({"name": "dev"})
+        result = _load_skill(mw, "dev")
         assert marker not in result, (
             "load_skill returned the domain dev body; built-in must win"
         )

--- a/tests/test_create_agent_extra_skill_sources.py
+++ b/tests/test_create_agent_extra_skill_sources.py
@@ -18,7 +18,6 @@ routes that hold skill files outside the assist repo.  The contract:
 import os
 import shutil
 import tempfile
-from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 from assist.backends import (
@@ -26,27 +25,13 @@ from assist.backends import (
     DOMAIN_SKILLS_PATH,
     STATEFUL_PATHS,
     create_composite_backend,
+    create_bundled_skills_backend,
     create_sandbox_composite_backend,
 )
 from assist.middleware.skills_middleware import SmallModelSkillsMiddleware
 from assist.spec import AgentSpec
 from deepagents.backends import FilesystemBackend
-from langgraph.types import Command
-
-
-def _load_skill(middleware, name):
-    update = middleware.before_agent({}, SimpleNamespace(), {})
-    state = {
-        "skills_metadata": update["skills_metadata"],
-        "loaded_skill_tools": frozenset(),
-    }
-    result = middleware.tools[0].func(
-        name,
-        SimpleNamespace(state=state, config={}, tool_call_id="test-load"),
-    )
-    if isinstance(result, Command):
-        return result.update["messages"][0].content
-    return result
+from tests.skill_test_utils import load_skill
 
 
 def _route_backend():
@@ -176,6 +161,19 @@ class TestCreateAgentExtraSkillSources:
             "before any embedder-supplied sources."
         )
         assert "/emacsos-skills/" in mw.sources
+
+    def test_only_explicitly_bundled_extra_routes_gate_tools(self):
+        external = _route_backend()
+        with tempfile.TemporaryDirectory() as root:
+            bundled = create_bundled_skills_backend(root)
+            kwargs = self._build(spec=AgentSpec(skill_sources={
+                "/external/": external,
+                "/bundled/": bundled,
+            }))
+        mw = next(m for m in kwargs["middleware"]
+                  if isinstance(m, SmallModelSkillsMiddleware))
+
+        assert mw._bundled_sources == frozenset({SKILLS_ROUTE, "/bundled/"})
 
     def test_multiple_extra_skill_sources(self):
         extras = {
@@ -354,7 +352,7 @@ class TestCreateAgentDomainSkills:
         backend = _create_standard_backend(wd)
         mw = SmallModelSkillsMiddleware(
             backend=backend, sources=[DOMAIN_SKILLS_PATH, SKILLS_ROUTE])
-        result = _load_skill(mw, "dev")
+        result = load_skill(mw, "dev")
         assert marker not in result, (
             "load_skill returned the domain dev body; built-in must win"
         )

--- a/tests/test_create_agent_spec.py
+++ b/tests/test_create_agent_spec.py
@@ -7,7 +7,6 @@ agent-directory and memory-source wiring, and `Thread`-level `spec=` /
 
 import os
 import tempfile
-from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -16,9 +15,9 @@ from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import StructuredTool
 from langchain.tools.tool_node import ToolCallRequest
-from langgraph.types import Command
 
 from assist.spec import AgentSpec
+from tests.skill_test_utils import load_skill
 
 
 def _tool_a(x: str) -> str:
@@ -62,22 +61,6 @@ class _CreateAgentHarness:
                 create_agent(MagicMock(), wd, **kwargs)
                 return fake.call_args.kwargs
 
-    @staticmethod
-    def _load_skill(middleware, name):
-        update = middleware.before_agent({}, SimpleNamespace(), {})
-        state = {
-            "skills_metadata": update["skills_metadata"],
-            "loaded_skill_tools": frozenset(),
-        }
-        result = middleware.tools[0].func(
-            name,
-            SimpleNamespace(state=state, config={}, tool_call_id="test-load"),
-        )
-        if isinstance(result, Command):
-            return result.update["messages"][0].content
-        return result
-
-
 class TestSpecWiring(_CreateAgentHarness):
     """The spec's fields reach create_deep_agent."""
 
@@ -93,6 +76,20 @@ class TestSpecWiring(_CreateAgentHarness):
         from assist.tools import directions, map_data, read_url, travel
         kwargs = self._build(spec=AgentSpec(tools=(_tool_a, _tool_b)))
         assert kwargs["tools"] == [_tool_a, _tool_b, travel, directions, map_data, read_url]
+
+    def test_nested_provider_schema_tool_reaches_create_deep_agent(self):
+        provider_tool = {
+            "type": "function",
+            "function": {
+                "name": "custom_tool",
+                "description": "A custom tool.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+
+        kwargs = self._build(spec=AgentSpec(tools=(provider_tool,)))
+
+        assert provider_tool in kwargs["tools"]
 
     def test_hitl_precedes_skills_and_is_not_appended_by_deepagents(self):
         from langchain.agents.middleware import HumanInTheLoopMiddleware
@@ -110,6 +107,16 @@ class TestSpecWiring(_CreateAgentHarness):
 
         assert hitl_index < skills_index
         assert "interrupt_on" not in kwargs
+
+    def test_critique_subagent_keeps_hitl_for_inherited_effect_tools(self):
+        interrupt_on = {"send_email": True}
+        kwargs = self._build(spec=AgentSpec(interrupt_on=interrupt_on))
+        critique = next(
+            subagent for subagent in kwargs["subagents"]
+            if isinstance(subagent, dict)
+            and subagent.get("name") == "critique-agent")
+
+        assert critique["interrupt_on"] == interrupt_on
 
     def test_async_subagent_tools_replace_blocking_subagents(self):
         from assist.agent import create_agent
@@ -191,7 +198,7 @@ class TestSpecWiring(_CreateAgentHarness):
         skills = next(m for m in kwargs["middleware"]
                       if isinstance(m, SmallModelSkillsMiddleware))
         assert "/main-skills/" not in skills.sources
-        assert "could not be loaded" in self._load_skill(skills, "complex-request")
+        assert "could not be loaded" in load_skill(skills, "complex-request")
         assert provenance._trust_human_messages is False
         assert provenance._trust_task_results is False
         from assist.middleware.tool_result_to_file import ToolResultToFileMiddleware
@@ -285,7 +292,7 @@ class TestSpecWiring(_CreateAgentHarness):
         skills = next(m for m in kwargs["middleware"]
                       if isinstance(m, SmallModelSkillsMiddleware))
         assert "/main-skills/" not in skills.sources
-        assert "could not be loaded" in self._load_skill(skills, "complex-request")
+        assert "could not be loaded" in load_skill(skills, "complex-request")
         assert provenance._trust_human_messages is True
 
     def test_async_main_can_load_supervisor_skill(self):
@@ -299,7 +306,7 @@ class TestSpecWiring(_CreateAgentHarness):
 
         assert "/main-skills/" in skills.sources
         assert skills.sources[0] == "/main-skills/"
-        loaded = self._load_skill(skills, "complex-request")
+        loaded = load_skill(skills, "complex-request")
         assert "start one `delegate-agent` per outcome" in loaded
         task_offload = next(
             middleware for middleware in kwargs["middleware"]

--- a/tests/test_create_agent_spec.py
+++ b/tests/test_create_agent_spec.py
@@ -91,6 +91,22 @@ class TestSpecWiring(_CreateAgentHarness):
 
         assert provider_tool in kwargs["tools"]
 
+    def test_provider_schema_name_dedupes_builtin_tool(self):
+        provider_tool = {
+            "type": "function",
+            "function": {
+                "name": "travel",
+                "description": "Provider travel tool.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+
+        kwargs = self._build(spec=AgentSpec(tools=(provider_tool,)))
+
+        assert kwargs["tools"].count(provider_tool) == 1
+        assert [tool for tool in kwargs["tools"]
+                if getattr(tool, "name", None) == "travel"] == []
+
     def test_hitl_precedes_skills_and_is_not_appended_by_deepagents(self):
         from langchain.agents.middleware import HumanInTheLoopMiddleware
         from assist.middleware.skills_middleware import SmallModelSkillsMiddleware

--- a/tests/test_create_agent_spec.py
+++ b/tests/test_create_agent_spec.py
@@ -7,6 +7,7 @@ agent-directory and memory-source wiring, and `Thread`-level `spec=` /
 
 import os
 import tempfile
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -15,6 +16,7 @@ from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import StructuredTool
 from langchain.tools.tool_node import ToolCallRequest
+from langgraph.types import Command
 
 from assist.spec import AgentSpec
 
@@ -60,6 +62,21 @@ class _CreateAgentHarness:
                 create_agent(MagicMock(), wd, **kwargs)
                 return fake.call_args.kwargs
 
+    @staticmethod
+    def _load_skill(middleware, name):
+        update = middleware.before_agent({}, SimpleNamespace(), {})
+        state = {
+            "skills_metadata": update["skills_metadata"],
+            "loaded_skill_tools": frozenset(),
+        }
+        result = middleware.tools[0].func(
+            name,
+            SimpleNamespace(state=state, config={}, tool_call_id="test-load"),
+        )
+        if isinstance(result, Command):
+            return result.update["messages"][0].content
+        return result
+
 
 class TestSpecWiring(_CreateAgentHarness):
     """The spec's fields reach create_deep_agent."""
@@ -76,6 +93,23 @@ class TestSpecWiring(_CreateAgentHarness):
         from assist.tools import directions, map_data, read_url, travel
         kwargs = self._build(spec=AgentSpec(tools=(_tool_a, _tool_b)))
         assert kwargs["tools"] == [_tool_a, _tool_b, travel, directions, map_data, read_url]
+
+    def test_hitl_precedes_skills_and_is_not_appended_by_deepagents(self):
+        from langchain.agents.middleware import HumanInTheLoopMiddleware
+        from assist.middleware.skills_middleware import SmallModelSkillsMiddleware
+
+        kwargs = self._build(spec=AgentSpec(
+            interrupt_on={"send_email": True}))
+        middleware = kwargs["middleware"]
+        hitl_index = next(
+            index for index, item in enumerate(middleware)
+            if isinstance(item, HumanInTheLoopMiddleware))
+        skills_index = next(
+            index for index, item in enumerate(middleware)
+            if isinstance(item, SmallModelSkillsMiddleware))
+
+        assert hitl_index < skills_index
+        assert "interrupt_on" not in kwargs
 
     def test_async_subagent_tools_replace_blocking_subagents(self):
         from assist.agent import create_agent
@@ -157,7 +191,7 @@ class TestSpecWiring(_CreateAgentHarness):
         skills = next(m for m in kwargs["middleware"]
                       if isinstance(m, SmallModelSkillsMiddleware))
         assert "/main-skills/" not in skills.sources
-        assert "not found" in skills.tools[0].invoke({"name": "complex-request"})
+        assert "could not be loaded" in self._load_skill(skills, "complex-request")
         assert provenance._trust_human_messages is False
         assert provenance._trust_task_results is False
         from assist.middleware.tool_result_to_file import ToolResultToFileMiddleware
@@ -251,7 +285,7 @@ class TestSpecWiring(_CreateAgentHarness):
         skills = next(m for m in kwargs["middleware"]
                       if isinstance(m, SmallModelSkillsMiddleware))
         assert "/main-skills/" not in skills.sources
-        assert "not found" in skills.tools[0].invoke({"name": "complex-request"})
+        assert "could not be loaded" in self._load_skill(skills, "complex-request")
         assert provenance._trust_human_messages is True
 
     def test_async_main_can_load_supervisor_skill(self):
@@ -265,7 +299,7 @@ class TestSpecWiring(_CreateAgentHarness):
 
         assert "/main-skills/" in skills.sources
         assert skills.sources[0] == "/main-skills/"
-        loaded = skills.tools[0].invoke({"name": "complex-request"})
+        loaded = self._load_skill(skills, "complex-request")
         assert "start one `delegate-agent` per outcome" in loaded
         task_offload = next(
             middleware for middleware in kwargs["middleware"]

--- a/tests/test_prompt_census.py
+++ b/tests/test_prompt_census.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 import re
 import subprocess
@@ -85,18 +86,42 @@ def test_final_provider_tools_are_the_visible_tools(census):
     assert "extra_body" not in capture["provider_payload"]
 
 
+def test_bundled_schema_disclosure_and_load_evidence_are_observed(census):
+    initial = _call(census, "web-main-full", 0)
+    disclosed = _call(census, "web-main-full", 1)
+
+    assert "send_email" not in initial["visible_tools"]
+    assert "send_email" in disclosed["visible_tools"]
+    assert "travel" not in initial["visible_tools"]
+    assert "notify" in initial["visible_tools"]
+    assert "Tools available for this response: " \
+        + ", ".join(initial["visible_tools"]) + "." in _system_prompt(initial)
+
+    load = census["observations"]["web-main-full"]["tool_messages"][0]
+    assert load["name"] == "load_skill"
+    assert set(load["artifact"]) == {
+        "schema", "requested_name", "winner_fingerprint", "result_sha256"}
+    assert load["artifact"]["requested_name"] == "send-email"
+    assert load["artifact"]["result_sha256"] == hashlib.sha256(
+        load["content"].encode("utf-8")).hexdigest()
+    assert "/render-skill/" not in json.dumps(load["artifact"])
+
+
 def test_registered_visible_and_classification_stay_separate(census):
     for surface in census["capabilities"].values():
         registered = [tool["name"] for tool in surface["registered_tools"]]
         visible = surface["model_visible_tools"]
         assert not surface["ambiguous_tool_node_matches"]
         assert all(name in registered for name in visible)
-        assert registered == visible or [
-            name for name in registered if name != "execute"] == visible
+        assert visible == [name for name in registered if name in visible]
+        hidden = [tool for tool in surface["registered_tools"]
+                  if tool["name"] not in visible]
+        assert all(tool["name"] == "execute" or tool["possible_owners"]
+                   for tool in hidden)
 
     surface = census["capabilities"]["web-main-core:0"]
     registered = [tool["name"] for tool in surface["registered_tools"]]
-    assert registered == surface["model_visible_tools"]
+    assert set(surface["model_visible_tools"]) < set(registered)
     assert {tool["classification"] for tool in surface["registered_tools"]} == {
         "framework-kernel candidate", "skill-scoped candidate"}
     assert next(tool for tool in surface["registered_tools"]
@@ -109,6 +134,8 @@ def test_registered_visible_and_classification_stay_separate(census):
                 if tool["name"] == "travel")["possible_owners"] == ["travel"]
     assert next(tool for tool in surface["registered_tools"]
                 if tool["name"] == "map_data")["possible_owners"] == ["render"]
+    assert "travel" not in surface["model_visible_tools"]
+    assert "map_data" not in surface["model_visible_tools"]
 
     delegate = census["capabilities"]["web-delegate:0"]
     assert next(tool for tool in delegate["registered_tools"]
@@ -511,10 +538,10 @@ def test_expected_audit_findings_are_reported_not_hidden(census):
     assert context["effective_actions"]["edit_file"] == "observed-denied"
     assert census["capabilities"]["research-leaf-provenance:0"][
         "effective_actions"]["read_url"] == "observed-denied-by-provenance"
-    assert census["capabilities"]["web-main-core:0"][
-        "effective_actions"]["read_url"] == "unexercised"
-    assert census["capabilities"]["web-delegate:0"][
-        "effective_actions"]["read_url"] == "unexercised"
+    assert "read_url" not in census["capabilities"]["web-main-core:0"][
+        "effective_actions"]
+    assert "read_url" not in census["capabilities"]["web-delegate:0"][
+        "effective_actions"]
     checked = json.loads(
         census["observations"]["async-task-return-contract"]["checked"])
     assert checked["agent_name"] == "research-agent"
@@ -641,7 +668,7 @@ def test_artifact_is_bounded_and_hygiene_checked(census, tmp_path):
 
     bad = _unsigned_copy(census)
     bad["capabilities"]["web-main-core:0"]["effective_actions"][
-        "read_url"] = "observed-permitted"
+        "load_skill"] = "observed-permitted"
     with pytest.raises(AssertionError, match="capability surfaces drifted"):
         _assert_hygiene(bad, tmp_path)
 
@@ -649,7 +676,7 @@ def test_artifact_is_bounded_and_hygiene_checked(census, tmp_path):
     call = _call(bad, "web-main-core")
     call["provider_payload"]["tools"] = [
         schema for schema in call["provider_payload"]["tools"]
-        if schema["function"]["name"] != "read_url"]
+        if schema["function"]["name"] != "load_skill"]
     with pytest.raises(AssertionError, match="schema surface drifted"):
         _assert_hygiene(bad, tmp_path)
 
@@ -1101,13 +1128,16 @@ def test_keyboard_interrupt_cleans_publication_staging(tmp_path, monkeypatch):
     assert not list(tmp_path.glob(".interrupted-*"))
 
 
-def test_p0_p2_history_and_p2b1_summary_match_the_current_capture(census):
+def test_p0_through_p2b2_history_matches_the_current_capture(census):
     document = Path("docs/2026-07-26-agent-prompt-architecture.org").read_text(
         encoding="utf-8")
     p2_document = Path("docs/2026-08-04-prompt-architecture-p2.org").read_text(
         encoding="utf-8")
     p2b1_document = Path(
         "docs/2026-08-05-prompt-architecture-p2b1.org").read_text(
+        encoding="utf-8")
+    p2b2_document = Path(
+        "docs/2026-08-05-prompt-architecture-p2b2.org").read_text(
         encoding="utf-8")
     current = _call(census, "web-main-core")
     historical_p0_prompt = _named_text_block("p0-current-web-main-bootstrap")
@@ -1120,14 +1150,14 @@ def test_p0_p2_history_and_p2b1_summary_match_the_current_capture(census):
         separators=(",", ":"),
     )
     assert len(historical_p0_prompt) == 31_279
-    assert len(current_prompt) == 29_600
-    assert len(schemas) == 28_037
-    assert len(census["calls"]) == 28
+    assert len(current_prompt) == 29_527
+    assert len(schemas) == 17_984
+    assert len(census["calls"]) == 29
     assert len(census["tool_nodes"]) == 38
     assert len(census["findings"]) == 25
-    assert len(artifact_bytes(census)) == 2_856_251
+    assert len(artifact_bytes(census)) == 2_992_991
     assert census["artifact_sha256"] == \
-        "cec33a06566de462cc9cc9ee0d7f81b5429293ff27982b75e0c3332e7ce0f586"
+        "a16e88ba2b5f0187a67423591138a856c81ed7c60aa1a547e4a5768d76df2490"
     assert "2,920,942 bytes (2.8 MiB)" in document
     assert "p0-100aa885-final-v2" in document
     expected_rows = [
@@ -1156,6 +1186,9 @@ def test_p0_p2_history_and_p2b1_summary_match_the_current_capture(census):
     assert "30 provider-bound schemas remain byte-identical at 28,037" \
         in p2b1_document
     assert "2,856,251 bytes with 25 retained" in p2b1_document
+    assert "29,527 characters" in p2b2_document
+    assert "17,984 characters" in p2b2_document
+    assert "2,992,991 bytes" in p2b2_document
 
     kernel = _named_text_block("proposed-main-bootstrap-kernel")
     headings = [

--- a/tests/test_prompt_census.py
+++ b/tests/test_prompt_census.py
@@ -1157,7 +1157,7 @@ def test_p0_through_p2b2_history_matches_the_current_capture(census):
     assert len(census["findings"]) == 25
     assert len(artifact_bytes(census)) == 2_992_683
     assert census["artifact_sha256"] == \
-            "ef83c31bb0864f412fcca8f79e0702191a7f3ec5f1d787081519084b7925c7d0"
+            "d3a0ce22fcf4be92c97423742fc66ebc85ea4b2dc575246b4316625dda82b45d"
     assert "2,920,942 bytes (2.8 MiB)" in document
     assert "p0-100aa885-final-v2" in document
     expected_rows = [

--- a/tests/test_prompt_census.py
+++ b/tests/test_prompt_census.py
@@ -1151,13 +1151,13 @@ def test_p0_through_p2b2_history_matches_the_current_capture(census):
     )
     assert len(historical_p0_prompt) == 31_279
     assert len(current_prompt) == 29_527
-    assert len(schemas) == 17_984
+    assert len(schemas) == 17_956
     assert len(census["calls"]) == 29
     assert len(census["tool_nodes"]) == 38
     assert len(census["findings"]) == 25
-    assert len(artifact_bytes(census)) == 2_992_991
+    assert len(artifact_bytes(census)) == 2_992_683
     assert census["artifact_sha256"] == \
-        "a16e88ba2b5f0187a67423591138a856c81ed7c60aa1a547e4a5768d76df2490"
+            "628b25ac3f13d73ba1482b983b3a9379cf90b642e0a584ad2d7ab449bfa0ad6f"
     assert "2,920,942 bytes (2.8 MiB)" in document
     assert "p0-100aa885-final-v2" in document
     expected_rows = [
@@ -1187,8 +1187,8 @@ def test_p0_through_p2b2_history_matches_the_current_capture(census):
         in p2b1_document
     assert "2,856,251 bytes with 25 retained" in p2b1_document
     assert "29,527 characters" in p2b2_document
-    assert "17,984 characters" in p2b2_document
-    assert "2,992,991 bytes" in p2b2_document
+    assert "17,956 characters" in p2b2_document
+    assert "2,992,683 bytes" in p2b2_document
 
     kernel = _named_text_block("proposed-main-bootstrap-kernel")
     headings = [

--- a/tests/test_prompt_census.py
+++ b/tests/test_prompt_census.py
@@ -1157,7 +1157,7 @@ def test_p0_through_p2b2_history_matches_the_current_capture(census):
     assert len(census["findings"]) == 25
     assert len(artifact_bytes(census)) == 2_992_683
     assert census["artifact_sha256"] == \
-            "628b25ac3f13d73ba1482b983b3a9379cf90b642e0a584ad2d7ab449bfa0ad6f"
+            "ef83c31bb0864f412fcca8f79e0702191a7f3ec5f1d787081519084b7925c7d0"
     assert "2,920,942 bytes (2.8 MiB)" in document
     assert "p0-100aa885-final-v2" in document
     expected_rows = [

--- a/tests/test_thread_manager_lazy.py
+++ b/tests/test_thread_manager_lazy.py
@@ -141,3 +141,21 @@ class TestThreadManagerLazy(TestCase):
         self.assertEqual(dict(spec.skill_sources), {})
         self.assertIsNone(spec.interrupt_on)
         self.assertNotIn("agent_dir", thread.call_args.kwargs)
+
+    def test_triage_profile_preserves_pre_disclosure_skill_composition(self):
+        from assist.backends import BundledSkillsBackend, SKILLS_ROUTE
+        from deepagents.backends import FilesystemBackend
+
+        with tempfile.TemporaryDirectory() as tmp:
+            manager = ThreadManager(root_dir=tmp)
+            manager._model = MagicMock()
+            manager.reserve("triage")
+            with patch("assist.thread_manager.Thread") as thread:
+                manager.get("triage", triage=True)
+            manager.close()
+
+        spec = thread.call_args.kwargs["spec"]
+        self.assertIn(SKILLS_ROUTE, spec.skill_sources)
+        for backend in spec.skill_sources.values():
+            self.assertIsInstance(backend, FilesystemBackend)
+            self.assertNotIsInstance(backend, BundledSkillsBackend)


### PR DESCRIPTION
## Summary

- gate bundled Assist-owned tool schemas and execution behind successful invocation-local `load_skill`
- derive disclosure from Deep Agents' winning skill metadata and the graph's actual registered tools, without a second registry
- preserve HITL ordering, SMS triage behavior, memory authority, development guidance, fixed-role agents, and external/domain/embedder skills
- reduce the initial web-main tool surface from 30 to 15 schemas and the combined bootstrap from 59,316 to 47,483 characters

## Design and implementation

`SmallModelSkillsMiddleware` now owns one allowed-set calculation used by both provider-schema filtering and tool execution. Successful exact loads return a `Command` that updates invocation-local union state and carries a four-field provenance artifact. Failed, fabricated, shadowed, invalid, or prose-only loads disclose nothing. Invalid mixed tool-call responses receive paired tool results and retry before HITL, so a hidden outward-effect call cannot trigger approval.

Bundled ownership is explicit through `BundledSkillsBackend`; generic read-only sources remain external. Longest-source matching preserves nested overrides, and each agent profile intersects declarations with the tools actually registered in that graph. Inbound SMS triage uses its existing composition seam to retain the byte-identical legacy skill prompt, loader, schemas, and permissions.

The full reviewed design, change log, hard parts, census, and experiment record are in `docs/2026-08-05-prompt-architecture-p2b2.org`.

## Evals

The frozen comparative cohort used these eleven nodes. Each item states its fixture, complete user prompt sequence, and pass validation.

1. Travel distance capability. A temporary personal workspace and the real routing-backed general agent receive: `How long does it take to get from the Ferry Building to Oakland City Hall?` Pass requires loading `travel` and calling the `travel` tool.
2. Directions capability. The same routing-backed fixture receives: `Give me step-by-step directions from Coit Tower to Oracle Park by car.` Pass requires loading `travel`, calling `directions`, and never calling `travel` for this directions-shaped request.
3. Website download natural journey. A deterministic fake asset-heavy website contains a manual two navigation hops deep. The user asks: `Download the Fathom Tide Kettle user manual PDF from <fixture base>/ and save it to /workspace. Tell me its page count.` Pass requires the correct PDF download, no asset dead-end fetches, at most three page fetches, and loading `explore-website`.
4. Day-of-month scheduling capability. A temporary workspace, isolated schedule store, registered schedule tools, and stubbed research agent receive: `Set up a recurring reminder on the 25th of each month to pay rent.` Pass requires loading `schedule` and a `create_schedule` call with `day_of_month=25`.
5. Subscription natural journey. A temporary string-named thread directory, isolated subscription store, registered subscription tools, and stubbed research agent receive: `Whenever a text comes in from a 415 number, check whether it is asking to schedule something and draft a short reply for me to review.` Pass requires loading `subscribe-events` and calling `create_subscription`.
6. Referential scheduling natural journey. The schedule fixture receives two turns in order: `Remind me every day at 7 AM to take my vitamins.` then `Actually, make it 8 AM instead.` Pass requires the second invocation to load `schedule` again and call `modify_schedule`.
7. Async delegation natural journey. A temporary workspace contains `/alpha-notes.md` and `/beta-notes.md`, with synthetic deterministic child completions and a calibrated outcome judge. The user asks: `Prepare two launch briefs for separate teams while I work on the agenda. Turn /alpha-notes.md into /alpha-brief.md with a recommendation and unresolved risks. Also turn /beta-notes.md into /beta-brief.md with its own recommendation, rollout limits, and monitoring triggers.` Pass requires unchanged source files, both requested briefs, required labeled content in each, and judge acceptance of both outcomes.
8. Render natural journey. A production-shaped temporary personal workspace, Docker sandbox, and web skill sources receive: `Can you show me a graph of how my weight has changed over the last 2 months?` Pass requires loading `render`, emitting a file render block naming a PNG, and producing a valid PNG at the rendered path.
9. Email natural journey. A temporary workspace with web skill sources, email tools, and the unchanged email HITL map receives: `Could you let Robin know at robin@example.test that the Tuesday meeting is moving to 2pm, and ask whether that still works?` Pass requires loading `send-email` and proposing one approval-gated email to the exact address with a nonempty subject and body mentioning Tuesday.
10. No-load causal control. A general agent receives: `Write a haiku about the ocean.` Pass requires that the `time` skill is not loaded.
11. Urgent-notification causal control. A temporary web-tool fixture with SMS delivery disabled receives: `I won't see this chat again until this evening. The landlord just said I must answer about the lease before 4pm today or the apartment goes to someone else. Please make sure I don't miss it.` Pass requires exactly one `notify` call, `notify` as the first effect, and a nonempty message containing the 4pm deadline.

Fresh comparison cohorts were run independently at N=3, N=5, and N=10. The decisive N=10 result was:

| Cohort | P2b.1 baseline | P2b.2 candidate |
|---|---:|---:|
| Overall | 72/110 (65.5%) | 87/110 (79.1%) |
| Natural | 41/70 (58.6%) | 50/70 (71.4%) |
| Capability | 21/30 (70.0%) | 27/30 (90.0%) |
| Control | 10/10 | 10/10 |

Per-node candidate counts meet or exceed baseline: travel 10>=9, directions 10=10, website 10=10, schedule 7>=2, subscription 10>=1, referential follow-up 0=0, async 10=10, render 10=10, email 10=10, time 10=10, urgent 0=0. All 220 N=10 samples produced valid XML with no timeout or harness failure.

## Verification

- `pytest -q tests/`: 1,606 passed, 2 skipped, 2 subtests passed
- Python compilation: pass
- `git diff --check`: pass
- prompt census: 29,527-character initial web-main prompt, 15 schemas / 17,956 schema characters, 47,483 combined characters, artifact SHA `628b25ac3f13d73ba1482b983b3a9379cf90b642e0a584ad2d7ab449bfa0ad6f`
- local review: five rounds; every verified in-scope finding fixed; theoretical ID-less recovery and broad graph-matrix expansion rejected
- deployed from this branch; `assist-web` active and HTTPS smoke returns 200
