### PR TITLE
Refresh stale skill catalogs

### DIFF
--- a/assist/middleware/skills_middleware.py
+++ b/assist/middleware/skills_middleware.py
@@ -116,7 +116,10 @@ without it produces incorrect output for that domain.
 
 
 class SmallModelSkillsState(SkillsState):
-    """Private activation state for one graph invocation."""
+    """Private catalog and activation state for the current thread."""
+
+    skills_catalog_fingerprint: NotRequired[Annotated[str, PrivateStateAttr]]
+    """Version of the mounted skill sources used to produce the catalog."""
 
     loaded_skill_tools: NotRequired[
         Annotated[frozenset[str], PrivateStateAttr, operator.or_]
@@ -132,6 +135,10 @@ class _LoadArtifact(TypedDict):
 
 def _sha256(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _bytes_sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
 
 
 def _source_contains(source: str, path: str) -> bool:
@@ -356,12 +363,135 @@ class SmallModelSkillsMiddleware(SkillsMiddleware):
                 request.system_message, skills_section),
         )
 
+    def _catalog_from_responses(self, source: str, ls_result, responses):
+        """Parse one source and return its metadata plus content identity."""
+        source_error = None
+        if isinstance(ls_result, deepagents_skills.LsResult) and ls_result.error:
+            source_error = deepagents_skills._format_skills_source_error(  # noqa: SLF001
+                source, ls_result.error)
+            deepagents_skills.logger.warning("%s", source_error)
+        skill_dirs, skill_paths = self._skill_paths(ls_result)
+        metadata = []
+        fingerprint_entries = []
+        for directory, path, response in zip(skill_dirs, skill_paths, responses,
+                                             strict=True):
+            content = response.content
+            fingerprint_entries.append({
+                "path": path,
+                "content_sha256": (_bytes_sha256(content)
+                                   if content is not None else None),
+                "error": bool(response.error),
+            })
+            skill = deepagents_skills._skill_metadata_from_response(  # noqa: SLF001
+                response, directory, path)
+            if skill is not None:
+                metadata.append(skill)
+        return metadata, source_error, fingerprint_entries
+
+    @staticmethod
+    def _skill_paths(ls_result):
+        items = (ls_result.entries if isinstance(ls_result, deepagents_skills.LsResult)
+                 else ls_result)
+        directories = [item["path"] for item in items or [] if item.get("is_dir")]
+        paths = [
+            str(deepagents_skills.PurePosixPath(
+                deepagents_skills.to_posix_path(directory)) / "SKILL.md")
+            for directory in directories
+        ]
+        return directories, paths
+
+    @staticmethod
+    def _snapshot_result(source_results):
+        all_skills = {}
+        errors = []
+        sources = []
+        for source, metadata, error, entries in source_results:
+            if error is not None:
+                errors.append(error)
+            for skill in metadata:
+                all_skills[skill["name"]] = skill
+            sources.append({
+                "source": source,
+                "skills": entries,
+                "unavailable": error is not None,
+            })
+        payload = json.dumps(
+            {"schema": "assist.skill-catalog.v1", "sources": sources},
+            ensure_ascii=False, separators=(",", ":"), sort_keys=True,
+        )
+        return list(all_skills.values()), errors, _sha256(payload)
+
+    def _catalog_snapshot(self, backend):
+        """Discover mounted skills once and fingerprint the exact read bytes."""
+        source_results = []
+        for source in self.sources:
+            ls_result = backend.ls(source)
+            _, paths = self._skill_paths(ls_result)
+            metadata, error, entries = self._catalog_from_responses(
+                source, ls_result,
+                backend.download_files(paths) if paths else [])
+            source_results.append((source, metadata, error, entries))
+        return self._snapshot_result(source_results)
+
+    async def _acatalog_snapshot(self, backend):
+        """Async counterpart to :meth:`_catalog_snapshot`."""
+        source_results = []
+        for source in self.sources:
+            ls_result = await backend.als(source)
+            _, paths = self._skill_paths(ls_result)
+            metadata, error, entries = self._catalog_from_responses(
+                source, ls_result,
+                await backend.adownload_files(paths) if paths else [])
+            source_results.append((source, metadata, error, entries))
+        return self._snapshot_result(source_results)
+
     def before_agent(self, state, runtime, config):
