### PR TITLE
P2b.3 gate domain and embedder skill tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ where reliability is harder than with frontier APIs.
   lives under `/agent`. Visible web main-agent turns auto-load both; other
   constructions retain repository memory alone.
 
-- **Small-LLM-tuned skills.** Shared skills are progressively-disclosed
-  capability bundles under `assist/skills/<name>/SKILL.md`; supervisor-only
-  workflows live under `assist/main_skills/`. Both are tuned to small LLMs.
+- **Small-LLM-tuned skills.** Shared, domain-repository, and embedder-supplied
+  skills are progressively-disclosed capability bundles. Assist-owned skills
+  live under `assist/skills/<name>/SKILL.md`; supervisor-only workflows live
+  under `assist/main_skills/`; domain skills use `.claude/skills/`.
 
 - **Web-path sandboxing.** When Docker is available, web turns run filesystem
   and code tools inside a per-turn container with the workspace bind-mounted at
@@ -579,10 +580,11 @@ middleware lists every skill it finds there alongside the built-ins, and
 `load_skill(name="<skill-name>")` loads the complete `SKILL.md`. (Skills are listed
 once per chat — add one and start a new chat to pick it up.)
 
-During the P2b migration, domain-repository declarations are validated and
-recorded but do not yet hide tools at runtime. Bundled Assist skills use
-progressive disclosure now; domain and embedder-owned skills join that contract
-in P2b.3.
+Domain-repository and embedder declarations now use the same progressive
+disclosure contract as bundled Assist skills.  A declared tool must already be
+registered in the current graph, remains hidden until its winning skill is
+loaded, and is rejected at execution if it is still hidden.  SMS triage keeps
+its legacy skill composition.
 
 **Authoring one on request.** Ask the agent to "make a skill for X" and
 the `author-skill` built-in walks it through writing a correct

