### PR TITLE
Add Pi web activity traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ where reliability is harder than with frontier APIs.
   preview; Deep Agents remains the default. Pi threads are visibly labelled,
   run only ordinary manual web turns, and can start a new Deep Agents thread
   from an optional visible summary without transferring their transcript or
-  workspace.
+  workspace. Each Pi turn also retains a collapsed, redacted activity trace
+  for model requests and workspace actions; it never includes prompts, paths,
+  commands, content, or tool results.
 
 ---
 

--- a/assist/pi_broker.py
+++ b/assist/pi_broker.py
@@ -17,7 +17,7 @@ import stat
 import threading
 import time
 from pathlib import Path
-from typing import Any, Literal, TypedDict
+from typing import Any, Callable, Literal, TypedDict
 
 from assist.sandbox import DockerSandboxBackend
 
@@ -53,11 +53,15 @@ class PiToolBroker:
     """Serve Pi coding-tool requests against exactly one Docker sandbox."""
 
     def __init__(self, backend: DockerSandboxBackend, control_dir: str | Path,
-                 capability: str) -> None:
+                 capability: str,
+                 trace_start: Callable[[str], object] | None = None,
+                 trace_settle: Callable[[object, bool], None] | None = None) -> None:
         self._backend = backend
         self._control_dir = Path(control_dir)
         self._socket_path = self._control_dir / "broker.sock"
         self._capability = capability
+        self._trace_start = trace_start
+        self._trace_settle = trace_settle
         self._listener: socket.socket | None = None
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
@@ -134,6 +138,8 @@ class PiToolBroker:
 
     def _serve_connection(self, connection: socket.socket) -> None:
         admitted = False
+        trace_operation: object | None = None
+        completed = False
         try:
             with connection:
                 connection.settimeout(5)
@@ -144,7 +150,11 @@ class PiToolBroker:
                     request_id = request["id"]
                     self._admit_request()
                     admitted = True
+                    name = self._trace_name(request)
+                    if name is not None:
+                        trace_operation = self._start_trace(name)
                     value = self._dispatch(request)
+                    completed = True
                     response: dict[str, Any] = {
                         "version": _VERSION, "id": request_id, "ok": True, "value": value,
                     }
@@ -155,9 +165,37 @@ class PiToolBroker:
                     }
                 self._write_frame(connection, response)
         finally:
+            self._settle_trace(trace_operation, completed)
             if admitted:
                 self._finish_request()
             self._request_slot.release()
+
+    @staticmethod
+    def _trace_name(request: _BrokerRequest) -> str | None:
+        """Map a fully admitted closed operation to a redacted display label."""
+        operation = request["operation"]
+        if operation == "access":
+            mode = request.get("mode")
+            return "read" if mode == "read" else "write" if mode == "write" else None
+        return {"mkdir": "write", "read": "read", "write": "write", "bash": "bash"}[operation]
+
+    def _start_trace(self, name: str) -> object | None:
+        """Keep optional observability from changing a permitted tool operation."""
+        if self._trace_start is None:
+            return None
+        try:
+            return self._trace_start(name)
+        except Exception:
+            return None
+
+    def _settle_trace(self, operation: object | None, completed: bool) -> None:
+        """Contain an activity-recorder failure after the tool operation ends."""
+        if operation is None or self._trace_settle is None:
+            return
+        try:
+            self._trace_settle(operation, completed)
+        except Exception:
+            pass
 
     def _admit_request(self) -> None:
         with self._request_gate:

--- a/assist/pi_provider_relay.py
+++ b/assist/pi_provider_relay.py
@@ -12,7 +12,7 @@ import threading
 import urllib.parse
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 
 _MAX_REQUEST_BYTES = 2 * 1024 * 1024
@@ -36,13 +36,17 @@ class PiProviderRelay:
     """Forward only bounded, authenticated chat-completion requests to one model."""
 
     def __init__(self, control_dir: str | Path, upstream_url: str,
-                 api_key: str, model: str, capability: str) -> None:
+                 api_key: str, model: str, capability: str,
+                 trace_start: Callable[[], object] | None = None,
+                 trace_settle: Callable[[object, bool], None] | None = None) -> None:
         self._control_dir = Path(control_dir)
         self._socket_path = self._control_dir / "provider.sock"
         self._upstream = self._validate_upstream(upstream_url)
         self._api_key = api_key
         self._model = model
         self._capability = capability
+        self._trace_start = trace_start
+        self._trace_settle = trace_settle
         self._validate_control_dir()
         if self._socket_path.exists():
             raise PiProviderRelayError("Pi provider socket already exists")
@@ -174,8 +178,9 @@ class PiProviderRelay:
             self._calls += 1
         return canonical
 
-    def forward(self, body: bytes) -> tuple[int, str, list[bytes]]:
+    def forward(self, body: bytes, trace_operation: object | None = None) -> tuple[int, str, list[bytes]]:
         """Forward one already-authorized request without forwarding its headers."""
+        completed = False
         connection_type = (http.client.HTTPSConnection
                            if self._upstream.scheme == "https" else http.client.HTTPConnection)
         connection = connection_type(self._upstream.hostname, self._upstream.port, timeout=_SOCKET_TIMEOUT_SECONDS)
@@ -205,11 +210,31 @@ class PiProviderRelay:
                 if total > _MAX_RESPONSE_BYTES:
                     raise PiProviderRelayError("Pi model response exceeds its bound")
                 chunks.append(chunk)
+            completed = True
             return response.status, "application/json", chunks
         finally:
             with self._state_lock:
                 self._connections.discard(connection)
             connection.close()
+            self.settle_trace(trace_operation, completed)
+
+    def start_trace(self) -> object | None:
+        """Keep optional activity recording from changing model admission."""
+        if self._trace_start is None:
+            return None
+        try:
+            return self._trace_start()
+        except Exception:
+            return None
+
+    def settle_trace(self, operation: object | None, completed: bool) -> None:
+        """Contain recorder failures after an admitted model request."""
+        if operation is None or self._trace_settle is None:
+            return
+        try:
+            self._trace_settle(operation, completed)
+        except Exception:
+            pass
 
 
 class _ProviderHandler(BaseHTTPRequestHandler):
