### PR TITLE
Add context-informed research handoff eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Skill-specific:
 - `test_dev_skill_multi_turn.py` — dev skill on the general agent: multi-turn TDD with approvals + mid-task clarification
 
 Cross-cutting:
-- `test_async_subagents.py` — 13-case supervisor/delegation acceptance suite
+- `test_async_subagents.py` — 16-case supervisor/delegation acceptance suite
 - `test_domain_integration.py` — git integration and domain management
 - `test_memory.py`, `test_thread_memory.py` — memory behavior
 - `test_thread_e2e.py` — thread/conversation persistence

--- a/edd/eval/test_async_subagents.py
+++ b/edd/eval/test_async_subagents.py
@@ -32,7 +32,12 @@ from assist.async_subagents import (
 )
 from assist.model_manager import select_assistant_model
 from assist.spec import AgentSpec
-from edd.outcome_judge import OutcomeJudge, OutcomeObservation
+from edd.outcome_judge import (
+    Evidence,
+    OutcomeJudge,
+    OutcomeObservation,
+    OutcomeRequirement,
+)
 
 from .utils import create_filesystem
 
@@ -40,6 +45,7 @@ from .utils import create_filesystem
 _TASK_DESCRIPTIONS: dict[str, str] = {}
 _TASK_TYPES: dict[str, str] = {}
 _TASK_STATUSES: dict[str, str] = {}
+_TASK_RESULTS: dict[str, str] = {}
 _TASK_ROOT: str | None = None
 _TASK_SEQUENCE = 0
 _DIRECT_WORK_TOOLS = {"write_file", "edit_file", "execute"}
@@ -48,6 +54,18 @@ _NETWORK_CAPABLE_TOOLS = {
 }
 _MAX_JUDGE_FILE_BYTES = 16 * 1024
 _MAX_JUDGE_OBSERVATION_BYTES = 64 * 1024
+_TRIP_CONTEXT_RESULT = "Weekend rail service resumes May 2 according to trip.org."
+_COAST_RESEARCH_RESULT = (
+    "The current published timetable lists Coast Starlight train 14 "
+    "departing Los Angeles at 9:51 a.m."
+)
+_ORCHID_CONTEXT_RESULT = (
+    "Trip notes say the Orchid Express weekend service resumes on May 17."
+)
+_ORCHID_RESEARCH_RESULT = (
+    "The mock operator timetable lists the northbound Orchid Express leaving "
+    "Harbor Junction at 06:47."
+)
 _CAREER_COMPANIES = (
     ("Aster Labs", "Engineering Director"),
     ("Beacon Systems", "VP Engineering"),
@@ -240,6 +258,8 @@ def _check(task_id: str) -> str:
         return _task_result(task_id, status)
     if status == "cancelled":
         return _task_result(task_id, status)
+    if result := _TASK_RESULTS.get(task_id):
+        return _task_result(task_id, "success", result=result)
     career_evidence = _career_evidence(description)
     if career_evidence is not None:
         return _task_result(task_id, "success", result=career_evidence)
@@ -298,13 +318,12 @@ def _check(task_id: str) -> str:
             and _TASK_TYPES.get(task_id) == "context-agent"):
         return _task_result(
             task_id, "success", agent_name="context-agent",
-            result="Weekend rail service resumes May 2 according to trip.org.")
+            result=_TRIP_CONTEXT_RESULT)
     if ("coast starlight" in description.lower()
             and _TASK_TYPES.get(task_id) == "research-agent"):
         return _task_result(
             task_id, "success", agent_name="research-agent", result=(
-                "The current published timetable lists Coast Starlight train 14 "
-                "departing Los Angeles at 9:51 a.m."
+                _COAST_RESEARCH_RESULT
             ))
     return _task_result(
         task_id, "success", result="The requested outcome is complete.")
@@ -368,17 +387,20 @@ class TestAsyncSubagentSupervisor(TestCase):
         _TASK_DESCRIPTIONS.clear()
         _TASK_TYPES.clear()
         _TASK_STATUSES.clear()