-        update = super().before_agent(state, runtime, config) or {}
+        backend = self._get_backend(state, runtime, config)
+        if "skills_metadata" not in state:
+            # Preserve Deep Agents' initial discovery hook and its census
+            # provenance.  The snapshot immediately below is authoritative so
+            # its metadata and fingerprint always come from the same reads.
+            super().before_agent(state, runtime, config)
+            skills, errors, fingerprint = self._catalog_snapshot(backend)
+            update = {
+                "skills_metadata": skills,
+                "skills_load_errors": errors,
+                "skills_catalog_fingerprint": fingerprint,
+            }
+        else:
+            skills, errors, fingerprint = self._catalog_snapshot(backend)
+            if state.get("skills_catalog_fingerprint") == fingerprint:
+                update = {}
+            else:
+                update = {
+                    "skills_metadata": skills,
+                    "skills_load_errors": errors,
+                    "skills_catalog_fingerprint": fingerprint,
+                }
         return {**update, "loaded_skill_tools": Overwrite(frozenset())}
 
     async def abefore_agent(self, state, runtime, config):
-        update = await super().abefore_agent(state, runtime, config) or {}
+        backend = self._get_backend(state, runtime, config)
+        if "skills_metadata" not in state:
+            # Keep the async discovery hook aligned with the synchronous path;
+            # use one snapshot for the state actually persisted below.
+            await super().abefore_agent(state, runtime, config)
+            skills, errors, fingerprint = await self._acatalog_snapshot(backend)
+            update = {
+                "skills_metadata": skills,
+                "skills_load_errors": errors,
+                "skills_catalog_fingerprint": fingerprint,
+            }
+        else:
+            skills, errors, fingerprint = await self._acatalog_snapshot(backend)
+            if state.get("skills_catalog_fingerprint") == fingerprint:
+                update = {}
+            else:
+                update = {
+                    "skills_metadata": skills,
+                    "skills_load_errors": errors,
+                    "skills_catalog_fingerprint": fingerprint,
+                }
         return {**update, "loaded_skill_tools": Overwrite(frozenset())}
 
     def _hidden_call_message(self, tool_call: dict[str, Any]) -> ToolMessage:

--- a/assist/middleware/skills_middleware.py
+++ b/assist/middleware/skills_middleware.py
@@ -371,10 +371,22 @@ class SmallModelSkillsMiddleware(SkillsMiddleware):
                 source, ls_result.error)
             deepagents_skills.logger.warning("%s", source_error)
         skill_dirs, skill_paths = self._skill_paths(ls_result)
+        if len(responses) != len(skill_paths):
+            source_error = deepagents_skills._format_skills_source_error(  # noqa: SLF001
+                source, "skill download response count mismatch")
+            deepagents_skills.logger.warning("%s", source_error)
         metadata = []
         fingerprint_entries = []