@@ -235,7 +260,8 @@ class _ProviderHandler(BaseHTTPRequestHandler):
                     return
                 body = self.rfile.read(int(length_text))
                 body = self.relay.validate_request(self.command, self.path, self.headers, body)
-                status, content_type, chunks = self.relay.forward(body)
+                operation = self.relay.start_trace()
+                status, content_type, chunks = self.relay.forward(body, operation)
             except PiProviderRelayError:
                 self.send_error(403)
                 return

--- a/assist/pi_provider_relay.py
+++ b/assist/pi_provider_relay.py
@@ -210,7 +210,7 @@ class PiProviderRelay:
                 if total > _MAX_RESPONSE_BYTES:
                     raise PiProviderRelayError("Pi model response exceeds its bound")
                 chunks.append(chunk)
-            completed = True
+            completed = 200 <= response.status < 300
             return response.status, "application/json", chunks
         finally:
             with self._state_lock:

--- a/assist/pi_runtime.py
+++ b/assist/pi_runtime.py
@@ -19,6 +19,7 @@ from urllib3.exceptions import ReadTimeoutError
 
 from assist.model_manager import OpenAIConfig, current_model_config
 from assist.pi_broker import PiToolBroker
+from assist.pi_trace import PiTraceRecorder, PiTraceStore
 from assist.pi_provider_relay import PiProviderRelay
 from assist.sandbox import DockerSandboxBackend
 from assist.sandbox_manager import SandboxManager
@@ -300,7 +301,8 @@ class PiRuntimeManager:
             history: Iterable[tuple[str, str]], system_prompt: str,
             max_turns: int = _MAX_TURNS, turn_id: str | None = None,
             admitted: Callable[[], bool] | None = None,