+        _TASK_RESULTS.clear()
         _TASK_ROOT = None
         _TASK_SEQUENCE = 0
         self.model = select_assistant_model(0.1)
 
-    def _agent(self) -> AgentHarness:
+    def _agent(
+            self, *, trip_note: str = "Weekend rail service resumes May 2."
+    ) -> AgentHarness:
         global _TASK_ROOT
         root = tempfile.mkdtemp()
         _TASK_ROOT = root
         create_filesystem(root, {
             "README.org": "Personal notes live here.",
-            "trip.org": "* Possible trip\nWeekend rail service resumes May 2.\n",
+            "trip.org": f"* Possible trip\n{trip_note}\n",
             "alpha-notes.md": (
                 "# Alpha launch\n\nPilot users like the faster setup. The import flow "
                 "still loses tags. Support needs a migration runbook. Decide whether "
@@ -609,6 +631,116 @@ class TestAsyncSubagentSupervisor(TestCase):
         self.assertEqual(checks[-1]["args"]["task_id"], task_id)
         self.assertFalse(any(call.get("name") == "read_file" for call in calls), calls)
         self.assertRegex(reply, r"(?i)weekend.*May 2")
+
+    def test_context_result_informs_research_then_final_response(self):
+        """A dependent research request waits for context and closes the loop."""
+        prompt = (
+            "I'm planning to take the Orchid Express the weekend service resumes. "
+            "I saved the date in my trip notes. What time does the northbound train "
+            "leave Harbor Junction that day?"
+        )
+        agent = self._agent(
+            trip_note="Orchid Express weekend service resumes on May 17.")
+        agent.message(prompt)
+        initial_calls = self._calls(agent)
+        initial_starts = [
+            call for call in initial_calls
+            if call.get("name") == "start_async_task"
+        ]
+        context_starts = [
+            call for call in initial_starts
+            if call.get("args", {}).get("subagent_type") == "context-agent"
+        ]
+        research_starts = [
+            call for call in initial_starts
+            if call.get("args", {}).get("subagent_type") == "research-agent"
+        ]
+        self.assertEqual(len(context_starts), 1, initial_calls)
+        self.assertEqual(
+            research_starts, [],
+            "research must wait for the local context result",
+        )
+
+        context_id = _task_id_for_call(context_starts[0])
+        context_result = _ORCHID_CONTEXT_RESULT
+        _TASK_RESULTS[context_id] = context_result
+        before_context_completion = len(initial_calls)
+        agent.message(_completion_wake(context_id, "success"))
+        context_completion_calls = self._calls(agent)[before_context_completion:]
+        self.assertTrue(
+            any(
+                call.get("name") == "check_async_task"
+                and call.get("args", {}).get("task_id") == context_id
+                for call in context_completion_calls
+            ),
+            context_completion_calls,
+        )
+        research_starts = [
+            call for call in context_completion_calls
+            if call.get("name") == "start_async_task"
+            and call.get("args", {}).get("subagent_type") == "research-agent"
+        ]
+        self.assertEqual(len(research_starts), 1, context_completion_calls)
+        research_brief = research_starts[0]["args"]["description"]
+        self.assertIn(
+            "may 17",
+            research_brief.lower(),
+            "the research brief must use the mocked context result",
+        )
+
+        research_id = _task_id_for_call(research_starts[0])
+        research_result = _ORCHID_RESEARCH_RESULT
+        _TASK_RESULTS[research_id] = research_result
+        before_research_completion = len(self._calls(agent))
+        final_reply = agent.message(_completion_wake(research_id, "success"))
+        research_completion_calls = self._calls(agent)[before_research_completion:]
+        self.assertTrue(
+            any(
+                call.get("name") == "check_async_task"
+                and call.get("args", {}).get("task_id") == research_id
+                for call in research_completion_calls
+            ),
+            research_completion_calls,
+        )
+
+        self._assert_judge_pass(OutcomeObservation(
+            requested=(OutcomeRequirement(
+                id="researched-train-answer",
+                description=(
+                    "The final reply tells the user that Orchid Express service resumes "
+                    "May 17 and that the northbound train leaves Harbor Junction at "
+                    "06:47."
+                ),
+                evidence_ids=("research-result", "final-reply"),
+            ),),
+            evidence=(
+                Evidence(id="prompt", kind="prompt", state="present", content=prompt),
+                Evidence(
+                    id="context-result",
+                    kind="event",
+                    state="present",
+                    content=context_result,
+                ),
+                Evidence(
+                    id="research-brief",
+                    kind="event",
+                    state="present",
+                    content=research_brief,
+                ),
+                Evidence(
+                    id="research-result",
+                    kind="event",
+                    state="present",
+                    content=research_result,
+                ),
+                Evidence(
+                    id="final-reply",
+                    kind="final",
+                    state="present",
+                    content=final_reply,
+                ),
+            ),
+        ))
 
     def test_user_stop_request_reports_cancellation_requested_for_running_tasks(self):
         agent = self._agent()

--- a/edd/eval/test_async_subagents.py
+++ b/edd/eval/test_async_subagents.py
@@ -258,8 +258,8 @@ def _check(task_id: str) -> str:
         return _task_result(task_id, status)
     if status == "cancelled":
         return _task_result(task_id, status)
-    if result := _TASK_RESULTS.get(task_id):
-        return _task_result(task_id, "success", result=result)
+    if task_id in _TASK_RESULTS:
+        return _task_result(task_id, "success", result=_TASK_RESULTS[task_id])
     career_evidence = _career_evidence(description)
     if career_evidence is not None:
         return _task_result(task_id, "success", result=career_evidence)
@@ -656,6 +656,7 @@ class TestAsyncSubagentSupervisor(TestCase):
             if call.get("args", {}).get("subagent_type") == "research-agent"
         ]
         self.assertEqual(len(context_starts), 1, initial_calls)
+        self.assertEqual(len(initial_starts), 1, initial_calls)
         self.assertEqual(
             research_starts, [],
             "research must wait for the local context result",


### PR DESCRIPTION
## Summary

Adds a natural, outcome-judged regression eval for the async handoff from local context to external research. This is test-only: it does not alter prompts, supervisor behavior, or deployment.

## Eval: context result informs research then final response

Setup and fixtures:

- The supervisor uses its existing synthetic async task tools; no child agent runs and no HTTP/search is performed.
- The scenario workspace contains a fictional trip note: Orchid Express weekend service resumes on May 17.
- Context completion is mocked by its generated task ID with that exact result. The dependent research task is likewise mocked by task ID to return: northbound Orchid Express leaves Harbor Junction at 06:47.
- The synthetic train, terminal, date, and time prevent the final answer from passing by recalling public timetable facts.

Full prompt sequence:

1. User: "I’m planning to take the Orchid Express the weekend service resumes. I saved the date in my trip notes. What time does the northbound train leave Harbor Junction that day?"
2. Trusted orchestration completion wake for the context task: `Task ID: <context-task-id>` / `Agent: context-agent` / `Status: success`, instructing the supervisor to call `check_async_task` before responding.
3. Trusted orchestration completion wake for the research task with the equivalent `research-agent` task ID and success status.

Pass validations:

- Initial turn starts exactly one task, the context task, and no research task.
- Context wake checks the exact completed task ID, starts one research task, and its brief includes the mocked May 17 result.
- Research wake checks the exact task ID.
- `OutcomeJudge` passes only when the final visible reply states both May 17 and the fictional Harbor Junction 06:47 departure.

## Verification

- `pytest -q tests`: 1611 passed, 2 skipped.
- New real-model eval rerun three times after the final review fixes: **1/3 passed**. The two failures were the intended regression: research-agent launched on the initial turn before the context result existed. The passing run completed all three turns and the outcome judge accepted the mock-only researched summary.
- Local review: 4 rounds, including correctness, edge cases, simplicity, design adherence, security/concurrency, and dedicated docstring/comment alignment. Fixed the task-ID mock binding, fictional outcome oracle, fixture consistency, README suite count, and Copilot’s empty-result/strict-initial-task findings. No remaining local findings.
- Copilot review round 1: both findings were addressed by Copilot’s eval-only commit on this PR branch; no runtime behavior changed.

No deployment, by request.