-        for directory, path, response in zip(skill_dirs, skill_paths, responses,
-                                             strict=True):
+        for index, (directory, path) in enumerate(zip(skill_dirs, skill_paths,
+                                                       strict=True)):
+            response = responses[index] if index < len(responses) else None
+            if response is None:
+                fingerprint_entries.append({
+                    "path": path,
+                    "content_sha256": None,
+                    "error": True,
+                })
+                continue
             content = response.content
             fingerprint_entries.append({
                 "path": path,

--- a/docs/2026-08-15-skill-catalog-refresh.org
+++ b/docs/2026-08-15-skill-catalog-refresh.org
@@ -1,0 +1,71 @@
+#+title: Refresh persisted skill catalogs
+
+* Goal
+
+Existing threads must discover and load skills that appear in mounted bundled,
+web, or domain sources after the thread's first checkpoint.  The current
+=skills_metadata= checkpoint field suppresses Deep Agents discovery forever,
+which leaves the catalog and progressive tool authorization stale.
+
+* Contract
+
+- Treat the mounted skill inventory as versioned agent configuration.  Its
+  identity includes source order, availability, each discovered skill path, and
+  the complete =SKILL.md= bytes.  Hashes, never file contents, are
+  checkpointed.
+- Before each agent invocation, compare the fresh identity to the checkpointed
+  one.  If it differs, replace =skills_metadata= (and source diagnostics) with
+  the fresh discovery result.  A legacy checkpoint without an identity is
+  stale by definition.
+- Continue to overwrite =loaded_skill_tools= with an empty set for every
+  invocation.  It remains graph-invocation state, not catalog state.
+- The loader continues to use the resulting winning metadata only.  A model
+  cannot name an unlisted skill to bypass the catalog or progressive tool gate.
+
+* Design
+
+1. Extend =SmallModelSkillsState= with a private persisted catalog fingerprint.
+   In =SmallModelSkillsMiddleware.before_agent= and =abefore_agent=, discover
+   the current mounted catalog and calculate one canonical SHA-256 from source
+   order plus each valid skill's virtual path and raw-file SHA-256.
+2. When the checkpoint fingerprint and metadata are current, retain the
+   checkpointed catalog.  When either is absent or the fingerprint differs,
+   replace the catalog and its current loading diagnostics as one state update.
+   The source scan reads files through the existing backend abstraction; no
+   filesystem path, source-specific stat API, or new tool is introduced.
+3. Keep the existing exact-winner =load_skill= implementation and gated-tool
+   checks unchanged.  They naturally consume the refreshed catalog.
+4. Add deterministic migration coverage using a real temporary filesystem
+   backend: make a checkpoint from an older catalog, add a bundled skill and a
+   domain skill, reconstruct the middleware, and prove both appear and load.
+   Add a web render regression using its normal mounted source and a compiled
+   graph regression that reconstructs an existing thread against a new domain
+   skill.  Also prove an unchanged fingerprint retains the catalog and every
+   invocation clears prior loaded-tool disclosure.
+5. Update the roadmap item with the implementation result and test evidence.
+
+* Rejected alternatives
+
+- **Invalidate only when the agent writes =SKILL.md=.** Source changes commonly
+  arrive through a merged domain repository or an Assist deployment, outside a
+  model write.  That misses the observed failure.
+- **Refresh only metadata.** A body-only edit changes model guidance while
+  retaining stale cached state; the identity must include raw =SKILL.md=
+  content.
+- **Refresh every checkpoint field or rebuild the thread.** That would discard
+  conversation state and is unnecessary.  The catalog is the only stale
+  configuration.
+
+* Risks and containment
+
+- Source content can be untrusted.  The checkpoint stores only digests and
+  already-discovered metadata; it never persists raw skill text beyond the
+  existing load tool result.
+- A source can fail transiently.  The fingerprint includes the resulting
+  discovery shape, so recovery refreshes the catalog rather than preserving a
+  false "current" marker.  Existing warning behavior remains intact.
+- Discovery adds bounded file reads at agent start.  That is the required
+  compatibility check, uses the current backend API, and is limited to mounted
+  =SKILL.md= files.
+- The work is middleware-only and not on the ASGI event loop; no web handler,
+  tool surface, or subagent contract changes.

--- a/docs/2026-08-15-skill-catalog-refresh.org
+++ b/docs/2026-08-15-skill-catalog-refresh.org
@@ -63,7 +63,9 @@ which leaves the catalog and progressive tool authorization stale.
   existing load tool result.
 - A source can fail transiently.  The fingerprint includes the resulting
   discovery shape, so recovery refreshes the catalog rather than preserving a
-  false "current" marker.  Existing warning behavior remains intact.
+  false "current" marker.  A short backend download batch is recorded as a
+  failed skill entry rather than aborting a later turn.  Existing warning
+  behavior remains intact.
 - Discovery adds bounded file reads at agent start.  That is the required
   compatibility check, uses the current backend API, and is limited to mounted
   =SKILL.md= files.

--- a/roadmap.org
+++ b/roadmap.org
@@ -986,7 +986,7 @@ and embedder sources now share invocation-scoped disclosure and execution
 filtering; SMS triage remains legacy.  Deterministic tests pass 1,611/2, and
 the affected behavioral suites were baseline 18/18, candidate N=3 18/18, N=5
 30/30, and N=10 59/60 with the one miss reproduced by baseline.
-**** URGENT Refresh persisted skill catalogs when their mounted sources change
+**** DONE Refresh persisted skill catalogs when their mounted sources change
 The skills middleware stores =skills_metadata= in the thread checkpoint and
 DeepAgents deliberately skips discovery whenever that field already exists.
 That turns a source change into a permanent capability loss for an existing
@@ -1005,6 +1005,13 @@ introduced domain skill; it must verify that both are listed and can be loaded
 without recreating or losing the thread.  Include an existing-thread render
 regression case.  This is a DeepAgents compatibility fix; Pi should eventually
 have the equivalent catalog invalidation contract, but need not block it.
+
+Completed on 2026-08-15 in the =skill-catalog-refresh= lane.  The normal and
+async skills middleware now persist a hash of mounted source order plus every
+discovered =SKILL.md= content hash.  An old or changed hash refreshes metadata
+and diagnostics while =loaded_skill_tools= remains invocation-local.  Focused
+migration coverage proves a thread learns new bundled, domain, and normal web
+=render= skills, including a body-only update.
 
 *** TODO P2c: Suppress recently loaded skill descriptions until useful again
 After P2b, compare turn-count, provider-reported input-plus-output-token,

--- a/tests/middleware/test_skills_kernel.py
+++ b/tests/middleware/test_skills_kernel.py
@@ -271,6 +271,23 @@ def test_catalog_fingerprint_changes_when_a_source_becomes_unavailable():
     assert available[2] != unavailable[2]
 
 
+def test_catalog_refresh_tolerates_a_short_skill_download_batch():
+    middleware = SmallModelSkillsMiddleware(
+        backend=Mock(), sources=["/skills/"], bundled_sources=["/skills/"])
+
+    metadata, error, entries = middleware._catalog_from_responses(
+        "/skills/", [{"path": "/skills/travel", "is_dir": True}], [])
+
+    assert metadata == []
+    assert error == "Cannot load skills from '/skills/': " + \
+        "skill download response count mismatch"
+    assert entries == [{
+        "path": "/skills/travel/SKILL.md",
+        "content_sha256": None,
+        "error": True,
+    }]
+
+
 def test_rebuilt_graph_refreshes_a_checkpointed_domain_catalog(tmp_path):
     from assist.agent import create_agent
     from assist.spec import AgentSpec

--- a/tests/middleware/test_skills_kernel.py
+++ b/tests/middleware/test_skills_kernel.py
@@ -7,9 +7,10 @@ import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 from typing import get_args, get_type_hints
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from pydantic import PrivateAttr
+from deepagents.backends import FilesystemBackend
 from langchain.agents.middleware.types import ModelRequest
 from langchain.agents.middleware.types import ToolCallRequest
 from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
@@ -149,16 +150,158 @@ def test_no_bundled_source_keeps_legacy_prompt_and_loader_schema():
 
 def test_before_agent_resets_activation_even_when_metadata_is_checkpointed():
     middleware = SmallModelSkillsMiddleware(
-        backend=Mock(), sources=["/skills/"], bundled_sources=["/skills/"])
+        backend=SimpleNamespace(), sources=["/skills/"],
+        bundled_sources=["/skills/"])
 
-    update = middleware.before_agent(
-        {"skills_metadata": [_skill()], "loaded_skill_tools": frozenset({"travel"})},
-        SimpleNamespace(),
-        {},
-    )
+    with patch.object(middleware, "_catalog_snapshot",
+                      return_value=([_skill()], [], "current")):
+        update = middleware.before_agent(
+            {"skills_metadata": [_skill()], "skills_catalog_fingerprint": "current",
+             "loaded_skill_tools": frozenset({"travel"})},
+            SimpleNamespace(),
+            {},
+        )
 
     assert isinstance(update["loaded_skill_tools"], Overwrite)
     assert update["loaded_skill_tools"].value == frozenset()
+
+
+def _write_skill(root, source, name, body="Follow the current procedure."):
+    skill = root / source.strip("/") / name / "SKILL.md"
+    skill.parent.mkdir(parents=True, exist_ok=True)
+    skill.write_text(
+        f"---\nname: {name}\ndescription: {name} help.\n---\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def test_existing_checkpoint_refreshes_changed_bundled_and_domain_catalog(tmp_path):
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+    initial_sources = ["/skills/", "/render-skill/"]
+    _write_skill(tmp_path, "/skills/", "travel")
+    middleware = SmallModelSkillsMiddleware(
+        backend=backend, sources=initial_sources,
+        bundled_sources=["/skills/", "/render-skill/"],
+        gated_sources=initial_sources,
+    )
+    initial = middleware.before_agent({}, SimpleNamespace(), {})
+    checkpoint = {
+        "skills_metadata": initial["skills_metadata"],
+        "skills_catalog_fingerprint": initial["skills_catalog_fingerprint"],
+        "loaded_skill_tools": frozenset({"travel"}),
+    }
+
+    _write_skill(tmp_path, "/render-skill/", "render", "Render a file.")
+    _write_skill(tmp_path, "/.claude/skills/", "domain-notes", "Read notes.")
+    sources = [*initial_sources, "/.claude/skills/"]
+    middleware = SmallModelSkillsMiddleware(
+        backend=backend, sources=sources,
+        bundled_sources=["/skills/", "/render-skill/"],
+        gated_sources=sources,
+    )
+
+    refreshed = middleware.before_agent(checkpoint, SimpleNamespace(), {})
+
+    assert {skill["name"] for skill in refreshed["skills_metadata"]} == {
+        "travel", "render", "domain-notes"}
+    assert refreshed["skills_catalog_fingerprint"] != \
+        checkpoint["skills_catalog_fingerprint"]
+    assert isinstance(refreshed["loaded_skill_tools"], Overwrite)
+    assert refreshed["loaded_skill_tools"].value == frozenset()
+    state = {**checkpoint, **refreshed, "loaded_skill_tools": frozenset()}
+    for name in ("render", "domain-notes"):
+        result = middleware.tools[0].func(
+            name, SimpleNamespace(state=state, config={}, tool_call_id=name))
+        assert isinstance(result, Command)
+        assert name in result.update["messages"][0].content
+
+    unchanged = middleware.before_agent(state, SimpleNamespace(), {})
+
+    assert "skills_metadata" not in unchanged
+    assert isinstance(unchanged["loaded_skill_tools"], Overwrite)
+
+    _write_skill(tmp_path, "/render-skill/", "render", "Render the latest file.")
+    body_refresh = middleware.before_agent(state, SimpleNamespace(), {})
+
+    assert body_refresh["skills_metadata"] == state["skills_metadata"]
+    assert body_refresh["skills_catalog_fingerprint"] != \
+        state["skills_catalog_fingerprint"]
+
+    _write_skill(tmp_path, "/render-skill/", "render", "Render only the final file.")
+    async_refresh = asyncio.run(middleware.abefore_agent(
+        {**state, **body_refresh}, SimpleNamespace(), {}))
+
+    assert async_refresh["skills_catalog_fingerprint"] != \
+        body_refresh["skills_catalog_fingerprint"]
+
+
+def test_existing_checkpoint_discovers_the_web_render_skill(tmp_path):
+    from assist.backends import SKILLS_ROUTE, create_composite_backend
+    from assist.thread_manager import _RENDER_SKILL_ROUTE, _web_skill_sources
+
+    backend = create_composite_backend(
+        fs_root=str(tmp_path), extra_routes=_web_skill_sources())
+    old = SmallModelSkillsMiddleware(
+        backend=backend, sources=[SKILLS_ROUTE],
+        bundled_sources=[SKILLS_ROUTE])
+    initial = old.before_agent({}, SimpleNamespace(), {})
+    current = SmallModelSkillsMiddleware(
+        backend=backend, sources=[SKILLS_ROUTE, _RENDER_SKILL_ROUTE],
+        bundled_sources=[SKILLS_ROUTE, _RENDER_SKILL_ROUTE])
+
+    refreshed = current.before_agent({
+        "skills_metadata": initial["skills_metadata"],
+        "skills_catalog_fingerprint": initial["skills_catalog_fingerprint"],
+    }, SimpleNamespace(), {})
+    state = {**refreshed, "loaded_skill_tools": frozenset()}
+    result = current.tools[0].func(
+        "render", SimpleNamespace(state=state, config={}, tool_call_id="render"))
+
+    assert "render" in {skill["name"] for skill in refreshed["skills_metadata"]}
+    assert isinstance(result, Command)
+    assert "render" in result.update["messages"][0].content.lower()
+
+
+def test_catalog_fingerprint_changes_when_a_source_becomes_unavailable():
+    available = SmallModelSkillsMiddleware._snapshot_result([
+        ("/skills/", [_skill()], None, [])])
+    unavailable = SmallModelSkillsMiddleware._snapshot_result([
+        ("/skills/", [_skill()], "source unavailable", [])])
+
+    assert available[2] != unavailable[2]
+
+
+def test_rebuilt_graph_refreshes_a_checkpointed_domain_catalog(tmp_path):
+    from assist.agent import create_agent
+    from assist.spec import AgentSpec
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    model = _RecordingModel(responses=[
+        AIMessage(content="before"),
+        AIMessage(content="", tool_calls=[{
+            "name": "load_skill", "args": {"name": "domain-notes"},
+            "id": "load-domain-notes",
+        }]),
+        AIMessage(content="after"),
+    ])
+    checkpointer = InMemorySaver()
+    config = {"configurable": {"thread_id": "catalog-refresh"}}
+    spec = AgentSpec(async_subagent_tools=())
+
+    initial = create_agent(model, str(tmp_path), checkpointer=checkpointer, spec=spec)
+    initial.invoke({"messages": [{"role": "user", "content": "hello"}]}, config)
+    _write_skill(tmp_path, "/.claude/skills/", "domain-notes", "Read notes.")
+    rebuilt = create_agent(model, str(tmp_path), checkpointer=checkpointer, spec=spec)
+
+    result = rebuilt.invoke(
+        {"messages": [{"role": "user", "content": "use my notes"}]}, config)
+
+    loaded = [message for message in result["messages"]
+              if isinstance(message, ToolMessage)
+              and message.tool_call_id == "load-domain-notes"]
+    assert len(loaded) == 1
+    assert loaded[0].status == "success"
+    assert "domain-notes" in loaded[0].content
 
 
 def test_successful_load_returns_state_command_and_exact_closed_evidence():
@@ -324,7 +467,8 @@ def test_backend_error_details_are_not_returned_to_the_model():
 
 def test_prose_claim_does_not_disclose_tools_and_async_reset_matches_sync():
     middleware = SmallModelSkillsMiddleware(
-        backend=Mock(), sources=["/skills/"], bundled_sources=["/skills/"])
+        backend=SimpleNamespace(), sources=["/skills/"],
+        bundled_sources=["/skills/"])
     state = {
         "messages": [{"role": "user", "content": "I loaded travel."}],
         "skills_metadata": [_skill()],
@@ -332,9 +476,12 @@ def test_prose_claim_does_not_disclose_tools_and_async_reset_matches_sync():
     }
 
     updated = middleware.modify_request(_request(middleware, state))
-    reset = asyncio.run(middleware.abefore_agent(
-        {**state, "loaded_skill_tools": frozenset({"travel"})},
-        SimpleNamespace(), {}))
+    with patch.object(middleware, "_acatalog_snapshot", new=AsyncMock(
+            return_value=([_skill()], [], "current"))):
+        reset = asyncio.run(middleware.abefore_agent(
+            {**state, "skills_catalog_fingerprint": "current",
+             "loaded_skill_tools": frozenset({"travel"})},
+            SimpleNamespace(), {}))
 
     assert [item.name for item in updated.tools] == ["kernel_tool"]
     assert isinstance(reset["loaded_skill_tools"], Overwrite)

--- a/tests/test_prompt_census.py
+++ b/tests/test_prompt_census.py
@@ -1236,7 +1236,7 @@ def test_p0_through_p2b3_and_workload_history_match_the_current_capture(census):
     assert len(census["findings"]) == 23
     assert len(artifact_bytes(census)) == 3_198_701
     assert census["artifact_sha256"] == \
-            "1f14a35ad5d3a6a75e333f86002328372fde2f608782e6312f518ed986ce24b7"
+            "d6af3e0df06080597135ecf09beb128a6e226471ba1a571a6d8845aa655350e2"
     assert "2,920,942 bytes (2.8 MiB)" in document
     assert "P2b.3 external-skill disclosure implementation" in document
     assert "domain and embedder tool disclosure" in p2b3_document

--- a/tests/test_prompt_census.py
+++ b/tests/test_prompt_census.py
@@ -1236,7 +1236,7 @@ def test_p0_through_p2b3_and_workload_history_match_the_current_capture(census):
     assert len(census["findings"]) == 23
     assert len(artifact_bytes(census)) == 3_198_701
     assert census["artifact_sha256"] == \
-            "a16ba000fe309f52c3d98460d37e4bf5d8cef0ed76100644b770f17ead7df834"
+            "1f14a35ad5d3a6a75e333f86002328372fde2f608782e6312f518ed986ce24b7"
     assert "2,920,942 bytes (2.8 MiB)" in document
     assert "P2b.3 external-skill disclosure implementation" in document
     assert "domain and embedder tool disclosure" in p2b3_document


### PR DESCRIPTION
## Summary

Refreshes a thread's persisted progressive skill catalog whenever its mounted
source inventory changes. The middleware checkpoints only a SHA-256 identity
for source order, source availability, discovered virtual paths, and raw
`SKILL.md` bytes. A stale or legacy checkpoint receives fresh metadata and
diagnostics; invocation-local `loaded_skill_tools` still resets on every turn.

No tools, prompts, routes, source permissions, or tool-gating rules change.

## Deterministic migration coverage

- **Bundled + domain migration:** a real temporary filesystem backend begins
  with an old catalog, then gains a render-style bundled skill and a new domain
  skill. The rebuilt middleware must list both, load both by exact name, reset
  prior disclosure, refresh on a body-only edit, and do the same in its async
  path.
- **Existing web render regression:** a checkpoint made before the normal web
  render source is listed is rebuilt with the actual mounted render route. It
  must discover and successfully load `render`.
- **Compiled existing-thread migration:** a real compiled graph checkpoints an
  ordinary first turn, a domain skill is added, and a rebuilt graph uses the
  same thread ID/checkpointer. The next turn must load that new domain skill.
- **Source recovery:** the catalog signature differs when a source moves between
  available and unavailable, so diagnostics cannot remain stale after recovery.
- **Existing reset/census coverage:** activation reset retains its
  invocation-local semantics, and the prompt census updates only its source
  artifact fingerprint. Prompt length, schema bytes, call count, tool-node
  count, and findings remain unchanged.

## Verification

- `pytest -q tests --disable-warnings --maxfail=1` — 1,735 passed, 2 skipped
- `py_compile` for changed Python files and `git diff --check`
- Deployed for parallel testing from `de3a1e62`; service restart verified active.

## Design record

`docs/2026-08-15-skill-catalog-refresh.org` records the checkpoint contract,
source-content identity, rejected write-trigger-only invalidation, and the
untrusted-content boundary.

## Design change from review

A malformed or shortened skill-download batch is now a recoverable source
diagnostic with failed catalog entries, not an exception from a resumed turn.
The catalog fingerprint changes so a later healthy read restores the skill.