-            should_yield: Callable[[], bool] | None = None) -> PiRuntimeResult:
+            should_yield: Callable[[], bool] | None = None,
+            trace_dir: str | None = None, trace_run_id: str | None = None) -> PiRuntimeResult:
         """Run one fresh Pi worker and tear down every authority it used."""
         if (not isinstance(prompt, str) or not isinstance(system_prompt, str)
                 or not system_prompt.strip() or not isinstance(max_turns, int)
@@ -309,6 +311,10 @@ class PiRuntimeManager:
         if len(prompt.encode("utf-8")) > _MAX_MESSAGE_BYTES:
             raise PiRuntimeError("Pi prompt exceeds its bound")
         config = current_model_config()
+        if (trace_dir is None) != (trace_run_id is None):
+            raise PiRuntimeError("Pi activity trace is invalid")
+        recorder = (PiTraceRecorder(PiTraceStore(), trace_dir, trace_run_id)
+                    if trace_dir is not None and trace_run_id is not None else None)
         control_dir = self._control_dir(work_dir)
         active = self._register(turn_id)
         sandbox: DockerSandboxBackend | None = None
@@ -332,10 +338,21 @@ class PiRuntimeManager:
             sandbox = self._sandbox_manager.get_pi_sandbox_backend(work_dir, timezone)
             if sandbox is None:
                 raise PiRuntimeError("Pi workspace sandbox is unavailable")
-            broker = PiToolBroker(sandbox, control_dir, broker_capability)
-            relay = PiProviderRelay(
-                control_dir, self._relay_url(config), config.api_key,
-                config.model, provider_capability)
+            if recorder is None:
+                broker = PiToolBroker(sandbox, control_dir, broker_capability)
+                relay = PiProviderRelay(
+                    control_dir, self._relay_url(config), config.api_key,
+                    config.model, provider_capability)
+            else:
+                broker = PiToolBroker(
+                    sandbox, control_dir, broker_capability,
+                    trace_start=lambda name: recorder.start("tool", name),
+                    trace_settle=recorder.settle)
+                relay = PiProviderRelay(
+                    control_dir, self._relay_url(config), config.api_key,
+                    config.model, provider_capability,
+                    trace_start=lambda: recorder.start("model", "model request"),
+                    trace_settle=recorder.settle)
             broker.start()
             relay.start()
             client = self._sandbox_manager._get_docker_client()
@@ -390,6 +407,8 @@ class PiRuntimeManager:
                     self._attempt(teardown_errors, broker.close)
                 if relay is not None:
                     self._attempt(teardown_errors, relay.close)
+                if recorder is not None:
+                    self._attempt(teardown_errors, recorder.finish_unsettled)
                 if result_sink is not None:
                     self._attempt(teardown_errors, result_sink.close)
                 self._attempt(teardown_errors, lambda: shutil.rmtree(control_dir))

--- a/assist/pi_trace.py
+++ b/assist/pi_trace.py
@@ -1,0 +1,250 @@
+"""Host-owned, redacted Pi activity records for visible web turns."""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import threading
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+
+_FILENAME = "pi-trace.jsonl"
+_VERSION = 1
+_MAX_BYTES = 2 * 1024 * 1024
+_MAX_EVENTS = 512
+_MAX_RUN_ID_BYTES = 256
+_KINDS = {"model", "tool"}
+_NAMES = {"model request", "read", "write", "bash"}
+_OUTCOMES = {"started", "completed", "did not complete"}
+
+
+class PiTraceError(ValueError):
+    """A Pi activity trace is malformed, unsafe, or unavailable."""
+
+
+@dataclass(frozen=True)
+class PiTraceEvent:
+    """One redacted lifecycle event for a host-authorized Pi operation."""
+
+    run_id: str
+    sequence: int
+    operation: int
+    kind: Literal["model", "tool"]
+    name: Literal["model request", "read", "write", "bash"]
+    outcome: Literal["started", "completed", "did not complete"]
+
+
+class PiTraceStore:
+    """Append-only Pi trace resource, independent from visible conversation state."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def _path(thread_dir: str | Path) -> Path:
+        return Path(thread_dir) / _FILENAME
+
+    @staticmethod
+    def _validate(value: object) -> PiTraceEvent:
+        expected = {"version", "ts", "run_id", "sequence", "operation", "kind", "name", "outcome"}
+        if not isinstance(value, dict) or set(value) != expected:
+            raise PiTraceError("Pi activity event has an invalid shape")
+        if (value["version"] != _VERSION or not isinstance(value["ts"], str)
+                or not isinstance(value["run_id"], str) or not value["run_id"]
+                or not isinstance(value["sequence"], int) or isinstance(value["sequence"], bool)
+                or not isinstance(value["operation"], int) or isinstance(value["operation"], bool)
+                or value["sequence"] < 1 or value["operation"] < 1
+                or value["kind"] not in _KINDS or value["name"] not in _NAMES
+                or value["outcome"] not in _OUTCOMES):
+            raise PiTraceError("Pi activity event has invalid fields")
+        try:
+            if (len(value["ts"].encode("utf-8")) > 128
+                    or len(value["run_id"].encode("utf-8")) > _MAX_RUN_ID_BYTES):
+                raise PiTraceError("Pi activity event exceeds its bound")
+        except UnicodeEncodeError as error:
+            raise PiTraceError("Pi activity event is not valid UTF-8") from error
+        return PiTraceEvent(value["run_id"], value["sequence"], value["operation"],
+                            value["kind"], value["name"], value["outcome"])
+
+    @classmethod
+    def _events(cls, raw: bytes) -> list[PiTraceEvent]:
+        """Validate the complete immutable history before exposing or extending it."""
+        if raw and not raw.endswith(b"\n"):
+            raise PiTraceError("Pi activity trace is malformed")
+        events: list[PiTraceEvent] = []
+        last_sequence: dict[str, int] = {}
+        started: dict[tuple[str, int], PiTraceEvent] = {}
+        settled: set[tuple[str, int]] = set()
+        for line in raw.splitlines():
+            try:
+                event = cls._validate(json.loads(line))
+            except (UnicodeDecodeError, json.JSONDecodeError, PiTraceError) as error:
+                raise PiTraceError("Pi activity trace is malformed") from error
+            if event.sequence != last_sequence.get(event.run_id, 0) + 1:
+                raise PiTraceError("Pi activity trace has an invalid sequence")
+            last_sequence[event.run_id] = event.sequence
+            key = (event.run_id, event.operation)
+            if event.outcome == "started":
+                if key in started:
+                    raise PiTraceError("Pi activity trace repeats an operation")
+                started[key] = event
+            elif key not in started or key in settled:
+                raise PiTraceError("Pi activity trace has an invalid operation outcome")
+            else:
+                prior = started[key]
+                if (event.kind, event.name) != (prior.kind, prior.name):
+                    raise PiTraceError("Pi activity trace changes an operation")
+                settled.add(key)
+            events.append(event)
+            if len(events) > _MAX_EVENTS:
+                raise PiTraceError("Pi activity trace exceeds its bound")
+        return events
+
+    @classmethod
+    def _read(cls, path: Path) -> tuple[bytes, list[PiTraceEvent]]:
+        try:
+            descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK)
+        except FileNotFoundError:
+            return b"", []
+        except OSError as error:
+            raise PiTraceError("Pi activity trace is unreadable") from error
+        try:
+            metadata = os.fstat(descriptor)
+            if (not stat.S_ISREG(metadata.st_mode) or metadata.st_uid != os.getuid()
+                    or metadata.st_mode & 0o022 or metadata.st_size > _MAX_BYTES):
+                raise PiTraceError("Pi activity trace is unsafe")
+            chunks: list[bytes] = []
+            remaining = _MAX_BYTES + 1
+            while remaining:
+                chunk = os.read(descriptor, remaining)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            raw = b"".join(chunks)
+            if len(raw) > _MAX_BYTES:
+                raise PiTraceError("Pi activity trace exceeds its bound")
+        except OSError as error:
+            raise PiTraceError("Pi activity trace is unreadable") from error
+        finally:
+            os.close(descriptor)
+        return raw, cls._events(raw)
+
+    def get_events(self, thread_dir: str | Path) -> list[PiTraceEvent]:
+        """Return complete validated activity history without affecting Pi execution."""
+        with self._lock:
+            _, events = self._read(self._path(thread_dir))
+            return events
+
+    def append(self, thread_dir: str | Path, event: PiTraceEvent) -> PiTraceEvent:
+        """Persist one validated event atomically, rejecting conflicting replay."""
+        path = self._path(thread_dir)
+        event = self._validate({
+            "version": _VERSION, "ts": "", "run_id": event.run_id,
+            "sequence": event.sequence, "operation": event.operation,
+            "kind": event.kind, "name": event.name, "outcome": event.outcome,
+        })
+        with self._lock:
+            raw, prior = self._read(path)
+            expected_sequence = 1 + max(
+                (item.sequence for item in prior if item.run_id == event.run_id), default=0)
+            if event.sequence != expected_sequence:
+                raise PiTraceError("Pi activity trace has a conflicting sequence")
+            payload = json.dumps({
+                "version": _VERSION, "ts": datetime.now(UTC).isoformat(),
+                "run_id": event.run_id, "sequence": event.sequence,
+                "operation": event.operation, "kind": event.kind,
+                "name": event.name, "outcome": event.outcome,
+            }, separators=(",", ":")).encode("utf-8") + b"\n"
+            if len(raw) + len(payload) > _MAX_BYTES:
+                raise PiTraceError("Pi activity trace is full")
+            self._events(raw + payload)
+            descriptor: int | None = None
+            temporary: str | None = None
+            try:
+                descriptor, temporary = tempfile.mkstemp(prefix=".pi-trace-", dir=path.parent)
+                os.fchmod(descriptor, 0o600)
+                view = memoryview(raw + payload)
+                while view:
+                    written = os.write(descriptor, view)
+                    if written <= 0:
+                        raise OSError("Pi activity trace write made no progress")
+                    view = view[written:]
+                os.fsync(descriptor)
+                os.replace(temporary, path)
+                temporary = None
+                directory = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+                try:
+                    os.fsync(directory)
+                finally:
+                    os.close(directory)
+            except OSError as error:
+                raise PiTraceError("Pi activity trace write failed") from error
+            finally:
+                if descriptor is not None:
+                    os.close(descriptor)
+                if temporary:
+                    try:
+                        os.unlink(temporary)
+                    except FileNotFoundError:
+                        pass
+            return event
+
+
+class PiTraceRecorder:
+    """One turn's opaque operation handles over a thread-owned Pi trace resource."""
+
+    def __init__(self, store: PiTraceStore, thread_dir: str | Path, run_id: str) -> None:
+        self._store = store
+        self._thread_dir = thread_dir
+        self._run_id = run_id
+        self._lock = threading.Lock()
+        self._sequence = 0
+        self._operation = 0
+        self._open: dict[int, tuple[str, str]] = {}
+        self._unavailable = False
+
+    def start(self, kind: Literal["model", "tool"],
+              name: Literal["model request", "read", "write", "bash"]) -> int | None:
+        """Persist an admitted operation and return an opaque handle for its terminal state."""
+        with self._lock:
+            if self._unavailable:
+                return None
+            self._sequence += 1
+            self._operation += 1
+            operation = self._operation
+            try:
+                self._store.append(self._thread_dir, PiTraceEvent(
+                    self._run_id, self._sequence, operation, kind, name, "started"))
+            except PiTraceError:
+                self._unavailable = True
+                return None
+            self._open[operation] = (kind, name)
+            return operation
+
+    def settle(self, operation: int | None, completed: bool) -> None:
+        """Persist one generic terminal outcome for an opaque operation handle."""
+        if operation is None:
+            return
+        with self._lock:
+            detail = self._open.pop(operation, None)
+            if detail is None or self._unavailable:
+                return
+            self._sequence += 1
+            try:
+                self._store.append(self._thread_dir, PiTraceEvent(
+                    self._run_id, self._sequence, operation, detail[0], detail[1],
+                    "completed" if completed else "did not complete"))
+            except PiTraceError:
+                self._unavailable = True
+
+    def finish_unsettled(self) -> None:
+        """Close surviving operations only after every trace producer has drained."""
+        with self._lock:
+            operations = tuple(self._open)
+        for operation in operations:
+            self.settle(operation, False)

--- a/docs/2026-08-12-pi-m2-observability.org
+++ b/docs/2026-08-12-pi-m2-observability.org
@@ -1,0 +1,126 @@
+#+title: Pi M2: visible activity traces
+#+date: 2026-08-12
+#+startup: overview
+
+State: Coding
+
+* Purpose
+
+M1 makes a Pi web thread usable, but it records only visible user and assistant
+messages.  A person cannot tell whether Pi is reasoning, calling the model, or
+using the workspace tools.  M2 adds a small, host-owned activity trace to each
+manual Pi turn.  It is observability, not a new Pi capability or an attempt to
+make Pi internally resemble Deep Agents.
+
+* User contract
+
+1. A Pi thread page shows the current turn's activity after an ordinary page
+   refresh, and completed turns retain their activity between the user message
+   and assistant reply.
+2. The trace is collapsed by default.  Its summary is short and useful, such as
+   =Pi activity: model, read, bash=.  Expanding it shows fixed labels and
+   completion state for each model request and workspace operation.
+3. The page still uses M1's existing refresh model.  M2 adds neither polling,
+   token streaming, a new browser endpoint, nor an unattended ingress path.
+4. Traces never disclose a command, path, file content, tool result, prompt,
+   hidden reasoning, provider response, exception text, capability, credential,
+   or container detail.  A failed action is shown only as =did not complete=.
+
+* Design
+
+** Host-owned trace resource
+
+Add =assist/pi_trace.py= beside =pi_conversation.py=.  It owns one private,
+schema-versioned, append-only =pi-trace.jsonl= per Pi thread.  A record contains
+only the durable Run id, a monotonically increasing per-Run sequence, an opaque
+per-Run operation number, a closed event kind (=model= or =tool=), a closed display name (=model request=, =read=,
+=write=, or =bash=), and an outcome (=started=, =completed=, or =did not
+complete=).  Broker =access(read)= maps to =read=; =access(write)= and =mkdir=
+map to =write=.  Thus every accepted broker request has one simple, fixed label
+without exposing its request fields.  The resource has strict regular-file,
+ownership, mode, record-count, byte,
+UTF-8, ordering, and duplicate checks matching the conversation store.  The
+worker never writes this file and does not receive its path.
+
+The resource is intentionally separate from the visible conversation.  Message
+history remains exactly user/assistant, which preserves M1's prompt and
+continuation boundary.  Trace corruption therefore makes traces unavailable
+without changing the transcript or causing a Deep graph to be constructed.
+
+** Trusted event producers
+
+=PiProviderRelay= records one =model request= only after it accepts the fixed,
+authenticated request.  =PiToolBroker= records a tool start only after it has
+parsed, authenticated, and admitted a closed broker request.  It maps the broker
+operation to a fixed visible label.  Neither forwards request fields nor a
+sandbox response to the trace callback.
+
+=PiRuntimeManager= creates the per-Run recorder and gives callbacks only to its
+relay and broker.  A recorder returns an opaque operation token on start and
+settles that exact token atomically under its own lock.  Callbacks execute on
+their existing worker threads, never in an async web handler.  The manager calls
+=finish_unsettled= only after =broker.close()= and =relay.close()= have drained
+their producer threads.  This gives each persisted start at most one terminal
+outcome and makes the final record ordering deterministic through cancellation.
+
+A trace write failure is contained to the activity view: it cannot change a
+provider request, tool result, worker cleanup, Run result, or visible
+conversation.  The recorder becomes unavailable after a failed write.  On a
+terminal Run, a poisoned recorder, unmatched persisted =started=, or missing
+trace renders =Activity unavailable=, never a false in-progress or completion
+claim.  This also makes pre-M2 Pi turns explicit about their lack of recorded
+activity.
+
+M2 does not subscribe to arbitrary Pi SDK session events.  Those event payloads
+are not a stable display contract and can contain model text, tool arguments, or
+reasoning.  The relay and broker already own the two externally observable
+operations and make the narrowest safe trace boundary.
+
+** Rendering
+
+=get_thread= reads the Pi conversation and trace resources together off the
+event loop and passes both to the existing renderer.  It retains each
+conversation record's Run id instead of reducing Pi messages to role and text.
+The renderer groups trace records only with a known user record carrying the
+same Run id.  Because the page renders newest-first, it inserts the collapsed
+trace immediately before that user bubble, which visually puts it between the
+user message and the later assistant reply.  An unknown, orphaned, or malformed
+trace Run id makes activity unavailable rather than silently joining it by
+position.  The renderer uses host constants for every visible label and never
+puts a Run id or other trace field into the DOM.  A malformed trace yields a
+small unavailable notice rather than an empty claim that no tools ran.
+
+* Scope and exclusions
+
+M2 remains manual visible web Pi only.  It does not add token/reasoning
+streaming, model/provider parallelism, Pi skills or todos, async subagents,
+phone/emacsos, schedules, approvals, egress, a Deep trace retrofit, or a
+Pi-only cutover decision.  It does not change Pi tool authority, provider
+policy, sandbox policy, queue behavior, transcript persistence, or the prompt.
+
+* Implementation plan
+
+1. Add the bounded host trace resource and focused corruption, idempotency,
+   ordering, persistence-failure, and no-payload-leak tests.
+2. Thread a narrow fixed-label recorder through the relay, broker, and runtime;
+   test every operation mapping and concurrent settle/teardown so each accepted
+   operation has exactly one terminal outcome without changing request or result
+   contracts.
+3. Render grouped collapsed traces for Pi pages and add browser-level tests for
+   completed, in-progress, old, malformed, and escaped trace states.
+4. Run the full deterministic suite and a Pi web smoke that exercises a tool;
+   review the real rendered page rather than only the JSONL file.
+
+* Design review record
+
+The design review found three important gaps and this revision resolves them:
+
+- Pi rendering discarded durable Run ids, so traces could not be placed without
+  unsafe positional matching.  M2 retains the Run id through rendering and
+  states the reverse-order insertion rule.
+- The broker accepts =access= and =mkdir= in addition to =read=, =write=, and
+  =bash=.  M2 maps every accepted operation to one closed, non-sensitive label.
+- Producer callbacks could settle after a generic teardown terminal outcome, or
+  a persistence failure could leave a false =started= record.  The recorder now
+  owns opaque tokens and finalizes only after both producers drain; a poisoned or
+  unresolved terminal trace is explicitly unavailable.

--- a/docs/2026-08-12-pi-m2-observability.org
+++ b/docs/2026-08-12-pi-m2-observability.org
@@ -124,3 +124,7 @@ The design review found three important gaps and this revision resolves them:
   a persistence failure could leave a false =started= record.  The recorder now
   owns opaque tokens and finalizes only after both producers drain; a poisoned or
   unresolved terminal trace is explicitly unavailable.
+- Copilot review clarified that a fully read upstream HTTP error is not a
+  completed model request, and a corrupt trace must produce one unavailable
+  notice.  M2 records completion only for a 2xx response and suppresses the
+  per-turn fallback when the page already carries the corrupt-trace notice.

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -67,6 +67,7 @@ from assist.thread_manager import InvalidThreadId
 from assist.thread_engine import ThreadEngineError, read_thread_engine
 from assist.pi_conversation import PiConversationStore
 from assist.pi_runtime import PiRuntimeError, PiRuntimeManager
+from assist.pi_trace import PiTraceError, PiTraceStore
 from assist.thread_queue import (THREAD_QUEUE, QueueWaitTimeout,
                                  ThreadHoldExpired, ThreadPauseRequested,
                                  active_handle)
@@ -444,6 +445,32 @@ def _tools_summary(names) -> str:
     return html.escape(", ".join(seen)) if seen else "tool call"
 
 
+def _render_pi_activity(events, terminal: bool) -> str:
+    """Render only validated fixed Pi activity labels, never operation payloads."""
+    started = {}
+    outcomes = {}
+    for event in events:
+        if event.outcome == "started":
+            started[event.operation] = event
+        else:
+            outcomes[event.operation] = event.outcome
+    if terminal and any(operation not in outcomes for operation in started):
+        return '<div class="msg tools"><div class="content">Activity unavailable</div></div>'
+    labels = []
+    details = []
+    for operation in sorted(started):
+        event = started[operation]
+        label = event.name
+        outcome = outcomes.get(operation, "in progress")
+        if label not in labels:
+            labels.append(label)
+        details.append(f"{html.escape(label)}: {html.escape(outcome)}")
+    if not details:
+        return ""
+    return (f'<details class="msg tools"><summary>Pi activity: {html.escape(", ".join(labels))}'
+            f'</summary><div class="content">{"<br/>".join(details)}</div></details>')
+
+
 def _now_ms() -> int:
     return int(time.time() * 1000)
 
@@ -496,6 +523,8 @@ def render_thread(
     tid: str,
     chat: Thread | None,
     pi_messages: list[dict] | None = None,
+    pi_traces: list | None = None,
+    pi_trace_unavailable: bool = False,
     captured: bool = False,
     merged: bool = False,
     reviewed: bool = False,
@@ -545,6 +574,15 @@ def render_thread(
     # During the initial setup stages there is no agent state worth showing yet.
     msgs: list[dict] = [] if is_init else (pi_messages if pi_messages is not None
                                             else ([] if chat is None else chat.get_messages()))
+    trace_by_run = {}
+    trace_run_ids = set()
+    if is_pi and pi_traces is not None:
+        user_run_ids = {message.get("run_id") for message in msgs if message.get("role") == "user"}
+        for event in pi_traces:
+            trace_run_ids.add(event.run_id)
+            trace_by_run.setdefault(event.run_id, []).append(event)
+        pi_trace_unavailable = pi_trace_unavailable or not trace_run_ids.issubset(user_run_ids)
+    pi_run_status = {run.id: run.status for run in _runs().list(tid)} if is_pi else {}
 
     # Completed-turn elapsed badges: map each turn's CONCLUDING assistant bubble (the last
     # assistant strictly before the next user bubble) to its recorded elapsed seconds.
@@ -724,7 +762,17 @@ def render_thread(
                          f'{html.escape(_format_elapsed(badge_at[_i]))}</span>')
             bubble = (f'<div class="msg {cls}"><div class="role">{role}{badge}</div>'
                       f'<div class="content">{content_html}</div></div>')
+        if is_pi and role == "user":
+            run_id = m.get("run_id")
+            terminal = pi_run_status.get(run_id) in {"success", "error", "cancelled"}
+            trace = _render_pi_activity(trace_by_run.get(run_id, []), terminal)
+            if terminal and not trace:
+                trace = '<div class="msg tools"><div class="content">Activity unavailable</div></div>'
+            if trace:
+                rendered.append(trace)
         rendered.append(bubble)
+    if is_pi and pi_trace_unavailable:
+        rendered.insert(0, '<div class="msg tools"><div class="content">Activity unavailable</div></div>')
     if busy:
         rendered.insert(
             0,
@@ -1487,6 +1535,7 @@ def _pending_email(chat) -> dict | None:
 _RUN_SERVICES_BY_ROOT = {RUN_SERVICE.root_dir: RUN_SERVICE}
 _RUN_SERVICES_LOCK = threading.Lock()
 _PI_CONVERSATIONS = PiConversationStore()
+_PI_TRACES = PiTraceStore()
 _PI_RUNTIME = PiRuntimeManager()
 _PI_CONTINUATION_SUMMARY_LIMIT = 8_000
 _PI_DESCRIPTION_LIMIT = 120
@@ -1968,7 +2017,7 @@ def _execute_pi_run(run: Run, *, user_priority: bool) -> None:
                 work_dir=MANAGER.thread_default_working_dir(tid), timezone=(run.rider or {}).get("tz"),
                 prompt=run.text, history=history, system_prompt=_pi_system_prompt(),
                 turn_id=tid, admitted=lambda: PI_PREVIEW.claim_admits("pi"),
-                should_yield=_pi_should_yield)
+                should_yield=_pi_should_yield, trace_dir=thread_dir, trace_run_id=run.id)
             # A worker can exit in the interval after its last one-second
             # admission observation. Recheck before making its reply durable.
             if not PI_PREVIEW.claim_admits("pi"):
@@ -2721,21 +2770,29 @@ async def get_thread(
         stage = _get_status(tid).get("stage", "ready")
         chat: Thread | None = None
         pi_messages: list[dict] | None = None
+        pi_traces = None
+        pi_trace_unavailable = False
         try:
             is_pi = _is_pi_thread(tid)
         except ThreadEngineError as error:
             raise HTTPException(status_code=409, detail="Thread engine is unavailable") from error
         if stage not in INIT_STAGES and is_pi:
             _backfill_pi_description(tid)
-            pi_messages = [{"role": message.role, "content": message.text}
+            pi_messages = [{"role": message.role, "content": message.text, "run_id": message.run_id}
                            for message in _PI_CONVERSATIONS.get_messages(MANAGER.thread_dir(tid))]
+            try:
+                pi_traces = _PI_TRACES.get_events(MANAGER.thread_dir(tid))
+            except PiTraceError:
+                pi_traces = []
+                pi_trace_unavailable = True
         elif stage not in INIT_STAGES:
             try:
                 chat = MANAGER.get(tid, sandbox_backend=None)
             except FileNotFoundError:
                 raise HTTPException(status_code=404, detail="Thread not found")
         return render_thread(
-            tid, chat, pi_messages=pi_messages, captured=bool(captured), merged=bool(merged),
+            tid, chat, pi_messages=pi_messages, pi_traces=pi_traces,
+            pi_trace_unavailable=pi_trace_unavailable, captured=bool(captured), merged=bool(merged),
             reviewed=bool(reviewed), pushed=bool(pushed))
 
     return await run_in_threadpool(load_and_render)

--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -766,7 +766,7 @@ def render_thread(
             run_id = m.get("run_id")
             terminal = pi_run_status.get(run_id) in {"success", "error", "cancelled"}
             trace = _render_pi_activity(trace_by_run.get(run_id, []), terminal)
-            if terminal and not trace:
+            if terminal and not trace and not pi_trace_unavailable:
                 trace = '<div class="msg tools"><div class="content">Activity unavailable</div></div>'
             if trace:
                 rendered.append(trace)

--- a/tests/test_pi_broker.py
+++ b/tests/test_pi_broker.py
@@ -80,6 +80,52 @@ def test_broker_rejects_wrong_capability(tmp_path: Path) -> None:
     assert backend.commands == []
 
 
+def test_broker_traces_only_admitted_fixed_labels(tmp_path: Path) -> None:
+    control = tmp_path / "control"
+    control.mkdir(mode=0o700)
+    events: list[tuple[str, object, object]] = []
+    broker = PiToolBroker(
+        _Backend(), control, "a" * 43,
+        trace_start=lambda name: events.append(("start", name, None)) or name,
+        trace_settle=lambda operation, completed: events.append(("settle", operation, completed)),
+    )  # type: ignore[arg-type]
+    broker.start()
+    try:
+        denied = _request(broker.socket_path, {
+            "version": 1, "id": 1, "capability": "b" * 43,
+            "operation": "read", "path": "/workspace/file.txt",
+        })
+        accepted = _request(broker.socket_path, {
+            "version": 1, "id": 2, "capability": "a" * 43,
+            "operation": "access", "path": "/workspace/file.txt", "mode": "read",
+        })
+    finally:
+        broker.close()
+
+    assert denied["ok"] is False
+    assert accepted["ok"] is True
+    assert events == [("start", "read", None), ("settle", "read", True)]
+
+
+def test_broker_continues_when_trace_callbacks_fail(tmp_path: Path) -> None:
+    control = tmp_path / "control"
+    control.mkdir(mode=0o700)
+    broker = PiToolBroker(
+        _Backend(), control, "a" * 43,
+        trace_start=lambda _name: (_ for _ in ()).throw(RuntimeError("trace failed")),
+    )  # type: ignore[arg-type]
+    broker.start()
+    try:
+        response = _request(broker.socket_path, {
+            "version": 1, "id": 1, "capability": "a" * 43,
+            "operation": "read", "path": "/workspace/file.txt",
+        })
+    finally:
+        broker.close()
+
+    assert response["ok"] is True
+
+
 def test_broker_rejects_multiple_frames_without_a_backend_call(tmp_path: Path) -> None:
     broker, backend, capability = _broker(tmp_path)
     try:

--- a/tests/test_pi_provider_relay.py
+++ b/tests/test_pi_provider_relay.py
@@ -108,6 +108,53 @@ def test_provider_relay_forwards_only_its_model_and_capability(tmp_path: Path) -
     assert payload["stream"] is True
 
 
+def test_provider_relay_traces_only_an_admitted_request(tmp_path: Path) -> None:
+    upstream = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Upstream)
+    thread = threading.Thread(target=upstream.serve_forever, daemon=True)
+    thread.start()
+    control = tmp_path / "control"
+    control.mkdir(mode=0o700)
+    events: list[tuple[str, object, object]] = []
+    relay = PiProviderRelay(
+        control, f"http://127.0.0.1:{upstream.server_port}/v1", "secret", "qwen", "a" * 43,
+        trace_start=lambda: events.append(("start", "model request", None)) or "model",
+        trace_settle=lambda operation, completed: events.append(("settle", operation, completed)),
+    )
+    relay.start()
+    try:
+        denied = _request(relay.socket_path, "b" * 43)
+        accepted = _request(relay.socket_path, "a" * 43)
+    finally:
+        relay.close()
+        upstream.shutdown()
+        upstream.server_close()
+
+    assert b" 403 " in denied
+    assert b" 200 " in accepted
+    assert events == [("start", "model request", None), ("settle", "model", True)]
+
+
+def test_provider_relay_continues_when_trace_callbacks_fail(tmp_path: Path) -> None:
+    upstream = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Upstream)
+    thread = threading.Thread(target=upstream.serve_forever, daemon=True)
+    thread.start()
+    control = tmp_path / "control"
+    control.mkdir(mode=0o700)
+    relay = PiProviderRelay(
+        control, f"http://127.0.0.1:{upstream.server_port}/v1", "secret", "qwen", "a" * 43,
+        trace_start=lambda: (_ for _ in ()).throw(RuntimeError("trace failed")),
+    )
+    relay.start()
+    try:
+        accepted = _request(relay.socket_path, "a" * 43)
+    finally:
+        relay.close()
+        upstream.shutdown()
+        upstream.server_close()
+
+    assert b" 200 " in accepted
+
+
 def test_provider_relay_rejects_generation_policy_override(tmp_path: Path) -> None:
     upstream = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Upstream)
     thread = threading.Thread(target=upstream.serve_forever, daemon=True)

--- a/tests/test_pi_provider_relay.py
+++ b/tests/test_pi_provider_relay.py
@@ -54,6 +54,17 @@ class _StalledUpstream(http.server.BaseHTTPRequestHandler):
         return
 
 
+class _FailedUpstream(http.server.BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        self.rfile.read(int(self.headers["Content-Length"]))
+        self.send_response(500)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+
 def _request(path: Path, capability: str, *, model: str = "qwen",
              extra: dict[str, object] | None = None) -> bytes:
     body = json.dumps({"model": model, "messages": []} | (extra or {})).encode()
@@ -153,6 +164,29 @@ def test_provider_relay_continues_when_trace_callbacks_fail(tmp_path: Path) -> N
         upstream.server_close()
 
     assert b" 200 " in accepted
+
+
+def test_provider_relay_marks_an_upstream_error_did_not_complete(tmp_path: Path) -> None:
+    upstream = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _FailedUpstream)
+    thread = threading.Thread(target=upstream.serve_forever, daemon=True)
+    thread.start()
+    control = tmp_path / "control"
+    control.mkdir(mode=0o700)
+    outcomes: list[bool] = []
+    relay = PiProviderRelay(
+        control, f"http://127.0.0.1:{upstream.server_port}/v1", "secret", "qwen", "a" * 43,
+        trace_start=lambda: "model", trace_settle=lambda _operation, completed: outcomes.append(completed),
+    )
+    relay.start()
+    try:
+        response = _request(relay.socket_path, "a" * 43)
+    finally:
+        relay.close()
+        upstream.shutdown()
+        upstream.server_close()
+
+    assert b" 500 " in response
+    assert outcomes == [False]
 
 
 def test_provider_relay_rejects_generation_policy_override(tmp_path: Path) -> None:

--- a/tests/test_pi_trace.py
+++ b/tests/test_pi_trace.py
@@ -1,0 +1,86 @@
+"""Durable, redacted Pi activity trace resource tests."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from assist.pi_trace import PiTraceError, PiTraceEvent, PiTraceRecorder, PiTraceStore
+
+
+def test_recorder_persists_a_closed_redacted_operation(tmp_path) -> None:
+    recorder = PiTraceRecorder(PiTraceStore(), tmp_path, "run-1")
+
+    operation = recorder.start("tool", "read")
+    recorder.settle(operation, True)
+
+    assert PiTraceStore().get_events(tmp_path) == [
+        PiTraceEvent("run-1", 1, 1, "tool", "read", "started"),
+        PiTraceEvent("run-1", 2, 1, "tool", "read", "completed"),
+    ]
+    raw = (tmp_path / "pi-trace.jsonl").read_text()
+    assert "/workspace" not in raw
+    assert "command" not in raw
+
+
+def test_store_rejects_an_invalid_event_before_it_persists(tmp_path) -> None:
+    store = PiTraceStore()
+
+    with pytest.raises(PiTraceError):
+        store.append(tmp_path, PiTraceEvent("run-1", 1, 1, "tool", "not a label", "started"))  # type: ignore[arg-type]
+
+    assert not (tmp_path / "pi-trace.jsonl").exists()
+
+
+def test_store_rejects_an_invalid_lifecycle_before_it_persists(tmp_path) -> None:
+    store = PiTraceStore()
+    store.append(tmp_path, PiTraceEvent("run-1", 1, 1, "tool", "read", "started"))
+
+    with pytest.raises(PiTraceError, match="outcome"):
+        store.append(tmp_path, PiTraceEvent("run-1", 2, 2, "tool", "read", "completed"))
+
+    assert PiTraceStore().get_events(tmp_path) == [
+        PiTraceEvent("run-1", 1, 1, "tool", "read", "started"),
+    ]
+
+
+def test_store_rejects_a_malformed_or_unsettled_trace(tmp_path) -> None:
+    path = tmp_path / "pi-trace.jsonl"
+    path.write_text(json.dumps({"version": 1}) + "\n")
+    path.chmod(0o600)
+
+    with pytest.raises(PiTraceError, match="malformed"):
+        PiTraceStore().get_events(tmp_path)
+
+
+def test_store_rejects_a_truncated_but_otherwise_valid_record(tmp_path) -> None:
+    (tmp_path / "pi-trace.jsonl").write_text(
+        '{"version":1,"ts":"","run_id":"run-1","sequence":1,'
+        '"operation":1,"kind":"tool","name":"read","outcome":"started"}')
+    (tmp_path / "pi-trace.jsonl").chmod(0o600)
+
+    with pytest.raises(PiTraceError, match="malformed"):
+        PiTraceStore().get_events(tmp_path)
+
+
+def test_recorder_stops_recording_after_a_write_failure(tmp_path, monkeypatch) -> None:
+    store = PiTraceStore()
+    recorder = PiTraceRecorder(store, tmp_path, "run-1")
+    original = store.append
+    calls = 0
+
+    def fail_second_write(directory, event):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise PiTraceError("disk unavailable")
+        return original(directory, event)
+
+    monkeypatch.setattr(store, "append", fail_second_write)
+    operation = recorder.start("model", "model request")
+    recorder.settle(operation, True)
+    recorder.finish_unsettled()
+
+    assert PiTraceStore().get_events(tmp_path) == [
+        PiTraceEvent("run-1", 1, 1, "model", "model request", "started"),
+    ]

--- a/tests/test_web_pi_preview.py
+++ b/tests/test_web_pi_preview.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from manage.web import threads
 from manage.web import state
 from assist.pi_runtime import PiRuntimeError
+from assist.pi_trace import PiTraceEvent
 from assist.thread_engine import read_thread_engine
 
 
@@ -225,6 +226,39 @@ def test_opening_a_pre_title_pi_thread_backfills_its_first_user_title(
 
     assert "Repair this title" in page
     assert (pi_threads_root / tid / "description.txt").read_text() == "Repair this title"
+
+
+def test_pi_activity_renders_between_a_user_turn_and_its_reply(pi_threads_root) -> None:
+    tid = threads.MANAGER.reserve_visible("pi", thread_id="pi-source")
+    page = threads.render_thread(
+        tid, None,
+        pi_messages=[
+            {"role": "user", "content": "Check the workspace", "run_id": "run-1"},
+            {"role": "assistant", "content": "Done", "run_id": "run-1"},
+        ],
+        pi_traces=[
+            PiTraceEvent("run-1", 1, 1, "tool", "read", "started"),
+            PiTraceEvent("run-1", 2, 1, "tool", "read", "completed"),
+        ],
+    )
+
+    assert "Pi activity: read" in page
+    assert page.index("Done") < page.index("Pi activity: read") < page.index("Check the workspace")
+
+
+def test_terminal_pi_turn_without_a_trace_is_unavailable(pi_threads_root) -> None:
+    tid = threads.MANAGER.reserve_visible("pi", thread_id="pi-source")
+    run = threads._runs().create(tid, "main", "Check the workspace")
+    threads._runs().claim(tid, run.id)
+    threads._runs().transition(tid, run.id, "success")
+
+    page = threads.render_thread(
+        tid, None,
+        pi_messages=[{"role": "user", "content": "Check the workspace", "run_id": run.id}],
+        pi_traces=[],
+    )
+
+    assert "Activity unavailable" in page
 
 
 def test_pi_title_backfill_preserves_a_user_rename(pi_threads_root) -> None:

--- a/tests/test_web_pi_preview.py
+++ b/tests/test_web_pi_preview.py
@@ -261,6 +261,21 @@ def test_terminal_pi_turn_without_a_trace_is_unavailable(pi_threads_root) -> Non
     assert "Activity unavailable" in page
 
 
+def test_corrupt_pi_trace_renders_one_unavailable_notice(pi_threads_root) -> None:
+    tid = threads.MANAGER.reserve_visible("pi", thread_id="pi-source")
+    run = threads._runs().create(tid, "main", "Check the workspace")
+    threads._runs().claim(tid, run.id)
+    threads._runs().transition(tid, run.id, "success")
+
+    page = threads.render_thread(
+        tid, None,
+        pi_messages=[{"role": "user", "content": "Check the workspace", "run_id": run.id}],
+        pi_traces=[], pi_trace_unavailable=True,
+    )
+
+    assert page.count("Activity unavailable") == 1
+
+
 def test_pi_title_backfill_preserves_a_user_rename(pi_threads_root) -> None:
     tid = threads.MANAGER.reserve_visible("pi", thread_id="pi-source")
     state.set_description(tid, "A name I chose")


### PR DESCRIPTION
## Summary

Adds a bounded, host-owned activity trace to manual Pi web turns. The page renders fixed redacted labels for admitted model requests and workspace actions, grouped with the relevant user turn. Trace persistence and callback failures are contained to observability; they do not affect Pi execution, transcripts, or authority.

## Tests

- `tests/test_pi_trace.py::test_recorder_persists_a_closed_redacted_operation` starts and settles a synthetic read operation, then validates the durable records and checks that a workspace path and command text are absent.
- `test_store_rejects_an_invalid_event_before_it_persists`, `test_store_rejects_an_invalid_lifecycle_before_it_persists`, `test_store_rejects_a_malformed_or_unsettled_trace`, and `test_store_rejects_a_truncated_but_otherwise_valid_record` use malformed, invalid-label, impossible lifecycle, and incomplete JSONL fixtures; each validates that the trace is rejected or prior valid state remains unchanged.
- `test_recorder_stops_recording_after_a_write_failure` makes the terminal write fail after a persisted start and validates that the durable trace remains unresolved, so a terminal page is unavailable rather than falsely complete.
- Broker and relay trace tests send both denied and authenticated requests through their real private-socket boundaries. They validate that only admitted requests yield fixed labels and that recorder callback exceptions do not alter successful tool/model responses.
- `test_pi_activity_renders_between_a_user_turn_and_its_reply` renders a Pi page with a durable Run id and read trace, validating visual order: reply, collapsed activity, user message. `test_terminal_pi_turn_without_a_trace_is_unavailable` creates a successful durable Run with no trace and validates the explicit unavailable state.
- Full deterministic suite: `1707 passed, 2 skipped`.

## Deployment

Deployed feature commit `05246e0` for parallel testing. Service is active and HTTPS smoke passed. Pi is presently disabled by the existing provider-health gate, so the live smoke could verify installation and web health but not run a Pi tool turn.