### PR TITLE
Confine location snapshots to admitted runs

### DIFF
--- a/manage/web/threads.py
+++ b/manage/web/threads.py
@@ -2335,12 +2335,9 @@ def _process_message(tid: str, text: str | None, rider: ContextRider | None = No
                     _cfg = {}
                     if rider:
                         _cfg[CONTEXT_RIDER_KEY] = rider
-                    if not sender and assistant_id == "general-agent":
-                        snapshot = location
-                        if snapshot is None and _run is None:
-                            snapshot = LOCATION_STORE.recent()
-                        if snapshot is not None:
-                            _cfg[LOCATION_CONTEXT_KEY] = snapshot
+                    if (not sender and assistant_id == "general-agent"
+                            and location is not None):
+                        _cfg[LOCATION_CONTEXT_KEY] = location
                     if sender:
                         _cfg[SMS_SENDER_KEY] = sender
                     # A triage turn (sender set) gets the reduced, HITL-gated tool surface.

--- a/tests/test_web_process_message_e2e.py
+++ b/tests/test_web_process_message_e2e.py
@@ -526,6 +526,31 @@ def test_child_turn_never_receives_global_location(client, monkeypatch):
     assert LOCATION_CONTEXT_KEY not in (captured.get("configurable") or {})
 
 
+def test_direct_main_turn_never_receives_global_location(client, monkeypatch):
+    """Only an admitted visible Run may carry the browser snapshot to the main agent."""
+    threads.LOCATION_STORE.record(37.7749, -122.4194)
+    captured = {}
+
+    class _FakeChat:
+        def message(self, text):
+            return "ok"
+        def pending_reply(self):
+            return None
+        def get_messages(self):
+            return [{"role": "user", "content": "continuation"}]
+
+    monkeypatch.setattr("manage.web.threads._get_sandbox_backend", lambda tid, tz=None: None)
+    monkeypatch.setattr(
+        web.MANAGER, "get",
+        lambda *args, **kwargs: captured.update(configurable=kwargs.get("configurable")) or _FakeChat())
+    monkeypatch.setattr(web.MANAGER, "touch", lambda tid: None)
+    monkeypatch.setattr("manage.web.threads._get_domain_manager", lambda tid: None)
+    monkeypatch.setattr("manage.web.threads.get_cached_description", lambda tid: "stub")
+
+    threads._process_message("thread-e2e", "continue", origin="continuation")
+    assert LOCATION_CONTEXT_KEY not in (captured.get("configurable") or {})
+
+
 def test_new_thread_form_flows_rider(client, monkeypatch):
     """The index new-thread form (/threads/with-message) now carries the rider too —
     sent_at/tz/lat/lon reach _initialize_thread (→ the first message's _process_message)."""


### PR DESCRIPTION
## Summary

Fixes the post-merge review finding in the deliberate current-location feature. A location snapshot now reaches a main agent only when the durable Run already carries the snapshot captured at visible web admission. Direct, scheduled, continuation, and other non-Run dispatches cannot read the process-global last-location record.

## Eval and test coverage

- `tests/test_web_process_message_e2e.py::test_browser_message_flows_rider` submits a normal browser message with a valid same-origin location token and coordinates. It verifies the admitted Run persists the snapshot and the main agent receives that exact snapshot in private tool configuration.
- `tests/test_web_process_message_e2e.py::test_direct_main_turn_never_receives_global_location` first records a location, then directly invokes a continuation-style main-agent dispatch with no Run. It verifies the agent configuration has no location value. This is the regression for the Copilot finding.
- `tests/test_web_process_message_e2e.py::test_child_turn_never_receives_global_location` records a location then directly invokes a context-agent turn. It verifies child configuration has no location value.
- Focused deterministic suite: `tests/test_location.py`, `tests/test_context_rider.py`, `tests/test_travel.py`, `tests/test_map.py`, `tests/test_run_service.py`, `tests/test_fair_scheduling_integration.py`, `tests/test_web_process_message_e2e.py`, `tests/test_web_inbound_sms.py`, and `tests/test_prompt_census.py`: 179 passed. `compileall` and Ruff passed.

## Deployment

Deployed from this branch and verified the running source, active service, and HTTPS smoke before opening the PR.