--- a/assist/agent.py
+++ b/assist/agent.py
@@ -19,6 +19,7 @@ from assist.spec import AgentSpec
 from assist.tools import directions, map_data, read_url, search_internet, travel
 from assist.backends import (
     DOMAIN_SKILLS_PATH,
+    LegacySkillsBackend,
     MAIN_SKILLS_DIR,
     MAIN_SKILLS_ROUTE,
     SKILLS_ROUTE,
@@ -400,10 +401,18 @@ def create_agent(model: BaseChatModel,
         bundled_skill_sources.add(SKILLS_ROUTE)
     if async_main and MAIN_SKILLS_ROUTE not in spec.skill_sources:
         bundled_skill_sources.add(MAIN_SKILLS_ROUTE)
+    legacy_skill_composition = any(
+        isinstance(route_backend, LegacySkillsBackend)
+        for route_backend in extra_routes.values())
     skills_mw = SmallModelSkillsMiddleware(
         backend=backend,
         sources=skill_sources,
         bundled_sources=bundled_skill_sources,
+        # Once a normal progressive-disclosure composition exists, every
+        # mounted skill source participates in the same exact-name contract.
+        # Triage has no bundled source and therefore retains its legacy loader
+        # and visibility unchanged.
+        gated_sources=(() if legacy_skill_composition else skill_sources),
         registered_tools=(_tool_name(tool_value) for tool_value in agent_tools),
     )
     memory_mw = SmallModelMemoryMiddleware(

--- a/assist/backends.py
+++ b/assist/backends.py
@@ -104,9 +104,18 @@ class BundledSkillsBackend(ReadOnlyFilesystemBackend):
     """Read-only backend marking an Assist-owned packaged skill route."""
 
 
+class LegacySkillsBackend(ReadOnlyFilesystemBackend):
+    """Read-only backend marking the unchanged inbound-SMS skill route."""
+
+
 def create_skills_backend(root_dir: str) -> BackendProtocol:
     """Return a read-only backend for a skill tree."""
     return ReadOnlyFilesystemBackend(root_dir=root_dir, virtual_mode=True)
+
+
+def create_legacy_skills_backend(root_dir: str) -> BackendProtocol:
+    """Return the pre-progressive-disclosure triage skill backend."""
+    return LegacySkillsBackend(root_dir=root_dir, virtual_mode=True)
 
 
 def create_bundled_skills_backend(root_dir: str) -> BackendProtocol:

--- a/assist/middleware/skills_middleware.py
+++ b/assist/middleware/skills_middleware.py
@@ -1,9 +1,10 @@
-"""Small-model skill loading and bundled-tool progressive disclosure.
+"""Small-model skill loading and progressive tool disclosure.
 
-The model always sees the skill catalog and ``load_skill``. Tools declared by
-winning packaged Assist skills are withheld until that exact skill loads
-successfully in the current graph invocation. Domain and embedder skill/tool
-sources remain baseline-visible until P2b.3.
+The model always sees the skill catalog and ``load_skill``. In normal
+progressive compositions, tools declared by the winning skill from any
+mounted source are withheld until that exact skill loads successfully in the
+current graph invocation. Inbound SMS triage deliberately retains its legacy
+composition.
 """
 from __future__ import annotations
 
@@ -236,14 +237,19 @@ def _make_load_skill_tool(middleware: "SmallModelSkillsMiddleware"):
             return _load_failure(name, "skill file is not UTF-8")
         skill_file = _sanitize(raw_skill_file)
 
-        newly_available = middleware._bundled_declared_tools(skill)
+        newly_available = middleware._disclosed_declared_tools(skill)
         already_loaded = frozenset(runtime.state.get("loaded_skill_tools", ()))
-        new_names = [name for name in skill.get("allowed_tools", ())
+        declared_names = tuple(skill.get("allowed_tools", ()))
+        new_names = [name for name in declared_names
                      if name in newly_available and name not in already_loaded]
         disclosure = (
             "Newly available tools: " + ", ".join(new_names) + "."
             if new_names else "No additional tools became available."
         )
+        unavailable = sorted(set(declared_names) - newly_available)
+        if unavailable:
+            disclosure += " Unavailable declared tools ignored: " + \
+                ", ".join(unavailable) + "."
         content = f"{skill_file}\n\n{disclosure}"
         fingerprint_payload = {
             "allowed_tools": list(skill.get("allowed_tools", ())),
@@ -275,17 +281,20 @@ def _make_load_skill_tool(middleware: "SmallModelSkillsMiddleware"):
 
 
 class SmallModelSkillsMiddleware(SkillsMiddleware):
-    """Name-based skill loader with invocation-local bundled-tool disclosure."""
+    """Name-based loader with invocation-local progressive tool disclosure."""
 
     state_schema = SmallModelSkillsState
 
     def __init__(self, *, backend, sources, bundled_sources: Iterable[str] = (),
+                 gated_sources: Iterable[str] | None = None,
                  registered_tools: Iterable[str] | None = None):
         super().__init__(backend=backend, sources=sources)
         self._bundled_sources = frozenset(bundled_sources)
+        self._gated_sources = frozenset(
+            self._bundled_sources if gated_sources is None else gated_sources)
         self._registered_tools = (None if registered_tools is None
                                   else frozenset(registered_tools))
-        if self._bundled_sources:
+        if self._gated_sources:
             self.system_prompt_template = SMALL_MODEL_SKILLS_PROMPT
             self.tools = [_make_load_skill_tool(self)]
         else:
@@ -300,16 +309,16 @@ class SmallModelSkillsMiddleware(SkillsMiddleware):
             f"- **{skill['name']}**: {skill['description']}" for skill in skills
         )
 
-    def _is_bundled(self, skill: dict[str, Any]) -> bool:
+    def _is_gated(self, skill: dict[str, Any]) -> bool:
         path = skill.get("path")
         if not isinstance(path, str):
             return False
         matches = [source for source in self.sources
                    if _source_contains(source, path)]
-        return bool(matches) and max(matches, key=len) in self._bundled_sources
+        return bool(matches) and max(matches, key=len) in self._gated_sources
 
-    def _bundled_declared_tools(self, skill: dict[str, Any]) -> frozenset[str]:
-        if not self._is_bundled(skill):
+    def _disclosed_declared_tools(self, skill: dict[str, Any]) -> frozenset[str]:
+        if not self._is_gated(skill):
             return frozenset()
         declared = frozenset(skill.get("allowed_tools", ()))
         return (declared if self._registered_tools is None
@@ -318,7 +327,7 @@ class SmallModelSkillsMiddleware(SkillsMiddleware):
     def _gated_tools(self, state: dict[str, Any]) -> frozenset[str]:
         gated: set[str] = set()
         for skill in state.get("skills_metadata", ()):
-            if self._is_bundled(skill):
+            if self._is_gated(skill):
                 gated.update(skill.get("allowed_tools", ()))
         return (frozenset(gated) if self._registered_tools is None
                 else frozenset(gated) & self._registered_tools)

--- a/assist/thread_manager.py
+++ b/assist/thread_manager.py
@@ -75,9 +75,10 @@ def _triage_skill_sources() -> dict:
     global _triage_skill_sources_cache
     if _triage_skill_sources_cache is None:
         from deepagents.backends import FilesystemBackend
-        from assist.backends import SKILLS_DIR, SKILLS_ROUTE, create_skills_backend
+        from assist.backends import (
+            SKILLS_DIR, SKILLS_ROUTE, create_legacy_skills_backend)
         _triage_skill_sources_cache = {
-            SKILLS_ROUTE: create_skills_backend(SKILLS_DIR),
+            SKILLS_ROUTE: create_legacy_skills_backend(SKILLS_DIR),
             _RENDER_SKILL_ROUTE: FilesystemBackend(
                 root_dir=_RENDER_SKILLS_DIR, virtual_mode=True)
         }

--- a/docs/2026-07-26-agent-prompt-architecture.org
+++ b/docs/2026-07-26-agent-prompt-architecture.org
@@ -3,7 +3,8 @@
 
 * State
 
-Status: architecture approved; P0, P1, P1b, P1c, P2, P2b.1, and P2b.2 complete;
+Status: architecture approved; P0, P1, P1b, P1c, P2, P2b.1, P2b.2, and P2b.3
+complete;
 P0b deferred.
 P2's duplicate-procedure deletion passed its registered functional and timing
 gates.  A post-review cleanup then removed an empty synchronous planning heading;
@@ -12,6 +13,22 @@ skill case passed the bounded 3/3 follow-up selected for that cleanup.  See
 [[file:2026-08-04-prompt-architecture-p2.org][the P2 state record]].
 
 ** Change log
+
+*** 2026-08-06: P2b.3 external-skill disclosure implementation
+
+- Extends invocation-scoped exact-name disclosure from Assist-owned packaged
+  skills to domain-repository and embedder skill sources.  Triage remains on
+  its legacy composition because it has no progressive-disclosure source.
+- The implementation uses the existing middleware and Agent Skills
+  =allowed-tools= metadata.  External declarations are intersected with the
+  profile's registered tools; an unknown declaration is reported in one
+  bounded load diagnostic and cannot enter the request or executor.
+- Deterministic domain and embedder graph tests cover pre-load absence,
+  post-load execution, and source-local reset.  Baseline domain/embedder
+  behavior was 18/18 at N=3.  The candidate was 18/18 at N=3, 30/30 at N=5,
+  and 59/60 at N=10.  The one N=10 miss was the pre-existing sandbox
+  arithmetic variance: baseline reproduced it at 1/5 while skill loading
+  itself succeeded.
 
 *** 2026-08-05: P2b.2 bundled disclosure implementation
 
@@ -2648,10 +2665,10 @@ separate P2c experiment and left invocation-scoped tool activation unchanged.
 Pierre satisfied the original design gate by approving and merging PR #216, and
 P0 subsequently shipped in PR #222.  Pierre deferred P0b on 2026-07-31 because
 shared-model contention has not been a material problem.  P1 shipped in PR #223,
-P1b shipped in PR #224, P1c is complete, P2 passed its final gate, and P2b.1
-shipped in PR #227.  P2b.2 is the active child and has not yet passed its
-behavioral gate.  Adding P2c to the program does not start its implementation or
-any other later phase automatically.
+P1b shipped in PR #224, P1c is complete, P2 passed its final gate, P2b.1
+shipped in PR #227, and P2b.2/P2b.3 completed in PR #230 and the current
+prompt-architecture-p2b3 lane.  Adding P2c to the program does not start its
+implementation or any other later phase automatically.
 
 * Decisions deliberately deferred to evidence
 

--- a/docs/2026-08-06-prompt-architecture-p2b3.org
+++ b/docs/2026-08-06-prompt-architecture-p2b3.org
@@ -1,0 +1,58 @@
+#+title: Prompt architecture P2b.3: domain and embedder tool disclosure
+#+date: <2026-08-06>
+
+* Objective
+
+Apply the P2b.2 progressive tool contract to skills loaded from a domain
+repository's =.claude/skills/= tree and from =AgentSpec.skill_sources=.
+SMS triage is deliberately unchanged.
+
+* Design
+
+The existing =SmallModelSkillsMiddleware= remains the sole disclosure and
+execution gate.  A normal progressive composition marks all mounted skill
+sources as gated, while the triage composition has no gated source and keeps
+its legacy loader and visible tools.  A skill's exact =allowed-tools= names
+are intersected with the tools registered in the current graph.  A declaration
+cannot create a tool or expand the graph.  Source precedence remains the
+existing last-source-wins listing/load behavior; only the winning skill's
+declaration is used.
+
+Unknown declarations are excluded from the allowed set and are named in one
+bounded load result diagnostic.  Schema filtering and execution rejection
+remain paired.  Activation is invocation-local and resets at the next graph
+invocation, exactly as in P2b.2.
+
+* Controlled implementation
+
+- `assist/agent.py` passes the complete normal skill-source list to the
+  existing disclosure middleware; triage passes none.
+- `assist/middleware/skills_middleware.py` separates the packaged-source
+  compatibility marker from the complete gated-source set and reports
+  unavailable declared names without exposing them.
+- Deterministic graph tests exercise a real `.claude/skills/` fixture and an
+  `AgentSpec.skill_sources` fixture with a custom tool.
+
+* Evidence and gates
+
+The focused deterministic suite must prove pre-load absence, post-load
+execution, reset, unknown-tool containment, collision behavior, and unchanged
+triage composition.  Natural domain and embedder acceptance cohorts were
+baseline 18/18 at N=3, candidate 18/18 at N=3, 30/30 at N=5, and 59/60 at
+N=10.  The single stability miss was the existing sandbox arithmetic
+variance and reproduced on baseline at 1/5; the skill loaded in both cases.
+
+* Change log
+
+** 2026-08-06: implementation started
+
+- Advanced the lane to merged P2b.2 commit `39d1d39` after detecting the local
+  main ref was stale.
+- Added the shared external-source gate and deterministic domain/embedder
+  coverage.
+
+** 2026-08-06: verification complete
+
+- The local review found and fixed the normal `SKILLS_ROUTE` override escape
+  hatch by marking only SMS triage as legacy.  Full deterministic evidence is
+  1,611 passed, 2 skipped; the focused disclosure suite is 88 passed.

--- a/roadmap.org
+++ b/roadmap.org
@@ -943,9 +943,14 @@ overall and 50/70 natural, met or exceeded all eleven P2b.1 baseline nodes, and
 reduced initial provider schemas from 30 to 15.  See
 [[https://github.com/pierrel/assist/pull/230][PR #230]] and
 [[file:docs/2026-08-05-prompt-architecture-p2b2.org][the P2b.2 state record]].
-**** TODO P2b.3: Apply the contract to domain and embedder skills
+**** DONE P2b.3: Apply the contract to domain and embedder skills
 Use the same winning-skill declaration and current composed tool registry for
 =.claude/skills/= and =AgentSpec.skill_sources=.  See [[file:docs/2026-07-26-agent-prompt-architecture.org::#phase-2b-tools-external][P2b.3]].
+Completed on 2026-08-06 in the prompt-architecture-p2b3 lane.  Normal domain
+and embedder sources now share invocation-scoped disclosure and execution
+filtering; SMS triage remains legacy.  Deterministic tests pass 1,611/2, and
+the affected behavioral suites were baseline 18/18, candidate N=3 18/18, N=5
+30/30, and N=10 59/60 with the one miss reproduced by baseline.
 
 *** TODO P2c: Suppress recently loaded skill descriptions until useful again
 After P2b, compare turn-count, provider-reported input-plus-output-token,

--- a/tests/middleware/test_skills_kernel.py
+++ b/tests/middleware/test_skills_kernel.py
@@ -102,6 +102,20 @@ def test_external_winner_stays_baseline_visible():
     assert [item.name for item in updated.tools] == ["kernel_tool", "travel"]
 
 
+def test_external_source_is_gated_when_disclosure_is_enabled():
+    middleware = SmallModelSkillsMiddleware(
+        backend=Mock(), sources=["/skills/", "/external/"],
+        bundled_sources=["/skills/"], gated_sources=["/skills/", "/external/"])
+    state = {
+        "skills_metadata": [_skill("/external/travel/SKILL.md")],
+        "loaded_skill_tools": frozenset(),
+    }
+
+    updated = middleware.modify_request(_request(middleware, state))
+
+    assert [item.name for item in updated.tools] == ["kernel_tool"]
+
+
 def test_nested_external_source_is_not_claimed_by_bundled_parent():
     middleware = SmallModelSkillsMiddleware(
         backend=Mock(), sources=["/skills/", "/skills/external/"],
@@ -197,8 +211,32 @@ def test_disclosure_intersects_declarations_with_this_agent_tools():
     result = middleware.tools[0].func("travel", runtime)
 
     assert result.update["loaded_skill_tools"] == frozenset({"travel"})
-    assert result.update["messages"][0].content.endswith(
-        "Newly available tools: travel.")
+    assert "Newly available tools: travel." in result.update["messages"][0].content
+    assert "Unavailable declared tools ignored: absent_tool." in \
+        result.update["messages"][0].content
+
+
+def test_disclosure_reports_unregistered_names_without_exposing_them():
+    body = b"---\nname: travel\ndescription: Travel help.\n---\n\nRULES"
+    backend = SimpleNamespace(download_files=lambda _paths: [
+        SimpleNamespace(error=None, content=body)])
+    middleware = SmallModelSkillsMiddleware(
+        backend=backend, sources=["/external/"],
+        gated_sources=["/external/"], registered_tools={"travel"})
+    skill = {**_skill("/external/travel/SKILL.md"),
+             "allowed_tools": ["travel", "not_registered"]}
+    runtime = SimpleNamespace(
+        state={"skills_metadata": [skill], "loaded_skill_tools": frozenset()},
+        config={}, tool_call_id="load-1")
+
+    result = middleware.tools[0].func("travel", runtime)
+
+    message = result.update["messages"][0]
+    assert result.update["loaded_skill_tools"] == frozenset({"travel"})
+    assert "Unavailable declared tools ignored: not_registered." in message.content
+    updated = middleware.modify_request(_request(
+        middleware, {**runtime.state, "loaded_skill_tools": frozenset({"travel"})}))
+    assert [item.name for item in updated.tools] == ["kernel_tool", "travel"]
 
 
 def test_parallel_load_updates_have_union_reducer():
@@ -412,6 +450,46 @@ def test_compiled_graph_discloses_after_load_then_resets_next_invocation():
     assert second["messages"][-1].content == "second done"
 
 
+def test_compiled_graph_discloses_domain_skill_tool_after_load():
+    from assist.agent import create_agent
+    from assist.spec import AgentSpec
+
+    @tool("travel")
+    def fake_travel(origin: str, destination: str) -> str:
+        """Return a deterministic route."""
+        return f"route:{origin}:{destination}"
+
+    model = _RecordingModel(responses=[
+        AIMessage(content="", tool_calls=[{
+            "name": "load_skill", "args": {"name": "domain-route"},
+            "id": "load-domain"}]),
+        AIMessage(content="", tool_calls=[{
+            "name": "travel", "args": {"origin": "a", "destination": "b"},
+            "id": "travel-domain"}]),
+        AIMessage(content="done"),
+    ])
+    with tempfile.TemporaryDirectory() as wd:
+        skill_dir = Path(wd) / ".claude" / "skills" / "domain-route"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: domain-route\ndescription: Route help.\n"
+            "allowed-tools: travel\n---\n\nUse travel.\n",
+            encoding="utf-8",
+        )
+        with patch("assist.agent.travel", fake_travel):
+            agent = create_agent(
+                model, wd, spec=AgentSpec(async_subagent_tools=()))
+            result = agent.invoke(
+                {"messages": [{"role": "user", "content": "route"}]},
+                {"configurable": {"thread_id": "domain-disclosure"}},
+            )
+
+    assert "travel" not in model.bound_tools[0]
+    assert "travel" in model.bound_tools[1]
+    assert any(message.name == "travel" and message.status == "success"
+               for message in result["messages"] if isinstance(message, ToolMessage))
+
+
 def test_compiled_graph_rejects_same_response_sibling_before_hitl():
     from assist.agent import create_agent
     from assist.backends import create_bundled_skills_backend
@@ -468,3 +546,50 @@ def test_compiled_graph_rejects_same_response_sibling_before_hitl():
               and message.tool_call_id in {"load-1", "send-1"}]
     assert paired == ["load-1", "send-1"]
     assert not result.get("__interrupt__")
+
+
+def test_compiled_graph_discloses_embedder_tool_after_load():
+    from deepagents.backends import FilesystemBackend
+    from assist.agent import create_agent
+    from assist.spec import AgentSpec
+
+    @tool("custom_lookup")
+    def custom_lookup(value: str) -> str:
+        """Return a deterministic custom lookup."""
+        return f"lookup:{value}"
+
+    model = _RecordingModel(responses=[
+        AIMessage(content="", tool_calls=[{
+            "name": "load_skill", "args": {"name": "embedder-route"},
+            "id": "load-embedder"}]),
+        AIMessage(content="", tool_calls=[{
+            "name": "custom_lookup", "args": {"value": "x"},
+            "id": "lookup-embedder"}]),
+        AIMessage(content="done"),
+    ])
+    with tempfile.TemporaryDirectory() as skill_root, tempfile.TemporaryDirectory() as wd:
+        skill_dir = Path(skill_root) / "embedder-route"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: embedder-route\ndescription: Lookup help.\n"
+            "allowed-tools: custom_lookup\n---\n\nUse custom_lookup.\n",
+            encoding="utf-8",
+        )
+        agent = create_agent(
+            model, wd,
+            spec=AgentSpec(
+                tools=(custom_lookup,), async_subagent_tools=(),
+                skill_sources={
+                    "/embedder-skills/": FilesystemBackend(
+                        root_dir=skill_root, virtual_mode=True)}
+            ),
+        )
+        result = agent.invoke(
+            {"messages": [{"role": "user", "content": "lookup"}]},
+            {"configurable": {"thread_id": "embedder-disclosure"}},
+        )
+
+    assert "custom_lookup" not in model.bound_tools[0]
+    assert "custom_lookup" in model.bound_tools[1]
+    assert any(message.name == "custom_lookup" and message.status == "success"
+               for message in result["messages"] if isinstance(message, ToolMessage))

--- a/tests/test_create_agent_extra_skill_sources.py
+++ b/tests/test_create_agent_extra_skill_sources.py
@@ -162,7 +162,7 @@ class TestCreateAgentExtraSkillSources:
         )
         assert "/emacsos-skills/" in mw.sources
 
-    def test_only_explicitly_bundled_extra_routes_gate_tools(self):
+    def test_all_normal_extra_routes_gate_tools(self):
         external = _route_backend()
         with tempfile.TemporaryDirectory() as root:
             bundled = create_bundled_skills_backend(root)
@@ -174,6 +174,8 @@ class TestCreateAgentExtraSkillSources:
                   if isinstance(m, SmallModelSkillsMiddleware))
 
         assert mw._bundled_sources == frozenset({SKILLS_ROUTE, "/bundled/"})
+        assert "/external/" in mw._gated_sources
+        assert "/bundled/" in mw._gated_sources
 
     def test_multiple_extra_skill_sources(self):
         extras = {
@@ -208,6 +210,7 @@ class TestCreateAgentExtraSkillSources:
         assert mw.sources.count(SKILLS_ROUTE) == 1, (
             f"SKILLS_ROUTE duplicated in middleware sources: {mw.sources}"
         )
+        assert SKILLS_ROUTE in mw._gated_sources
 
 
 class TestCreateAgentDomainSkills:
@@ -268,6 +271,7 @@ class TestCreateAgentDomainSkills:
         # Prepended → index 0 (lowest precedence under last-wins), built-in next.
         assert mw.sources[0] == DOMAIN_SKILLS_PATH
         assert mw.sources[1] == SKILLS_ROUTE
+        assert DOMAIN_SKILLS_PATH in mw._gated_sources
 
     def test_domain_source_absent_when_no_claude_dir(self):
         wd = self._tmpdir()
@@ -303,6 +307,7 @@ class TestCreateAgentDomainSkills:
             wd, spec=AgentSpec(skill_sources={"/emacsos-skills/": extra})))
         # domain < built-in < embedder-extras.
         assert mw.sources == [DOMAIN_SKILLS_PATH, SKILLS_ROUTE, "/emacsos-skills/"]
+        assert "/emacsos-skills/" in mw._gated_sources
 
     def test_domain_skill_discovered_through_default_backend(self):
         """The assist wiring seam: ``/.claude/skills/`` is NOT a composite

--- a/tests/test_prompt_census.py
+++ b/tests/test_prompt_census.py
@@ -1128,7 +1128,7 @@ def test_keyboard_interrupt_cleans_publication_staging(tmp_path, monkeypatch):
     assert not list(tmp_path.glob(".interrupted-*"))
 
 
-def test_p0_through_p2b2_history_matches_the_current_capture(census):
+def test_p0_through_p2b3_history_matches_the_current_capture(census):
     document = Path("docs/2026-07-26-agent-prompt-architecture.org").read_text(
         encoding="utf-8")
     p2_document = Path("docs/2026-08-04-prompt-architecture-p2.org").read_text(
@@ -1138,6 +1138,9 @@ def test_p0_through_p2b2_history_matches_the_current_capture(census):
         encoding="utf-8")
     p2b2_document = Path(
         "docs/2026-08-05-prompt-architecture-p2b2.org").read_text(
+        encoding="utf-8")
+    p2b3_document = Path(
+        "docs/2026-08-06-prompt-architecture-p2b3.org").read_text(
         encoding="utf-8")
     current = _call(census, "web-main-core")
     historical_p0_prompt = _named_text_block("p0-current-web-main-bootstrap")
@@ -1157,8 +1160,10 @@ def test_p0_through_p2b2_history_matches_the_current_capture(census):
     assert len(census["findings"]) == 25
     assert len(artifact_bytes(census)) == 2_992_683
     assert census["artifact_sha256"] == \
-            "d3a0ce22fcf4be92c97423742fc66ebc85ea4b2dc575246b4316625dda82b45d"
+            "879604a08b337fecc5a0f5b2a4b8cfded0c96c9fbcead14f31b401f15362c2b2"
     assert "2,920,942 bytes (2.8 MiB)" in document
+    assert "P2b.3 external-skill disclosure implementation" in document
+    assert "domain and embedder tool disclosure" in p2b3_document
     assert "p0-100aa885-final-v2" in document
     expected_rows = [
         "| Assist role instructions | P0 baseline custom main template: role, routing, trust, research, artifact, and lifecycle procedure | 13,068 | 3,267 |",

--- a/tests/test_thread_manager_lazy.py
+++ b/tests/test_thread_manager_lazy.py
@@ -143,7 +143,8 @@ class TestThreadManagerLazy(TestCase):
         self.assertNotIn("agent_dir", thread.call_args.kwargs)
 
     def test_triage_profile_preserves_pre_disclosure_skill_composition(self):
-        from assist.backends import BundledSkillsBackend, SKILLS_ROUTE
+        from assist.backends import (
+            BundledSkillsBackend, LegacySkillsBackend, SKILLS_ROUTE)
         from deepagents.backends import FilesystemBackend
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -156,6 +157,7 @@ class TestThreadManagerLazy(TestCase):
 
         spec = thread.call_args.kwargs["spec"]
         self.assertIn(SKILLS_ROUTE, spec.skill_sources)
+        self.assertIsInstance(spec.skill_sources[SKILLS_ROUTE], LegacySkillsBackend)
         for backend in spec.skill_sources.values():
             self.assertIsInstance(backend, FilesystemBackend)
             self.assertNotIsInstance(backend, BundledSkillsBackend)


### PR DESCRIPTION
## Summary

P2b.3 extends P2b.2 progressive tool disclosure from Assist-owned packaged skills to normal domain-repository and embedder skill sources. The existing middleware remains the single schema and execution gate. SMS triage keeps its legacy skill composition unchanged.

A normal composition now gates every mounted skill source, including an overridden `/skills/` route. Only the explicit triage backend marker selects the legacy loader. Declarations are intersected with the tools registered in the current graph; unknown names produce a bounded diagnostic and never enter the schema or executor.

## Deterministic evidence

- Full suite: 1,611 passed, 2 skipped.
- Focused disclosure/census suite: 88 passed.
- Prompt census fingerprint: `879604a08b337fecc5a0f5b2a4b8cfded0c96c9fbcead14f31b401f15362c2b2`.

## Behavioral evals

Each trial used the local Qwen model through the normal `create_agent` path. The domain suite includes local and Docker-sandbox fixtures; the embedder case mounts a custom `SKILL.md` through `AgentSpec.skill_sources`, supplies its custom tool through `AgentSpec.tools`, and validates that the skill was loaded and the tool's requested outcome was proposed. The domain validations require the skill load plus the derived reconciliation result `210.00`; the embedder validation requires the loaded `send-email` skill and exactly one pending email proposal with the expected recipient, subject, and Tuesday content.

- Baseline on merged P2b.2 (`39d1d39`): N=3, 18/18 passed.
- Candidate post-implementation: N=3, 18/18 passed.
- Candidate post-review: N=5, 30/30 passed.
- Candidate stability: 59/60 assertions passed across ten six-test runs. One sandbox arithmetic miss reproduced on baseline at 1/5; skill loading succeeded in both cases, so this is recorded as pre-existing model variance rather than a P2b.3 regression.

## Scope

- `assist/agent.py`, `assist/backends.py`, `assist/middleware/skills_middleware.py`, and the triage backend seam.
- Deterministic domain/embedder disclosure, collision, unknown-tool, reset, and triage-preservation tests.
- Prompt architecture state doc, roadmap, README, and census fingerprint.

No SMS triage behavior, development guidance, memory authorization, or P2c catalog lifecycle work is included.
